### PR TITLE
feat(repo-graph): add content-based freshness probes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -661,10 +661,16 @@ Controls phase completion gating and validation.
 
 ## Repo Graph Configuration (`repo_graph`)
 
-Controls the repository dependency graph that the plugin builds on session start.
+Controls the persistent repository dependency graph, its bounded freshness
+probe, and automatic incremental refresh behavior.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `enabled` | boolean | `true` | Master switch. When `false`, no startup or write-trigger maintenance runs, `repo_map` returns a disabled notice, and graph context is not injected. The tool remains registered. |
+| `init_refresh` | boolean | `true` | Probe the persisted fingerprint on session start and refresh only detected drift. Set to `false` to retain the legacy full rebuild on every session start. |
+| `refresh_cap` | integer (0-500) | `50` | Maximum complete drift set that a `repo_map` read may refresh incrementally. `0` disables read-time auto-refresh. Startup also uses this value in its incremental-versus-full-build cutover. |
+| `walk_budget_ms` | integer (1000-60000) | `5000` | Wall-clock budget for graph and freshness walks. An incomplete freshness walk is `inconclusive` and never authorizes refresh or deletion. |
+| `max_files` | integer (100-100000) | `10000` | Source-file cap for graph and freshness walks. Hitting the cap is conservative and produces an incomplete result. |
 | `exclude_dirs` | string[] | `[]` | Extra directory **names** to skip when scanning the workspace, in addition to the built-in defaults. |
 
 The graph scanner already skips common generated directories by default:
@@ -678,11 +684,37 @@ in the workspace. Entries are directory names, **not** glob or path patterns.
 The exclude also applies to write-triggered incremental updates, so files under
 an excluded directory are never (re-)added to the graph.
 
