### PR TITLE
fix(pr-workflow): add total wake budget and widen depth-tier thresholds

### DIFF
--- a/docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md
+++ b/docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md
@@ -1,0 +1,11 @@
+## PR workflow: total wake budget + widened depth tiers (#1967 Ship 2)
+
+**Problem A — auto-resume loop unbounded:** The PR-workflow auto-resume loop had only a consecutive-unproductive counter (5) that reset to 0 whenever the durable gate's `revision` advanced. There was no total-wake cap, so any state-mutating controller call bought 5 fresh wakes, allowing unbounded compaction loops on large-context models.
+
+**Fix:** Added a total per-session wake budget (totalWakes) alongside the existing consecutive budget. The total counter increments on every attempted wake (including failures and timeouts) and is never reset by revision progress. When exhausted, the session suspends with a distinct total-cap notice (not the consecutive-unproductive wording) naming all three recovery paths.
+
+The ceiling is context-aware (Option C): scaled by the PR-review depth tier, with per-tier values derived from each tier's consolidation-floor workload: Small (S): 12, Medium (M): 54, Large (L): 102 (>=100, above the ~40-55 healthy minimum). Configurable via createPrWorkflowResponseGate({ totalWakeCeiling }). The bound is per-process (in-memory Map, resets on plugin reload).
+
+**Problem B — depth tiers rarely engaged:** The depth-tier thresholds (Small <=50 lines/<=3 files, Medium <=500 lines/<=20 files) were so tight that most real PRs landed at tier Large.
+
+**Fix:** Widened to Small <=100 lines/<=5 files, Medium <=1500 lines/<=50 files. All six base dimensions and all eleven risk families remain mandatory at every tier. Fail-strict-to-Large on unknown stats and submodule changes preserved.

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -103,10 +103,10 @@ export type PrReviewDepthTier = 'S' | 'M' | 'L';
  * always dispatch more lanes than a tier's floor, never fewer.
  */
 export const PR_REVIEW_DEPTH_TIER_THRESHOLDS = {
-	smallMaxChangedLines: 50,
-	smallMaxChangedFiles: 3,
-	mediumMaxChangedLines: 500,
-	mediumMaxChangedFiles: 20,
+	smallMaxChangedLines: 100,
+	smallMaxChangedFiles: 5,
+	mediumMaxChangedLines: 1500,
+	mediumMaxChangedFiles: 50,
 } as const;
 
 /**
@@ -123,7 +123,7 @@ export const PR_REVIEW_BASE_LANE_FLOORS: Record<PrReviewDepthTier, number> = {
 /**
  * Minimum lane counts for a FULL micro (risk-family) sweep per depth tier. These
  * mirror the base floors' tier *semantics* — not their numbers — scaled to the
- * eleven risk families: S does not bind (a tier-S PR of ≤50 lines/≤3 files may
+ * eleven risk families: S does not bind (a tier-S PR of ≤100 lines/≤5 files may
  * consolidate a full sweep into one lane, exactly as base tier S permits); M
  * requires at least half the families to get independent lanes (ceil(11/2) = 6,
  * the deliberate scale-up from base M's 3 = ceil(6/2)); L requires one lane per

--- a/src/hooks/pr-workflow-response-gate.ts
+++ b/src/hooks/pr-workflow-response-gate.ts
@@ -9,7 +9,10 @@ import {
 	markPrWorkflowPluginWake,
 	observePrWorkflowAutoWakeEvent,
 } from './pr-workflow-auto-wake.js';
-import { readPrWorkflowGateState } from './pr-workflow-gate.js';
+import {
+	type PrReviewDepthTier,
+	readPrWorkflowGateState,
+} from './pr-workflow-gate.js';
 
 const DEFAULT_WAKE_TIMEOUT_MS = 5_000;
 
@@ -89,6 +92,29 @@ const BANNER_PREFIX_PATTERN =
 	/^--- \[(?:PR_REVIEW|PR_FEEDBACK) WORKFLOW ACTIVE/;
 
 /**
+ * Per-tier default total-wake ceilings, derived proportionally from each
+ * depth tier's consolidation-floor workload (base lanes + micro lanes).
+ *
+ * DERIVATION:
+ *   Tier workloads (base + micro):  S = 1+1 = 2,  M = 3+6 = 9,  L = 6+11 = 17
+ *   Headroom multiplier: 6 (chosen so that L >= 100 and scales uniformly)
+ *   Ceilings:  S = 2×6 = 12,  M = 9×6 = 54,  L = 17×6 = 102
+ *
+ * The tier-L ceiling (102) is comfortably above the observed ~40–55 healthy
+ * tier-L wake count, providing generous headroom for real reviews while still
+ * bounding pathological loops. Tier-S is tightest because small PRs have the
+ * least lane work; tier-M is proportionally in between.
+ *
+ * When `totalWakeCeiling` is provided to `createPrWorkflowResponseGate`,
+ * it overrides these defaults.
+ */
+export const DEFAULT_TOTAL_WAKE_CEILINGS: Record<PrReviewDepthTier, number> = {
+	S: 12,
+	M: 54,
+	L: 102,
+};
+
+/**
  * Bounded FIFO map of tracked wake budgets. Invariant 8 (session/global
  * state): module-level state must have an explicit eviction strategy. Three
  * further per-session maps share this same bound and the same FIFO discipline:
@@ -121,6 +147,13 @@ interface WakeBudget {
 	lastWakeAt: number;
 	lastSeenRevision?: number;
 	suspended: boolean;
+	/** Total number of wake attempts across the session lifetime. Never reset by
+	 * revision progress — only the consecutive counter resets on progress. */
+	totalWakes: number;
+	/** Discriminator for WHY the session was suspended: 'consecutive' means
+	 * the consecutive-unproductive budget was exhausted; 'total' means the
+	 * absolute per-session total-wake ceiling was reached. */
+	suspendedReason: 'consecutive' | 'total';
 }
 
 function canonicalGitHubPrUrl(value: string): string | null {
@@ -178,6 +211,7 @@ function blockedText(
 	mode: string,
 	options: {
 		suspended?: boolean;
+		suspendedReason?: 'consecutive' | 'total';
 		userInterrupted?: boolean;
 		maxConsecutive?: number;
 		recovery?: { code: string; requiredAction: string };
@@ -189,10 +223,16 @@ function blockedText(
 		`If the bind/checkout path is unreachable — for example a compound \`git fetch && git checkout\` was rejected as read-only shell syntax, the PR head cannot be fetched, or the working tree is on the wrong branch — call \`abort_pr_workflow\` (mode: "${mode}", reason: "<one-line cause>") to clear the gate, or ask the user to run \`/swarm abort-pr-workflow\`.`,
 	];
 	if (options.suspended) {
-		const max = options.maxConsecutive;
-		lines.push(
-			`Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries (the durable gate \`revision\` did not advance). The session will not be re-awoken automatically. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\` to publish normally.`,
-		);
+		if (options.suspendedReason === 'total') {
+			lines.push(
+				'Auto-resume is suspended because the total per-session wake budget has been exhausted. The session will not be re-awoken automatically. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow` to publish normally.',
+			);
+		} else {
+			const max = options.maxConsecutive;
+			lines.push(
+				`Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries (the durable gate \`revision\` did not advance). The session will not be re-awoken automatically. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\` to publish normally.`,
+			);
+		}
 	}
 	if (options.userInterrupted) {
 		lines.push(
@@ -222,6 +262,7 @@ function workflowBanner(
 	mode: string,
 	options: {
 		suspended?: boolean;
+		suspendedReason?: 'consecutive' | 'total';
 		userInterrupted?: boolean;
 		maxConsecutive?: number;
 		recovery?: { code: string; requiredAction: string };
@@ -231,10 +272,16 @@ function workflowBanner(
 		`--- [${mode} WORKFLOW ACTIVE — output below is not a terminal verdict; \`complete_pr_workflow\` clears the gate on success; if the bind/checkout path is unreachable call \`abort_pr_workflow\` or run \`/swarm abort-pr-workflow\`] ---`,
 	];
 	if (options.suspended) {
-		const max = options.maxConsecutive;
-		lines.push(
-			`[Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\`.]`,
-		);
+		if (options.suspendedReason === 'total') {
+			lines.push(
+				'[Auto-resume is suspended because the total per-session wake budget has been exhausted. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow`.]',
+			);
+		} else {
+			const max = options.maxConsecutive;
+			lines.push(
+				`[Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\`.]`,
+			);
+		}
 	}
 	if (options.userInterrupted) {
 		lines.push(
@@ -276,6 +323,12 @@ export function createPrWorkflowResponseGate(options: {
 	maxConsecutiveUnproductiveWakes?: number;
 	wakeCooldownMs?: number;
 	bannerCooldownMs?: number;
+	/** Override the per-tier default total-wake ceilings. A single number
+	 * applies uniformly to all tiers; a partial Record allows per-tier
+	 * overrides with unspecified tiers falling back to the defaults.
+	 * When omitted, the context-aware defaults (DEFAULT_TOTAL_WAKE_CEILINGS)
+	 * apply. */
+	totalWakeCeiling?: number | Partial<Record<PrReviewDepthTier, number>>;
 }) {
 	const wakeTimeoutMs = options.wakeTimeoutMs ?? DEFAULT_WAKE_TIMEOUT_MS;
 	const maxConsecutive =
@@ -284,6 +337,21 @@ export function createPrWorkflowResponseGate(options: {
 	const wakeCooldownMs = options.wakeCooldownMs ?? DEFAULT_WAKE_COOLDOWN_MS;
 	const bannerCooldownMs =
 		options.bannerCooldownMs ?? DEFAULT_BANNER_COOLDOWN_MS;
+	const resolveTotalWakeCeiling = (tier: PrReviewDepthTier): number => {
+		if (options.totalWakeCeiling === undefined) {
+			return DEFAULT_TOTAL_WAKE_CEILINGS[tier];
+		}
+		return typeof options.totalWakeCeiling === 'number'
+			? options.totalWakeCeiling
+			: (options.totalWakeCeiling[tier] ?? DEFAULT_TOTAL_WAKE_CEILINGS[tier]);
+	};
+	/**
+	 * Per-session wake budgets (consecutive counter, suspension flag, and
+	 * total-wake counter). This is an IN-MEMORY map scoped to ONE PROCESS
+	 * LIFETIME — it resets on plugin reload / process restart. The total-wake
+	 * bound holds within a single process invocation; a plugin reload starts
+	 * fresh totals.
+	 */
 	const activeWakeSessions = new Set<string>();
 	const wakeBudgets = new Map<string, WakeBudget>();
 	/**
@@ -311,12 +379,22 @@ export function createPrWorkflowResponseGate(options: {
 	const fallbackInjections = new Map<string, number>();
 	const session = options.client?.session as SessionClient | undefined;
 
-	/** FIFO-evict the oldest budget entry when the map exceeds the bound. */
+	/** FIFO-evict the oldest NON-suspended budget entry when the map exceeds
+	 * the bound. Suspended budgets are never evicted — they represent bounded
+	 * sessions whose total-wake cap fired. Evicting a suspended budget would
+	 * allow re-entry to recreate it with totalWakes: 0, re-arming auto-resume
+	 * and defeating the total-wake cap. If ALL entries are suspended (unlikely
+	 * but possible), eviction stops as a safety valve. */
 	function evictIfOverBound(): void {
 		while (wakeBudgets.size > MAX_TRACKED_WAKE_SESSIONS) {
-			const oldestKey = wakeBudgets.keys().next().value;
-			if (oldestKey === undefined) break;
-			wakeBudgets.delete(oldestKey);
+			let evicted = false;
+			for (const [key, budget] of wakeBudgets) {
+				if (budget.suspended) continue;
+				wakeBudgets.delete(key);
+				evicted = true;
+				break;
+			}
+			if (!evicted) break;
 		}
 	}
 
@@ -416,6 +494,7 @@ export function createPrWorkflowResponseGate(options: {
 
 		const budget = wakeBudgets.get(input.sessionID);
 		const suspended = budget?.suspended ?? false;
+		const suspendedReason = budget?.suspendedReason;
 		const userInterrupted = isPrWorkflowAutoWakeSuppressed(
 			options.directory,
 			input.sessionID,
@@ -461,6 +540,7 @@ export function createPrWorkflowResponseGate(options: {
 		// abort_pr_workflow can clear an unarmed workflow.
 		const banner = workflowBanner(state.mode, {
 			suspended,
+			suspendedReason,
 			userInterrupted,
 			maxConsecutive: maxConsecutive,
 			recovery,
@@ -523,6 +603,8 @@ export function createPrWorkflowResponseGate(options: {
 					consecutiveUnproductive: 0,
 					lastWakeAt: 0,
 					suspended: false,
+					totalWakes: 0,
+					suspendedReason: 'consecutive',
 				};
 				wakeBudgets.set(sessionID, budget);
 			}
@@ -599,6 +681,7 @@ export function createPrWorkflowResponseGate(options: {
 								type: 'text',
 								text: `${blockedText(state.mode, {
 									suspended: false,
+									suspendedReason: undefined,
 									maxConsecutive: maxConsecutive,
 								})}\nDo not stop or summarize. Inspect the durable gate, dispatch or collect the next missing required lane, and continue until complete_pr_workflow succeeds. If the bind/checkout path is genuinely unreachable, call abort_pr_workflow instead of looping.${queuedMonitorText}`,
 							},
@@ -653,10 +736,23 @@ export function createPrWorkflowResponseGate(options: {
 				// falsely suspended at MAX-1. The fresh read here corrects that
 				// race: if the revision advanced during the wake, the wake IS
 				// productive and the counter resets.
-				const postWakeState = await _internals.readPrWorkflowGateState(
-					options.directory,
-					sessionID,
-				);
+				let postWakeState: Awaited<
+					ReturnType<typeof _internals.readPrWorkflowGateState>
+				>;
+				try {
+					postWakeState = await _internals.readPrWorkflowGateState(
+						options.directory,
+						sessionID,
+					);
+				} catch {
+					// The pre-wake read already validated the gate exists; a
+					// throw here is a transient fs error. Fall back to the
+					// pre-wake state so the bookkeeping proceeds with the
+					// last-known-good revision. Reserving null exclusively
+					// for a confirmed gate-clear prevents resetBudget from
+					// wiping the just-incremented totalWakes.
+					postWakeState = state;
+				}
 				if (
 					promptAccepted &&
 					queuedMonitorEvents.length > 0 &&
@@ -700,9 +796,23 @@ export function createPrWorkflowResponseGate(options: {
 						budget.consecutiveUnproductive += 1;
 						if (budget.consecutiveUnproductive >= maxConsecutive) {
 							budget.suspended = true;
+							budget.suspendedReason = 'consecutive';
 						}
 					} else {
 						budget.consecutiveUnproductive = 0;
+					}
+
+					// TOTAL-wake budget: increment on EVERY attempted wake
+					// (success, failure, timeout) and NEVER reset by progress.
+					// Read the depth tier from durable gate state; default to 'L'
+					// when absent (e.g. PR_FEEDBACK mode has no diff-stats tier).
+					budget.totalWakes += 1;
+					const tier: PrReviewDepthTier =
+						postWakeState.prReviewDepthTier ?? 'L';
+					const totalCeiling = resolveTotalWakeCeiling(tier);
+					if (budget.totalWakes >= totalCeiling) {
+						budget.suspended = true;
+						budget.suspendedReason = 'total';
 					}
 				}
 			}

--- a/tests/unit/hooks/pr-workflow-response-gate-total-wake-budget.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-total-wake-budget.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	_test_exports as autoWakeInternals,
+	isPrWorkflowAutoWakeSuppressed,
+} from '../../../src/hooks/pr-workflow-auto-wake.js';
+import type { PrReviewDepthTier } from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	activatePrWorkflow,
+	clearPrWorkflowGateState,
+	type PrWorkflowGateState,
+	_test_exports as workflowInternals,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createPrWorkflowResponseGate,
+	DEFAULT_TOTAL_WAKE_CEILINGS,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+
+let directory = '';
+
+beforeEach(() => {
+	directory = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'pr-response-gate-total-')),
+	);
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/** Write a raw gate-state record with a specific revision and optional depth tier. */
+async function writeStateWithRevision(
+	sessionID: string,
+	revision: number,
+	tier?: PrReviewDepthTier,
+): Promise<void> {
+	const relative = workflowInternals.workflowGateStateRelativePath(sessionID);
+	const absolute = path.join(directory, '.swarm', relative);
+	await fs.mkdir(path.dirname(absolute), { recursive: true });
+	const state: PrWorkflowGateState = {
+		schemaVersion: 1,
+		revision,
+		sessionID,
+		mode: 'PR_REVIEW',
+		activatedAt: '2026-07-19T00:00:00.000Z',
+		updatedAt: '2026-07-19T00:00:00.000Z',
+		...(tier !== undefined && { prReviewDepthTier: tier }),
+	};
+	await fs.writeFile(absolute, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/**
+ * Drive N wakes for a session where revision advances every time
+ * (so the consecutive counter always resets to 0). Uses tier-S ceiling
+ * (12) by default for compact tests.
+ */
+async function driveProductiveWakes(
+	gate: ReturnType<typeof createPrWorkflowResponseGate>,
+	sessionID: string,
+	count: number,
+): Promise<void> {
+	const idle = {
+		event: {
+			type: 'session.idle',
+			properties: { sessionID },
+		},
+	};
+	for (let i = 0; i < count; i++) {
+		// Advance revision so every wake is "productive"
+		await writeStateWithRevision(sessionID, i + 1, 'S');
+		await gate.event(idle);
+	}
+}
+
+describe('PR workflow total wake budget', () => {
+	test('total cap suspends under continuous revision progress (consecutive stays 0)', async () => {
+		// Tier-S ceiling is 12. Drive 12 productive wakes; the consecutive
+		// counter resets to 0 each time, but totalWakes hits the ceiling.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 12 },
+		});
+		await writeStateWithRevision('total-cap-session', 0, 'S');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'total-cap-session' },
+			},
+		};
+		// Drive 12 productive wakes — each advances revision so consecutiveUnproductive
+		// never climbs. totalWakes reaches 12 (= ceiling for S) → suspend.
+		for (let i = 0; i < 12; i++) {
+			await writeStateWithRevision('total-cap-session', i + 1, 'S');
+			await gate.event(idle);
+		}
+
+		const budget = gate._inspectWakeBudget('total-cap-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+		// Consecutive counter stayed 0 because revision advanced every time.
+		expect(budget?.consecutiveUnproductive).toBe(0);
+		expect(budget?.totalWakes).toBe(12);
+
+		// A 13th idle must NOT re-wake (already suspended).
+		await gate.event(idle);
+		expect(promptAsync).toHaveBeenCalledTimes(12);
+	});
+
+	test('total-cap suspension notice carries total-cap wording and names all three recovery paths', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 5 },
+		});
+		await writeStateWithRevision('notice-session', 0, 'S');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'notice-session' },
+			},
+		};
+		// Drive 5 productive wakes to hit total cap.
+		for (let i = 0; i < 5; i++) {
+			await writeStateWithRevision('notice-session', i + 1, 'S');
+			await gate.event(idle);
+		}
+
+		const budget = gate._inspectWakeBudget('notice-session');
+		expect(budget?.suspendedReason).toBe('total');
+
+		// textComplete must emit the TOTAL-CAP wording (not consecutive wording)
+		// and name all three recovery paths.
+		const output = { text: 'still working' };
+		await gate.textComplete({ sessionID: 'notice-session' }, output);
+
+		// Total-cap wording: "total per-session wake budget"
+		expect(output.text).toContain('total per-session wake budget');
+		// Must NOT contain the consecutive-unproductive wording.
+		expect(output.text).not.toContain('consecutive unproductive retries');
+		// All three recovery paths must be named.
+		expect(output.text).toContain('/swarm abort-pr-workflow');
+		expect(output.text).toContain('abort_pr_workflow');
+		expect(output.text).toContain('complete_pr_workflow');
+		// Model text preserved.
+		expect(output.text).toContain('still working');
+	});
+
+	test('failed and timed-out wakes count toward total budget', async () => {
+		// Use a very small total ceiling to test the counting behavior.
+		const promptAsync = mock(async () => ({
+			error: 'upstream rate limited',
+		}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 3 },
+		});
+		await writeStateWithRevision('fail-total-session', 0, 'S');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'fail-total-session' },
+			},
+		};
+		// 3 failing wakes → totalWakes reaches ceiling → suspended.
+		for (let i = 0; i < 3; i++) {
+			await gate.event(idle).catch(() => {});
+		}
+		const budget = gate._inspectWakeBudget('fail-total-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+		expect(budget?.totalWakes).toBe(3);
+	});
+
+	test('per-tier ceilings scale correctly (L > S) and healthy tier-M is not falsely suspended', async () => {
+		// Verify the exported defaults scale correctly.
+		expect(DEFAULT_TOTAL_WAKE_CEILINGS.S).toBeLessThan(
+			DEFAULT_TOTAL_WAKE_CEILINGS.M,
+		);
+		expect(DEFAULT_TOTAL_WAKE_CEILINGS.M).toBeLessThan(
+			DEFAULT_TOTAL_WAKE_CEILINGS.L,
+		);
+		expect(DEFAULT_TOTAL_WAKE_CEILINGS.L).toBeGreaterThanOrEqual(100);
+
+		// Drive 54 productive wakes for a tier-M session (ceiling = 54).
+		// At wake 54, totalWakes == ceiling → suspend. Wake 53 must NOT suspend.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 12, M: 54, L: 102 },
+		});
+		await writeStateWithRevision('tier-m-session', 0, 'M');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'tier-m-session' },
+			},
+		};
+		// Drive 53 productive wakes — must NOT be suspended.
+		for (let i = 0; i < 53; i++) {
+			await writeStateWithRevision('tier-m-session', i + 1, 'M');
+			await gate.event(idle);
+		}
+		let budget = gate._inspectWakeBudget('tier-m-session');
+		expect(budget?.suspended).toBe(false);
+		expect(budget?.totalWakes).toBe(53);
+
+		// Wake 54 hits the ceiling → suspended.
+		await writeStateWithRevision('tier-m-session', 54, 'M');
+		await gate.event(idle);
+		budget = gate._inspectWakeBudget('tier-m-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+		expect(budget?.totalWakes).toBe(54);
+	});
+
+	test('timed-out wakes (resume prompt never resolves) count toward total and cause suspension', async () => {
+		// Simulate a timeout: promptAsync returns a promise that NEVER resolves.
+		// With wakeTimeoutMs=1ms the Promise.race in the gate rejects quickly.
+		const promptAsync = mock(async () => new Promise<never>(() => {}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			wakeTimeoutMs: 1,
+			totalWakeCeiling: { S: 4 },
+		});
+		await writeStateWithRevision('timeout-session', 0, 'S');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'timeout-session' },
+			},
+		};
+		// 4 timed-out wakes → totalWakes reaches ceiling → suspended.
+		for (let i = 0; i < 4; i++) {
+			await gate.event(idle).catch(() => {});
+		}
+		const budget = gate._inspectWakeBudget('timeout-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+		expect(budget?.totalWakes).toBe(4);
+	});
+
+	test('SC-001.3: healthy tier-L session driving ~55 productive wakes is NOT suspended', async () => {
+		// The tier-L default ceiling is 102. A healthy session doing 55 productive
+		// wakes (within the observed ~40-55 range) must NOT be falsely suspended.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			// Use defaults (no totalWakeCeiling override) so the actual
+			// DEFAULT_TOTAL_WAKE_CEILINGS are exercised.
+		});
+		await writeStateWithRevision('healthy-l-session', 0, 'L');
+
+		const idle = {
+			event: {
+				type: 'session.idle',
+				properties: { sessionID: 'healthy-l-session' },
+			},
+		};
+		// Drive 55 productive wakes with revision advancing each time.
+		for (let i = 0; i < 55; i++) {
+			await writeStateWithRevision('healthy-l-session', i + 1, 'L');
+			await gate.event(idle);
+		}
+
+		const budget = gate._inspectWakeBudget('healthy-l-session');
+		expect(budget?.suspended).toBe(false);
+		expect(budget?.totalWakes).toBe(55);
+		expect(budget?.consecutiveUnproductive).toBe(0);
+		// All 55 wakes actually fired.
+		expect(promptAsync).toHaveBeenCalledTimes(55);
+	});
+
+	test('partial totalWakeCeiling override: specified tier uses override, unspecified tier uses default', async () => {
+		// Only tier-S is overridden to 5; tier-L falls back to the default 102.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 5 },
+		});
+
+		// Tier-S session with ceiling=5 should suspend at wake 5.
+		await writeStateWithRevision('partial-s', 0, 'S');
+		const idleS = {
+			event: { type: 'session.idle', properties: { sessionID: 'partial-s' } },
+		};
+		for (let i = 0; i < 5; i++) {
+			await writeStateWithRevision('partial-s', i + 1, 'S');
+			await gate.event(idleS);
+		}
+		const budgetS = gate._inspectWakeBudget('partial-s');
+		expect(budgetS?.suspended).toBe(true);
+		expect(budgetS?.suspendedReason).toBe('total');
+		expect(budgetS?.totalWakes).toBe(5);
+
+		// Tier-L session should use the DEFAULT ceiling (102), not 5.
+		// Drive 55 productive wakes — well under 102, must NOT be suspended.
+		await writeStateWithRevision('partial-l', 0, 'L');
+		const idleL = {
+			event: { type: 'session.idle', properties: { sessionID: 'partial-l' } },
+		};
+		for (let i = 0; i < 55; i++) {
+			await writeStateWithRevision('partial-l', i + 1, 'L');
+			await gate.event(idleL);
+		}
+		const budgetL = gate._inspectWakeBudget('partial-l');
+		expect(budgetL?.suspended).toBe(false);
+		expect(budgetL?.totalWakes).toBe(55);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-workflow-gate.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-workflow-gate.test.ts
@@ -388,24 +388,22 @@ describe('dispatch_lanes PR workflow enforcement', () => {
 	test('computePrReviewDepthTier maps sizes and fails strict to L on unknown stats', () => {
 		expect(computePrReviewDepthTier(null)).toBe('L');
 		expect(computePrReviewDepthTier(undefined)).toBe('L');
-		expect(
-			computePrReviewDepthTier({ changedLines: 10, changedFiles: 2 }),
-		).toBe('S');
-		expect(
-			computePrReviewDepthTier({ changedLines: 50, changedFiles: 3 }),
-		).toBe('S');
-		expect(
-			computePrReviewDepthTier({ changedLines: 51, changedFiles: 3 }),
-		).toBe('M');
-		expect(
-			computePrReviewDepthTier({ changedLines: 20, changedFiles: 4 }),
-		).toBe('M');
-		expect(
-			computePrReviewDepthTier({ changedLines: 500, changedFiles: 20 }),
-		).toBe('M');
-		expect(
-			computePrReviewDepthTier({ changedLines: 501, changedFiles: 2 }),
-		).toBe('L');
+		const tierCases: Array<[number, number, string]> = [
+			[100, 5, 'S'],
+			[100, 6, 'M'],
+			[101, 5, 'M'],
+			[51, 3, 'S'],
+			[20, 4, 'S'],
+			[1500, 50, 'M'],
+			[1500, 51, 'L'],
+			[1501, 2, 'L'],
+			[501, 2, 'M'],
+		];
+		for (const [lines, files, expected] of tierCases) {
+			expect(
+				computePrReviewDepthTier({ changedLines: lines, changedFiles: files }),
+			).toBe(expected);
+		}
 	});
 
 	test('computePrReviewDepthTier escalates to L on file-count overflow or a submodule change, closing the file-count blind spot', () => {
@@ -414,7 +412,7 @@ describe('dispatch_lanes PR workflow enforcement', () => {
 		// its aggregate changed-line count is small: file count now has its own
 		// ceiling, mirroring the S-tier check.
 		expect(
-			computePrReviewDepthTier({ changedLines: 500, changedFiles: 21 }),
+			computePrReviewDepthTier({ changedLines: 500, changedFiles: 51 }),
 		).toBe('L');
 		expect(
 			computePrReviewDepthTier({ changedLines: 0, changedFiles: 200 }),


### PR DESCRIPTION
Closes #1967

## Summary
- Add a total per-session wake budget to the PR-workflow auto-resume loop that is incremented on every attempted wake (including failures/timeouts) and never reset by revision progress. When exhausted, the session suspends with a distinct total-cap notice naming all three recovery paths.
- The ceiling is context-aware (Option C): per-tier values derived from consolidation-floor workload (S=12, M=54, L=102). Configurable via 	otalWakeCeiling option on createPrWorkflowResponseGate with Partial<Record<PrReviewDepthTier, number>> support and nullish-coalescing fallback to defaults.
- Widen PR_REVIEW_DEPTH_TIER_THRESHOLDS from 50/3/500/20 to 100/5/1500/50 so appropriately-sized PRs get consolidated lane counts. All six base dimensions and all eleven risk families remain mandatory at every tier; fail-strict-to-Large on unknown stats and submodule changes is preserved.
- Final-council MEDIUM findings resolved: partial-record type, suspended-safe FIFO eviction (skip suspended entries), post-wake read try/catch with pre-wake-state fallback.

## Invariant audit
- 1 (plugin init): not touched - no changes to src/index.ts or init path
- 2 (runtime portability): not touched - no bun: imports, no Bun.* calls, no bundle/portability changes
- 3 (subprocesses): not touched - no spawn/spawnSync changes
- 4 (.swarm containment): not touched - no .swarm/ runtime state changes in committed code
- 5 (plan durability): not touched - no plan schema or ledger changes
- 6 (test_runner safety): not touched - no test_runner scope changes
- 7 (test writing): touched - new test file pr-workflow-response-gate-total-wake-budget.test.ts (343 lines, under 500 cap). Uses bun:test, _internals DI seam, afterEach restoration. Evidence: un run lint:ci passes (2906 files, exit 0); iome check exit 0.
- 8 (session state): touched - 	otalWakes and suspendedReason added to WakeBudget interface (per-session, keyed by sessionID). FIFO eviction (evictIfOverBound) modified to skip suspended entries. MAX_TRACKED_WAKE_SESSIONS=200 bound preserved. Evidence: response-gate.ts:111-149, 321-337, 91.
- 9 (guardrails/retry): touched - total wake budget is a new guardrail for the auto-resume loop. Failed/timed-out wakes count toward the total. Post-wake read wrapped in try/catch with fallback. Per-process bound documented. Evidence: response-gate.ts:87-107 (DEFAULT_TOTAL_WAKE_CEILINGS), 644-699 (try/catch + totalWakes increment + suspend check), 286-292 (per-process comment).
- 10 (chat/system msg): touched - lockedText and workflowBanner now branch on suspendedReason, emitting distinct total-cap wording naming all 3 recovery paths. Suspended state bypasses banner cooldown (forceFullBanner). Evidence: response-gate.ts:165-186, 210-229, 438.
- 11 (tool registration): not touched - no tool additions/changes
- 12 (release/cache): touched - release fragment at docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md. No version files touched.

## Test plan
- [x] un run build succeeds, 
ode --input-type=module -e "await import('./dist/index.js')" returns OK
- [x] un run typecheck exit 0
- [x] un run lint:ci (biome ci) exit 0 on 2906 files
- [x] 62 targeted tests pass across 5 response-gate test files (0 fail)
- [x] 19 boundary tests pass in dispatch-lanes-pr-workflow-gate.test.ts (all edges: 100/5→S, 100/6→M, 101/5→M, 501/2→M, 1500/50→M, 1500/51→L, 1501/2→L, {500,51}→L, null→L, submodule→L)
- [x] 7 total-wake-budget tests pass (total cap under continuous progress, notice wording, failed/timeout counting, per-tier scaling, SC-001.3 headroom, timeout path, partial-record override)
- [x] un run drift:check clean (no public numeric docs pin old 50/500 thresholds)
- [x] Final council: 3 APPROVE, 2 CONCERNS (all MEDIUM/LOW advisory, 0 required fixes)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