+Changing the exclusion policy invalidates the prior fingerprint and causes a
+configured startup rebuild. Changes to `package.json`, `Cargo.toml`,
+`pyproject.toml`, or `go.mod` also require a full rebuild because those
+manifests affect inferred package boundaries rather than a single source node.
+
+The freshness sidecar at `.swarm/repo-graph.fingerprint.json` records file size
+and modification time for source files and package manifests. This is a bounded
+`readdir` plus `stat` walk; it does not read or hash file contents. A change that
+preserves both size and filesystem mtime is outside the probe's detection model.
+Probe results are cached per normalized workspace for up to 30 seconds with
+bounded LRU eviction.
+
+`clean` means the current walk matches the persisted fingerprint. `drifted`
+means a complete walk found additions, metadata changes, or removals.
+`no-fingerprint` triggers a startup rebuild. `inconclusive` means a budget, cap,
+or filesystem error prevented complete observation; existing query answers are
+served with freshness marked unknown, and no refresh or deletion is attempted.
+Coder/reviewer graph context follows the same rule: inconclusive results remain
+available as freshness-unknown, while uncertified graphs and complete drift
+above `refresh_cap` are suppressed.
+
 **Example** — exclude a generated-code directory and a docs build dir:
 
 ```json
 {
   "repo_graph": {
+    "enabled": true,
+    "init_refresh": true,
+    "refresh_cap": 30,
+    "walk_budget_ms": 8000,
+    "max_files": 25000,
     "exclude_dirs": ["generated", "site"]
   }
 }

--- a/docs/releases/pending/1986-repo-graph-content-freshness.md
+++ b/docs/releases/pending/1986-repo-graph-content-freshness.md
@@ -1,0 +1,6 @@
+---
+category: Added
+---
+
+- Replace repository-graph age checks and unconditional session rebuilds with a bounded, cached workspace fingerprint probe. Unchanged sessions reuse the persisted graph, small complete drift refreshes incrementally, large or manifest drift rebuilds safely, and incomplete walks never authorize deletion.
+- Add `repo_graph.enabled`, `init_refresh`, `refresh_cap`, `walk_budget_ms`, and `max_files` configuration. Repository-map queries and coder/reviewer context share the same freshness state; uncertified and over-cap graph guidance is suppressed, while incomplete probes stay read-only and freshness-unknown.

--- a/docs/releases/pending/validate-symlink-boundary-nonexistent-target-symlinked-root.md
+++ b/docs/releases/pending/validate-symlink-boundary-nonexistent-target-symlinked-root.md
@@ -1,0 +1,24 @@
+# `fix(security)`: resolve not-yet-existing targets against their nearest existing ancestor in validateSymlinkBoundary
+
+## Summary
+
+- `validateSymlinkBoundary` (`src/utils/path-security.ts`) threw a spurious "Symlink resolution escaped boundary" error whenever the target path did **not exist yet** and the root path sat behind a symlink.
+- Root cause: `fs.realpathSync` throws `ENOENT` for a path that has not been created, so the target fell back to `path.resolve` — a purely lexical resolution that leaves symlinks intact. The root, which *does* exist, resolved fully via `realpathSync`. Comparing an unresolved target against a resolved root via `startsWith` is an apples-to-oranges comparison that fails regardless of whether a real boundary violation occurred. This is the symlink analogue of the drive-letter asymmetry fixed previously in the same function; that fix made both fallback branches use `path.resolve` for consistent drive anchoring, but did not address symlinks.
+- Fix: both inputs now resolve through a shared `resolveNearestExistingCanonical` helper. It first tries `realpathSync` on the full path (unchanged behavior for paths that exist), and on failure lexically collapses the input, walks up to the nearest **existing** ancestor in a bounded loop, resolves that ancestor's symlinks, and rejoins the not-yet-created tail. Both sides therefore always share a comparison basis.
+
+## User-facing changes
+
+- Repository-graph writes no longer fail on workspaces whose root resolves through a symlink. The canonical case is macOS, where `/tmp` and `/var` are symlinks to `/private/tmp` and `/private/var`, but the same failure applied to symlinked home directories, network mounts, and container bind mounts on any platform. Previously, `getGraphPath` (`src/tools/repo-graph/storage.ts`) and the freshness sidecar's atomic write (`src/tools/repo-graph/freshness.ts`) would refuse to create `.swarm/repo-graph.json` and `.swarm/repo-graph.fingerprint.json` on such a workspace.
+- **Newly enforced restriction:** a workspace whose `.swarm/` directory (or any parent component) is itself a symlink pointing *outside* the workspace now correctly fails with a boundary-escape error on first write. Previously this was silently accepted, because the unresolved-target fallback never followed the escaping symlink at all. Any setup relying on that behavior was relying on a containment hole.
+
+## Migration notes
+
+None required.
+
+## Discovery context
+
+Found while investigating why PR #2026 was dropped from the GitHub merge queue: 15 unit-test failures across three `unit (macos-latest, N)` shards, with ubuntu and windows green. The failures reported the asymmetry directly — target `/var/folders/.../.swarm/repo-graph.json` "is not within" root `/private/var/folders/...`.
+
+The bug is **pre-existing** (`validateSymlinkBoundary` and its `getGraphPath` caller are unchanged by PR #2026); that PR merely added two more call sites on not-yet-existing paths (`freshness.ts:158`, `:173`), which widened the failure from one test to fifteen. As with the earlier drive-letter fix, ordinary `pull_request` CI runs only the ubuntu shard — the macOS and Windows shards run on `merge_group` (`.github/workflows/ci.yml:246`) — so the defect was invisible to normal PR validation.
+
+An independent review empirically confirmed both directions on Windows using directory junctions: the reported false rejection is fixed, and the previously-accepted escaping-symlink-with-nonexistent-tail case is now correctly rejected.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1164,8 +1164,21 @@ export const ContextMapConfigSchema = z.object({
 
 export type ContextMapConfig = z.infer<typeof ContextMapConfigSchema>;
 
-// Repo dependency-graph configuration (issue #1448)
+// Repo dependency-graph configuration (issues #1448 and #1986)
 export const RepoGraphConfigSchema = z.object({
+	/** Enable graph startup, incremental maintenance, reads, and injection. */
+	enabled: z.boolean().default(true),
+	/**
+	 * Use the bounded content-freshness probe at session start. When disabled,
+	 * startup retains the legacy full-rebuild behavior.
+	 */
+	init_refresh: z.boolean().default(true),
+	/** Maximum complete drift set eligible for an incremental refresh. */
+	refresh_cap: z.number().int().min(0).max(500).default(50),
+	/** Wall-clock budget for each bounded source-tree walk. */
+	walk_budget_ms: z.number().int().min(1_000).max(60_000).default(5_000),
+	/** Maximum source files a bounded source-tree walk may inspect. */
+	max_files: z.number().int().min(100).max(100_000).default(10_000),
 	/**
 	 * Extra directory names to skip when the repo dependency graph is built,
 	 * in addition to the built-in defaults (node_modules, .git, dist, build,
@@ -3016,7 +3029,9 @@ export const PluginConfigSchema = z.object({
 	context_map: ContextMapConfigSchema.optional(),
 
 	// Repo dependency-graph configuration (issue #1448 — directory excludes)
-	repo_graph: RepoGraphConfigSchema.optional(),
+	// Materialize nested defaults so every consumer observes one coherent
+	// policy even when the user omits the entire repo_graph section.
+	repo_graph: RepoGraphConfigSchema.prefault({}),
 
 	// Evidence configuration
 	evidence: EvidenceConfigSchema.optional(),

--- a/src/hooks/repo-graph-builder.ts
+++ b/src/hooks/repo-graph-builder.ts
@@ -19,12 +19,21 @@
 import * as path from 'node:path';
 import { WRITE_TOOL_NAMES } from '../config/constants';
 import {
+	type BuildWorkspaceGraphOptions,
 	buildWorkspaceGraphAsync,
 	isScannableSourcePath,
+	loadGraph,
 	type RepoGraph,
 	saveGraph,
 	updateGraphForFiles,
 } from '../tools/repo-graph';
+import { isGraphWideInputPath } from '../tools/repo-graph/builder';
+import {
+	type FreshnessOptions,
+	type FreshnessProbe,
+	probeFreshness,
+	writeFingerprint,
+} from '../tools/repo-graph/freshness';
 import { safeRealpathSync } from '../tools/repo-graph/safe-realpath';
 import * as logger from '../utils/logger';
 import { yieldToEventLoop } from '../utils/timeout';
@@ -40,13 +49,7 @@ export interface RepoGraphBuilderHook {
 export interface RepoGraphDeps {
 	buildWorkspaceGraph: (
 		workspace: string,
-		options?: {
-			maxFileSizeBytes?: number;
-			maxFiles?: number;
-			walkBudgetMs?: number;
-			followSymlinks?: boolean;
-			excludeDirs?: readonly string[];
-		},
+		options?: BuildWorkspaceGraphOptions,
 	) => Promise<RepoGraph>;
 	saveGraph: (
 		workspace: string,
@@ -56,9 +59,32 @@ export interface RepoGraphDeps {
 	updateGraphForFiles: (
 		workspace: string,
 		files: string[],
-		options?: { forceRebuild?: boolean },
+		options?: {
+			forceRebuild?: boolean;
+			buildOptions?: BuildWorkspaceGraphOptions;
+		},
 	) => Promise<RepoGraph>;
+	loadGraph: (workspace: string) => Promise<RepoGraph | null>;
+	probeFreshness: (
+		workspace: string,
+		options?: FreshnessOptions,
+	) => Promise<FreshnessProbe>;
+	writeFingerprint: (
+		workspace: string,
+		graph: RepoGraph,
+		options?: FreshnessOptions,
+	) => Promise<boolean>;
+	isGraphWideInputPath: (filePath: string) => boolean;
 	safeRealpathSync?: typeof safeRealpathSync;
+}
+
+export interface RepoGraphBuilderOptions {
+	enabled?: boolean;
+	initRefresh?: boolean;
+	refreshCap?: number;
+	maxFiles?: number;
+	walkBudgetMs?: number;
+	excludeDirs?: readonly string[];
 }
 
 function extractFilePath(args: unknown): string | null {
@@ -145,19 +171,45 @@ export function rebaseOntoWorkspace(
 export function createRepoGraphBuilderHook(
 	workspaceRoot: string,
 	deps?: Partial<RepoGraphDeps>,
-	options?: { excludeDirs?: readonly string[] },
+	options?: RepoGraphBuilderOptions,
 ): RepoGraphBuilderHook {
 	const _buildWorkspaceGraph =
 		deps?.buildWorkspaceGraph ?? buildWorkspaceGraphAsync;
 	const _saveGraph = deps?.saveGraph ?? saveGraph;
 	const _updateGraphForFiles = deps?.updateGraphForFiles ?? updateGraphForFiles;
+	const _loadGraph = deps?.loadGraph ?? loadGraph;
+	const _probeFreshness = deps?.probeFreshness ?? probeFreshness;
+	const _writeFingerprint = deps?.writeFingerprint ?? writeFingerprint;
+	const _isGraphWideInputPath =
+		deps?.isGraphWideInputPath ?? isGraphWideInputPath;
 	const _safeRealpathSync = deps?.safeRealpathSync ?? safeRealpathSync;
+	const _enabled = options?.enabled ?? true;
+	const _initRefresh = options?.initRefresh ?? true;
+	const _refreshCap = options?.refreshCap ?? 50;
+	const _maxFiles = options?.maxFiles ?? 10_000;
+	const _walkBudgetMs = options?.walkBudgetMs ?? 5_000;
 
 	// User-configured directory excludes (issue #1448). Empty entries are
 	// dropped; the Set is used both to scope the initial scan and to keep
 	// incremental write-triggered updates consistent with the scan.
 	const _excludeDirs = (options?.excludeDirs ?? []).filter((d) => d.length > 0);
 	const _excludeDirSet = new Set<string>(_excludeDirs);
+	const _buildOptions: BuildWorkspaceGraphOptions = {
+		excludeDirs: _excludeDirs,
+		...(options?.maxFiles === undefined ? {} : { maxFiles: _maxFiles }),
+		...(options?.walkBudgetMs === undefined
+			? {}
+			: { walkBudgetMs: _walkBudgetMs }),
+	};
+	const _hasConfiguredBuildOptions =
+		options?.maxFiles !== undefined ||
+		options?.walkBudgetMs !== undefined ||
+		options?.excludeDirs !== undefined;
+	const _freshnessOptions: FreshnessOptions = {
+		maxFiles: _maxFiles,
+		walkBudgetMs: _walkBudgetMs,
+		excludeDirs: _excludeDirs,
+	};
 
 	let initStarted = false;
 	let initPromise: Promise<void> = Promise.resolve();
@@ -217,6 +269,36 @@ export function createRepoGraphBuilderHook(
 		return { count: state.failures, advise };
 	}
 
+	async function rebuildGraph(reason: string): Promise<void> {
+		const graph = await _buildWorkspaceGraph(workspaceRoot, _buildOptions);
+		await _saveGraph(workspaceRoot, graph);
+		const fingerprintWritten = await _writeFingerprint(
+			workspaceRoot,
+			graph,
+			_freshnessOptions,
+		);
+		logger.log(
+			`[repo-graph] Built graph (${reason}): ${graph.metadata.nodeCount} nodes, ${graph.metadata.edgeCount} edges`,
+		);
+		if (!fingerprintWritten) {
+			logger.warn(
+				'[repo-graph] Graph saved, but its freshness fingerprint could not be certified; the next session will rebuild it safely.',
+			);
+		}
+	}
+
+	function uniqueDriftFiles(probe: FreshnessProbe): string[] {
+		return [...new Set([...probe.changed, ...probe.removed])];
+	}
+
+	function updateFiles(files: string[]): Promise<RepoGraph> {
+		return _hasConfiguredBuildOptions
+			? _updateGraphForFiles(workspaceRoot, files, {
+					buildOptions: _buildOptions,
+				})
+			: _updateGraphForFiles(workspaceRoot, files);
+	}
+
 	async function doInit(): Promise<void> {
 		// Yield once before any scan work so the caller's promise chain has
 		// a chance to settle. Combined with the bounded async walker, this
@@ -224,12 +306,71 @@ export function createRepoGraphBuilderHook(
 		// even if the scan itself takes seconds.
 		await yieldToEventLoop();
 		try {
-			const graph = await _buildWorkspaceGraph(workspaceRoot, {
-				excludeDirs: _excludeDirs,
-			});
-			await _saveGraph(workspaceRoot, graph);
+			if (!_initRefresh) {
+				await rebuildGraph('configured legacy startup rebuild');
+				return;
+			}
+
+			let graph: RepoGraph | null;
+			try {
+				graph = await _loadGraph(workspaceRoot);
+			} catch (error) {
+				if (
+					error instanceof Error &&
+					'code' in error &&
+					(error as NodeJS.ErrnoException).code === 'CORRUPTION'
+				) {
+					await rebuildGraph('corrupt saved graph');
+					return;
+				}
+				throw error;
+			}
+
+			if (!graph) {
+				await rebuildGraph('no saved graph');
+				return;
+			}
+
+			const probe = await _probeFreshness(workspaceRoot, _freshnessOptions);
+			if (probe.state === 'clean' || probe.state === 'inconclusive') {
+				logger.log(
+					`[repo-graph] Startup freshness probe: ${probe.state}; no refresh`,
+				);
+				return;
+			}
+			if (probe.state === 'no-fingerprint') {
+				await rebuildGraph('no compatible freshness fingerprint');
+				return;
+			}
+
+			const driftFiles = uniqueDriftFiles(probe);
+			if (driftFiles.length === 0) {
+				logger.log(
+					'[repo-graph] Startup freshness probe reported no drift files',
+				);
+				return;
+			}
+
+			const fullRebuildThreshold = Math.max(
+				_refreshCap * 4,
+				graph.metadata.nodeCount * 0.4,
+			);
+			const requiresGraphWideRebuild = driftFiles.some(_isGraphWideInputPath);
+			if (
+				requiresGraphWideRebuild ||
+				driftFiles.length > fullRebuildThreshold
+			) {
+				await rebuildGraph(
+					requiresGraphWideRebuild
+						? 'graph-wide input drift'
+						: `drift set exceeded ${fullRebuildThreshold} files`,
+				);
+				return;
+			}
+
+			const refreshed = await updateFiles(driftFiles);
 			logger.log(
-				`[repo-graph] Built graph: ${graph.metadata.nodeCount} nodes, ${graph.metadata.edgeCount} edges`,
+				`[repo-graph] Incrementally refreshed ${driftFiles.length} startup drift files: ${refreshed.metadata.nodeCount} nodes`,
 			);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -249,6 +390,7 @@ export function createRepoGraphBuilderHook(
 
 	return {
 		init(): Promise<void> {
+			if (!_enabled) return Promise.resolve();
 			if (!initStarted) {
 				initStarted = true;
 				initPromise = doInit();
@@ -260,6 +402,7 @@ export function createRepoGraphBuilderHook(
 			input: { tool: string; sessionID: string; args?: unknown },
 			_output: { output?: unknown; args?: unknown },
 		): Promise<void> {
+			if (!_enabled) return;
 			// Wait for the initial scan before applying incremental updates.
 			// Without this gate, an early write tool could race the initial
 			// scan and stomp the saved graph with a partial update. The
@@ -335,7 +478,7 @@ export function createRepoGraphBuilderHook(
 					realWorkspace,
 					workspaceRoot,
 				);
-				await _updateGraphForFiles(workspaceRoot, [pathForUpdate]);
+				await updateFiles([pathForUpdate]);
 				recordSuccess(input.sessionID);
 				logger.log(
 					`[repo-graph] Incremental update for ${path.basename(filePath)}`,

--- a/src/hooks/repo-graph-injection.ts
+++ b/src/hooks/repo-graph-injection.ts
@@ -11,18 +11,23 @@
  * the agent simply doesn't get the extra context. The graph is built
  * on-demand by the agent calling `repo_map` with action="build".
  *
- * Caching: the loaded graph is cached per-directory in module scope to
- * avoid re-reading the JSON on every system prompt construction. The
- * cache is bypassed if the file's mtime advances.
+ * Caching: the loaded graph is cached in a bounded per-directory LRU and
+ * invalidated when the graph artifact changes. Before returning it, the shared
+ * bounded workspace probe gates use of the graph. Uncertified graphs and
+ * complete drift above the configured refresh cap are suppressed;
+ * inconclusive probes remain usable as freshness-unknown, without mutation.
  */
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
+	type FreshnessOptions,
 	getBlastRadius,
 	getGraphNode,
 	getGraphPath,
 	getLocalizationContext,
 	loadGraphSync,
+	probeFreshness,
 	type RepoGraph,
 } from '../tools/repo-graph';
 
@@ -33,39 +38,81 @@ interface CachedGraph {
 }
 
 const cache = new Map<string, CachedGraph>();
+const MAX_CACHED_DIRECTORIES = 16;
+
+export interface RepoGraphInjectionOptions extends FreshnessOptions {
+	enabled?: boolean;
+	refreshCap?: number;
+}
+
+export const _internals = {
+	probeFreshness,
+	cacheSize: () => cache.size,
+};
+
+function touchCache(key: string, value: CachedGraph): void {
+	cache.delete(key);
+	cache.set(key, value);
+	while (cache.size > MAX_CACHED_DIRECTORIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest === undefined) break;
+		cache.delete(oldest);
+	}
+}
 
 /**
- * Load the repo graph for `directory`, using a per-directory cache that
- * invalidates on file mtime change. Returns null if no graph exists.
+ * Load the repo graph for `directory`, using a bounded per-directory cache that
+ * invalidates on file mtime/size change and a shared content-freshness gate.
+ * Returns null if no graph exists or its workspace alignment is unsafe.
  *
  * Exported only for tests; production callers use the buildXxxBlock helpers below.
  */
-export function getCachedGraph(directory: string): RepoGraph | null {
+export async function getCachedGraph(
+	directory: string,
+	options?: RepoGraphInjectionOptions,
+): Promise<RepoGraph | null> {
+	const key = path.normalize(path.resolve(directory));
+	if (options?.enabled === false) {
+		cache.delete(key);
+		return null;
+	}
 	const file = getGraphPath(directory);
 	let stat: fs.Stats;
 	try {
 		stat = fs.statSync(file);
 	} catch {
 		// No graph file. Drop any stale cache entry.
-		cache.delete(directory);
+		cache.delete(key);
 		return null;
 	}
-	const cached = cache.get(directory);
-	if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
-		return cached.graph;
-	}
+	const cached = cache.get(key);
 	let graph: RepoGraph | null;
-	try {
-		graph = loadGraphSync(directory);
-	} catch {
-		cache.delete(directory);
+	if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+		graph = cached.graph;
+		touchCache(key, cached);
+	} else {
+		try {
+			graph = loadGraphSync(directory);
+		} catch {
+			cache.delete(key);
+			return null;
+		}
+		if (!graph) {
+			cache.delete(key);
+			return null;
+		}
+		touchCache(key, { graph, mtimeMs: stat.mtimeMs, size: stat.size });
+	}
+
+	const probe = await _internals.probeFreshness(directory, options);
+	const observedDrift = probe.changed.length + probe.removed.length;
+	const refreshCap = options?.refreshCap ?? 50;
+	if (
+		probe.state === 'no-fingerprint' ||
+		(probe.state === 'drifted' && observedDrift > refreshCap)
+	) {
 		return null;
 	}
-	if (!graph) {
-		cache.delete(directory);
-		return null;
-	}
-	cache.set(directory, { graph, mtimeMs: stat.mtimeMs, size: stat.size });
 	return graph;
 }
 
@@ -82,12 +129,13 @@ export function resetGraphInjectionCache(): void {
  *   - No graph exists.
  *   - The target isn't tracked in the graph (file too new, language unsupported).
  */
-export function buildCoderLocalizationBlock(
+export async function buildCoderLocalizationBlock(
 	directory: string,
 	targetFile: string,
-): string | null {
+	options?: RepoGraphInjectionOptions,
+): Promise<string | null> {
 	if (!targetFile) return null;
-	const graph = getCachedGraph(directory);
+	const graph = await getCachedGraph(directory, options);
 	if (!graph) return null;
 	const normalized = targetFile.replace(/\\/g, '/').replace(/^\.\/+/, '');
 	const targetNode = getGraphNode(graph, normalized);
@@ -112,12 +160,13 @@ export function buildCoderLocalizationBlock(
  * graph. The result is bounded to the top 8 dependents to stay within
  * the per-block context budget.
  */
-export function buildReviewerBlastRadiusBlock(
+export async function buildReviewerBlastRadiusBlock(
 	directory: string,
 	changedFiles: string[],
-): string | null {
+	options?: RepoGraphInjectionOptions,
+): Promise<string | null> {
 	if (changedFiles.length === 0) return null;
-	const graph = getCachedGraph(directory);
+	const graph = await getCachedGraph(directory, options);
 	if (!graph) return null;
 	const normalized = changedFiles
 		.map((f) => f.replace(/\\/g, '/').replace(/^\.\/+/, ''))

--- a/src/hooks/semantic-diff-injection.ts
+++ b/src/hooks/semantic-diff-injection.ts
@@ -26,7 +26,10 @@ import {
 	GitBinaryMissingError,
 	isGitBinaryMissing,
 } from '../utils/git-binary-missing-error.js';
-import { getCachedGraph } from './repo-graph-injection.js';
+import {
+	getCachedGraph,
+	type RepoGraphInjectionOptions,
+} from './repo-graph-injection.js';
 
 export const _internals = {
 	execFile: child_process.execFile,
@@ -104,6 +107,7 @@ export async function buildSemanticDiffBlock(
 	directory: string,
 	changedFiles: string[],
 	maxFiles = 10,
+	repoGraphOptions?: RepoGraphInjectionOptions,
 ): Promise<string | null> {
 	if (changedFiles.length === 0) return null;
 
@@ -116,7 +120,7 @@ export async function buildSemanticDiffBlock(
 		const astDiffs: ASTDiffResult[] = [];
 
 		// Build fileConsumers map from repo graph
-		const graph = _internals.getCachedGraph(directory);
+		const graph = await _internals.getCachedGraph(directory, repoGraphOptions);
 		const fileConsumers: Record<string, number> = {};
 		if (graph) {
 			for (const f of filesToProcess) {

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -20,7 +20,11 @@ import {
 } from '../config/constants';
 import type { RetrospectiveEvidence } from '../config/evidence-schema';
 import type { RuntimePlan } from '../config/plan-schema';
-import { LearningConfigSchema, stripKnownSwarmPrefix } from '../config/schema';
+import {
+	LearningConfigSchema,
+	RepoGraphConfigSchema,
+	stripKnownSwarmPrefix,
+} from '../config/schema';
 import { listEvidenceTaskIds, loadEvidence } from '../evidence/manager';
 import { getProfileForFile } from '../lang/detector';
 import { loadPlan } from '../plan/manager';
@@ -662,6 +666,14 @@ export function createSystemEnhancerHook(
 	const realtimeAdmission = LearningConfigSchema.parse(
 		config.learning ?? {},
 	).realtime_admission;
+	const repoGraphConfig = RepoGraphConfigSchema.parse(config.repo_graph ?? {});
+	const repoGraphInjectionOptions = {
+		enabled: repoGraphConfig.enabled,
+		refreshCap: repoGraphConfig.refresh_cap,
+		maxFiles: repoGraphConfig.max_files,
+		walkBudgetMs: repoGraphConfig.walk_budget_ms,
+		excludeDirs: repoGraphConfig.exclude_dirs,
+	};
 
 	return {
 		'experimental.chat.system.transform': safeHook(
@@ -1356,9 +1368,10 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 							try {
 								const coderScopePrimary = ccpSession?.declaredCoderScope?.[0];
 								if (coderScopePrimary) {
-									const localizationBlock = buildCoderLocalizationBlock(
+									const localizationBlock = await buildCoderLocalizationBlock(
 										directory,
 										coderScopePrimary,
+										repoGraphInjectionOptions,
 									);
 									if (localizationBlock) {
 										tryInject(localizationBlock);
@@ -1402,9 +1415,10 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 									swarmState.agentSessions.get(reviewerSessionId);
 								const changed = reviewerSession?.declaredCoderScope ?? [];
 								if (changed.length > 0) {
-									const blastBlock = buildReviewerBlastRadiusBlock(
+									const blastBlock = await buildReviewerBlastRadiusBlock(
 										directory,
 										changed,
+										repoGraphInjectionOptions,
 									);
 									if (blastBlock) {
 										tryInject(blastBlock);
@@ -1425,6 +1439,8 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 									const semDiffBlock = await buildSemanticDiffBlock(
 										directory,
 										semDiffChanged,
+										10,
+										repoGraphInjectionOptions,
 									);
 									if (semDiffBlock) {
 										tryInject(semDiffBlock);
@@ -2373,6 +2389,8 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 								const semDiffBlock_b = await buildSemanticDiffBlock(
 									directory,
 									semDiffChanged_b,
+									10,
+									repoGraphInjectionOptions,
 								);
 								if (semDiffBlock_b) {
 									candidates.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import {
 	type PluginConfig,
 	PrMonitorConfigSchema,
 	PrmConfigSchema,
+	RepoGraphConfigSchema,
 	resolveAutoReviewConfig,
 	SelfReviewConfigSchema,
 	SkillImproverConfigSchema,
@@ -719,29 +720,36 @@ async function initializeOpenCodeSwarm(
 	initTelemetry(ctx.directory);
 	startHeartbeatTracking();
 
-	const repoGraphHook = createRepoGraphBuilderHookForInit(
-		ctx.directory,
-		undefined,
-		{
-			excludeDirs: config.repo_graph?.exclude_dirs,
-		},
-	);
-	postResolutionTasks.push(() => {
-		const watchdog = setTimeout(() => {
-			log(
-				'[repo-graph] init exceeded 30s budget; scan will continue but is overdue',
-			);
-		}, 30_000);
-		if (typeof (watchdog as { unref?: () => void }).unref === 'function') {
-			(watchdog as { unref: () => void }).unref();
-		}
-		repoGraphHook
-			.init()
-			.catch(() => {
-				/* logged inside init */
+	const repoGraphConfig = RepoGraphConfigSchema.parse(config.repo_graph ?? {});
+	const repoGraphHookFactory = createRepoGraphBuilderHookForInit;
+	const repoGraphHook = repoGraphConfig.enabled
+		? repoGraphHookFactory(ctx.directory, undefined, {
+				enabled: true,
+				initRefresh: repoGraphConfig.init_refresh,
+				refreshCap: repoGraphConfig.refresh_cap,
+				walkBudgetMs: repoGraphConfig.walk_budget_ms,
+				maxFiles: repoGraphConfig.max_files,
+				excludeDirs: repoGraphConfig.exclude_dirs,
 			})
-			.finally(() => clearTimeout(watchdog));
-	});
+		: null;
+	if (repoGraphHook) {
+		postResolutionTasks.push(() => {
+			const watchdog = setTimeout(() => {
+				log(
+					'[repo-graph] init exceeded 30s budget; scan will continue but is overdue',
+				);
+			}, 30_000);
+			if (typeof (watchdog as { unref?: () => void }).unref === 'function') {
+				(watchdog as { unref: () => void }).unref();
+			}
+			repoGraphHook
+				.init()
+				.catch(() => {
+					/* logged inside init */
+				})
+				.finally(() => clearTimeout(watchdog));
+		});
+	}
 
 	// `ensureSwarmGitExcluded` was awaited in the parallel block above. Its
 	// comment (preserved here for context): protects .swarm/ from Git before
@@ -3169,7 +3177,9 @@ async function initializeOpenCodeSwarm(
 				}
 
 				// Repo graph incremental update on write tools
-				await safeHook(repoGraphHook.toolAfter)(input, output);
+				if (repoGraphHook) {
+					await safeHook(repoGraphHook.toolAfter)(input, output);
+				}
 
 				// Context Map: post-agent update after Task tool completes
 				if (

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -15,14 +15,21 @@
  * All existing imports of this module continue to work unchanged.
  */
 
-export type { ScanResult } from './repo-graph/builder';
+export type {
+	RepoGraphInputMetadata,
+	RepoGraphInputWalkOptions,
+	RepoGraphInputWalkResult,
+	ScanResult,
+} from './repo-graph/builder';
 export {
 	addEdge,
 	buildWorkspaceGraph,
 	buildWorkspaceGraphAsync,
+	isGraphWideInputPath,
 	isScannableSourcePath,
 	resolveModuleSpecifier,
 	upsertNode,
+	walkRepoGraphInputs,
 } from './repo-graph/builder';
 export {
 	clearCache,
@@ -32,6 +39,18 @@ export {
 	markDirty,
 	setCachedGraph,
 } from './repo-graph/cache';
+export type {
+	FreshnessOptions,
+	FreshnessProbe,
+} from './repo-graph/freshness';
+export {
+	EXTRACTOR_STAMP,
+	FINGERPRINT_SCHEMA_VERSION,
+	invalidateFreshnessCache,
+	probeFreshness,
+	REPO_GRAPH_FINGERPRINT_FILENAME,
+	writeFingerprint,
+} from './repo-graph/freshness';
 export { updateGraphForFiles } from './repo-graph/incremental';
 export type { ExtractFileOntologyInput } from './repo-graph/ontology';
 export { extractFileOntology } from './repo-graph/ontology';
@@ -75,8 +94,10 @@ export type {
 	FileOntology,
 	FileReference,
 	FileRole,
+	FreshnessProbeState,
 	GraphEdge,
 	GraphExtractionFailure,
+	GraphExtractorInputWitness,
 	GraphHealthResult,
 	GraphNode,
 	GraphUnresolvedImport,

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -32,6 +32,7 @@ import { safeRealpathSync } from './safe-realpath';
 import type {
 	BuildWorkspaceGraphOptions,
 	GraphEdge,
+	GraphExtractorInputWitness,
 	GraphNode,
 	GraphUnresolvedImport,
 	RepoGraph,
@@ -161,6 +162,8 @@ const DEFAULT_WALK_BUDGET_MS = 5000;
 const ASYNC_WALK_YIELD_INTERVAL = 200;
 const ASYNC_SCAN_YIELD_INTERVAL = 16;
 const MAX_DIAGNOSTIC_ENTRIES = 200;
+/** Correctness witnesses are not display diagnostics and must cover the full walk. */
+export const MAX_EXTRACTOR_INPUT_WITNESSES = 100_256;
 
 /**
  * Mapping of file extensions to tree-sitter grammar identifiers.
@@ -571,6 +574,8 @@ function createEmptyDiagnostics(): FilledDiagnostics {
 		unsupportedFiles: [],
 		binaryFiles: [],
 		unreadableFiles: [],
+		validationSkippedFiles: [],
+		extractorInputWitnesses: [],
 		lowConfidenceEdgeCount: 0,
 		walkTruncated: false,
 		incrementalFallbacks: 0,
@@ -585,6 +590,8 @@ function diagnosticsHaveEntries(diagnostics: RepoGraphDiagnostics): boolean {
 		(diagnostics.unsupportedFiles?.length ?? 0) > 0 ||
 		(diagnostics.binaryFiles?.length ?? 0) > 0 ||
 		(diagnostics.unreadableFiles?.length ?? 0) > 0 ||
+		(diagnostics.validationSkippedFiles?.length ?? 0) > 0 ||
+		(diagnostics.extractorInputWitnesses?.length ?? 0) > 0 ||
 		(diagnostics.lowConfidenceEdgeCount ?? 0) > 0 ||
 		diagnostics.walkTruncated === true ||
 		diagnostics.walkTruncationReason !== undefined ||
@@ -596,6 +603,13 @@ function pushCapped<T>(target: T[], value: T): void {
 	if (target.length < MAX_DIAGNOSTIC_ENTRIES) {
 		target.push(value);
 	}
+}
+
+function pushInputWitness(
+	target: GraphExtractorInputWitness[],
+	value: GraphExtractorInputWitness,
+): void {
+	if (target.length < MAX_EXTRACTOR_INPUT_WITNESSES) target.push(value);
 }
 
 function mergeDiagnostics(
@@ -620,6 +634,12 @@ function mergeDiagnostics(
 	}
 	for (const entry of source.unreadableFiles ?? []) {
 		pushCapped(target.unreadableFiles, entry);
+	}
+	for (const entry of source.validationSkippedFiles ?? []) {
+		pushCapped(target.validationSkippedFiles, entry);
+	}
+	for (const entry of source.extractorInputWitnesses ?? []) {
+		pushInputWitness(target.extractorInputWitnesses, entry);
 	}
 	target.lowConfidenceEdgeCount += source.lowConfidenceEdgeCount ?? 0;
 	// incrementalFallbacks accumulates across per-file scans (rare, but a
@@ -1340,6 +1360,8 @@ interface WalkContext {
 	 * never consults it (no seg0/seg1 at depth 1).
 	 */
 	manifestDirs: Set<string>;
+	/** Build-time witnesses for graph-wide manifests found by the sync walk. */
+	manifestWitnesses: GraphExtractorInputWitness[];
 }
 
 /** Manifest basenames that mark a directory as a package root (defect A8). */
@@ -1349,6 +1371,15 @@ const MANIFEST_BASENAMES = new Set([
 	'pyproject.toml',
 	'go.mod',
 ]);
+
+/**
+ * Return whether a path is a graph-wide extractor input. Changes to these
+ * manifests can alter package-boundary ontology for many nodes, so consumers
+ * must rebuild rather than treating them as an ordinary one-file refresh.
+ */
+export function isGraphWideInputPath(filePath: string): boolean {
+	return MANIFEST_BASENAMES.has(path.basename(filePath));
+}
 
 /**
  * Record `dir`'s workspace-relative path into `manifestDirs` when one of its
@@ -1419,6 +1450,7 @@ function findSourceFiles(
 		followSymlinks: options?.followSymlinks ?? false,
 		skipDirs: resolveSkipDirectories(options?.excludeDirs),
 		manifestDirs: new Set<string>(),
+		manifestWitnesses: [],
 	};
 	const files: string[] = [];
 	walkSyncInto(dir, ctx, files);
@@ -1482,6 +1514,19 @@ function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
 			if (absoluteRoot !== undefined) {
 				recordManifestDir(ctx.manifestDirs, absoluteRoot, dir, entry.name);
 			}
+			if (absoluteRoot !== undefined && isGraphWideInputPath(fullPath)) {
+				try {
+					const manifestStats = fsSync.statSync(fullPath);
+					pushInputWitness(ctx.manifestWitnesses, {
+						file: toModuleName(fullPath, absoluteRoot),
+						kind: 'manifest',
+						sizeBytes: manifestStats.size,
+						mtimeMs: manifestStats.mtimeMs,
+					});
+				} catch {
+					// Build stays fail-open; persistence will refuse certification.
+				}
+			}
 			const ext = path.extname(fullPath).toLowerCase();
 			if (SUPPORTED_EXTENSIONS.has(ext)) {
 				files.push(fullPath);
@@ -1498,16 +1543,56 @@ function walkSyncInto(dir: string, ctx: WalkContext, files: string[]): void {
  * the variant called from the plugin init path; the sync variant remains
  * available for non-init callers (tools, tests) for compatibility.
  */
-async function findSourceFilesAsync(
+export interface RepoGraphInputMetadata {
+	absolutePath: string;
+	kind: 'source' | 'manifest';
+	sizeBytes: number;
+	mtimeMs: number;
+}
+
+export interface RepoGraphInputWalkResult {
+	sourceFiles: string[];
+	manifestFiles: string[];
+	metadata: RepoGraphInputMetadata[];
+	manifestDirs: Set<string>;
+	truncated: boolean;
+	truncationReason?: 'budget' | 'cap';
+	incomplete: boolean;
+	unreadableDirectories: string[];
+	unreadableFiles: string[];
+	probedFiles: number;
+	elapsedMs: number;
+}
+
+export interface RepoGraphInputWalkOptions {
+	walkBudgetMs?: number;
+	maxFiles?: number;
+	followSymlinks?: boolean;
+	excludeDirs?: readonly string[];
+	/** Capture size/mtime for every source and manifest during this same walk. */
+	captureMetadata?: boolean;
+	/** Capture only graph-wide manifest metadata (used by the graph builder). */
+	captureManifestMetadata?: boolean;
+}
+
+/**
+ * Enumerate every input used by repository-graph extraction with the same
+ * bounded, deterministic, cycle-safe traversal as the async graph builder.
+ * Directory and metadata I/O failures are surfaced through `incomplete` so a
+ * caller can refuse removals/certification instead of guessing.
+ */
+export async function walkRepoGraphInputs(
 	dir: string,
-	stats: ScanStats,
-	options?: {
-		walkBudgetMs?: number;
-		maxFiles?: number;
-		followSymlinks?: boolean;
-		excludeDirs?: readonly string[];
-	},
-): Promise<{ files: string[]; ctx: WalkContext }> {
+	options?: RepoGraphInputWalkOptions,
+): Promise<RepoGraphInputWalkResult> {
+	const absoluteRoot = path.resolve(dir);
+	const stats: ScanStats = {
+		filesScanned: 0,
+		skippedDirs: 0,
+		skippedFiles: 0,
+		truncated: false,
+		_absoluteRoot: absoluteRoot,
+	};
 	const ctx: WalkContext = {
 		stats,
 		seenRealPaths: new Set<string>(),
@@ -1517,9 +1602,14 @@ async function findSourceFilesAsync(
 		followSymlinks: options?.followSymlinks ?? false,
 		skipDirs: resolveSkipDirectories(options?.excludeDirs),
 		manifestDirs: new Set<string>(),
+		manifestWitnesses: [],
 	};
 	const files: string[] = [];
-	const queue: string[] = [dir];
+	const manifestFiles: string[] = [];
+	const metadata: RepoGraphInputMetadata[] = [];
+	const unreadableDirectories: string[] = [];
+	const unreadableFiles: string[] = [];
+	const queue: string[] = [absoluteRoot];
 	let processed = 0;
 	while (queue.length > 0) {
 		if (isWalkBudgetExceeded(ctx) || isFileCapReached(ctx, files.length)) {
@@ -1533,12 +1623,15 @@ async function findSourceFilesAsync(
 				continue;
 			}
 			ctx.seenRealPaths.add(key);
+		} else {
+			unreadableDirectories.push(current);
 		}
 
 		let entries: fsSync.Dirent[];
 		try {
 			entries = await fsPromises.readdir(current, { withFileTypes: true });
 		} catch {
+			unreadableDirectories.push(current);
 			continue;
 		}
 		entries.sort((a, b) =>
@@ -1571,8 +1664,29 @@ async function findSourceFilesAsync(
 					);
 				}
 				const ext = path.extname(fullPath).toLowerCase();
-				if (SUPPORTED_EXTENSIONS.has(ext)) {
+				const isSource = SUPPORTED_EXTENSIONS.has(ext);
+				const isManifest = isGraphWideInputPath(fullPath);
+				if (isSource) {
 					files.push(fullPath);
+				}
+				if (isManifest) {
+					manifestFiles.push(fullPath);
+				}
+				if (
+					(options?.captureMetadata && (isSource || isManifest)) ||
+					(options?.captureManifestMetadata && isManifest)
+				) {
+					try {
+						const fileStats = await fsPromises.stat(fullPath);
+						metadata.push({
+							absolutePath: fullPath,
+							kind: isManifest ? 'manifest' : 'source',
+							sizeBytes: fileStats.size,
+							mtimeMs: fileStats.mtimeMs,
+						});
+					} catch {
+						unreadableFiles.push(fullPath);
+					}
 				}
 			}
 			processed++;
@@ -1584,7 +1698,22 @@ async function findSourceFilesAsync(
 	if (ctx.abortReason === 'cap' || ctx.abortReason === 'budget') {
 		ctx.stats.truncated = true;
 	}
-	return { files, ctx };
+	return {
+		sourceFiles: files,
+		manifestFiles,
+		metadata,
+		manifestDirs: ctx.manifestDirs,
+		truncated: stats.truncated,
+		truncationReason: ctx.abortReason,
+		incomplete:
+			stats.truncated ||
+			unreadableDirectories.length > 0 ||
+			unreadableFiles.length > 0,
+		unreadableDirectories,
+		unreadableFiles,
+		probedFiles: metadata.length,
+		elapsedMs: Math.max(0, _internals.now() - ctx.startedAt),
+	};
 }
 
 /**
@@ -1651,6 +1780,8 @@ export interface AsyncScanResult {
 	symbolEdges: SymbolEdge[];
 	/** Optional file-level diagnostics collected during async scanning. */
 	diagnostics?: RepoGraphDiagnostics;
+	/** Build-time witness for a deterministic non-node skip. */
+	inputWitness?: GraphExtractorInputWitness;
 }
 
 /**
@@ -1736,6 +1867,8 @@ export function scanFile(
 			imports: parsedImports.map((p) => p.specifier),
 			language: getLanguage(filePath),
 			mtime: fileStats.mtime.toISOString(),
+			sizeBytes: fileStats.size,
+			mtimeMs: fileStats.mtimeMs,
 			ontology: _internals.extractFileOntology({
 				moduleName,
 				filePath,
@@ -1809,11 +1942,18 @@ export async function scanFileAsync(
 	try {
 		fileStats = await fsPromises.stat(filePath);
 		if (fileStats.size > maxFileSize) {
+			const moduleName = toModuleName(filePath, absoluteRoot);
 			return {
 				node: null,
 				edges: [],
 				symbolEdges: [],
-				diagnostics: { oversizedFiles: [toModuleName(filePath, absoluteRoot)] },
+				diagnostics: { oversizedFiles: [moduleName] },
+				inputWitness: {
+					file: moduleName,
+					kind: 'stable-skip',
+					sizeBytes: fileStats.size,
+					mtimeMs: fileStats.mtimeMs,
+				},
 			};
 		}
 		content = await fsPromises.readFile(filePath, 'utf-8');
@@ -1828,11 +1968,18 @@ export async function scanFileAsync(
 
 	// Skip binary files
 	if (isBinaryContent(content)) {
+		const moduleName = toModuleName(filePath, absoluteRoot);
 		return {
 			node: null,
 			edges: [],
 			symbolEdges: [],
-			diagnostics: { binaryFiles: [toModuleName(filePath, absoluteRoot)] },
+			diagnostics: { binaryFiles: [moduleName] },
+			inputWitness: {
+				file: moduleName,
+				kind: 'stable-skip',
+				sizeBytes: fileStats.size,
+				mtimeMs: fileStats.mtimeMs,
+			},
 		};
 	}
 
@@ -1965,6 +2112,8 @@ export async function scanFileAsync(
 		imports,
 		language,
 		mtime: fileStats.mtime.toISOString(),
+		sizeBytes: fileStats.size,
+		mtimeMs: fileStats.mtimeMs,
 		ontology: _internals.extractFileOntology({
 			moduleName,
 			filePath,
@@ -2216,6 +2365,10 @@ export function buildWorkspaceGraph(
 	// go straight in via appendNodeFast — metadata is computed once below. This
 	// keeps construction O(N) on large repos (issue #1144).
 	const seenEdges = new Set<string>();
+	const syncDiagnostics: FilledDiagnostics = createEmptyDiagnostics();
+	for (const witness of walkCtx.manifestWitnesses) {
+		pushInputWitness(syncDiagnostics.extractorInputWitnesses, witness);
+	}
 	for (const filePath of sourceFiles) {
 		let content: string;
 		let fileStats: fsSync.Stats;
@@ -2224,17 +2377,41 @@ export function buildWorkspaceGraph(
 			fileStats = fsSync.statSync(filePath);
 			if (fileStats.size > maxFileSize) {
 				stats.skippedFiles++;
+				pushCapped(
+					syncDiagnostics.oversizedFiles,
+					toModuleName(filePath, absoluteRoot),
+				);
+				pushInputWitness(syncDiagnostics.extractorInputWitnesses, {
+					file: toModuleName(filePath, absoluteRoot),
+					kind: 'stable-skip',
+					sizeBytes: fileStats.size,
+					mtimeMs: fileStats.mtimeMs,
+				});
 				continue;
 			}
 			content = fsSync.readFileSync(filePath, 'utf-8');
 		} catch {
 			stats.skippedFiles++;
+			pushCapped(
+				syncDiagnostics.unreadableFiles,
+				toModuleName(filePath, absoluteRoot),
+			);
 			continue;
 		}
 
 		// Skip binary files
 		if (isBinaryContent(content)) {
 			stats.skippedFiles++;
+			pushCapped(
+				syncDiagnostics.binaryFiles,
+				toModuleName(filePath, absoluteRoot),
+			);
+			pushInputWitness(syncDiagnostics.extractorInputWitnesses, {
+				file: toModuleName(filePath, absoluteRoot),
+				kind: 'stable-skip',
+				sizeBytes: fileStats.size,
+				mtimeMs: fileStats.mtimeMs,
+			});
 			continue;
 		}
 
@@ -2293,6 +2470,8 @@ export function buildWorkspaceGraph(
 			imports: parsedImports.map((p) => p.specifier),
 			language,
 			mtime: fileStats.mtime.toISOString(),
+			sizeBytes: fileStats.size,
+			mtimeMs: fileStats.mtimeMs,
 			ontology: _internals.extractFileOntology({
 				moduleName,
 				filePath,
@@ -2313,6 +2492,13 @@ export function buildWorkspaceGraph(
 		} catch {
 			stats.filesScanned--;
 			stats.skippedFiles++;
+			pushCapped(syncDiagnostics.validationSkippedFiles, moduleName);
+			pushInputWitness(syncDiagnostics.extractorInputWitnesses, {
+				file: moduleName,
+				kind: 'stable-skip',
+				sizeBytes: fileStats.size,
+				mtimeMs: fileStats.mtimeMs,
+			});
 			continue;
 		}
 
@@ -2361,7 +2547,6 @@ export function buildWorkspaceGraph(
 
 	// Surface walk-truncation diagnostics (defect A7) so getGraphHealth can
 	// report an INCOMPLETE graph instead of confidently wrong results.
-	const syncDiagnostics: FilledDiagnostics = createEmptyDiagnostics();
 	syncDiagnostics.walkTruncated = stats.truncated;
 	syncDiagnostics.walkTruncationReason = walkCtx.abortReason;
 	if (diagnosticsHaveEntries(syncDiagnostics)) {
@@ -2421,14 +2606,25 @@ export async function buildWorkspaceGraphAsync(
 	};
 	const diagnostics = createEmptyDiagnostics();
 
-	const walked = await findSourceFilesAsync(absoluteRoot, stats, {
+	const walked = await walkRepoGraphInputs(absoluteRoot, {
 		walkBudgetMs,
 		maxFiles,
 		followSymlinks,
 		excludeDirs: options?.excludeDirs,
+		captureManifestMetadata: true,
 	});
-	const sourceFiles = walked.files;
-	const walkCtx = walked.ctx;
+	const sourceFiles = walked.sourceFiles;
+	stats.truncated = walked.truncated;
+	for (const input of walked.metadata) {
+		if (input.kind !== 'manifest') continue;
+		const relative = toModuleName(input.absolutePath, absoluteRoot);
+		pushInputWitness(diagnostics.extractorInputWitnesses, {
+			file: relative,
+			kind: 'manifest',
+			sizeBytes: input.sizeBytes,
+			mtimeMs: input.mtimeMs,
+		});
+	}
 
 	sourceFiles.sort((a, b) => {
 		const normA = normalizeGraphPath(a);
@@ -2444,7 +2640,7 @@ export async function buildWorkspaceGraphAsync(
 	}
 
 	// Manifest-directory closure for the generic package-boundary rule (A8).
-	const hasManifest = (relDir: string) => walkCtx.manifestDirs.has(relDir);
+	const hasManifest = (relDir: string) => walked.manifestDirs.has(relDir);
 
 	// Edge dedup tracked in a loop-local Set (O(1)); nodes inserted via
 	// appendNodeFast — metadata is computed once below. Keeps construction O(N)
@@ -2463,6 +2659,12 @@ export async function buildWorkspaceGraphAsync(
 			hasManifest,
 		);
 		mergeDiagnostics(diagnostics, result.diagnostics);
+		if (result.inputWitness) {
+			pushInputWitness(
+				diagnostics.extractorInputWitnesses,
+				result.inputWitness,
+			);
+		}
 		if (result.node) {
 			// A node that fails validation (e.g. control characters in ontology
 			// evidence from a minified/generated file) must skip that one file,
@@ -2474,6 +2676,13 @@ export async function buildWorkspaceGraphAsync(
 				appended = true;
 			} catch {
 				stats.skippedFiles++;
+				pushCapped(diagnostics.validationSkippedFiles, result.node.moduleName);
+				pushInputWitness(diagnostics.extractorInputWitnesses, {
+					file: result.node.moduleName,
+					kind: 'stable-skip',
+					sizeBytes: result.node.sizeBytes as number,
+					mtimeMs: result.node.mtimeMs as number,
+				});
 			}
 			if (appended) {
 				for (const edge of result.edges) {
@@ -2524,7 +2733,7 @@ export async function buildWorkspaceGraphAsync(
 	// Surface walk-truncation diagnostics (defect A7) — walk-level fields are
 	// set once after the walk, NOT merged per-file (extraction diagnostics are).
 	diagnostics.walkTruncated = stats.truncated;
-	diagnostics.walkTruncationReason = walkCtx.abortReason;
+	diagnostics.walkTruncationReason = walked.truncationReason;
 	graph.diagnostics = diagnosticsHaveEntries(diagnostics)
 		? diagnostics
 		: createEmptyDiagnostics();

--- a/src/tools/repo-graph/cache.ts
+++ b/src/tools/repo-graph/cache.ts
@@ -1,93 +1,94 @@
 /**
- * In-memory cache for loaded repo graphs.
+ * Bounded in-memory cache for loaded repo graphs.
  *
- * Three maps keyed by normalized workspace path:
- * - graphCache  — the last loaded/saved RepoGraph for each workspace
- * - dirtyFlags  — whether the cached graph has been modified since the last save
- * - mtimeCache  — the file mtime at the time the graph was last loaded/saved,
- *                 used by the optimistic concurrency check in incremental.ts
- *
- * All public functions normalize the workspace path before use so callers
- * are not required to pre-normalize.
+ * Graph, dirty, and mtime state intentionally share one entry so eviction can
+ * never leave one piece of workspace state behind. Entries are keyed by an
+ * absolute normalized workspace path and maintained as a true LRU: every read
+ * moves the entry to the newest position and insertion evicts the oldest.
  */
 
 import * as path from 'node:path';
 import type { RepoGraph } from './types';
 
-// ============ Module-Level Cache ============
+const MAX_CACHED_WORKSPACES = 16;
 
-/** In-memory cache of the loaded graph, keyed by workspace directory */
-const graphCache = new Map<string, RepoGraph>();
+interface CacheEntry {
+	graph?: RepoGraph;
+	dirty: boolean;
+	mtime?: number;
+}
 
-/** Cache for modified/dirty state per workspace */
-const dirtyFlags = new Map<string, boolean>();
+/** Oldest entry is first, newest entry is last. */
+const workspaceCache = new Map<string, CacheEntry>();
 
-/** Cache for file mtime (for cache invalidation), keyed by workspace directory */
-const mtimeCache = new Map<string, number>();
+function normalizeWorkspace(workspace: string): string {
+	const resolved = path.normalize(path.resolve(workspace));
+	return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
 
-// ============ Cache Operations ============
+function touch(key: string, entry: CacheEntry): CacheEntry {
+	workspaceCache.delete(key);
+	workspaceCache.set(key, entry);
+	return entry;
+}
 
-/**
- * Get the cached graph for a workspace.
- * @param workspace - The workspace directory (absolute or relative path)
- * @returns The cached graph or undefined if not cached
- */
+function getEntry(workspace: string): CacheEntry | undefined {
+	const key = normalizeWorkspace(workspace);
+	const entry = workspaceCache.get(key);
+	return entry ? touch(key, entry) : undefined;
+}
+
+function setEntry(workspace: string, entry: CacheEntry): void {
+	const key = normalizeWorkspace(workspace);
+	touch(key, entry);
+	while (workspaceCache.size > MAX_CACHED_WORKSPACES) {
+		const oldestKey = workspaceCache.keys().next().value as string | undefined;
+		if (oldestKey === undefined) break;
+		workspaceCache.delete(oldestKey);
+	}
+}
+
+/** Return the cached graph for a workspace, if present. */
 export function getCachedGraph(workspace: string): RepoGraph | undefined {
-	return graphCache.get(path.normalize(workspace));
+	return getEntry(workspace)?.graph;
 }
 
 /**
- * Set the cached graph for a workspace.
- * @param workspace - The workspace directory (absolute or relative path)
- * @param graph - The graph to cache
- * @param mtime - Optional file mtime to track for cache invalidation
+ * Cache a graph and mark it clean. Omitting mtime clears any previous mtime so
+ * an old optimistic-concurrency witness cannot survive a new graph value.
  */
 export function setCachedGraph(
 	workspace: string,
 	graph: RepoGraph,
 	mtime?: number,
 ): void {
-	const normalized = path.normalize(workspace);
-	graphCache.set(normalized, graph);
-	dirtyFlags.set(normalized, false);
-	if (mtime !== undefined) {
-		mtimeCache.set(normalized, mtime);
-	}
+	setEntry(workspace, {
+		graph,
+		dirty: false,
+		...(mtime === undefined ? {} : { mtime }),
+	});
 }
 
-/**
- * Mark a workspace's cache as dirty (modified since last save).
- * @param workspace - The workspace directory (absolute or relative path)
- */
+/** Mark a workspace's cached state dirty, preserving its graph and mtime. */
 export function markDirty(workspace: string): void {
-	dirtyFlags.set(path.normalize(workspace), true);
+	const existing = getEntry(workspace);
+	setEntry(workspace, {
+		...(existing ?? {}),
+		dirty: true,
+	});
 }
 
-/**
- * Check if a workspace's cache is dirty.
- * @param workspace - The workspace directory (absolute or relative path)
- * @returns True if the cache has been modified since last save
- */
+/** Return whether the workspace's cached state is dirty. */
 export function isDirty(workspace: string): boolean {
-	return dirtyFlags.get(path.normalize(workspace)) ?? false;
+	return getEntry(workspace)?.dirty ?? false;
 }
 
-/**
- * Clear the cache for a workspace.
- * @param workspace - The workspace directory (absolute or relative path)
- */
+/** Remove all cached state for one workspace. */
 export function clearCache(workspace: string): void {
-	const normalized = path.normalize(workspace);
-	graphCache.delete(normalized);
-	dirtyFlags.delete(normalized);
-	mtimeCache.delete(normalized);
+	workspaceCache.delete(normalizeWorkspace(workspace));
 }
 
-/**
- * Get the cached file mtime for a workspace (used for optimistic concurrency).
- * @param workspace - The workspace directory (absolute or relative path)
- * @returns The cached mtime in milliseconds, or undefined if not cached
- */
+/** Return the graph-file mtime captured with the cached graph, if present. */
 export function getCachedMtime(workspace: string): number | undefined {
-	return mtimeCache.get(path.normalize(workspace));
+	return getEntry(workspace)?.mtime;
 }

--- a/src/tools/repo-graph/freshness.ts
+++ b/src/tools/repo-graph/freshness.ts
@@ -1,0 +1,627 @@
+/**
+ * Bounded content-freshness certification for repository graphs.
+ *
+ * A probe is one bounded readdir+stat directory walk, not a stat pass over
+ * already-known graph nodes. It reads no source contents and performs no
+ * parsing, so it is much cheaper than graph construction while still finding
+ * additions and removals. The sidecar deliberately fingerprints metadata
+ * (byte size + numeric mtime), not file bytes, so a tool that preserves both
+ * values can evade detection. Results may also be cached for up to 30 seconds.
+ * Callers must therefore treat `inconclusive` as unknown and may mutate/delete
+ * only after a complete `drifted` probe.
+ */
+
+import { createHash } from 'node:crypto';
+import * as fsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+import packageJson from '../../../package.json' with { type: 'json' };
+import { validateSwarmPath } from '../../hooks/utils';
+import { bunWrite } from '../../utils/bun-compat';
+import {
+	containsControlChars,
+	validateSymlinkBoundary,
+} from '../../utils/path-security';
+import { type RepoGraphInputWalkResult, walkRepoGraphInputs } from './builder';
+import type {
+	FreshnessProbeState,
+	GraphExtractorInputWitness,
+	RepoGraph,
+	RepoGraphDiagnostics,
+} from './types';
+import { GRAPH_SCHEMA_VERSION } from './types';
+
+export const REPO_GRAPH_FINGERPRINT_FILENAME = 'repo-graph.fingerprint.json';
+export const FINGERPRINT_SCHEMA_VERSION = 1;
+export const EXTRACTOR_STAMP = createHash('sha256')
+	.update(`${packageJson.version}\0${GRAPH_SCHEMA_VERSION}`)
+	.digest('hex');
+
+const DEFAULT_WALK_BUDGET_MS = 5000;
+const DEFAULT_MAX_FILES = 10000;
+const CACHE_TTL_MS = 30_000;
+const MAX_CACHE_ENTRIES = 16;
+const MAX_FINGERPRINT_BYTES = 24 * 1024 * 1024;
+const MAX_FINGERPRINT_ENTRIES = 100_256;
+const MAX_RELATIVE_PATH_LENGTH = 4096;
+const WINDOWS_RENAME_MAX_RETRIES = 5;
+const WINDOWS_RENAME_RETRY_DELAY_MS = 100;
+
+export interface FreshnessOptions {
+	walkBudgetMs?: number;
+	maxFiles?: number;
+	followSymlinks?: boolean;
+	excludeDirs?: readonly string[];
+}
+
+export interface FreshnessProbe {
+	state: FreshnessProbeState;
+	/** Absolute paths positively observed as new or metadata-changed. */
+	changed: string[];
+	/** Absolute paths absent from a complete walk. Empty when inconclusive. */
+	removed: string[];
+	truncated: boolean;
+	probedFiles: number;
+	elapsedMs: number;
+}
+
+interface FingerprintEntry {
+	size: number;
+	mtimeMs: number;
+}
+
+interface FingerprintFile {
+	schema_version: number;
+	extractorStamp: string;
+	exclusionStamp: string;
+	files: Record<string, FingerprintEntry>;
+}
+
+interface CacheEntry {
+	signature: string;
+	expiresAt: number;
+	value?: FreshnessProbe;
+	inFlight?: Promise<FreshnessProbe>;
+}
+
+const probeCache = new Map<string, CacheEntry>();
+
+export const _internals: {
+	now: () => number;
+	walkRepoGraphInputs: typeof walkRepoGraphInputs;
+	open: typeof fsPromises.open;
+	bunWrite: typeof bunWrite;
+	fsRename: typeof fsPromises.rename;
+	fsUnlink: typeof fsPromises.unlink;
+	retryDelayMs: number;
+} = {
+	now: Date.now,
+	walkRepoGraphInputs,
+	open: fsPromises.open,
+	bunWrite,
+	fsRename: fsPromises.rename,
+	fsUnlink: fsPromises.unlink,
+	retryDelayMs: WINDOWS_RENAME_RETRY_DELAY_MS,
+};
+
+function normalizeRoot(root: string): string {
+	const resolved = path.normalize(path.resolve(root));
+	return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function normalizedExcludes(options?: FreshnessOptions): string[] {
+	return [...new Set((options?.excludeDirs ?? []).filter(Boolean))].sort(
+		(a, b) => a.localeCompare(b),
+	);
+}
+
+function exclusionStamp(options?: FreshnessOptions): string {
+	return createHash('sha256')
+		.update(
+			JSON.stringify({
+				excludeDirs: normalizedExcludes(options),
+				followSymlinks: options?.followSymlinks ?? false,
+			}),
+		)
+		.digest('hex');
+}
+
+function optionSignature(options?: FreshnessOptions): string {
+	return JSON.stringify({
+		walkBudgetMs: options?.walkBudgetMs ?? DEFAULT_WALK_BUDGET_MS,
+		maxFiles: options?.maxFiles ?? DEFAULT_MAX_FILES,
+		followSymlinks: options?.followSymlinks ?? false,
+		excludeDirs: normalizedExcludes(options),
+	});
+}
+
+function touchCache(rootKey: string, entry: CacheEntry): void {
+	probeCache.delete(rootKey);
+	probeCache.set(rootKey, entry);
+	while (probeCache.size > MAX_CACHE_ENTRIES) {
+		const oldest = probeCache.keys().next().value as string | undefined;
+		if (oldest === undefined) break;
+		probeCache.delete(oldest);
+	}
+}
+
+/** Invalidate one project's probe cache, or every entry when root is omitted. */
+export function invalidateFreshnessCache(root?: string): void {
+	if (root === undefined) {
+		probeCache.clear();
+		return;
+	}
+	probeCache.delete(normalizeRoot(root));
+}
+
+function fingerprintPath(root: string): string {
+	const target = validateSwarmPath(root, REPO_GRAPH_FINGERPRINT_FILENAME);
+	validateSymlinkBoundary(target, root);
+	return target;
+}
+
+async function writeFingerprintAtomic(
+	root: string,
+	data: string,
+): Promise<void> {
+	const target = fingerprintPath(root);
+	const temp = path.join(
+		path.dirname(target),
+		`.repo-graph.fingerprint.${process.pid}.${Date.now()}.${Math.random()
+			.toString(36)
+			.slice(2, 10)}.tmp`,
+	);
+	validateSymlinkBoundary(temp, root);
+	try {
+		await _internals.bunWrite(temp, data);
+		let lastError: unknown;
+		for (let attempt = 0; attempt < WINDOWS_RENAME_MAX_RETRIES; attempt++) {
+			try {
+				await _internals.fsRename(temp, target);
+				lastError = undefined;
+				break;
+			} catch (error) {
+				lastError = error;
+				const code = (error as NodeJS.ErrnoException).code;
+				if (
+					(code !== 'EEXIST' && code !== 'EPERM' && code !== 'EBUSY') ||
+					attempt === WINDOWS_RENAME_MAX_RETRIES - 1
+				) {
+					break;
+				}
+				await new Promise((resolve) =>
+					setTimeout(resolve, _internals.retryDelayMs),
+				);
+			}
+		}
+		if (lastError !== undefined) throw lastError;
+	} finally {
+		try {
+			await _internals.fsUnlink(temp);
+		} catch {
+			// Temp was renamed or never created.
+		}
+	}
+}
+
+async function refuseFingerprint(root: string): Promise<false> {
+	try {
+		await _internals.fsUnlink(fingerprintPath(root));
+	} catch {
+		// Missing/locked sidecar is already fail-safe or will reveal prior drift.
+	}
+	invalidateFreshnessCache(root);
+	return false;
+}
+
+function safeRelativePath(value: string): string | null {
+	if (
+		value.length === 0 ||
+		value.length > MAX_RELATIVE_PATH_LENGTH ||
+		containsControlChars(value) ||
+		path.isAbsolute(value) ||
+		/^[A-Za-z]:[/\\]/.test(value)
+	) {
+		return null;
+	}
+	const normalized = value.replace(/\\/g, '/').replace(/^(?:\.\/)+/, '');
+	if (
+		normalized.length === 0 ||
+		normalized.split('/').some((segment) => segment === '..' || segment === '')
+	) {
+		return null;
+	}
+	return normalized;
+}
+
+function relativeFromRoot(root: string, absolutePath: string): string | null {
+	const relative = path.relative(
+		path.resolve(root),
+		path.resolve(absolutePath),
+	);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+	return safeRelativePath(relative);
+}
+
+function absoluteFromRelative(
+	root: string,
+	relativePath: string,
+): string | null {
+	const safe = safeRelativePath(relativePath);
+	if (safe === null) return null;
+	const resolvedRoot = path.resolve(root);
+	const absolute = path.resolve(resolvedRoot, safe);
+	const relative = path.relative(resolvedRoot, absolute);
+	if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+	return absolute;
+}
+
+function validMetadata(value: unknown): value is FingerprintEntry {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	return (
+		Object.keys(record).length === 2 &&
+		typeof record.size === 'number' &&
+		Number.isFinite(record.size) &&
+		record.size >= 0 &&
+		typeof record.mtimeMs === 'number' &&
+		Number.isFinite(record.mtimeMs) &&
+		record.mtimeMs >= 0
+	);
+}
+
+function parseFingerprint(
+	value: unknown,
+	options?: FreshnessOptions,
+): FingerprintFile | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	if (
+		Object.keys(record).sort().join(',') !==
+			'exclusionStamp,extractorStamp,files,schema_version' ||
+		record.schema_version !== FINGERPRINT_SCHEMA_VERSION ||
+		record.extractorStamp !== EXTRACTOR_STAMP ||
+		record.exclusionStamp !== exclusionStamp(options) ||
+		!record.files ||
+		typeof record.files !== 'object' ||
+		Array.isArray(record.files)
+	) {
+		return null;
+	}
+	const rawFiles = record.files as Record<string, unknown>;
+	const entries = Object.entries(rawFiles);
+	if (entries.length > MAX_FINGERPRINT_ENTRIES) return null;
+	const files: Record<string, FingerprintEntry> = Object.create(null);
+	for (const [rawPath, metadata] of entries) {
+		const safe = safeRelativePath(rawPath);
+		if (safe === null || safe !== rawPath || !validMetadata(metadata))
+			return null;
+		files[safe] = metadata;
+	}
+	return {
+		schema_version: FINGERPRINT_SCHEMA_VERSION,
+		extractorStamp: EXTRACTOR_STAMP,
+		exclusionStamp: exclusionStamp(options),
+		files,
+	};
+}
+
+function emptyProbe(
+	state: FreshnessProbeState,
+	elapsedMs: number,
+): FreshnessProbe {
+	return {
+		state,
+		changed: [],
+		removed: [],
+		truncated: false,
+		probedFiles: 0,
+		elapsedMs: Math.max(0, elapsedMs),
+	};
+}
+
+async function readFingerprint(
+	root: string,
+	options?: FreshnessOptions,
+): Promise<FingerprintFile | null> {
+	const target = fingerprintPath(root);
+	const handle = await _internals.open(target, 'r');
+	try {
+		const stats = await handle.stat();
+		if (stats.size > MAX_FINGERPRINT_BYTES) return null;
+		// Read at most the stat-observed bounded size. If a concurrent writer grows
+		// the file, the truncated JSON fails parsing rather than allocating beyond
+		// the hard cap or accepting a partially replaced sidecar.
+		const buffer = Buffer.alloc(stats.size);
+		let offset = 0;
+		while (offset < buffer.length) {
+			const read = await handle.read(
+				buffer,
+				offset,
+				buffer.length - offset,
+				offset,
+			);
+			if (read.bytesRead === 0) break;
+			offset += read.bytesRead;
+		}
+		const data = buffer.subarray(0, offset).toString('utf8');
+		return parseFingerprint(JSON.parse(data), options);
+	} finally {
+		await handle.close();
+	}
+}
+
+async function probeUncached(
+	root: string,
+	options?: FreshnessOptions,
+): Promise<FreshnessProbe> {
+	const startedAt = _internals.now();
+	let fingerprint: FingerprintFile | null;
+	try {
+		fingerprint = await readFingerprint(root, options);
+	} catch {
+		fingerprint = null;
+	}
+	if (fingerprint === null) {
+		return emptyProbe('no-fingerprint', _internals.now() - startedAt);
+	}
+
+	let walk: RepoGraphInputWalkResult;
+	try {
+		walk = await _internals.walkRepoGraphInputs(root, {
+			walkBudgetMs: options?.walkBudgetMs,
+			maxFiles: options?.maxFiles,
+			followSymlinks: options?.followSymlinks,
+			excludeDirs: options?.excludeDirs,
+			captureMetadata: true,
+		});
+	} catch {
+		return {
+			...emptyProbe('inconclusive', _internals.now() - startedAt),
+			truncated: false,
+		};
+	}
+
+	const current = new Map<string, FingerprintEntry>();
+	const changed: string[] = [];
+	for (const input of walk.metadata) {
+		const relative = relativeFromRoot(root, input.absolutePath);
+		if (relative === null) continue;
+		const metadata = { size: input.sizeBytes, mtimeMs: input.mtimeMs };
+		current.set(relative, metadata);
+		const previous = fingerprint.files[relative];
+		if (
+			previous === undefined ||
+			previous.size !== metadata.size ||
+			previous.mtimeMs !== metadata.mtimeMs
+		) {
+			changed.push(path.resolve(input.absolutePath));
+		}
+	}
+
+	const incomplete = walk.incomplete;
+	const removed: string[] = [];
+	if (!incomplete) {
+		for (const relative of Object.keys(fingerprint.files)) {
+			if (!current.has(relative)) {
+				const absolute = absoluteFromRelative(root, relative);
+				if (absolute !== null) removed.push(absolute);
+			}
+		}
+	}
+	changed.sort((a, b) => a.localeCompare(b));
+	removed.sort((a, b) => a.localeCompare(b));
+	return {
+		state: incomplete
+			? 'inconclusive'
+			: changed.length > 0 || removed.length > 0
+				? 'drifted'
+				: 'clean',
+		changed,
+		removed: incomplete ? [] : removed,
+		truncated: walk.truncated,
+		probedFiles: walk.probedFiles,
+		elapsedMs: Math.max(0, _internals.now() - startedAt),
+	};
+}
+
+/** Probe workspace metadata using a bounded per-directory 16-entry LRU cache. */
+export async function probeFreshness(
+	root: string,
+	options?: FreshnessOptions,
+): Promise<FreshnessProbe> {
+	const rootKey = normalizeRoot(root);
+	const signature = optionSignature(options);
+	const now = _internals.now();
+	const cached = probeCache.get(rootKey);
+	if (cached?.signature === signature) {
+		if (cached.value && cached.expiresAt > now) {
+			touchCache(rootKey, cached);
+			return cached.value;
+		}
+		if (cached.inFlight) {
+			touchCache(rootKey, cached);
+			return cached.inFlight;
+		}
+	}
+
+	const inFlight = probeUncached(root, options);
+	const entry: CacheEntry = { signature, expiresAt: 0, inFlight };
+	touchCache(rootKey, entry);
+	try {
+		const value = await inFlight;
+		if (probeCache.get(rootKey)?.inFlight === inFlight) {
+			entry.value = value;
+			entry.expiresAt = _internals.now() + CACHE_TTL_MS;
+			entry.inFlight = undefined;
+			touchCache(rootKey, entry);
+		}
+		return value;
+	} catch {
+		if (probeCache.get(rootKey)?.inFlight === inFlight) {
+			probeCache.delete(rootKey);
+		}
+		return emptyProbe('inconclusive', 0);
+	}
+}
+
+function diagnosticPaths(
+	root: string,
+	diagnostics: RepoGraphDiagnostics | undefined,
+): {
+	stable: Set<string>;
+	witnesses: Map<string, GraphExtractorInputWitness>;
+} | null {
+	const reportedStable = new Set<string>();
+	for (const raw of [
+		...(diagnostics?.oversizedFiles ?? []),
+		...(diagnostics?.binaryFiles ?? []),
+		...(diagnostics?.validationSkippedFiles ?? []),
+	]) {
+		const safe = safeRelativePath(raw);
+		if (safe === null) return null;
+		const absolute = absoluteFromRelative(root, safe);
+		if (absolute === null) return null;
+		reportedStable.add(safe);
+	}
+	const witnesses = new Map<string, GraphExtractorInputWitness>();
+	const stable = new Set<string>();
+	for (const witness of diagnostics?.extractorInputWitnesses ?? []) {
+		const safe = safeRelativePath(witness.file);
+		if (
+			safe === null ||
+			(witness.kind !== 'manifest' && witness.kind !== 'stable-skip') ||
+			!Number.isFinite(witness.sizeBytes) ||
+			witness.sizeBytes < 0 ||
+			!Number.isFinite(witness.mtimeMs) ||
+			witness.mtimeMs < 0 ||
+			witnesses.has(safe)
+		) {
+			return null;
+		}
+		witnesses.set(safe, { ...witness, file: safe });
+		if (witness.kind === 'stable-skip') stable.add(safe);
+	}
+	// Display diagnostics are intentionally capped at 200 entries, but every
+	// reported stable skip still needs a correctness witness. The witness set is
+	// the exhaustive certification source for large repositories.
+	for (const relative of reportedStable) {
+		if (witnesses.get(relative)?.kind !== 'stable-skip') return null;
+	}
+	return { stable, witnesses };
+}
+
+/**
+ * Atomically persist a sidecar only when a complete walk certifies that the
+ * graph and every intentional stable skip match current metadata. Never
+ * throws; `false` means the graph remains deliberately uncertified.
+ */
+export async function writeFingerprint(
+	root: string,
+	graph: RepoGraph,
+	options?: FreshnessOptions,
+): Promise<boolean> {
+	invalidateFreshnessCache(root);
+	try {
+		const walk = await _internals.walkRepoGraphInputs(root, {
+			walkBudgetMs: options?.walkBudgetMs,
+			maxFiles: options?.maxFiles,
+			followSymlinks: options?.followSymlinks,
+			excludeDirs: options?.excludeDirs,
+			captureMetadata: true,
+		});
+		// A cap/budget-truncated walk can safely certify its positively witnessed
+		// prefix. Future probes with the same policy remain `inconclusive` and
+		// never infer removals. I/O-incomplete walks are different: unreadable
+		// inputs are unknown, so they must never produce a sidecar.
+		if (
+			walk.unreadableDirectories.length > 0 ||
+			walk.unreadableFiles.length > 0
+		)
+			return refuseFingerprint(root);
+
+		const certifiedInputs = diagnosticPaths(root, graph.diagnostics);
+		if (certifiedInputs === null) return refuseFingerprint(root);
+		const current = new Map<string, FingerprintEntry>();
+		for (const input of walk.metadata) {
+			const relative = relativeFromRoot(root, input.absolutePath);
+			if (relative === null) return refuseFingerprint(root);
+			current.set(relative, {
+				size: input.sizeBytes,
+				mtimeMs: input.mtimeMs,
+			});
+		}
+		for (const [relative, witness] of certifiedInputs.witnesses) {
+			const observed = current.get(relative);
+			if (
+				observed === undefined ||
+				observed.size !== witness.sizeBytes ||
+				observed.mtimeMs !== witness.mtimeMs
+			) {
+				return refuseFingerprint(root);
+			}
+		}
+
+		const nodePaths = new Set<string>();
+		for (const node of Object.values(graph.nodes)) {
+			const relative = relativeFromRoot(root, node.filePath);
+			if (relative === null) return refuseFingerprint(root);
+			if (
+				typeof node.sizeBytes !== 'number' ||
+				!Number.isFinite(node.sizeBytes) ||
+				node.sizeBytes < 0 ||
+				typeof node.mtimeMs !== 'number' ||
+				!Number.isFinite(node.mtimeMs) ||
+				node.mtimeMs < 0
+			) {
+				return refuseFingerprint(root);
+			}
+			const observed = current.get(relative);
+			if (
+				observed === undefined ||
+				observed.size !== node.sizeBytes ||
+				observed.mtimeMs !== node.mtimeMs
+			) {
+				return refuseFingerprint(root);
+			}
+			nodePaths.add(relative);
+		}
+
+		for (const input of walk.metadata) {
+			const relative = relativeFromRoot(root, input.absolutePath);
+			if (relative === null) return refuseFingerprint(root);
+			if (
+				input.kind === 'manifest' &&
+				certifiedInputs.witnesses.get(relative)?.kind !== 'manifest'
+			) {
+				return refuseFingerprint(root);
+			}
+			if (input.kind !== 'source') continue;
+			if (!nodePaths.has(relative) && !certifiedInputs.stable.has(relative)) {
+				return refuseFingerprint(root);
+			}
+		}
+
+		const files: Record<string, FingerprintEntry> = Object.create(null);
+		for (const relative of [...current.keys()].sort((a, b) =>
+			a.localeCompare(b),
+		)) {
+			files[relative] = current.get(relative) as FingerprintEntry;
+		}
+		if (Object.keys(files).length > MAX_FINGERPRINT_ENTRIES)
+			return refuseFingerprint(root);
+		const sidecar: FingerprintFile = {
+			schema_version: FINGERPRINT_SCHEMA_VERSION,
+			extractorStamp: EXTRACTOR_STAMP,
+			exclusionStamp: exclusionStamp(options),
+			files,
+		};
+		const serialized = `${JSON.stringify(sidecar, null, 2)}\n`;
+		if (Buffer.byteLength(serialized, 'utf8') > MAX_FINGERPRINT_BYTES)
+			return refuseFingerprint(root);
+		await writeFingerprintAtomic(root, serialized);
+		invalidateFreshnessCache(root);
+		return true;
+	} catch {
+		return refuseFingerprint(root);
+	}
+}

--- a/src/tools/repo-graph/incremental.ts
+++ b/src/tools/repo-graph/incremental.ts
@@ -21,31 +21,55 @@ import * as path from 'node:path';
 import * as logger from '../../utils/logger';
 import { containsControlChars } from '../../utils/path-security';
 
-/**
- * DI seam for the optimistic-concurrency stat check (defect A4). Tests override
- * `stat` to inject deterministic mtime shifts between load and the pre-save
- * re-check, exercising the reload-and-replay branch without races. Defaults to
- * the real `fsPromises.stat`. Restore in afterEach.
- */
-export const _internals: {
-	stat: (path: string) => Promise<Stats>;
-} = {
-	stat: (p: string) => fsPromises.stat(p),
-};
-
 import {
 	addEdge,
 	buildWorkspaceGraphAsync,
 	isAssetEdge,
 	isScannableSourcePath,
+	MAX_EXTRACTOR_INPUT_WITNESSES,
 	scanFileAsync,
 	upsertNode,
 } from './builder';
 import { clearCache, getCachedMtime } from './cache';
+import { writeFingerprint } from './freshness';
 import { resetQueryCache } from './query';
 import { getGraphPath, loadGraph, saveGraph } from './storage';
-import type { GraphEdge, RepoGraph, SymbolEdge } from './types';
+import type {
+	BuildWorkspaceGraphOptions,
+	GraphEdge,
+	GraphExtractorInputWitness,
+	RepoGraph,
+	RepoGraphDiagnostics,
+	SymbolEdge,
+} from './types';
 import { normalizeGraphPath, updateGraphMetadata } from './types';
+
+/** Public options shared by hook, read-repair, and direct callers. */
+export interface IncrementalUpdateOptions {
+	forceRebuild?: boolean;
+	/** Bounds and exclusions used by both direct and fallback full builds. */
+	buildOptions?: BuildWorkspaceGraphOptions;
+}
+
+/**
+ * DI seam for concurrency, scan-failure, and paired-persistence tests. Tests
+ * must restore every replaced entry in afterEach.
+ */
+export const _internals: {
+	stat: (path: string) => Promise<Stats>;
+	scanFileAsync: typeof scanFileAsync;
+	buildWorkspaceGraphAsync: typeof buildWorkspaceGraphAsync;
+	saveGraph: typeof saveGraph;
+	writeFingerprint: typeof writeFingerprint;
+} = {
+	stat: (p: string) => fsPromises.stat(p),
+	scanFileAsync,
+	buildWorkspaceGraphAsync,
+	saveGraph,
+	writeFingerprint,
+};
+
+const MAX_DIAGNOSTIC_ENTRIES = 200;
 
 /** Manifest basenames that mark a directory as a package root (mirrors builder). */
 const MANIFEST_BASENAMES = new Set([
@@ -104,49 +128,14 @@ function buildManifestClosure(
 }
 
 /**
- * Delete + validation half of the per-file update. For each changed file that
- * no longer exists on disk, remove its node and all edges referencing it; then
- * validate the resulting edge set. The async re-scan of still-existing files
- * is handled separately by {@link applyAsyncFileUpdates}. Splitting the two
- * halves lets both the normal incremental path and the concurrent-save replay
- * path (defect A4) share one validation implementation.
- *
- * Asset edges only require their source node to exist; node→node edges require
- * both endpoints (defect A1). Returns `validationFailed: true` when a genuine
- * orphan edge remains, along with the offending edge for diagnostics.
+ * Validate the graph after filesystem reconciliation. Asset edges require
+ * only their source node; node-to-node edges require both endpoints.
  */
-function applyFileUpdates(
-	graph: RepoGraph,
-	filePaths: string[],
-): {
+function validateFileUpdates(graph: RepoGraph): {
 	validationFailed: boolean;
 	offendingEdge?: GraphEdge;
 	reason?: 'missing-source-node' | 'missing-target-node';
 } {
-	for (const rawFilePath of filePaths) {
-		const normalizedPath = normalizeGraphPath(rawFilePath);
-		if (existsSync(rawFilePath)) continue;
-
-		// File was deleted - remove its node and all edges referencing it.
-		// NOTE (defect A1): asset edges whose target no longer exists on disk
-		// are retained but query-inert (assets are excluded from the reverse /
-		// forward indexes and every direct edge loop); pruning them is out of
-		// scope for this fix.
-		delete graph.nodes[normalizedPath];
-		graph.edges = graph.edges.filter(
-			(e) =>
-				normalizeGraphPath(e.source) !== normalizedPath &&
-				normalizeGraphPath(e.target) !== normalizedPath,
-		);
-		if (graph.symbolEdges) {
-			graph.symbolEdges = graph.symbolEdges.filter(
-				(se) =>
-					normalizeGraphPath(se.fromFile) !== normalizedPath &&
-					normalizeGraphPath(se.toFile) !== normalizedPath,
-			);
-		}
-	}
-
 	// Validate that edge endpoints have corresponding nodes. Asset edges
 	// (targetKind 'asset', or untagged edges whose target is not a scannable
 	// source file on pre-1.3.0 graphs) only require their source node; node→node
@@ -188,6 +177,135 @@ function applyFileUpdates(
 	return { validationFailed: false };
 }
 
+function diagnosticName(filePath: string, absoluteRoot: string): string {
+	return path.relative(absoluteRoot, filePath).split(path.sep).join('/');
+}
+
+function dedupeCapped<T>(
+	entries: readonly T[],
+	keyOf: (entry: T) => string,
+	limit = MAX_DIAGNOSTIC_ENTRIES,
+): T[] {
+	const seen = new Set<string>();
+	const result: T[] = [];
+	for (const entry of entries) {
+		const key = keyOf(entry);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		result.push(entry);
+		if (result.length >= limit) break;
+	}
+	return result;
+}
+
+/** Replace diagnostics for one file while retaining unrelated entries. */
+function replaceFileDiagnostics(
+	graph: RepoGraph,
+	file: string,
+	replacement?: RepoGraphDiagnostics,
+): void {
+	const diagnostics: RepoGraphDiagnostics = { ...(graph.diagnostics ?? {}) };
+	const replaceStrings = (
+		current: readonly string[] | undefined,
+		incoming: readonly string[] | undefined,
+	): string[] =>
+		dedupeCapped(
+			[
+				...(current ?? []).filter((entry) => entry !== file),
+				...(incoming ?? []),
+			],
+			(entry) => entry,
+		);
+
+	diagnostics.extractionFailures = dedupeCapped(
+		[
+			...(diagnostics.extractionFailures ?? []).filter(
+				(entry) => entry.file !== file,
+			),
+			...(replacement?.extractionFailures ?? []),
+		],
+		(entry) => `${entry.file}\u0000${entry.language}\u0000${entry.reason}`,
+	);
+	diagnostics.unresolvedImports = dedupeCapped(
+		[
+			...(diagnostics.unresolvedImports ?? []).filter(
+				(entry) => entry.file !== file,
+			),
+			...(replacement?.unresolvedImports ?? []),
+		],
+		(entry) => `${entry.file}\u0000${entry.specifier}`,
+	);
+	diagnostics.oversizedFiles = replaceStrings(
+		diagnostics.oversizedFiles,
+		replacement?.oversizedFiles,
+	);
+	diagnostics.binaryFiles = replaceStrings(
+		diagnostics.binaryFiles,
+		replacement?.binaryFiles,
+	);
+	diagnostics.unreadableFiles = replaceStrings(
+		diagnostics.unreadableFiles,
+		replacement?.unreadableFiles,
+	);
+	diagnostics.validationSkippedFiles = replaceStrings(
+		diagnostics.validationSkippedFiles,
+		replacement?.validationSkippedFiles,
+	);
+	diagnostics.extractorInputWitnesses = dedupeCapped(
+		[
+			...(diagnostics.extractorInputWitnesses ?? []).filter(
+				(entry) => entry.file !== file,
+			),
+			...(replacement?.extractorInputWitnesses ?? []),
+		],
+		(entry) => `${entry.kind}\u0000${entry.file}`,
+		MAX_EXTRACTOR_INPUT_WITNESSES,
+	);
+	graph.diagnostics = diagnostics;
+}
+
+function scanDiagnostics(
+	diagnostics: RepoGraphDiagnostics | undefined,
+	inputWitness?: GraphExtractorInputWitness,
+): RepoGraphDiagnostics | undefined {
+	if (!diagnostics && !inputWitness) return undefined;
+	return {
+		...(diagnostics ?? {}),
+		extractorInputWitnesses: inputWitness ? [inputWitness] : [],
+	};
+}
+
+function isEnoent(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		'code' in error &&
+		(error as NodeJS.ErrnoException).code === 'ENOENT'
+	);
+}
+
+/** Delete only when the immediately preceding async stat returned ENOENT. */
+function applyAuthorizedDeletion(
+	graph: RepoGraph,
+	filePath: string,
+	absoluteRoot: string,
+): void {
+	const normalizedPath = normalizeGraphPath(filePath);
+	delete graph.nodes[normalizedPath];
+	graph.edges = graph.edges.filter(
+		(edge) =>
+			normalizeGraphPath(edge.source) !== normalizedPath &&
+			normalizeGraphPath(edge.target) !== normalizedPath,
+	);
+	if (graph.symbolEdges) {
+		graph.symbolEdges = graph.symbolEdges.filter(
+			(edge) =>
+				normalizeGraphPath(edge.fromFile) !== normalizedPath &&
+				normalizeGraphPath(edge.toFile) !== normalizedPath,
+		);
+	}
+	replaceFileDiagnostics(graph, diagnosticName(filePath, absoluteRoot));
+}
+
 /**
  * Incrementally update the graph for a set of changed files.
  * Re-scans only the specified files, updates their nodes and edges,
@@ -202,12 +320,15 @@ function applyFileUpdates(
 export async function updateGraphForFiles(
 	workspaceRoot: string,
 	filePaths: string[],
-	options?: { forceRebuild?: boolean },
+	options?: IncrementalUpdateOptions,
 ): Promise<RepoGraph> {
 	// If forced rebuild, do full rebuild and save
 	if (options?.forceRebuild) {
-		const graph = await buildWorkspaceGraphAsync(workspaceRoot);
-		await saveGraph(workspaceRoot, graph);
+		const graph = await _internals.buildWorkspaceGraphAsync(
+			workspaceRoot,
+			options.buildOptions,
+		);
+		await persistGraph(workspaceRoot, graph, options.buildOptions);
 		return graph;
 	}
 
@@ -215,14 +336,17 @@ export async function updateGraphForFiles(
 	const existingGraph = await loadGraph(workspaceRoot);
 	if (!existingGraph) {
 		// No existing graph - fall back to full rebuild
-		const graph = await buildWorkspaceGraphAsync(workspaceRoot);
-		await saveGraph(workspaceRoot, graph);
+		const graph = await _internals.buildWorkspaceGraphAsync(
+			workspaceRoot,
+			options?.buildOptions,
+		);
+		await persistGraph(workspaceRoot, graph, options?.buildOptions);
 		return graph;
 	}
 
 	const graph = existingGraph;
 	const absoluteRoot = path.resolve(workspaceRoot);
-	const maxFileSize = 1024 * 1024; // 1MB default
+	const maxFileSize = options?.buildOptions?.maxFileSizeBytes ?? 1024 * 1024;
 
 	// Manifest-aware package boundaries must stay consistent with the initial
 	// build across incremental edits (defect A8). Re-derive a bounded
@@ -237,12 +361,13 @@ export async function updateGraphForFiles(
 		hasManifest,
 	);
 
-	const firstCheck = applyFileUpdates(graph, filePaths);
+	const firstCheck = validateFileUpdates(graph);
 	if (firstCheck.validationFailed) {
 		return await fallBackToFullRebuild(
 			workspaceRoot,
 			firstCheck.offendingEdge,
 			firstCheck.reason,
+			options?.buildOptions,
 		);
 	}
 
@@ -277,7 +402,12 @@ export async function updateGraphForFiles(
 			if (!freshGraph) {
 				// File vanished between our load and the concurrent write —
 				// full rebuild reconciles from the live workspace.
-				return await fallBackToFullRebuild(workspaceRoot);
+				return await fallBackToFullRebuild(
+					workspaceRoot,
+					undefined,
+					undefined,
+					options?.buildOptions,
+				);
 			}
 			await applyAsyncFileUpdates(
 				freshGraph,
@@ -286,12 +416,13 @@ export async function updateGraphForFiles(
 				maxFileSize,
 				buildManifestClosure(freshGraph, absoluteRoot),
 			);
-			const replayCheck = applyFileUpdates(freshGraph, filePaths);
+			const replayCheck = validateFileUpdates(freshGraph);
 			if (replayCheck.validationFailed) {
 				return await fallBackToFullRebuild(
 					workspaceRoot,
 					replayCheck.offendingEdge,
 					replayCheck.reason,
+					options?.buildOptions,
 				);
 			}
 			// Re-stat before save: if the mtime moved AGAIN during replay,
@@ -307,33 +438,36 @@ export async function updateGraphForFiles(
 					logger.warn(
 						'[repo-graph] Concurrent modification persisted during replay — falling back to full rebuild',
 					);
-					return await fallBackToFullRebuild(workspaceRoot);
+					return await fallBackToFullRebuild(
+						workspaceRoot,
+						undefined,
+						undefined,
+						options?.buildOptions,
+					);
 				}
 			} catch {
 				logger.warn(
 					'[repo-graph] Re-stat failed after concurrent-modification replay — falling back to full rebuild',
 				);
-				return await fallBackToFullRebuild(workspaceRoot);
+				return await fallBackToFullRebuild(
+					workspaceRoot,
+					undefined,
+					undefined,
+					options?.buildOptions,
+				);
 			}
 
-			return finalizeAndSave(workspaceRoot, freshGraph);
+			return finalizeAndSave(workspaceRoot, freshGraph, options?.buildOptions);
 		}
 	}
 
-	return finalizeAndSave(workspaceRoot, graph);
+	return finalizeAndSave(workspaceRoot, graph, options?.buildOptions);
 }
 
 /**
- * Async re-scan half of the per-file update: for each existing file, remove
- * its old outgoing edges/symbolEdges, re-scan, and fold the new node + edges
- * + symbolEdges into `graph`. Deleted files are handled by the synchronous
- * `applyFileUpdates` delete branch.
- *
- * `hasManifest` (when available) is forwarded to the scanner so manifest-aware
- * package boundaries stay consistent with the initial build (defect A8). A
- * previously-tracked source file whose rescan returns `node: null` (it became
- * oversized, binary, or unreadable) has its stale node removed and any
- * incoming node→node edges caught by the subsequent validation fallback.
+ * Reconcile changed paths against live filesystem state. ENOENT is the only
+ * file-deletion authorization; recreation is scanned normally, and transient
+ * read failures preserve the last-known-good node and edges.
  */
 async function applyAsyncFileUpdates(
 	graph: RepoGraph,
@@ -344,7 +478,6 @@ async function applyAsyncFileUpdates(
 ): Promise<void> {
 	for (const rawFilePath of filePaths) {
 		const normalizedPath = normalizeGraphPath(rawFilePath);
-		if (!existsSync(rawFilePath)) continue;
 
 		// Defense in depth: only scannable source files become nodes. The write
 		// hook already filters, but updateGraphForFiles is a public entry point
@@ -352,17 +485,21 @@ async function applyAsyncFileUpdates(
 		// extension rather than letting scanFileAsync create an 'unknown' node.
 		if (!isScannableSourcePath(rawFilePath)) continue;
 
-		// Remove old edges from this file before adding new ones.
-		graph.edges = graph.edges.filter(
-			(e) => normalizeGraphPath(e.source) !== normalizedPath,
-		);
-		if (graph.symbolEdges) {
-			graph.symbolEdges = graph.symbolEdges.filter(
-				(se) => normalizeGraphPath(se.fromFile) !== normalizedPath,
-			);
+		const fileDiagnosticName = diagnosticName(rawFilePath, absoluteRoot);
+		try {
+			await _internals.stat(rawFilePath);
+		} catch (error: unknown) {
+			if (isEnoent(error)) {
+				applyAuthorizedDeletion(graph, rawFilePath, absoluteRoot);
+			} else {
+				replaceFileDiagnostics(graph, fileDiagnosticName, {
+					unreadableFiles: [fileDiagnosticName],
+				});
+			}
+			continue;
 		}
 
-		const result = await scanFileAsync(
+		const result = await _internals.scanFileAsync(
 			rawFilePath,
 			absoluteRoot,
 			maxFileSize,
@@ -380,8 +517,41 @@ async function applyAsyncFileUpdates(
 				imports: sanitizedImports,
 			};
 
-			delete graph.nodes[normalizedPath];
-			upsertNode(graph, sanitizedNode);
+			try {
+				upsertNode(graph, sanitizedNode);
+			} catch {
+				const validationWitness =
+					typeof sanitizedNode.sizeBytes === 'number' &&
+					typeof sanitizedNode.mtimeMs === 'number'
+						? {
+								file: fileDiagnosticName,
+								kind: 'stable-skip' as const,
+								sizeBytes: sanitizedNode.sizeBytes,
+								mtimeMs: sanitizedNode.mtimeMs,
+							}
+						: undefined;
+				replaceFileDiagnostics(
+					graph,
+					fileDiagnosticName,
+					scanDiagnostics(
+						{
+							...result.diagnostics,
+							validationSkippedFiles: [fileDiagnosticName],
+						},
+						validationWitness,
+					),
+				);
+				continue;
+			}
+
+			graph.edges = graph.edges.filter(
+				(edge) => normalizeGraphPath(edge.source) !== normalizedPath,
+			);
+			if (graph.symbolEdges) {
+				graph.symbolEdges = graph.symbolEdges.filter(
+					(edge) => normalizeGraphPath(edge.fromFile) !== normalizedPath,
+				);
+			}
 
 			for (const edge of result.edges) {
 				const edgeExists = graph.edges.some(
@@ -391,7 +561,11 @@ async function applyAsyncFileUpdates(
 						e.importSpecifier === edge.importSpecifier,
 				);
 				if (!edgeExists) {
-					addEdge(graph, edge);
+					try {
+						addEdge(graph, edge);
+					} catch {
+						/* invalid individual edge: retain the valid node */
+					}
 				}
 			}
 
@@ -413,12 +587,49 @@ async function applyAsyncFileUpdates(
 					}
 				}
 			}
+			replaceFileDiagnostics(
+				graph,
+				fileDiagnosticName,
+				scanDiagnostics(result.diagnostics, result.inputWitness),
+			);
 		} else {
-			// The file was previously a node but is now oversized/binary/
-			// unreadable. Remove its stale node so the subsequent validation
-			// pass catches any dangling incoming node→node edges and triggers
-			// the documented full-rebuild fallback (issue #1985 review).
-			delete graph.nodes[normalizedPath];
+			const definitelyUnindexable =
+				(result.diagnostics?.oversizedFiles?.length ?? 0) > 0 ||
+				(result.diagnostics?.binaryFiles?.length ?? 0) > 0;
+			if (definitelyUnindexable) {
+				graph.edges = graph.edges.filter(
+					(edge) => normalizeGraphPath(edge.source) !== normalizedPath,
+				);
+				if (graph.symbolEdges) {
+					graph.symbolEdges = graph.symbolEdges.filter(
+						(edge) => normalizeGraphPath(edge.fromFile) !== normalizedPath,
+					);
+				}
+				delete graph.nodes[normalizedPath];
+				replaceFileDiagnostics(
+					graph,
+					fileDiagnosticName,
+					scanDiagnostics(result.diagnostics, result.inputWitness),
+				);
+				continue;
+			}
+
+			try {
+				await _internals.stat(rawFilePath);
+				replaceFileDiagnostics(graph, fileDiagnosticName, {
+					...result.diagnostics,
+					unreadableFiles: [fileDiagnosticName],
+				});
+			} catch (error: unknown) {
+				if (isEnoent(error)) {
+					applyAuthorizedDeletion(graph, rawFilePath, absoluteRoot);
+				} else {
+					replaceFileDiagnostics(graph, fileDiagnosticName, {
+						...result.diagnostics,
+						unreadableFiles: [fileDiagnosticName],
+					});
+				}
+			}
 		}
 	}
 }
@@ -431,6 +642,7 @@ function clearCacheAndResetQuery(normalizedWorkspace: string): void {
 async function finalizeAndSave(
 	workspaceRoot: string,
 	graph: RepoGraph,
+	buildOptions?: BuildWorkspaceGraphOptions,
 ): Promise<RepoGraph> {
 	// Only keep symbolEdges when non-empty (matches buildWorkspaceGraphAsync behavior)
 	if (graph.symbolEdges && graph.symbolEdges.length === 0) {
@@ -438,8 +650,22 @@ async function finalizeAndSave(
 	}
 	updateGraphMetadata(graph);
 	resetQueryCache();
-	await saveGraph(workspaceRoot, graph);
+	await persistGraph(workspaceRoot, graph, buildOptions);
 	return graph;
+}
+
+async function persistGraph(
+	workspaceRoot: string,
+	graph: RepoGraph,
+	buildOptions?: BuildWorkspaceGraphOptions,
+): Promise<void> {
+	await _internals.saveGraph(workspaceRoot, graph);
+	await _internals.writeFingerprint(workspaceRoot, graph, {
+		maxFiles: buildOptions?.maxFiles,
+		walkBudgetMs: buildOptions?.walkBudgetMs,
+		followSymlinks: buildOptions?.followSymlinks,
+		excludeDirs: buildOptions?.excludeDirs,
+	});
 }
 
 /**
@@ -451,6 +677,7 @@ async function fallBackToFullRebuild(
 	workspaceRoot: string,
 	offendingEdge?: GraphEdge,
 	reason?: 'missing-source-node' | 'missing-target-node',
+	buildOptions?: BuildWorkspaceGraphOptions,
 ): Promise<RepoGraph> {
 	if (offendingEdge) {
 		logger.warn(
@@ -465,7 +692,10 @@ async function fallBackToFullRebuild(
 			'[repo-graph] Concurrent modification detected — falling back to full rebuild',
 		);
 	}
-	const rebuiltGraph = await buildWorkspaceGraphAsync(workspaceRoot);
+	const rebuiltGraph = await _internals.buildWorkspaceGraphAsync(
+		workspaceRoot,
+		buildOptions,
+	);
 	// Bump the fallback counter without clobbering extraction diagnostics.
 	const prev = rebuiltGraph.diagnostics ?? {};
 	const prevFallbacks =
@@ -476,6 +706,6 @@ async function fallBackToFullRebuild(
 		...prev,
 		incrementalFallbacks: prevFallbacks + 1,
 	};
-	await saveGraph(workspaceRoot, rebuiltGraph);
+	await persistGraph(workspaceRoot, rebuiltGraph, buildOptions);
 	return rebuiltGraph;
 }

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -1,10 +1,10 @@
-import * as fsSync from 'node:fs';
 import * as path from 'node:path';
 import {
 	containsControlChars,
 	containsPathTraversal,
 } from '../../utils/path-security';
 import { isAssetEdge } from './builder';
+import type { FreshnessProbe } from './freshness';
 import type {
 	BlastRadiusResult,
 	CallerReference,
@@ -145,6 +145,11 @@ export function resetQueryCache(): void {
 	cachedReverseIndex = null;
 }
 
+/**
+ * @deprecated Graph age is not a content-freshness signal. Internal consumers
+ * use {@link probeFreshness}; this compatibility helper intentionally retains
+ * its historical five-minute TTL semantics for external callers.
+ */
 export function isGraphFresh(
 	graph: RepoGraph | null,
 	maxAgeMs: number = 5 * 60 * 1000,
@@ -213,35 +218,37 @@ function sanitizePathList(value: unknown): string[] {
 	return cap(value.filter(isSafeHealthPath));
 }
 
-function getStaleFiles(graph: RepoGraph, workspaceRoot?: string): string[] {
-	const built = Date.parse(graph.metadata.generatedAt);
-	if (!Number.isFinite(built)) return [];
-	const root = workspaceRoot ?? graph.workspaceRoot;
-	const stale: string[] = [];
-	for (const node of Object.values(graph.nodes)) {
-		const moduleName = normalizeGraphPath(node.moduleName);
-		if (!isSafeHealthPath(moduleName)) continue;
-		const filePath = path.join(root, moduleName);
-		try {
-			if (fsSync.statSync(filePath).mtimeMs > built) {
-				stale.push(moduleName);
-				if (stale.length >= GRAPH_HEALTH_OUTPUT_LIMIT) break;
-			}
-		} catch {
-			// Missing or unreadable files are handled by build diagnostics.
+function getProbeStaleFiles(
+	probe: FreshnessProbe | undefined,
+	workspaceRoot: string,
+): string[] {
+	if (!probe) return [];
+	const root = path.resolve(workspaceRoot);
+	const stale = new Set<string>();
+	for (const absolutePath of [...probe.changed, ...probe.removed]) {
+		if (typeof absolutePath !== 'string' || !path.isAbsolute(absolutePath)) {
+			continue;
 		}
+		const relative = normalizeGraphPath(path.relative(root, absolutePath));
+		if (!isSafeHealthPath(relative)) continue;
+		stale.add(relative);
 	}
-	return stale;
+	return [...stale]
+		.sort((a, b) => a.localeCompare(b))
+		.slice(0, GRAPH_HEALTH_OUTPUT_LIMIT);
 }
 
 export function getGraphHealth(
 	graph: RepoGraph | null,
 	workspaceRoot?: string,
+	probe?: FreshnessProbe,
 ): GraphHealthResult {
+	const probeState = probe?.state ?? 'no-fingerprint';
 	if (!graph) {
 		return {
 			schemaVersion: null,
 			fresh: false,
+			probeState,
 			staleFiles: [],
 			extractionFailures: [],
 			unresolvedImports: [],
@@ -249,6 +256,7 @@ export function getGraphHealth(
 			unsupportedFiles: [],
 			binaryFiles: [],
 			unreadableFiles: [],
+			validationSkippedFiles: [],
 			lowConfidenceEdgeCount: 0,
 			walkTruncated: false,
 			walkTruncationReason: null,
@@ -260,11 +268,24 @@ export function getGraphHealth(
 	}
 
 	const diagnostics = graph.diagnostics as Record<string, unknown> | undefined;
-	const fresh = isGraphFresh(graph);
-	const staleFiles = getStaleFiles(graph, workspaceRoot);
+	const fresh = probeState === 'clean';
+	const staleFiles = getProbeStaleFiles(
+		probe,
+		workspaceRoot ?? graph.workspaceRoot,
+	);
 	const notes: string[] = [];
-	if (!fresh || staleFiles.length > 0) {
-		notes.push('Graph is stale. Run repo_map with action="build" to refresh.');
+	if (probeState === 'drifted') {
+		notes.push(
+			'Graph content is stale relative to the workspace. Run repo_map with action="build" if automatic refresh is unavailable.',
+		);
+	} else if (probeState === 'no-fingerprint') {
+		notes.push(
+			'Graph has no matching content fingerprint. Run repo_map with action="build" to certify it.',
+		);
+	} else if (probeState === 'inconclusive') {
+		notes.push(
+			'Graph freshness is unknown because the bounded workspace probe did not complete; no refresh or deletion was attempted.',
+		);
 	}
 	if (!diagnostics) {
 		notes.push(
@@ -310,6 +331,7 @@ export function getGraphHealth(
 	return {
 		schemaVersion: graph.schema_version,
 		fresh,
+		probeState,
 		staleFiles,
 		extractionFailures: sanitizeExtractionFailures(
 			diagnostics?.extractionFailures,
@@ -321,6 +343,9 @@ export function getGraphHealth(
 		unsupportedFiles: sanitizePathList(diagnostics?.unsupportedFiles),
 		binaryFiles,
 		unreadableFiles,
+		validationSkippedFiles: sanitizePathList(
+			diagnostics?.validationSkippedFiles,
+		),
 		lowConfidenceEdgeCount:
 			typeof diagnostics?.lowConfidenceEdgeCount === 'number' &&
 			Number.isFinite(diagnostics.lowConfidenceEdgeCount) &&

--- a/src/tools/repo-graph/storage.ts
+++ b/src/tools/repo-graph/storage.ts
@@ -23,6 +23,7 @@ import {
 	isDirty,
 	setCachedGraph,
 } from './cache';
+import { type FreshnessOptions, writeFingerprint } from './freshness';
 import { safeRealpathSync } from './safe-realpath';
 import type { RepoGraph } from './types';
 import {
@@ -71,10 +72,12 @@ export const _internals: {
 	safeRealpathSync: typeof safeRealpathSync;
 	fsRename: typeof fsPromises.rename;
 	retryDelayMs: number;
+	writeFingerprint: typeof writeFingerprint;
 } = {
 	safeRealpathSync,
 	fsRename: fsPromises.rename.bind(fsPromises),
 	retryDelayMs: WINDOWS_RENAME_RETRY_DELAY_MS,
+	writeFingerprint,
 };
 
 function validateLoadedGraph(parsed: RepoGraph): void {
@@ -543,7 +546,10 @@ export async function loadOrCreateGraph(workspace: string): Promise<RepoGraph> {
  * @throws Error if workspace is dirty but cache is missing (inconsistent state)
  * @throws Error if save fails
  */
-export async function saveIfDirty(workspace: string): Promise<void> {
+export async function saveIfDirty(
+	workspace: string,
+	freshnessOptions?: FreshnessOptions,
+): Promise<void> {
 	const normalized = path.normalize(workspace);
 	if (isDirty(normalized)) {
 		const graph = getCachedGraph(normalized);
@@ -553,5 +559,6 @@ export async function saveIfDirty(workspace: string): Promise<void> {
 			);
 		}
 		await saveGraph(workspace, graph);
+		await _internals.writeFingerprint(workspace, graph, freshnessOptions);
 	}
 }

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -40,8 +40,14 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * Diagnostics are additive and optional on all schema versions. Old graphs
  * without diagnostics remain readable; graph-health queries surface empty
  * diagnostics with an explicit rebuild note.
+ *
+ * 1.4.0 adds optional numeric `sizeBytes` and `mtimeMs` witnesses to each
+ * node. Builders capture them from the same stat used immediately before the
+ * source read. The content-freshness sidecar requires both witnesses before
+ * it will certify a graph; older graphs remain readable but are intentionally
+ * treated as needing a rebuild before certification.
  */
-export const GRAPH_SCHEMA_VERSION = '1.3.0';
+export const GRAPH_SCHEMA_VERSION = '1.4.0';
 
 /**
  * Compare dotted numeric version strings (e.g. '1.1.0' >= '1.1.0').
@@ -224,6 +230,10 @@ export interface GraphNode {
 	language: string;
 	/** Last modified timestamp */
 	mtime: string;
+	/** Exact byte size captured by the stat that preceded the source read. */
+	sizeBytes?: number;
+	/** Numeric mtime captured with `sizeBytes`; avoids ISO precision loss. */
+	mtimeMs?: number;
 	/** Optional code ontology facts for agent context/preflight packets */
 	ontology?: FileOntology;
 }
@@ -389,6 +399,15 @@ export interface GraphUnresolvedImport {
 	specifier: string;
 }
 
+/** Build-time metadata witness for a non-node extractor input. */
+export interface GraphExtractorInputWitness {
+	/** Normalized workspace-relative path. */
+	file: string;
+	kind: 'manifest' | 'stable-skip';
+	sizeBytes: number;
+	mtimeMs: number;
+}
+
 export interface RepoGraphDiagnostics {
 	extractionFailures?: GraphExtractionFailure[];
 	unresolvedImports?: GraphUnresolvedImport[];
@@ -396,6 +415,14 @@ export interface RepoGraphDiagnostics {
 	unsupportedFiles?: string[];
 	binaryFiles?: string[];
 	unreadableFiles?: string[];
+	/** Source files intentionally skipped because their extracted node failed validation. */
+	validationSkippedFiles?: string[];
+	/**
+	 * Build-time witnesses for manifests and deterministic non-node skips.
+	 * Persistence compares them against its live walk so an edit between graph
+	 * extraction and sidecar persistence cannot be blessed as clean.
+	 */
+	extractorInputWitnesses?: GraphExtractorInputWitness[];
 	lowConfidenceEdgeCount?: number;
 	/**
 	 * True when the last workspace walk was truncated by the file cap or wall-
@@ -416,6 +443,7 @@ export interface RepoGraphDiagnostics {
 export interface GraphHealthResult {
 	schemaVersion: string | null;
 	fresh: boolean;
+	probeState: FreshnessProbeState;
 	staleFiles: string[];
 	extractionFailures: GraphExtractionFailure[];
 	unresolvedImports: GraphUnresolvedImport[];
@@ -423,12 +451,20 @@ export interface GraphHealthResult {
 	unsupportedFiles: string[];
 	binaryFiles: string[];
 	unreadableFiles: string[];
+	validationSkippedFiles: string[];
 	lowConfidenceEdgeCount: number;
 	walkTruncated: boolean;
 	walkTruncationReason: 'budget' | 'cap' | null;
 	incrementalFallbacks: number;
 	notes: string[];
 }
+
+/** Authoritative states returned by the bounded repository freshness probe. */
+export type FreshnessProbeState =
+	| 'clean'
+	| 'drifted'
+	| 'no-fingerprint'
+	| 'inconclusive';
 
 export interface BlastRadiusResult {
 	target: string[];

--- a/src/tools/repo-graph/validation.ts
+++ b/src/tools/repo-graph/validation.ts
@@ -105,6 +105,31 @@ export function validateGraphNode(node: GraphNode): void {
 	if (typeof node.mtime !== 'string') {
 		throw new Error('Invalid node: mtime is required');
 	}
+	if ((node.sizeBytes === undefined) !== (node.mtimeMs === undefined)) {
+		throw new Error(
+			'Invalid node: sizeBytes and mtimeMs must either both be present or both be absent',
+		);
+	}
+	if (
+		node.sizeBytes !== undefined &&
+		(typeof node.sizeBytes !== 'number' ||
+			!Number.isFinite(node.sizeBytes) ||
+			node.sizeBytes < 0)
+	) {
+		throw new Error(
+			'Invalid node: sizeBytes must be a finite non-negative number',
+		);
+	}
+	if (
+		node.mtimeMs !== undefined &&
+		(typeof node.mtimeMs !== 'number' ||
+			!Number.isFinite(node.mtimeMs) ||
+			node.mtimeMs < 0)
+	) {
+		throw new Error(
+			'Invalid node: mtimeMs must be a finite non-negative number',
+		);
+	}
 	if (!Array.isArray(node.exports)) {
 		throw new Error('Invalid node: exports must be an array');
 	}

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
 import type { ToolContext } from '@opencode-ai/plugin';
 import { z } from 'zod';
+import { loadPluginConfigWithMeta } from '../config/loader';
+import { type RepoGraphConfig, RepoGraphConfigSchema } from '../config/schema';
 import {
 	containsControlChars,
 	containsPathTraversal,
@@ -9,6 +11,8 @@ import { createSwarmTool } from './create-tool';
 import {
 	buildOntologyPreflightPacket,
 	buildWorkspaceGraphAsync,
+	type FreshnessOptions,
+	type FreshnessProbe,
 	getBlastRadius,
 	getCallers,
 	getContextPack,
@@ -21,11 +25,14 @@ import {
 	getLocalizationContext,
 	getPackageBoundaries,
 	getSymbolConsumers,
-	isGraphFresh,
+	isGraphWideInputPath,
 	loadGraph,
 	normalizeGraphPath,
+	probeFreshness,
 	type RepoGraph,
 	saveGraph,
+	updateGraphForFiles,
+	writeFingerprint,
 } from './repo-graph';
 
 /**
@@ -43,9 +50,9 @@ import {
  *   { success: false, error: '...', action }.
  *
  * Auto-load: every action except `build` lazily loads the graph from
- * `.swarm/repo-graph.json`; if absent or stale, the caller is told to run
- * `action: "build"` first (we do not auto-rebuild — builds can take seconds
- * and should be explicit so the agent sees the cost).
+ * `.swarm/repo-graph.json`. Complete source drift at/below `refresh_cap` is
+ * refreshed incrementally before answering. Missing, graph-wide, over-cap, or
+ * inconclusive freshness is reported explicitly without an implicit full build.
  */
 
 const VALID_ACTIONS = [
@@ -68,6 +75,15 @@ type RepoMapAction = (typeof VALID_ACTIONS)[number];
 
 const MAX_FILE_PATH_LENGTH = 500;
 const MAX_SYMBOL_LENGTH = 256;
+const REPO_GRAPH_DISABLED_NOTICE =
+	'Repository graph is disabled by configuration (repo_graph.enabled=false).';
+
+export const _internals = {
+	loadPluginConfigWithMeta,
+	probeFreshness,
+	updateGraphForFiles,
+	writeFingerprint,
+};
 
 interface RepoMapArgs {
 	action: string;
@@ -110,6 +126,50 @@ function err(action: string, message: string): string {
 
 function ok(action: string, payload: Record<string, unknown>): string {
 	return JSON.stringify({ success: true, action, ...payload }, null, 2);
+}
+
+function resolveRepoGraphConfig(directory: string): RepoGraphConfig {
+	try {
+		const { config } = _internals.loadPluginConfigWithMeta(directory);
+		return RepoGraphConfigSchema.parse(config.repo_graph ?? {});
+	} catch {
+		return RepoGraphConfigSchema.parse({});
+	}
+}
+
+function freshnessOptions(config: RepoGraphConfig): FreshnessOptions {
+	return {
+		maxFiles: config.max_files,
+		walkBudgetMs: config.walk_budget_ms,
+		excludeDirs: config.exclude_dirs,
+	};
+}
+
+function uniqueDriftPaths(probe: FreshnessProbe): string[] {
+	return [...new Set([...probe.changed, ...probe.removed])];
+}
+
+interface RepoMapFreshnessMetadata {
+	stale: boolean;
+	probeState: FreshnessProbe['state'];
+	changedFiles: number;
+	refreshedFiles: number;
+	freshnessNote?: string;
+}
+
+function metadataForProbe(
+	probe: FreshnessProbe,
+	detectedFiles: number,
+	refreshedFiles: number,
+	freshnessNote?: string,
+): RepoMapFreshnessMetadata {
+	return {
+		stale: probe.state === 'drifted' || probe.state === 'no-fingerprint',
+		probeState: probe.state,
+		changedFiles: detectedFiles,
+		refreshedFiles,
+		...(freshnessNote ? { freshnessNote } : {}),
+	};
 }
 
 /**
@@ -237,12 +297,23 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			);
 		}
 
+		const repoGraphConfig = resolveRepoGraphConfig(directory);
+		if (!repoGraphConfig.enabled) {
+			return err(action, REPO_GRAPH_DISABLED_NOTICE);
+		}
+		const probeOptions = freshnessOptions(repoGraphConfig);
+
 		// ----- build -----
 		if (action === 'build') {
 			try {
 				const start = Date.now();
-				const graph = await buildWorkspaceGraphAsync(directory);
+				const graph = await buildWorkspaceGraphAsync(directory, probeOptions);
 				await saveGraph(directory, graph);
+				const fingerprintWritten = await _internals.writeFingerprint(
+					directory,
+					graph,
+					probeOptions,
+				);
 				const elapsedMs = Date.now() - start;
 				const fileCount = Object.keys(graph.nodes).length;
 				const edgeCount = graph.edges.length;
@@ -256,6 +327,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					buildTimestamp: graph.metadata.generatedAt,
 					elapsedMs,
 					truncated: graph.diagnostics?.walkTruncated === true,
+					fingerprintWritten,
 					path: '.swarm/repo-graph.json',
 				});
 			} catch (e) {
@@ -267,7 +339,8 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		if (action === 'graph_health') {
 			try {
 				const graph = await loadGraph(directory);
-				return ok(action, { ...getGraphHealth(graph, directory) });
+				const probe = await _internals.probeFreshness(directory, probeOptions);
+				return ok(action, { ...getGraphHealth(graph, directory, probe) });
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
 				return err(action, `failed to load repo graph: ${message}`);
@@ -277,8 +350,57 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		// All other actions need a loaded graph.
 		const loaded = await loadOrError(directory, action);
 		if (!loaded.ok) return loaded.response;
-		const graph = loaded.graph;
-		const stale = !isGraphFresh(graph);
+		let graph = loaded.graph;
+		let probe = await _internals.probeFreshness(directory, probeOptions);
+		const driftPaths = uniqueDriftPaths(probe);
+		const detectedFiles = driftPaths.length;
+		let refreshedFiles = 0;
+		let freshnessNote: string | undefined;
+
+		if (probe.state === 'drifted' && detectedFiles > 0) {
+			const graphWideDrift = driftPaths.some(isGraphWideInputPath);
+			if (graphWideDrift) {
+				freshnessNote =
+					'Graph-wide package manifest drift requires a full repo_map build; the stale graph was served without mutation.';
+			} else if (
+				repoGraphConfig.refresh_cap > 0 &&
+				detectedFiles <= repoGraphConfig.refresh_cap
+			) {
+				try {
+					graph = await _internals.updateGraphForFiles(directory, driftPaths, {
+						buildOptions: probeOptions,
+					});
+					refreshedFiles = detectedFiles;
+					probe = await _internals.probeFreshness(directory, probeOptions);
+					if (probe.state !== 'clean') {
+						freshnessNote =
+							'Incremental refresh completed, but the follow-up probe did not certify a clean graph.';
+					}
+				} catch (error) {
+					freshnessNote = `Incremental refresh failed; serving the stale graph: ${
+						error instanceof Error ? error.message : String(error)
+					}`;
+				}
+			} else {
+				freshnessNote =
+					repoGraphConfig.refresh_cap === 0
+						? 'Automatic read-time refresh is disabled by repo_graph.refresh_cap=0; serving the stale graph.'
+						: `Detected ${detectedFiles} changed files, above repo_graph.refresh_cap=${repoGraphConfig.refresh_cap}; serving the stale graph.`;
+			}
+		} else if (probe.state === 'no-fingerprint') {
+			freshnessNote =
+				'No matching repository-graph fingerprint is available; run repo_map action="build" to certify the graph.';
+		} else if (probe.state === 'inconclusive') {
+			freshnessNote =
+				'Workspace freshness is unknown because the bounded probe did not complete; the existing graph was served without refresh or deletion.';
+		}
+
+		const freshness = metadataForProbe(
+			probe,
+			detectedFiles,
+			refreshedFiles,
+			freshnessNote,
+		);
 
 		// ----- key_files -----
 		if (action === 'key_files') {
@@ -295,7 +417,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			return ok(action, {
 				count: reverseCounts.length,
 				files: reverseCounts,
-				stale,
+				...freshness,
 			});
 		}
 
@@ -305,13 +427,13 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			return ok(action, {
 				count: boundaries.length,
 				boundaries,
-				stale,
+				...freshness,
 			});
 		}
 
 		if (action === 'dead_exports') {
 			const result = getDeadExports(graph, { maxCandidates: a.top_n ?? 100 });
-			return ok(action, { ...result, stale });
+			return ok(action, { ...result, ...freshness });
 		}
 
 		if (action === 'preflight_packet') {
@@ -327,7 +449,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					maxFiles: a.top_n ?? 12,
 					maxBoundaries: 10,
 				}),
-				stale,
+				...freshness,
 			});
 		}
 
@@ -344,7 +466,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			}
 			const targets = inputs.map((f) => toRelativeGraphPath(f, directory));
 			const result = getBlastRadius(graph, targets, a.max_depth ?? 3);
-			return ok(action, { ...result, stale });
+			return ok(action, { ...result, ...freshness });
 		}
 
 		if (!a.file) {
@@ -364,7 +486,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					symbol: a.symbol,
 					count: consumers.length,
 					consumers,
-					stale,
+					...freshness,
 				});
 			}
 			const importers = getImporters(graph, target);
@@ -372,7 +494,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				target,
 				count: importers.length,
 				importers,
-				stale,
+				...freshness,
 			});
 		}
 
@@ -388,7 +510,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				symbol: a.symbol,
 				count: callers.length,
 				callers,
-				stale,
+				...freshness,
 			});
 		}
 
@@ -434,7 +556,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				spans: cappedSpans,
 				truncated,
 				estimatedTokens: raw.estimatedTokens,
-				stale,
+				...freshness,
 				schemaSupported: raw.schemaSupported,
 				...(raw.note ? { note: raw.note } : {}),
 			});
@@ -446,7 +568,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				target,
 				count: deps.length,
 				dependencies: deps,
-				stale,
+				...freshness,
 			});
 		}
 
@@ -454,7 +576,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			const ctx = getLocalizationContext(graph, target, {
 				maxDepth: a.max_depth,
 			});
-			return ok(action, { ...ctx, stale });
+			return ok(action, { ...ctx, ...freshness });
 		}
 
 		if (action === 'ontology') {
@@ -465,7 +587,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					`No ontology facts found for ${target}. Rebuild the graph if the file was recently added.`,
 				);
 			}
-			return ok(action, { target, ontology, stale });
+			return ok(action, { target, ontology, ...freshness });
 		}
 
 		// Should be unreachable due to enum validation above.

--- a/src/utils/path-security.ts
+++ b/src/utils/path-security.ts
@@ -85,6 +85,75 @@ export function validateDirectory(directory: string): void {
 }
 
 /**
+ * Resolve a path to its canonical (symlink-free) form, tolerating the case
+ * where the path (or some suffix of it) does not exist yet.
+ *
+ * Strategy:
+ * 1. Try `resolver(inputPath)` directly — the common case where the path
+ *    already exists. This preserves the exact historical behavior (and the
+ *    exact string handed to the resolver) for existing paths.
+ * 2. On failure (ENOENT — the path, or a not-yet-created tail of it, does
+ *    not exist), lexically resolve the input with `path.resolve` (attaches a
+ *    drive letter on Windows, matching what `realpathSync` would produce for
+ *    a path that DOES exist — see the drive-letter-consistency note on
+ *    `validateSymlinkBoundary` below) so any `..`/`.` segments in the input
+ *    are collapsed BEFORE any ancestor is examined. This is what prevents a
+ *    `..` in the non-existent tail from surviving into the composed result
+ *    and climbing back out of a resolved ancestor.
+ * 3. Walk up the lexically-resolved path one component at a time (bounded
+ *    to 4096 iterations to guard against unbounded loops on malformed
+ *    input), calling `resolver` on each shorter ancestor. The first
+ *    ancestor that resolves successfully is the nearest EXISTING ancestor —
+ *    resolving it follows any symlink on that component (or any component
+ *    above it). The already-lexically-normalized tail (which cannot contain
+ *    `..`) is then rejoined onto that canonical ancestor, so the returned
+ *    path reflects every symlink that exists on disk today while still
+ *    describing the not-yet-created target.
+ * 4. If no ancestor resolves (walk reaches the filesystem root without a
+ *    single successful `resolver` call — effectively unreachable on a real
+ *    OS, since the filesystem root always exists), fall back to the
+ *    lexically-resolved path.
+ */
+function resolveNearestExistingCanonical(
+	inputPath: string,
+	resolver: (p: string) => string,
+): string {
+	try {
+		return resolver(inputPath);
+	} catch {
+		// Path (or a suffix of it) does not exist yet — fall through to the
+		// ancestor walk below.
+	}
+
+	const lexicallyResolved = path.resolve(inputPath);
+	let probe = lexicallyResolved;
+	const tail: string[] = [];
+	for (let i = 0; i < 4096; i++) {
+		const parent = path.dirname(probe);
+		if (parent === probe) {
+			// Reached the filesystem root without finding an existing ancestor.
+			return lexicallyResolved;
+		}
+		// unshift runs before every resolver() attempt below, so by the time
+		// resolver(probe) can succeed, tail always has at least one entry —
+		// the composed-path branch below is the only reachable outcome.
+		tail.unshift(path.basename(probe));
+		probe = parent;
+		try {
+			const canonicalAncestor = resolver(probe);
+			// tail contains only plain path components — lexicallyResolved was
+			// already normalized above, so no '..'/'.' segment can be present —
+			// rejoining it onto the canonical ancestor cannot escape further
+			// than the ancestor itself already has.
+			return path.normalize(path.join(canonicalAncestor, ...tail));
+		} catch {
+			// Keep climbing.
+		}
+	}
+	return lexicallyResolved;
+}
+
+/**
  * Validate that a resolved path stays within an allowed root directory.
  * Resolves symlinks via realpathSync for both the target path and the root,
  * then verifies the resolved target is within the resolved root.
@@ -102,6 +171,28 @@ export function validateDirectory(directory: string): void {
  * both fallback branches keeps the comparison basis consistent whether
  * realpathSync succeeds or not, independent of incidental filesystem state.
  *
+ * Not-yet-existing targets (e.g. a file about to be created by an atomic
+ * write) are handled the same way: realpathSync on the full target throws
+ * ENOENT, so resolution falls back to `resolveNearestExistingCanonical`,
+ * which walks up to the nearest existing ancestor, resolves symlinks on
+ * that ancestor (and everything above it), and rejoins the not-yet-existing
+ * tail. Without this, a target under a workspace root that itself sits
+ * behind a symlink (e.g. macOS `/tmp` and `/var`, which are symlinks to
+ * `/private/tmp` and `/private/var`) would resolve to its unresolved literal
+ * path while the (already-existing) root resolves to its `/private/...`
+ * form, producing a spurious boundary-escape error even though the target
+ * is genuinely inside the root. See issue #1986.
+ *
+ * This also TIGHTENS containment versus the pre-#1986-fix behavior in one
+ * case: if `.swarm/` or any other ancestor between the target and the
+ * workspace root is itself a symlink/junction pointing outside the
+ * workspace, the old fallback (unresolved `path.resolve`) could let a
+ * not-yet-existing target through on its first write; the ancestor walk now
+ * resolves that symlinked ancestor and correctly throws. If a deployment
+ * relies on a symlinked `.swarm/` (or similar) pointing outside the
+ * workspace root, that setup will now be rejected — this is the intended,
+ * correct behavior, not a regression.
+ *
  * @param targetPath - The path to validate (absolute)
  * @param rootPath - The root directory boundary (absolute)
  * @throws Error if the resolved target escapes the root boundary
@@ -110,19 +201,14 @@ export function validateSymlinkBoundary(
 	targetPath: string,
 	rootPath: string,
 ): void {
-	let realTarget: string;
-	try {
-		realTarget = _internals.realpathSync(targetPath);
-	} catch {
-		realTarget = path.resolve(targetPath);
-	}
-
-	let realRoot: string;
-	try {
-		realRoot = _internals.realpathSync(rootPath);
-	} catch {
-		realRoot = path.resolve(rootPath);
-	}
+	const realTarget = resolveNearestExistingCanonical(
+		targetPath,
+		_internals.realpathSync,
+	);
+	const realRoot = resolveNearestExistingCanonical(
+		rootPath,
+		_internals.realpathSync,
+	);
 
 	const normalizedTarget = path.normalize(realTarget);
 	const normalizedRoot = path.normalize(realRoot);

--- a/tests/unit/config/loader.test.ts
+++ b/tests/unit/config/loader.test.ts
@@ -204,11 +204,11 @@ describe('config/loader', () => {
 
 		it('returns defaults when no config files exist', () => {
 			const result = loadPluginConfig(tempDir);
-
+			const { repo_graph: _repoGraph, ...legacyDefaults } = result;
 			// Should return defaults when no user config and no project config exist.
 			// adversarial_testing and config_format_version have schema-level defaults
-			// and are always present.
-			expect(result).toEqual({
+			// are always present; repo_graph defaults are pinned in its focused schema test.
+			expect(legacyDefaults).toEqual({
 				config_format_version: 1,
 				max_iterations: 5,
 				qa_retry_limit: 3,

--- a/tests/unit/config/repo-graph-config-schema.test.ts
+++ b/tests/unit/config/repo-graph-config-schema.test.ts
@@ -10,7 +10,10 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { RepoGraphConfigSchema } from '../../../src/config/schema';
+import {
+	PluginConfigSchema,
+	RepoGraphConfigSchema,
+} from '../../../src/config/schema';
 
 describe('RepoGraphConfigSchema.exclude_dirs', () => {
 	it('accepts valid directory basenames', () => {
@@ -43,5 +46,48 @@ describe('RepoGraphConfigSchema.exclude_dirs', () => {
 	it('defaults to an empty array when omitted', () => {
 		const parsed = RepoGraphConfigSchema.parse({});
 		expect(parsed.exclude_dirs).toEqual([]);
+	});
+});
+
+describe('RepoGraphConfigSchema freshness policy (issue #1986)', () => {
+	it('materializes safe defaults when the entire section is omitted', () => {
+		const parsed = PluginConfigSchema.parse({});
+		expect(parsed.repo_graph).toEqual({
+			enabled: true,
+			init_refresh: true,
+			refresh_cap: 50,
+			walk_budget_ms: 5_000,
+			max_files: 10_000,
+			exclude_dirs: [],
+		});
+	});
+
+	it('accepts the documented boundary values', () => {
+		const parsed = RepoGraphConfigSchema.parse({
+			enabled: false,
+			init_refresh: false,
+			refresh_cap: 0,
+			walk_budget_ms: 60_000,
+			max_files: 100_000,
+		});
+		expect(parsed).toMatchObject({
+			enabled: false,
+			init_refresh: false,
+			refresh_cap: 0,
+			walk_budget_ms: 60_000,
+			max_files: 100_000,
+		});
+	});
+
+	it.each([
+		['refresh_cap', -1],
+		['refresh_cap', 501],
+		['walk_budget_ms', 999],
+		['walk_budget_ms', 60_001],
+		['max_files', 99],
+		['max_files', 100_001],
+		['max_files', 100.5],
+	] as const)('rejects out-of-policy %s=%s', (key, value) => {
+		expect(() => RepoGraphConfigSchema.parse({ [key]: value })).toThrow();
 	});
 });

--- a/tests/unit/hooks/repo-graph-builder-freshness.test.ts
+++ b/tests/unit/hooks/repo-graph-builder-freshness.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, mock, test } from 'bun:test';
+import path from 'node:path';
+import {
+	createRepoGraphBuilderHook,
+	type RepoGraphDeps,
+} from '../../../src/hooks/repo-graph-builder';
+import {
+	createEmptyGraph,
+	type RepoGraph,
+} from '../../../src/tools/repo-graph';
+import type { FreshnessProbe } from '../../../src/tools/repo-graph/freshness';
+
+function graphWithNodes(root: string, count: number): RepoGraph {
+	const graph = createEmptyGraph(root);
+	for (let index = 0; index < count; index += 1) {
+		const filePath = path.join(root, 'src', `file-${index}.ts`);
+		graph.nodes[filePath] = {
+			filePath,
+			moduleName: `src/file-${index}`,
+			language: 'typescript',
+			imports: [],
+			exports: [],
+			mtime: '2026-01-01T00:00:00.000Z',
+			sizeBytes: 1,
+		};
+	}
+	graph.metadata.nodeCount = count;
+	return graph;
+}
+
+function probe(
+	state: FreshnessProbe['state'],
+	changed: string[] = [],
+	removed: string[] = [],
+): FreshnessProbe {
+	return {
+		state,
+		changed,
+		removed,
+		truncated: state === 'inconclusive',
+		probedFiles: changed.length,
+		elapsedMs: 1,
+	};
+}
+
+function fixture(
+	root: string,
+	savedGraph: RepoGraph | null,
+	result: FreshnessProbe,
+) {
+	const builtGraph = graphWithNodes(root, 3);
+	const buildWorkspaceGraph = mock(async () => builtGraph);
+	const saveGraph = mock(async () => {});
+	const updateGraphForFiles = mock(async () => savedGraph ?? builtGraph);
+	const loadGraph = mock(async () => savedGraph);
+	const probeFreshness = mock(async () => result);
+	const writeFingerprint = mock(async () => true);
+	// These injected fakes model successful I/O only. Error/corruption and
+	// fingerprint-refusal branches are exercised explicitly in dedicated tests
+	// below; real filesystem semantics belong to the freshness/storage suites.
+	const deps: RepoGraphDeps = {
+		buildWorkspaceGraph,
+		saveGraph,
+		updateGraphForFiles,
+		loadGraph,
+		probeFreshness,
+		writeFingerprint,
+		isGraphWideInputPath: (filePath) =>
+			path.basename(filePath) === 'package.json',
+		safeRealpathSync: (filePath) => filePath,
+	};
+	return {
+		deps,
+		buildWorkspaceGraph,
+		saveGraph,
+		updateGraphForFiles,
+		loadGraph,
+		probeFreshness,
+		writeFingerprint,
+	};
+}
+
+const options = {
+	refreshCap: 1,
+	maxFiles: 321,
+	walkBudgetMs: 4_321,
+	excludeDirs: ['generated'],
+};
+
+describe('repo graph startup freshness decisions (issue #1986)', () => {
+	test('enabled:false is a defensive no-op for init and write hooks', async () => {
+		const root = path.resolve('disabled-repo-graph');
+		const f = fixture(root, null, probe('no-fingerprint'));
+		const hook = createRepoGraphBuilderHook(root, f.deps, {
+			...options,
+			enabled: false,
+		});
+
+		await hook.init();
+		await hook.toolAfter(
+			{ tool: 'write', sessionID: 's1', args: { file_path: 'src/a.ts' } },
+			{},
+		);
+
+		expect(f.loadGraph).not.toHaveBeenCalled();
+		expect(f.buildWorkspaceGraph).not.toHaveBeenCalled();
+		expect(f.updateGraphForFiles).not.toHaveBeenCalled();
+		expect(f.writeFingerprint).not.toHaveBeenCalled();
+	});
+
+	test.each([
+		'clean',
+		'inconclusive',
+	] as const)('%s probe leaves the saved graph untouched', async (state) => {
+		const root = path.resolve(`repo-graph-${state}`);
+		const saved = graphWithNodes(root, 10);
+		const f = fixture(root, saved, probe(state, [path.join(root, 'src/a.ts')]));
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.init();
+
+		expect(f.buildWorkspaceGraph).not.toHaveBeenCalled();
+		expect(f.updateGraphForFiles).not.toHaveBeenCalled();
+		expect(f.writeFingerprint).not.toHaveBeenCalled();
+	});
+
+	test.each([
+		['missing graph', null, probe('no-fingerprint')],
+		[
+			'missing fingerprint',
+			graphWithNodes(path.resolve('no-fp'), 2),
+			probe('no-fingerprint'),
+		],
+	] as const)('full-builds for %s and certifies the result', async (_label, saved, result) => {
+		const root = path.resolve(`repo-graph-${_label.replaceAll(' ', '-')}`);
+		const f = fixture(root, saved, result);
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.init();
+
+		expect(f.buildWorkspaceGraph).toHaveBeenCalledWith(root, {
+			maxFiles: 321,
+			walkBudgetMs: 4_321,
+			excludeDirs: ['generated'],
+		});
+		expect(f.saveGraph).toHaveBeenCalledTimes(1);
+		expect(f.writeFingerprint).toHaveBeenCalledTimes(1);
+	});
+
+	test('corrupt saved graph triggers a full rebuild', async () => {
+		const root = path.resolve('repo-graph-corrupt');
+		const f = fixture(root, null, probe('clean'));
+		f.loadGraph.mockImplementation(async () => {
+			throw Object.assign(new Error('corrupt graph'), { code: 'CORRUPTION' });
+		});
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.init();
+
+		expect(f.buildWorkspaceGraph).toHaveBeenCalledTimes(1);
+		expect(f.probeFreshness).not.toHaveBeenCalled();
+	});
+
+	test('initRefresh:false retains the configured legacy full rebuild', async () => {
+		const root = path.resolve('repo-graph-legacy');
+		const f = fixture(root, graphWithNodes(root, 2), probe('clean'));
+		const hook = createRepoGraphBuilderHook(root, f.deps, {
+			...options,
+			initRefresh: false,
+		});
+
+		await hook.init();
+
+		expect(f.loadGraph).not.toHaveBeenCalled();
+		expect(f.probeFreshness).not.toHaveBeenCalled();
+		expect(f.buildWorkspaceGraph).toHaveBeenCalledTimes(1);
+	});
+
+	test('complete drift at the strict cutover is incremental and deduplicated', async () => {
+		const root = path.resolve('repo-graph-incremental');
+		const saved = graphWithNodes(root, 10);
+		const a = path.join(root, 'src/a.ts');
+		const b = path.join(root, 'src/b.ts');
+		const c = path.join(root, 'src/c.ts');
+		const d = path.join(root, 'src/d.ts');
+		const f = fixture(root, saved, probe('drifted', [a, b, c], [c, d]));
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.init();
+
+		expect(f.updateGraphForFiles).toHaveBeenCalledWith(root, [a, b, c, d], {
+			buildOptions: {
+				maxFiles: 321,
+				walkBudgetMs: 4_321,
+				excludeDirs: ['generated'],
+			},
+		});
+		expect(f.buildWorkspaceGraph).not.toHaveBeenCalled();
+	});
+
+	test.each([
+		['above strict cutover', ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts']],
+		['graph-wide manifest', ['package.json']],
+	] as const)('full-builds complete drift for %s', async (_label, names) => {
+		const root = path.resolve(`repo-graph-${_label.replaceAll(' ', '-')}`);
+		const saved = graphWithNodes(root, 10);
+		const changed = names.map((name) => path.join(root, name));
+		const f = fixture(root, saved, probe('drifted', changed));
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.init();
+
+		expect(f.buildWorkspaceGraph).toHaveBeenCalledTimes(1);
+		expect(f.updateGraphForFiles).not.toHaveBeenCalled();
+	});
+
+	test('write-triggered fallback receives the configured build limits', async () => {
+		const root = path.resolve('repo-graph-tool-after');
+		const filePath = path.join(root, 'src', 'a.ts');
+		const f = fixture(root, graphWithNodes(root, 1), probe('clean'));
+		const hook = createRepoGraphBuilderHook(root, f.deps, options);
+
+		await hook.toolAfter(
+			{ tool: 'write', sessionID: 's1', args: { file_path: filePath } },
+			{},
+		);
+
+		expect(f.updateGraphForFiles).toHaveBeenCalledWith(root, [filePath], {
+			buildOptions: {
+				maxFiles: 321,
+				walkBudgetMs: 4_321,
+				excludeDirs: ['generated'],
+			},
+		});
+	});
+});

--- a/tests/unit/hooks/repo-graph-injection-freshness.test.ts
+++ b/tests/unit/hooks/repo-graph-injection-freshness.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	_internals,
+	getCachedGraph,
+	resetGraphInjectionCache,
+} from '../../../src/hooks/repo-graph-injection';
+import {
+	createEmptyGraph,
+	type FreshnessProbe,
+	saveGraph,
+} from '../../../src/tools/repo-graph';
+
+const originalProbe = _internals.probeFreshness;
+let tmp: string;
+
+function result(
+	state: FreshnessProbe['state'],
+	changed: string[] = [],
+	removed: string[] = [],
+): FreshnessProbe {
+	return {
+		state,
+		changed,
+		removed,
+		truncated: state === 'inconclusive',
+		probedFiles: 1,
+		elapsedMs: 1,
+	};
+}
+
+beforeEach(async () => {
+	resetGraphInjectionCache();
+	tmp = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-injection-freshness-')),
+	);
+	await saveGraph(tmp, createEmptyGraph(tmp));
+});
+
+afterEach(() => {
+	_internals.probeFreshness = originalProbe;
+	resetGraphInjectionCache();
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('repo graph injection freshness gate', () => {
+	test('serves clean and all inconclusive graphs as freshness-unknown', async () => {
+		_internals.probeFreshness = async () => result('clean');
+		expect(await getCachedGraph(tmp)).not.toBeNull();
+
+		_internals.probeFreshness = async () =>
+			result('inconclusive', [path.join(tmp, 'src/a.ts')]);
+		expect(await getCachedGraph(tmp)).not.toBeNull();
+	});
+
+	test('applies the configured cap to complete changed and removed drift', async () => {
+		_internals.probeFreshness = async () =>
+			result(
+				'drifted',
+				[path.join(tmp, 'src/a.ts')],
+				[path.join(tmp, 'src/b.ts')],
+			);
+		expect(await getCachedGraph(tmp, { refreshCap: 2 })).not.toBeNull();
+		expect(await getCachedGraph(tmp, { refreshCap: 1 })).toBeNull();
+
+		_internals.probeFreshness = async () => result('no-fingerprint');
+		expect(await getCachedGraph(tmp)).toBeNull();
+	});
+
+	test('disabled mode evicts and returns null without probing', async () => {
+		let probeCalls = 0;
+		_internals.probeFreshness = async () => {
+			probeCalls++;
+			return result('clean');
+		};
+
+		expect(await getCachedGraph(tmp)).not.toBeNull();
+		expect(await getCachedGraph(tmp, { enabled: false })).toBeNull();
+		expect(probeCalls).toBe(1);
+	});
+
+	test('bounds the graph-file cache to sixteen normalized workspaces', async () => {
+		_internals.probeFreshness = async () => result('clean');
+		const roots: string[] = [];
+		try {
+			for (let index = 0; index < 17; index++) {
+				const root = fs.realpathSync(
+					fs.mkdtempSync(path.join(os.tmpdir(), `repo-graph-lru-${index}-`)),
+				);
+				roots.push(root);
+				await saveGraph(root, createEmptyGraph(root));
+				expect(await getCachedGraph(root)).not.toBeNull();
+			}
+			expect(_internals.cacheSize()).toBe(16);
+		} finally {
+			for (const root of roots) {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		}
+	});
+});

--- a/tests/unit/hooks/repo-graph-injection.test.ts
+++ b/tests/unit/hooks/repo-graph-injection.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	buildWorkspaceGraphAsync,
 	saveGraph,
+	writeFingerprint,
 } from '../../../src/tools/repo-graph';
 
 let tmp: string;
@@ -43,31 +44,35 @@ afterEach(() => {
 async function buildAndSaveStartupGraph(): Promise<void> {
 	const graph = await buildWorkspaceGraphAsync(tmp);
 	await saveGraph(tmp, graph);
+	await writeFingerprint(tmp, graph);
 }
 
 describe('graph injection — silent fallback when no graph exists', () => {
-	it('returns null for coder block', () => {
-		expect(buildCoderLocalizationBlock(tmp, 'src/util.ts')).toBeNull();
+	it('returns null for coder block', async () => {
+		expect(await buildCoderLocalizationBlock(tmp, 'src/util.ts')).toBeNull();
 	});
 
-	it('returns null for reviewer block', () => {
-		expect(buildReviewerBlastRadiusBlock(tmp, ['src/util.ts'])).toBeNull();
+	it('returns null for reviewer block', async () => {
+		expect(
+			await buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']),
+		).toBeNull();
 	});
 
-	it('returns null when getCachedGraph called pre-build', () => {
-		expect(getCachedGraph(tmp)).toBeNull();
+	it('returns null when getCachedGraph called pre-build', async () => {
+		expect(await getCachedGraph(tmp)).toBeNull();
 	});
 
-	it('regression RGI-001: corrupt graph files fail open instead of throwing', () => {
+	it('regression RGI-001: corrupt graph files fail open instead of throwing', async () => {
 		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
 		fs.writeFileSync(path.join(tmp, '.swarm', 'repo-graph.json'), '{ nope');
 
 		// Previous code let loadGraphSync corruption errors escape into prompt
 		// construction, violating this hook's documented silent-fallback contract.
-		expect(() => getCachedGraph(tmp)).not.toThrow();
-		expect(getCachedGraph(tmp)).toBeNull();
-		expect(buildCoderLocalizationBlock(tmp, 'src/util.ts')).toBeNull();
-		expect(buildReviewerBlastRadiusBlock(tmp, ['src/util.ts'])).toBeNull();
+		expect(await getCachedGraph(tmp)).toBeNull();
+		expect(await buildCoderLocalizationBlock(tmp, 'src/util.ts')).toBeNull();
+		expect(
+			await buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']),
+		).toBeNull();
 	});
 });
 
@@ -76,8 +81,8 @@ describe('graph injection — after build', () => {
 		await buildAndSaveStartupGraph();
 	});
 
-	it('coder block contains the localization summary', () => {
-		const block = buildCoderLocalizationBlock(tmp, 'src/util.ts');
+	it('coder block contains the localization summary', async () => {
+		const block = await buildCoderLocalizationBlock(tmp, 'src/util.ts');
 		expect(block).not.toBeNull();
 		expect(block?.split('\n')[0]).toBe('## REPO GRAPH — LOCALIZATION');
 		expect(block).toContain('LOCALIZATION CONTEXT');
@@ -90,26 +95,26 @@ describe('graph injection — after build', () => {
 		expect(block!.length).toBeLessThanOrEqual(500);
 	});
 
-	it('coder block returns null for files not in the graph', () => {
-		const block = buildCoderLocalizationBlock(tmp, 'src/missing.ts');
+	it('coder block returns null for files not in the graph', async () => {
+		const block = await buildCoderLocalizationBlock(tmp, 'src/missing.ts');
 		expect(block).toBeNull();
 	});
 
-	it('coder block returns null for empty target', () => {
-		expect(buildCoderLocalizationBlock(tmp, '')).toBeNull();
+	it('coder block returns null for empty target', async () => {
+		expect(await buildCoderLocalizationBlock(tmp, '')).toBeNull();
 	});
 
-	it('coder block normalizes backslashes and ./ prefixes', () => {
-		const a = buildCoderLocalizationBlock(tmp, 'src/util.ts');
-		const b = buildCoderLocalizationBlock(tmp, './src/util.ts');
-		const c = buildCoderLocalizationBlock(tmp, 'src\\util.ts');
+	it('coder block normalizes backslashes and ./ prefixes', async () => {
+		const a = await buildCoderLocalizationBlock(tmp, 'src/util.ts');
+		const b = await buildCoderLocalizationBlock(tmp, './src/util.ts');
+		const c = await buildCoderLocalizationBlock(tmp, 'src\\util.ts');
 		expect(a).not.toBeNull();
 		expect(b).toBe(a as string);
 		expect(c).toBe(a as string);
 	});
 
-	it('reviewer block lists direct dependents and risk', () => {
-		const block = buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']);
+	it('reviewer block lists direct dependents and risk', async () => {
+		const block = await buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']);
 		expect(block).not.toBeNull();
 		expect(block).toContain('BLAST RADIUS');
 		expect(block).toContain('src/util.ts');
@@ -127,26 +132,28 @@ describe('graph injection — after build', () => {
 		}
 		await buildAndSaveStartupGraph();
 
-		const block = buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']);
+		const block = await buildReviewerBlastRadiusBlock(tmp, ['src/util.ts']);
 		expect(block).not.toBeNull();
 		expect(block).toContain('+1 more');
 		expect(block).toContain('extra-0.ts');
 	});
 
-	it('reviewer block returns null when no changed files match the graph', () => {
-		const block = buildReviewerBlastRadiusBlock(tmp, ['does/not/exist.ts']);
+	it('reviewer block returns null when no changed files match the graph', async () => {
+		const block = await buildReviewerBlastRadiusBlock(tmp, [
+			'does/not/exist.ts',
+		]);
 		expect(block).toBeNull();
 	});
 
-	it('reviewer block returns null on empty input', () => {
-		expect(buildReviewerBlastRadiusBlock(tmp, [])).toBeNull();
+	it('reviewer block returns null on empty input', async () => {
+		expect(await buildReviewerBlastRadiusBlock(tmp, [])).toBeNull();
 	});
 });
 
 describe('cache invalidation', () => {
 	it('reloads the graph when the file mtime changes', async () => {
 		await buildAndSaveStartupGraph();
-		const block1 = buildCoderLocalizationBlock(tmp, 'src/util.ts');
+		const block1 = await buildCoderLocalizationBlock(tmp, 'src/util.ts');
 		expect(block1).not.toBeNull();
 
 		// Add a new importer, then rebuild the graph (this updates the file mtime).
@@ -160,7 +167,7 @@ describe('cache invalidation', () => {
 		await new Promise((r) => setTimeout(r, 20));
 		await buildAndSaveStartupGraph();
 
-		const block2 = buildCoderLocalizationBlock(tmp, 'src/util.ts');
+		const block2 = await buildCoderLocalizationBlock(tmp, 'src/util.ts');
 		expect(block2).not.toBeNull();
 		expect(block2).toContain('Imported by (3)');
 	});

--- a/tests/unit/index-repo-graph-disabled.test.ts
+++ b/tests/unit/index-repo-graph-disabled.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { getSafeDefaultConfigLoadResult } from '../../src/config';
+import OpenCodeSwarm, { overrideIndexInternalsForTest } from '../../src/index';
+import { withSafeTestDir } from '../helpers/safe-test-dir';
+
+describe('repo_graph.enabled plugin wiring (issue #1986)', () => {
+	let restore = () => {};
+
+	afterEach(() => {
+		restore();
+		restore = () => {};
+	});
+
+	test('disabled config avoids hook construction and startup registration', async () => {
+		await withSafeTestDir(async (directory) => {
+			const defaults = getSafeDefaultConfigLoadResult();
+			const createRepoGraphBuilderHook = mock(() => {
+				throw new Error('disabled repo graph hook must not be constructed');
+			});
+			const scheduledTasks: Array<readonly (() => unknown)[]> = [];
+
+			// Only the repo-graph admission decision is under test. Snapshot and
+			// git-hygiene I/O are stubbed because their success/failure branches are
+			// covered by tests/unit/index.test.ts.
+			restore = overrideIndexInternalsForTest({
+				loadPluginConfigWithMetaAsync: (async () => ({
+					...defaults,
+					config: {
+						...defaults.config,
+						repo_graph: {
+							...defaults.config.repo_graph,
+							enabled: false,
+						},
+					},
+				})) as never,
+				loadSnapshot: (async () => {}) as never,
+				ensureSwarmGitExcluded: (async () => {}) as never,
+				createRepoGraphBuilderHook: createRepoGraphBuilderHook as never,
+				schedulePostResolutionTasks: ((tasks: readonly (() => unknown)[]) => {
+					scheduledTasks.push(tasks);
+				}) as never,
+			});
+
+			const plugin = await OpenCodeSwarm.server({
+				client: {} as never,
+				project: {} as never,
+				directory,
+				worktree: directory,
+				serverUrl: new URL('http://localhost:3000'),
+				$: {} as never,
+			});
+
+			expect(plugin).toHaveProperty('tool');
+			expect(createRepoGraphBuilderHook).not.toHaveBeenCalled();
+			// The wrapper scheduler still receives other optional startup work; the
+			// absence of a constructed repo hook proves no repo watchdog/init task or
+			// toolAfter callback can have been registered.
+			expect(scheduledTasks.length).toBe(1);
+		});
+	}, 30_000);
+});

--- a/tests/unit/tools/repo-graph-cache-lru.test.ts
+++ b/tests/unit/tools/repo-graph-cache-lru.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	clearCache,
+	getCachedGraph,
+	getCachedMtime,
+	isDirty,
+	markDirty,
+	setCachedGraph,
+} from '../../../src/tools/repo-graph/cache';
+import { createEmptyGraph } from '../../../src/tools/repo-graph/types';
+
+const workspaces = Array.from({ length: 18 }, (_, index) =>
+	path.join(tmpdir(), `repo-graph-cache-lru-${process.pid}-${index}`),
+);
+
+afterEach(() => {
+	for (const workspace of workspaces) clearCache(workspace);
+});
+
+describe('repo-graph workspace cache', () => {
+	test('evicts the least-recently-used workspace at the 16-entry cap', () => {
+		for (const workspace of workspaces.slice(0, 16)) {
+			setCachedGraph(workspace, createEmptyGraph(workspace));
+		}
+
+		// Refresh entry 0, making entry 1 the least recently used.
+		expect(getCachedGraph(workspaces[0])).toBeDefined();
+		setCachedGraph(workspaces[16], createEmptyGraph(workspaces[16]));
+
+		expect(getCachedGraph(workspaces[0])).toBeDefined();
+		expect(getCachedGraph(workspaces[1])).toBeUndefined();
+		expect(getCachedGraph(workspaces[16])).toBeDefined();
+	});
+
+	test('keeps graph, dirty, and mtime state coherent under one key', () => {
+		const workspace = workspaces[0];
+		const graph = createEmptyGraph(workspace);
+		setCachedGraph(workspace, graph, 123);
+		markDirty(path.join(workspace, '.'));
+
+		expect(getCachedGraph(workspace)).toBe(graph);
+		expect(isDirty(workspace)).toBe(true);
+		expect(getCachedMtime(workspace)).toBe(123);
+
+		// Replacing without an mtime must not retain the previous witness.
+		setCachedGraph(workspace, createEmptyGraph(workspace));
+		expect(isDirty(workspace)).toBe(false);
+		expect(getCachedMtime(workspace)).toBeUndefined();
+
+		clearCache(workspace);
+		expect(getCachedGraph(workspace)).toBeUndefined();
+		expect(isDirty(workspace)).toBe(false);
+		expect(getCachedMtime(workspace)).toBeUndefined();
+	});
+
+	test('retains dirty-without-graph state without orphaning another map', () => {
+		const workspace = workspaces[0];
+		markDirty(workspace);
+
+		expect(isDirty(workspace)).toBe(true);
+		expect(getCachedGraph(workspace)).toBeUndefined();
+	});
+});

--- a/tests/unit/tools/repo-graph-fingerprint-certification.test.ts
+++ b/tests/unit/tools/repo-graph-fingerprint-certification.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { buildWorkspaceGraph } from '../../../src/tools/repo-graph/builder';
+import {
+	invalidateFreshnessCache,
+	probeFreshness,
+	writeFingerprint,
+} from '../../../src/tools/repo-graph/freshness';
+
+const roots: string[] = [];
+
+function workspace(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-certification-'));
+	roots.push(root);
+	return root;
+}
+
+function write(root: string, name: string, content: string): string {
+	const target = path.join(root, name);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, content);
+	return target;
+}
+
+afterEach(() => {
+	invalidateFreshnessCache();
+	for (const root of roots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe('repo graph fingerprint certification', () => {
+	test('refuses legacy nodes without exact numeric witnesses', async () => {
+		const root = workspace();
+		write(root, 'a.ts', 'export const a = 1;\n');
+		const graph = buildWorkspaceGraph(root);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		const node = Object.values(graph.nodes)[0];
+		delete node.sizeBytes;
+		delete node.mtimeMs;
+		expect(await writeFingerprint(root, graph)).toBe(false);
+		expect((await probeFreshness(root)).state).toBe('no-fingerprint');
+	});
+
+	test('refuses to bless a file changed after graph extraction', async () => {
+		const root = workspace();
+		const target = write(root, 'a.ts', 'export const a = 1;\n');
+		const graph = buildWorkspaceGraph(root);
+		fs.appendFileSync(target, '// changed after extraction\n');
+		expect(await writeFingerprint(root, graph)).toBe(false);
+	});
+
+	test('certifies deterministic oversized skips but not unexplained omissions', async () => {
+		const root = workspace();
+		write(root, 'large.ts', 'export const oversized = true;\n');
+		const graph = buildWorkspaceGraph(root, { maxFileSizeBytes: 1 });
+		expect(graph.diagnostics?.oversizedFiles).toEqual(['large.ts']);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+
+		const unexplained = buildWorkspaceGraph(root, { maxFileSizeBytes: 1 });
+		delete unexplained.diagnostics;
+		expect(await writeFingerprint(root, unexplained)).toBe(false);
+	});
+
+	test('includes package manifests and stable skipped sources in the sidecar', async () => {
+		const root = workspace();
+		write(root, 'package.json', '{"name":"fixture"}\n');
+		write(root, 'binary.ts', 'binary\0payload');
+		const graph = buildWorkspaceGraph(root);
+		expect(graph.diagnostics?.binaryFiles).toEqual(['binary.ts']);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		const sidecar = JSON.parse(
+			fs.readFileSync(
+				path.join(root, '.swarm', 'repo-graph.fingerprint.json'),
+				'utf8',
+			),
+		) as { files: Record<string, unknown> };
+		expect(Object.keys(sidecar.files)).toEqual(['binary.ts', 'package.json']);
+	});
+
+	test('certifies validation skips but refuses transient unreadable omissions', async () => {
+		const root = workspace();
+		const target = write(root, 'invalid.ts', 'export const invalid = true;\n');
+		const stats = fs.statSync(target);
+		const validationSkip = buildWorkspaceGraph(root);
+		validationSkip.nodes = {};
+		validationSkip.diagnostics = {
+			validationSkippedFiles: ['invalid.ts'],
+			extractorInputWitnesses: [
+				{
+					file: 'invalid.ts',
+					kind: 'stable-skip',
+					sizeBytes: stats.size,
+					mtimeMs: stats.mtimeMs,
+				},
+			],
+		};
+		expect(await writeFingerprint(root, validationSkip)).toBe(true);
+
+		const unreadable = buildWorkspaceGraph(root);
+		unreadable.nodes = {};
+		unreadable.diagnostics = { unreadableFiles: ['invalid.ts'] };
+		expect(await writeFingerprint(root, unreadable)).toBe(false);
+		expect((await probeFreshness(root)).state).toBe('no-fingerprint');
+	});
+
+	test('refuses a package manifest changed after graph extraction', async () => {
+		const root = workspace();
+		const manifest = write(root, 'package.json', '{"name":"before"}\n');
+		write(root, 'a.ts', 'export const a = 1;\n');
+		const graph = buildWorkspaceGraph(root);
+		fs.appendFileSync(manifest, ' ');
+		expect(await writeFingerprint(root, graph)).toBe(false);
+	});
+
+	test('refuses a stable skip changed after graph extraction', async () => {
+		const root = workspace();
+		const oversized = write(root, 'large.ts', 'export const large = true;\n');
+		const graph = buildWorkspaceGraph(root, { maxFileSizeBytes: 1 });
+		fs.appendFileSync(oversized, '// changed\n');
+		expect(await writeFingerprint(root, graph)).toBe(false);
+	});
+});

--- a/tests/unit/tools/repo-graph-freshness-wiring.test.ts
+++ b/tests/unit/tools/repo-graph-freshness-wiring.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../../..');
+const SRC_ROOT = path.join(REPO_ROOT, 'src');
+
+function productionTypeScriptFiles(directory: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...productionTypeScriptFiles(absolute));
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith('.ts') &&
+			!entry.name.endsWith('.test.ts')
+		) {
+			files.push(absolute);
+		}
+	}
+	return files;
+}
+
+describe('repo graph freshness production wiring', () => {
+	test('the deprecated TTL helper has no production caller', () => {
+		const matches: string[] = [];
+		for (const file of productionTypeScriptFiles(SRC_ROOT)) {
+			const source = readFileSync(file, 'utf8');
+			const count = source.match(/\bisGraphFresh\s*\(/g)?.length ?? 0;
+			for (let index = 0; index < count; index++) {
+				matches.push(path.relative(SRC_ROOT, file).replace(/\\/g, '/'));
+			}
+		}
+
+		expect(matches).toEqual(['tools/repo-graph/query.ts']);
+	});
+
+	test('all prompt graph consumers await and receive freshness options', () => {
+		const systemEnhancer = readFileSync(
+			path.join(SRC_ROOT, 'hooks/system-enhancer.ts'),
+			'utf8',
+		);
+		const semanticDiff = readFileSync(
+			path.join(SRC_ROOT, 'hooks/semantic-diff-injection.ts'),
+			'utf8',
+		);
+
+		expect(systemEnhancer).toContain('await buildCoderLocalizationBlock(');
+		expect(systemEnhancer).toContain('await buildReviewerBlastRadiusBlock(');
+		const semanticDiffCalls = [
+			...systemEnhancer.matchAll(
+				/await buildSemanticDiffBlock\(([\s\S]*?)\);/g,
+			),
+		];
+		expect(semanticDiffCalls).toHaveLength(2);
+		for (const call of semanticDiffCalls) {
+			expect(call[1]).toContain('repoGraphInjectionOptions');
+		}
+		expect(semanticDiff).toContain('await _internals.getCachedGraph(');
+		expect(semanticDiff).toContain('repoGraphOptions');
+	});
+});

--- a/tests/unit/tools/repo-graph-freshness.test.ts
+++ b/tests/unit/tools/repo-graph-freshness.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { buildWorkspaceGraph } from '../../../src/tools/repo-graph/builder';
+import {
+	_internals,
+	invalidateFreshnessCache,
+	probeFreshness,
+	REPO_GRAPH_FINGERPRINT_FILENAME,
+	writeFingerprint,
+} from '../../../src/tools/repo-graph/freshness';
+
+const realNow = _internals.now;
+const realWalk = _internals.walkRepoGraphInputs;
+const realRename = _internals.fsRename;
+const realUnlink = _internals.fsUnlink;
+const realRetryDelayMs = _internals.retryDelayMs;
+const roots: string[] = [];
+
+function workspace(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-freshness-'));
+	roots.push(root);
+	return root;
+}
+
+function source(
+	root: string,
+	name = 'src/a.ts',
+	content = 'export const a = 1;\n',
+) {
+	const target = path.join(root, name);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, content);
+	return target;
+}
+
+afterEach(() => {
+	_internals.now = realNow;
+	_internals.walkRepoGraphInputs = realWalk;
+	_internals.fsRename = realRename;
+	_internals.fsUnlink = realUnlink;
+	_internals.retryDelayMs = realRetryDelayMs;
+	invalidateFreshnessCache();
+	for (const root of roots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe('repo graph freshness sidecar', () => {
+	test('reports clean, changed, added, removed, and graph-wide manifest drift', async () => {
+		const root = workspace();
+		const a = source(root);
+		const manifest = source(root, 'package.json', '{"name":"fixture"}\n');
+		const graph = buildWorkspaceGraph(root);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		expect((await probeFreshness(root)).state).toBe('clean');
+
+		fs.appendFileSync(a, '// changed\n');
+		const added = source(root, 'src/b.ts', 'export const b = 2;\n');
+		fs.rmSync(manifest);
+		invalidateFreshnessCache(root);
+		const drift = await probeFreshness(root);
+		expect(drift.state).toBe('drifted');
+		expect(drift.changed).toEqual(
+			[a, added].sort((x, y) => x.localeCompare(y)),
+		);
+		expect(drift.removed).toEqual([manifest]);
+	});
+
+	test('missing, malformed, and exclusion-policy mismatches are no-fingerprint', async () => {
+		const root = workspace();
+		source(root);
+		expect((await probeFreshness(root)).state).toBe('no-fingerprint');
+
+		const graph = buildWorkspaceGraph(root);
+		expect(
+			await writeFingerprint(root, graph, { excludeDirs: ['generated'] }),
+		).toBe(true);
+		expect((await probeFreshness(root)).state).toBe('no-fingerprint');
+
+		fs.writeFileSync(
+			path.join(root, '.swarm', REPO_GRAPH_FINGERPRINT_FILENAME),
+			'{broken',
+		);
+		invalidateFreshnessCache(root);
+		expect((await probeFreshness(root)).state).toBe('no-fingerprint');
+	});
+
+	test('incomplete walks expose positive changes but never infer removals', async () => {
+		const root = workspace();
+		const a = source(root);
+		const removed = source(root, 'src/removed.ts');
+		const graph = buildWorkspaceGraph(root);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		fs.rmSync(removed);
+
+		const stats = fs.statSync(a);
+		_internals.walkRepoGraphInputs = async () => ({
+			sourceFiles: [a],
+			manifestFiles: [],
+			metadata: [
+				{
+					absolutePath: a,
+					kind: 'source',
+					sizeBytes: stats.size + 1,
+					mtimeMs: stats.mtimeMs,
+				},
+			],
+			manifestDirs: new Set(),
+			truncated: true,
+			truncationReason: 'budget',
+			incomplete: true,
+			unreadableDirectories: [],
+			unreadableFiles: [],
+			probedFiles: 1,
+			elapsedMs: 5,
+		});
+		invalidateFreshnessCache(root);
+		const result = await probeFreshness(root);
+		expect(result.state).toBe('inconclusive');
+		expect(result.changed).toEqual([a]);
+		expect(result.removed).toEqual([]);
+		expect(result.truncated).toBe(true);
+	});
+
+	test('coalesces concurrent probes and expires cached results after 30 seconds', async () => {
+		const root = workspace();
+		source(root);
+		const graph = buildWorkspaceGraph(root);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+
+		let now = 100;
+		let walks = 0;
+		_internals.now = () => now;
+		_internals.walkRepoGraphInputs = async (...args) => {
+			walks++;
+			await Promise.resolve();
+			return realWalk(...args);
+		};
+		invalidateFreshnessCache(root);
+		await Promise.all([
+			probeFreshness(root),
+			probeFreshness(root),
+			probeFreshness(root),
+		]);
+		expect(walks).toBe(1);
+		await probeFreshness(root);
+		expect(walks).toBe(1);
+		now += 30_001;
+		await probeFreshness(root);
+		expect(walks).toBe(2);
+	});
+
+	test('evicts the least-recently-used project after 16 cached roots', async () => {
+		const projects = Array.from({ length: 17 }, () => workspace());
+		for (const root of projects) {
+			expect(await writeFingerprint(root, buildWorkspaceGraph(root))).toBe(
+				true,
+			);
+		}
+
+		const walks = new Map<string, number>();
+		_internals.walkRepoGraphInputs = async (root, options) => {
+			walks.set(root, (walks.get(root) ?? 0) + 1);
+			return realWalk(root, options);
+		};
+		invalidateFreshnessCache();
+		for (const root of projects.slice(0, 16)) await probeFreshness(root);
+		await probeFreshness(projects[0]); // refresh root 0's LRU position
+		await probeFreshness(projects[16]); // evicts root 1
+		await probeFreshness(projects[0]);
+		await probeFreshness(projects[1]);
+		expect(walks.get(projects[0])).toBe(1);
+		expect(walks.get(projects[1])).toBe(2);
+	});
+
+	test('retries transient Windows-style atomic rename failures', async () => {
+		const root = workspace();
+		source(root);
+		const graph = buildWorkspaceGraph(root);
+		let attempts = 0;
+		_internals.retryDelayMs = 0;
+		_internals.fsRename = async (...args) => {
+			attempts++;
+			if (attempts < 3) {
+				throw Object.assign(new Error('locked by scanner'), { code: 'EPERM' });
+			}
+			return realRename(...args);
+		};
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		expect(attempts).toBe(3);
+		expect((await probeFreshness(root)).state).toBe('clean');
+	});
+
+	test('bounds exhausted atomic rename retries and fails without a partial sidecar', async () => {
+		const root = workspace();
+		source(root);
+		const graph = buildWorkspaceGraph(root);
+		let attempts = 0;
+		_internals.retryDelayMs = 0;
+		_internals.fsRename = async () => {
+			attempts++;
+			throw Object.assign(new Error('still locked'), { code: 'EBUSY' });
+		};
+		expect(await writeFingerprint(root, graph)).toBe(false);
+		expect(attempts).toBe(5);
+		const files = fs.readdirSync(path.join(root, '.swarm'));
+		expect(files.some((file) => file.includes('repo-graph.fingerprint'))).toBe(
+			false,
+		);
+	});
+
+	test('persists a truncated positive prefix that probes as inconclusive', async () => {
+		const root = workspace();
+		source(root, 'src/a.ts');
+		source(root, 'src/b.ts');
+		const options = { maxFiles: 1 };
+		const graph = buildWorkspaceGraph(root, options);
+		expect(graph.diagnostics?.walkTruncated).toBe(true);
+		expect(await writeFingerprint(root, graph, options)).toBe(true);
+		const probe = await probeFreshness(root, options);
+		expect(probe.state).toBe('inconclusive');
+		expect(probe.removed).toEqual([]);
+		expect(probe.truncated).toBe(true);
+	});
+});

--- a/tests/unit/tools/repo-graph-health.test.ts
+++ b/tests/unit/tools/repo-graph-health.test.ts
@@ -7,6 +7,7 @@ import {
 	buildWorkspaceGraphAsync,
 	clearCache,
 	createEmptyGraph,
+	type FreshnessProbe,
 	getGraphHealth,
 	loadGraph,
 	type RepoGraph,
@@ -136,6 +137,7 @@ describe('repo graph health diagnostics', () => {
 			unsupportedFiles: ['README.md', '/etc/passwd'],
 			binaryFiles: ['src/blob.ts'],
 			unreadableFiles: ['src/secret.ts'],
+			validationSkippedFiles: ['src/invalid.ts', '../invalid.ts'],
 			lowConfidenceEdgeCount: 3,
 		};
 
@@ -153,11 +155,48 @@ describe('repo graph health diagnostics', () => {
 		expect(health.unsupportedFiles).toEqual(['README.md']);
 		expect(health.binaryFiles).toEqual(['src/blob.ts']);
 		expect(health.unreadableFiles).toEqual(['src/secret.ts']);
+		expect(health.validationSkippedFiles).toEqual(['src/invalid.ts']);
 		expect(health.lowConfidenceEdgeCount).toBe(3);
 		expect(health.notes).toContain('1 binary files skipped during last build.');
 		expect(health.notes).toContain(
 			'1 unreadable files skipped during last build.',
 		);
+	});
+
+	test('health derives additions and removals from the content probe', () => {
+		const graph = createEmptyGraph(tmp);
+		const probe: FreshnessProbe = {
+			state: 'drifted',
+			changed: [path.join(tmp, 'src/new.ts')],
+			removed: [path.join(tmp, 'src/removed.ts')],
+			truncated: false,
+			probedFiles: 2,
+			elapsedMs: 1,
+		};
+
+		const health = getGraphHealth(graph, tmp, probe);
+
+		expect(health.fresh).toBe(false);
+		expect(health.probeState).toBe('drifted');
+		expect(health.staleFiles).toEqual(['src/new.ts', 'src/removed.ts']);
+	});
+
+	test('health reports incomplete probe state without claiming stale content', () => {
+		const graph = createEmptyGraph(tmp);
+		const probe: FreshnessProbe = {
+			state: 'inconclusive',
+			changed: [],
+			removed: [],
+			truncated: true,
+			probedFiles: 1,
+			elapsedMs: 1,
+		};
+
+		const health = getGraphHealth(graph, tmp, probe);
+
+		expect(health.fresh).toBe(false);
+		expect(health.probeState).toBe('inconclusive');
+		expect(health.notes.join('\n')).toContain('freshness is unknown');
 	});
 
 	test('old graph without diagnostics loads and reports empty health diagnostics', async () => {

--- a/tests/unit/tools/repo-graph-incremental-freshness.test.ts
+++ b/tests/unit/tools/repo-graph-incremental-freshness.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { clearCache } from '../../../src/tools/repo-graph/cache';
+import {
+	_internals,
+	updateGraphForFiles,
+} from '../../../src/tools/repo-graph/incremental';
+import { saveGraph } from '../../../src/tools/repo-graph/storage';
+import {
+	type BuildWorkspaceGraphOptions,
+	createEmptyGraph,
+	type GraphNode,
+	normalizeGraphPath,
+	type RepoGraph,
+} from '../../../src/tools/repo-graph/types';
+
+const realInternals = { ..._internals };
+
+function makeNode(filePath: string, exports = ['old']): GraphNode {
+	return {
+		filePath,
+		moduleName: path.basename(filePath),
+		exports,
+		imports: [],
+		language: 'typescript',
+		mtime: new Date().toISOString(),
+	};
+}
+
+describe('incremental freshness persistence and filesystem safety', () => {
+	let root: string;
+	let source: string;
+	let graph: RepoGraph;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(
+			path.join(tmpdir(), 'repo-graph-incremental-1986-'),
+		);
+		source = path.join(root, 'a.ts');
+		await fs.writeFile(source, 'export const old = 1;\n', 'utf8');
+		graph = createEmptyGraph(root);
+		graph.nodes[normalizeGraphPath(source)] = makeNode(source);
+		graph.metadata.nodeCount = 1;
+		await saveGraph(root, graph);
+	});
+
+	afterEach(async () => {
+		Object.assign(_internals, realInternals);
+		clearCache(root);
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	test('persists graph before fingerprint and threads freshness limits', async () => {
+		const calls: string[] = [];
+		let fingerprintOptions: BuildWorkspaceGraphOptions | undefined;
+		_internals.saveGraph = async () => {
+			calls.push('graph');
+		};
+		_internals.writeFingerprint = async (_root, _graph, options) => {
+			calls.push('fingerprint');
+			fingerprintOptions = options;
+			return true;
+		};
+		const buildOptions: BuildWorkspaceGraphOptions = {
+			maxFiles: 321,
+			walkBudgetMs: 4321,
+			followSymlinks: true,
+			excludeDirs: ['generated'],
+		};
+
+		await updateGraphForFiles(root, [], { buildOptions });
+
+		expect(calls).toEqual(['graph', 'fingerprint']);
+		expect(fingerprintOptions).toEqual({
+			maxFiles: 321,
+			walkBudgetMs: 4321,
+			followSymlinks: true,
+			excludeDirs: ['generated'],
+		});
+	});
+
+	test('threads build options through forced and missing-graph rebuilds', async () => {
+		const observed: Array<BuildWorkspaceGraphOptions | undefined> = [];
+		_internals.buildWorkspaceGraphAsync = async (_root, options) => {
+			observed.push(options);
+			return createEmptyGraph(root);
+		};
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+		const buildOptions = { maxFiles: 123, walkBudgetMs: 2345 };
+
+		await updateGraphForFiles(root, [], { forceRebuild: true, buildOptions });
+		clearCache(root);
+		await fs.rm(path.join(root, '.swarm', 'repo-graph.json'));
+		await updateGraphForFiles(root, [], { buildOptions });
+
+		expect(observed).toEqual([buildOptions, buildOptions]);
+	});
+
+	test('deletes a node only after ENOENT authorization', async () => {
+		await fs.rm(source);
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]).toBeUndefined();
+	});
+
+	test('preserves the last-known graph on a transient stat error', async () => {
+		const realStat = _internals.stat;
+		_internals.stat = async (target) => {
+			if (target === source) {
+				throw Object.assign(new Error('sharing violation'), { code: 'EACCES' });
+			}
+			return realStat(target);
+		};
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]?.exports).toEqual(['old']);
+		expect(updated.diagnostics?.unreadableFiles).toContain('a.ts');
+	});
+
+	test('scans a removed path that was recreated before reconciliation', async () => {
+		_internals.scanFileAsync = async () => ({
+			node: makeNode(source, ['recreated']),
+			edges: [],
+			symbolEdges: [],
+		});
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]?.exports).toEqual([
+			'recreated',
+		]);
+	});
+
+	test('preserves prior data when a live file cannot be read', async () => {
+		_internals.scanFileAsync = async () => ({
+			node: null,
+			edges: [],
+			symbolEdges: [],
+			diagnostics: { unreadableFiles: ['a.ts'] },
+		});
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]?.exports).toEqual(['old']);
+		expect(updated.diagnostics?.unreadableFiles).toEqual(['a.ts']);
+		expect(updated.diagnostics?.extractorInputWitnesses).toEqual([]);
+	});
+
+	test('records a stable witness when a file becomes oversized', async () => {
+		const witness = {
+			file: 'a.ts',
+			kind: 'stable-skip' as const,
+			sizeBytes: 2_000_000,
+			mtimeMs: 1234,
+		};
+		_internals.scanFileAsync = async () => ({
+			node: null,
+			edges: [],
+			symbolEdges: [],
+			diagnostics: { oversizedFiles: ['a.ts'] },
+			inputWitness: witness,
+		});
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]).toBeUndefined();
+		expect(updated.diagnostics?.extractorInputWitnesses).toEqual([witness]);
+	});
+
+	test('preserves prior data and records a validation-skipped diagnostic', async () => {
+		_internals.scanFileAsync = async () => ({
+			node: { ...makeNode(source, ['invalid']), moduleName: 'bad\u0000name' },
+			edges: [],
+			symbolEdges: [],
+		});
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.nodes[normalizeGraphPath(source)]?.exports).toEqual(['old']);
+		expect(updated.diagnostics?.validationSkippedFiles).toEqual(['a.ts']);
+	});
+
+	test('replaces stale per-file diagnostics without disturbing other files', async () => {
+		graph.diagnostics = {
+			oversizedFiles: ['a.ts', 'other.ts'],
+			binaryFiles: ['a.ts'],
+			unreadableFiles: ['a.ts'],
+			validationSkippedFiles: ['a.ts'],
+			extractorInputWitnesses: [
+				{
+					file: 'a.ts',
+					kind: 'stable-skip',
+					sizeBytes: 100,
+					mtimeMs: 10,
+				},
+				{
+					file: 'package.json',
+					kind: 'manifest',
+					sizeBytes: 200,
+					mtimeMs: 20,
+				},
+			],
+		};
+		await saveGraph(root, graph);
+		_internals.scanFileAsync = async () => ({
+			node: makeNode(source, ['healthy']),
+			edges: [],
+			symbolEdges: [],
+		});
+		_internals.saveGraph = async () => {};
+		_internals.writeFingerprint = async () => true;
+
+		const updated = await updateGraphForFiles(root, [source]);
+
+		expect(updated.diagnostics?.oversizedFiles).toEqual(['other.ts']);
+		expect(updated.diagnostics?.binaryFiles).toEqual([]);
+		expect(updated.diagnostics?.unreadableFiles).toEqual([]);
+		expect(updated.diagnostics?.validationSkippedFiles).toEqual([]);
+		expect(updated.diagnostics?.extractorInputWitnesses).toEqual([
+			{
+				file: 'package.json',
+				kind: 'manifest',
+				sizeBytes: 200,
+				mtimeMs: 20,
+			},
+		]);
+	});
+});

--- a/tests/unit/tools/repo-graph-input-walk.test.ts
+++ b/tests/unit/tools/repo-graph-input-walk.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	isGraphWideInputPath,
+	walkRepoGraphInputs,
+} from '../../../src/tools/repo-graph/builder';
+
+const roots: string[] = [];
+
+function workspace(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-input-walk-'));
+	roots.push(root);
+	return root;
+}
+
+function write(root: string, name: string): string {
+	const target = path.join(root, name);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, `${name}\n`);
+	return target;
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) {
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe('shared repo graph input walker', () => {
+	test('enumerates source files and graph-wide manifests with metadata', async () => {
+		const root = workspace();
+		const source = write(root, 'src/a.ts');
+		const manifest = write(root, 'packages/a/Cargo.toml');
+		write(root, 'README.md');
+		const walked = await walkRepoGraphInputs(root, { captureMetadata: true });
+		expect(walked.sourceFiles).toEqual([source]);
+		expect(walked.manifestFiles).toEqual([manifest]);
+		expect(walked.metadata.map((entry) => entry.absolutePath).sort()).toEqual(
+			[source, manifest].sort(),
+		);
+		expect(walked.metadata.every((entry) => entry.sizeBytes > 0)).toBe(true);
+		expect(walked.incomplete).toBe(false);
+		expect(walked.manifestDirs.has('packages/a')).toBe(true);
+	});
+
+	test('uses one shared graph-wide manifest classifier', () => {
+		for (const name of [
+			'package.json',
+			'Cargo.toml',
+			'pyproject.toml',
+			'go.mod',
+		]) {
+			expect(isGraphWideInputPath(path.join('nested', name))).toBe(true);
+		}
+		expect(isGraphWideInputPath('nested/tsconfig.json')).toBe(false);
+	});
+
+	test('honors exclusions and reports cap truncation conservatively', async () => {
+		const root = workspace();
+		write(root, 'generated/skip.ts');
+		write(root, 'src/a.ts');
+		write(root, 'src/b.ts');
+		const walked = await walkRepoGraphInputs(root, {
+			captureMetadata: true,
+			excludeDirs: ['generated'],
+			maxFiles: 1,
+		});
+		expect(walked.sourceFiles).toHaveLength(1);
+		expect(walked.sourceFiles[0]).not.toContain('generated');
+		expect(walked.truncated).toBe(true);
+		expect(walked.truncationReason).toBe('cap');
+		expect(walked.incomplete).toBe(true);
+	});
+});

--- a/tests/unit/tools/repo-graph-node-witness.test.ts
+++ b/tests/unit/tools/repo-graph-node-witness.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import type { GraphNode } from '../../../src/tools/repo-graph/types';
+import { validateGraphNode } from '../../../src/tools/repo-graph/validation';
+
+function node(overrides: Partial<GraphNode> = {}): GraphNode {
+	return {
+		filePath:
+			process.platform === 'win32' ? 'C:\\workspace\\a.ts' : '/workspace/a.ts',
+		moduleName: 'a.ts',
+		exports: [],
+		imports: [],
+		language: 'typescript',
+		mtime: new Date(0).toISOString(),
+		...overrides,
+	};
+}
+
+describe('GraphNode freshness witnesses', () => {
+	test('accepts legacy nodes and paired finite non-negative witnesses', () => {
+		expect(() => validateGraphNode(node())).not.toThrow();
+		expect(() =>
+			validateGraphNode(node({ sizeBytes: 12, mtimeMs: 123.456 })),
+		).not.toThrow();
+	});
+
+	test('rejects unpaired, negative, and non-finite witnesses', () => {
+		expect(() => validateGraphNode(node({ sizeBytes: 1 }))).toThrow(
+			/must either both be present/,
+		);
+		expect(() =>
+			validateGraphNode(node({ sizeBytes: -1, mtimeMs: 1 })),
+		).toThrow(/sizeBytes/);
+		expect(() =>
+			validateGraphNode(node({ sizeBytes: 1, mtimeMs: Number.NaN })),
+		).toThrow(/mtimeMs/);
+	});
+});

--- a/tests/unit/tools/repo-graph-save-if-dirty-freshness.test.ts
+++ b/tests/unit/tools/repo-graph-save-if-dirty-freshness.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	clearCache,
+	markDirty,
+	setCachedGraph,
+} from '../../../src/tools/repo-graph/cache';
+import {
+	_internals,
+	getGraphPath,
+	saveIfDirty,
+} from '../../../src/tools/repo-graph/storage';
+import { createEmptyGraph } from '../../../src/tools/repo-graph/types';
+
+const realWriteFingerprint = _internals.writeFingerprint;
+
+describe('saveIfDirty freshness pairing', () => {
+	let root: string;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(tmpdir(), 'repo-graph-dirty-1986-'));
+	});
+
+	afterEach(async () => {
+		_internals.writeFingerprint = realWriteFingerprint;
+		clearCache(root);
+		await fs.rm(root, { recursive: true, force: true });
+	});
+
+	test('writes the graph before certifying its fingerprint', async () => {
+		const graph = createEmptyGraph(root);
+		setCachedGraph(root, graph);
+		markDirty(root);
+		let persistedBeforeFingerprint = false;
+		_internals.writeFingerprint = async (workspace, savedGraph, options) => {
+			const persisted = JSON.parse(
+				await fs.readFile(getGraphPath(workspace), 'utf8'),
+			) as { schema_version?: string };
+			persistedBeforeFingerprint =
+				persisted.schema_version === savedGraph.schema_version;
+			expect(options).toEqual({ maxFiles: 777 });
+			return true;
+		};
+
+		await saveIfDirty(root, { maxFiles: 777 });
+
+		expect(persistedBeforeFingerprint).toBe(true);
+	});
+});

--- a/tests/unit/tools/repo-graph-witness-scale.test.ts
+++ b/tests/unit/tools/repo-graph-witness-scale.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	invalidateFreshnessCache,
+	loadGraph,
+	probeFreshness,
+	saveGraph,
+	updateGraphForFiles,
+	writeFingerprint,
+} from '../../../src/tools/repo-graph';
+
+const roots: string[] = [];
+
+async function workspace(): Promise<string> {
+	const root = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'repo-graph-witness-scale-'),
+	);
+	roots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	invalidateFreshnessCache();
+	for (const root of roots.splice(0)) {
+		clearCache(root);
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+describe('repo graph correctness witnesses above the display cap', () => {
+	test('certifies 201 stable skips even though display diagnostics stop at 200', async () => {
+		const root = await workspace();
+		for (let index = 0; index < 201; index++) {
+			await fs.writeFile(
+				path.join(root, `oversized-${index}.ts`),
+				'export const oversized = true;\n',
+			);
+		}
+
+		const graph = await buildWorkspaceGraphAsync(root, {
+			maxFileSizeBytes: 1,
+		});
+		expect(graph.diagnostics?.oversizedFiles).toHaveLength(200);
+		expect(
+			graph.diagnostics?.extractorInputWitnesses?.filter(
+				(entry) => entry.kind === 'stable-skip',
+			),
+		).toHaveLength(201);
+		await saveGraph(root, graph);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		expect((await probeFreshness(root)).state).toBe('clean');
+	});
+
+	test('retains and certifies 201 manifests after a small incremental refresh', async () => {
+		const root = await workspace();
+		for (let index = 0; index < 201; index++) {
+			const directory = path.join(root, 'packages', `p${index}`);
+			await fs.mkdir(directory, { recursive: true });
+			await fs.writeFile(
+				path.join(directory, 'package.json'),
+				`{"name":"p${index}"}\n`,
+			);
+		}
+		const source = path.join(root, 'source.ts');
+		await fs.writeFile(source, 'export const value = 1;\n');
+
+		const graph = await buildWorkspaceGraphAsync(root);
+		await saveGraph(root, graph);
+		expect(await writeFingerprint(root, graph)).toBe(true);
+		await fs.writeFile(source, 'export const value = 2;\n');
+
+		await updateGraphForFiles(root, [source]);
+		const updated = await loadGraph(root);
+		expect(
+			updated?.diagnostics?.extractorInputWitnesses?.filter(
+				(entry) => entry.kind === 'manifest',
+			),
+		).toHaveLength(201);
+		expect((await probeFreshness(root)).state).toBe('clean');
+	});
+});

--- a/tests/unit/tools/repo-map-freshness.test.ts
+++ b/tests/unit/tools/repo-map-freshness.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	type FreshnessProbe,
+	type RepoGraph,
+	saveGraph,
+} from '../../../src/tools/repo-graph';
+import { _internals, repo_map } from '../../../src/tools/repo-map';
+
+type Executable = {
+	execute: (
+		args: Record<string, unknown>,
+		ctx: { directory: string },
+	) => Promise<string>;
+};
+
+const originalLoadConfig = _internals.loadPluginConfigWithMeta;
+const originalProbe = _internals.probeFreshness;
+const originalUpdate = _internals.updateGraphForFiles;
+
+let tmp: string;
+let graph: RepoGraph;
+
+function config(overrides: Record<string, unknown> = {}): void {
+	_internals.loadPluginConfigWithMeta = (() => ({
+		config: { repo_graph: overrides },
+		recovery: 'none',
+		removedKeys: [],
+		warnings: [],
+		loadedFromFile: false,
+		configHadErrors: false,
+	})) as typeof _internals.loadPluginConfigWithMeta;
+}
+
+function probe(
+	state: FreshnessProbe['state'],
+	changed: string[] = [],
+	removed: string[] = [],
+): FreshnessProbe {
+	return {
+		state,
+		changed,
+		removed,
+		truncated: state === 'inconclusive',
+		probedFiles: 2,
+		elapsedMs: 1,
+	};
+}
+
+async function call(
+	args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const raw = await (repo_map as unknown as Executable).execute(args, {
+		directory: tmp,
+	});
+	return JSON.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+	tmp = fs.realpathSync(
+		fs.mkdtempSync(path.join(os.tmpdir(), 'repo-map-freshness-')),
+	);
+	fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+	fs.writeFileSync(path.join(tmp, 'src/a.ts'), 'export const a = 1;\n');
+	graph = await buildWorkspaceGraphAsync(tmp);
+	await saveGraph(tmp, graph);
+	config();
+});
+
+afterEach(() => {
+	_internals.loadPluginConfigWithMeta = originalLoadConfig;
+	_internals.probeFreshness = originalProbe;
+	_internals.updateGraphForFiles = originalUpdate;
+	clearCache(tmp);
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('repo_map bounded freshness refresh', () => {
+	test('refreshes complete source drift at the cap and reports the detected set', async () => {
+		const changed = path.join(tmp, 'src/a.ts');
+		let probeCalls = 0;
+		let updatePaths: string[] = [];
+		config({ refresh_cap: 1 });
+		_internals.probeFreshness = async () =>
+			probeCalls++ === 0 ? probe('drifted', [changed]) : probe('clean');
+		_internals.updateGraphForFiles = (async (_root, paths) => {
+			updatePaths = paths;
+			return graph;
+		}) as typeof _internals.updateGraphForFiles;
+
+		const result = await call({ action: 'key_files' });
+
+		expect(updatePaths).toEqual([changed]);
+		expect(result.probeState).toBe('clean');
+		expect(result.changedFiles).toBe(1);
+		expect(result.refreshedFiles).toBe(1);
+		expect(result.stale).toBe(false);
+	});
+
+	test('does not refresh drift above the configured cap', async () => {
+		const changed = [path.join(tmp, 'src/a.ts'), path.join(tmp, 'src/b.ts')];
+		let updateCalls = 0;
+		config({ refresh_cap: 1 });
+		_internals.probeFreshness = async () => probe('drifted', changed);
+		_internals.updateGraphForFiles = (async () => {
+			updateCalls++;
+			return graph;
+		}) as typeof _internals.updateGraphForFiles;
+
+		const result = await call({ action: 'key_files' });
+
+		expect(updateCalls).toBe(0);
+		expect(result.stale).toBe(true);
+		expect(result.changedFiles).toBe(2);
+		expect(result.freshnessNote).toContain('refresh_cap=1');
+	});
+
+	test('keeps incomplete positive observations read-only and marks freshness unknown', async () => {
+		let updateCalls = 0;
+		_internals.probeFreshness = async () =>
+			probe('inconclusive', [path.join(tmp, 'src/a.ts')]);
+		_internals.updateGraphForFiles = (async () => {
+			updateCalls++;
+			return graph;
+		}) as typeof _internals.updateGraphForFiles;
+
+		const result = await call({ action: 'key_files' });
+
+		expect(updateCalls).toBe(0);
+		expect(result.probeState).toBe('inconclusive');
+		expect(result.changedFiles).toBe(1);
+		expect(result.refreshedFiles).toBe(0);
+		expect(result.stale).toBe(false);
+	});
+
+	test('reports manifest drift as rebuild-only even below the refresh cap', async () => {
+		let updateCalls = 0;
+		_internals.probeFreshness = async () =>
+			probe('drifted', [path.join(tmp, 'package.json')]);
+		_internals.updateGraphForFiles = (async () => {
+			updateCalls++;
+			return graph;
+		}) as typeof _internals.updateGraphForFiles;
+
+		const result = await call({ action: 'key_files' });
+
+		expect(updateCalls).toBe(0);
+		expect(result.stale).toBe(true);
+		expect(result.freshnessNote).toContain('manifest drift');
+	});
+
+	test('short-circuits every action when repository graphs are disabled', async () => {
+		config({ enabled: false });
+
+		const result = await call({ action: 'key_files' });
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('repo_graph.enabled=false');
+	});
+});

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -113,15 +113,12 @@ describe('repo_map: graph_health', () => {
 		expect(r.unresolvedImports).toEqual([]);
 	});
 
-	it('reports stale graph health after persisted timestamp changes', async () => {
+	it('reports stale graph health after source content changes', async () => {
 		await call({ action: 'build' });
-		const graphPath = path.join(tmp, '.swarm', 'repo-graph.json');
-		const graph = JSON.parse(fs.readFileSync(graphPath, 'utf-8')) as {
-			metadata: { generatedAt: string };
-		};
-		graph.metadata.generatedAt = '2000-01-01T00:00:00.000Z';
-		fs.writeFileSync(graphPath, JSON.stringify(graph), 'utf-8');
-		fs.utimesSync(graphPath, new Date(), new Date());
+		fs.appendFileSync(
+			path.join(tmp, 'src/main.ts'),
+			'\nexport const drift = 1;\n',
+		);
 
 		const out = await call({ action: 'graph_health' });
 		const r = JSON.parse(out) as {
@@ -133,7 +130,7 @@ describe('repo_map: graph_health', () => {
 		expect(r.success).toBe(true);
 		expect(r.fresh).toBe(false);
 		expect(r.staleFiles).toContain('src/main.ts');
-		expect(r.notes.join('\n')).toContain('Graph is stale');
+		expect(r.notes.join('\n')).toContain('Graph content is stale');
 	});
 
 	it('returns a structured graph_health error for corrupt graph JSON', async () => {

--- a/tests/unit/utils/path-security.test.ts
+++ b/tests/unit/utils/path-security.test.ts
@@ -225,4 +225,96 @@ describe('validateSymlinkBoundary', () => {
 			fs.rmSync(tmpDir, { recursive: true });
 		},
 	);
+
+	test('rejects a not-yet-existing target whose ".." tail would escape the root', () => {
+		const root = fs.mkdtempSync(
+			path.join(fs.realpathSync(os.tmpdir()), 'dotdot-tail-root-'),
+		);
+		try {
+			// subdir/../../escaped.txt: neither 'subdir' nor 'escaped.txt'
+			// exists, and the '..' segments climb out past root once resolved.
+			// The fix must normalize this tail before composing with the
+			// resolved ancestor, not just check the ancestor in isolation. This
+			// is a general containment guard test, not #1986 regression coverage
+			// — it also passes against the pre-#1986-fix implementation.
+			const target = `${root}${path.sep}subdir${path.sep}..${path.sep}..${path.sep}escaped.txt`;
+			expect(() => validateSymlinkBoundary(target, root)).toThrow(
+				'Symlink resolution escaped boundary',
+			);
+		} finally {
+			fs.rmSync(root, { recursive: true });
+		}
+	});
 });
+
+describe(
+	'validateSymlinkBoundary — regression: not-yet-existing target under a ' +
+		'symlinked root spuriously rejected (#1986)',
+	() => {
+		// Previous code resolved a not-yet-existing target via path.resolve
+		// (unresolved literal path) while an existing, symlinked root resolved
+		// via realpathSync (fully resolved) — an apples-to-oranges comparison
+		// that spuriously threw "escaped boundary" even though the target was
+		// genuinely inside the root. This mirrors macOS's /var -> /private/var
+		// symlink: any workspace root under /tmp or /var hit this on first
+		// write, before the target file existed.
+		//
+		// Both tests below are falsifiable against the pre-fix implementation:
+		// reverting resolveNearestExistingCanonical to a direct
+		// realpathSync-or-path.resolve fallback (the old validateSymlinkBoundary
+		// body) makes the first test throw spuriously and the second test throw
+		// for the wrong reason (both symptoms of the apples-to-oranges bug).
+		test.skipIf(process.platform === 'win32')(
+			'accepts a not-yet-existing target directly under a symlinked root',
+			() => {
+				const realBase = fs.mkdtempSync(
+					path.join(fs.realpathSync(os.tmpdir()), 'symlink-root-real-'),
+				);
+				const linkRoot = path.join(
+					fs.realpathSync(os.tmpdir()),
+					`symlink-root-link-${process.pid}-${Date.now()}`,
+				);
+				fs.symlinkSync(realBase, linkRoot, 'dir');
+
+				try {
+					// repo-graph.json does not exist yet — this is the exact shape
+					// of the pre-fix failure (creating .swarm/repo-graph.json under
+					// a workspace root that is itself a symlink).
+					const target = path.join(linkRoot, 'repo-graph.json');
+					expect(() => validateSymlinkBoundary(target, linkRoot)).not.toThrow();
+				} finally {
+					fs.unlinkSync(linkRoot);
+					fs.rmSync(realBase, { recursive: true });
+				}
+			},
+		);
+
+		test.skipIf(process.platform === 'win32')(
+			'rejects a not-yet-existing target under a symlinked subdirectory that escapes the root',
+			() => {
+				const root = fs.mkdtempSync(
+					path.join(fs.realpathSync(os.tmpdir()), 'symlink-escape-root-'),
+				);
+				const elsewhere = fs.mkdtempSync(
+					path.join(fs.realpathSync(os.tmpdir()), 'symlink-escape-target-'),
+				);
+				const linkedSubdir = path.join(root, 'escape-link');
+				fs.symlinkSync(elsewhere, linkedSubdir, 'dir');
+
+				try {
+					// evil.txt does not exist yet, but its parent (the symlinked
+					// subdirectory) does — the nearest-existing-ancestor walk must
+					// still resolve that symlink and reject the escape.
+					const target = path.join(linkedSubdir, 'evil.txt');
+					expect(() => validateSymlinkBoundary(target, root)).toThrow(
+						'Symlink resolution escaped boundary',
+					);
+				} finally {
+					fs.unlinkSync(linkedSubdir);
+					fs.rmSync(root, { recursive: true });
+					fs.rmSync(elsewhere, { recursive: true });
+				}
+			},
+		);
+	},
+);


### PR DESCRIPTION
Closes #1986

## Summary
- Add a bounded, content-based repository-graph fingerprint probe and reuse a certified persisted graph across clean sessions.
- Refresh small complete source drift incrementally, while manifest drift, over-cap changes, and inconclusive walks fall back conservatively without unsafe deletion.
- Wire freshness state through startup, repository-map queries, and graph-context injection; add configuration, scale-safe witnesses, documentation, and a release fragment.

## Invariant audit
- 1 (plugin init): touched — `bun run build`, `node scripts/repro-704.mjs` (T1 254.1 ms, under the 400 ms deadline), and disabled-startup coverage passed.
- 2 (runtime portability): touched — `bun run build`; bundle-portability (10 pass), plugin-shape (2 pass), Node ESM import, and `bun run repro:1873` passed.
- 3 (subprocesses): not touched — no production subprocess call was added or changed.
- 4 (.swarm containment): touched — the sidecar fingerprint is validated and stored only alongside `.swarm/repo-graph.json`; certification and atomic-persistence tests passed.
- 5 (plan durability): not touched — no plan ledger, projection, import, or export path changed.
- 6 (test_runner safety): not touched — no `test_runner` change and no broad tool invocation was used.
- 7 (test writing): touched — new focused `bun:test` files remain under the 500-line cap, use DI seams, and add no `mock.module` calls; `check-test-file-cap.sh` passed.
- 8 (session state): touched — per-directory bounded LRU caches (16 entries) and a 30-second single-flight probe cache are covered by cache tests.
- 9 (guardrails/retry): not touched — no guardrail or retry behavior changed.
- 10 (chat/system msg): touched — both graph-context injection paths now receive the same freshness state; focused hook tests passed.
- 11 (tool registration): not touched — no tool was added, removed, or remapped; `check-tool-registration.ts` passed (116 coherent tools).
- 12 (release/cache): touched — added the required pending release fragment and bounded fingerprint/cache lifecycle coverage; generated `dist/` remains unstaged.

## Test plan
- `bun run test:unit:ci` on the 10 directly affected graph/config/startup files — passed.
- 50 isolated graph/config/system unit files (687 pass), plus bundle contract tests (12 pass) — passed.
- `bun run typecheck`, `bun run lint:ci`, `bun run build`, `bun run drift:check`, `git diff --check`, `bun run repro:1873`, Node ESM import, and `node scripts/repro-704.mjs` — passed.
- `bun test tests/security --timeout 120000` — 163 pass, 4 intentional skips; `bun test tests/adversarial --timeout 120000` — 846 pass; `bun test tests/smoke --timeout 120000` — 10 pass.
- `check-tool-registration.ts`, `check-test-file-cap.sh`, `check-mock-cleanup.sh`, `check-cross-contamination.sh`, and `check-test-clock.sh` — passed, with documented pre-existing warnings only.
- `bun test tests/integration --timeout 120000` — 590 pass / 236 existing failures in unrelated shared-state and port-binding suites; the issue diff has no overlap with the failing paths, while the affected CI-isolated suite above passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

