### PR TITLE
fix(pr-workflow): close swarm-pr-review findings on the wake budget

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -757,9 +757,9 @@ never which review dimensions or risk families get evaluated:
 
 | Tier | Diff shape | Dispatch shape (Profiles B/C) |
 |---|---|---|
-| S | ≤ ~50 changed lines, ≤ 3 files, no risk triggers | Consolidate: 1–2 explorer lanes covering all six dimensions (B), or one candidate-generation pass (C); Phase 4 risk families fold into the same lanes as an explicit per-family checklist |
-| M | ≤ ~500 changed lines, or any risk trigger | Dedicated lanes for the triggered dimensions/families; consolidate the remaining thin dimensions into 1–2 lanes |
-| L | > ~500 changed lines, > ~20 files, multi-subsystem, or security-sensitive surface | Full fan-out: one lane per dimension (six) and per-family micro dispatch in Phase 4 |
+| S | ≤ ~100 changed lines, ≤ 5 files, no risk triggers | Consolidate: 1–2 explorer lanes covering all six dimensions (B), or one candidate-generation pass (C); Phase 4 risk families fold into the same lanes as an explicit per-family checklist |
+| M | ≤ ~1500 changed lines, or any risk trigger | Dedicated lanes for the triggered dimensions/families; consolidate the remaining thin dimensions into 1–2 lanes |
+| L | > ~1500 changed lines, > ~50 files, multi-subsystem, or security-sensitive surface | Full fan-out: one lane per dimension (six) and per-family micro dispatch in Phase 4 |
 
 Risk triggers (any one escalates to at least tier M, and the triggered
 dimension/family always gets a dedicated lane at M and above):
@@ -1733,8 +1733,17 @@ checkout …` is repeatedly rejected as read-only shell syntax (the runtime
 requires each git intake command to be a single standalone command), when
 the PR ref is missing, or when the working tree is on the wrong branch and
 the merge-base bind can never verify. In that state the response gate
-suspends further auto-resumes after a small number of consecutive
-unproductive wakes, and the only exits are:
+suspends further auto-resumes for either of two independent reasons: a
+small number of consecutive unproductive wakes (the durable gate `revision`
+did not advance), or the total wake ceiling being reached (tier-scaled
+defaults S=12 / M=54 / L=102, overridable via the `totalWakeCeiling`
+option, and in-memory/per-process so the count resets on plugin reload and
+when the durable gate clears — but NOT across the PR_REVIEW → PR_FEEDBACK
+handoff, which keeps accumulating). Either suspension appends a
+`pr_workflow_wake_suspended` record to `.swarm/events.jsonl` naming the
+reason, both counters, the tier, and the ceiling in force — read that first
+when diagnosing why a review stopped resuming. Either way, the only exits
+are:
 
 1. **Diagnose and retry the canonical standalone sequence.** Run
    `git fetch origin refs/pull/<N>/head`, verify

--- a/docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md
+++ b/docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md
@@ -2,10 +2,32 @@
 
 **Problem A — auto-resume loop unbounded:** The PR-workflow auto-resume loop had only a consecutive-unproductive counter (5) that reset to 0 whenever the durable gate's `revision` advanced. There was no total-wake cap, so any state-mutating controller call bought 5 fresh wakes, allowing unbounded compaction loops on large-context models.
 
-**Fix:** Added a total per-session wake budget (totalWakes) alongside the existing consecutive budget. The total counter increments on every attempted wake (including failures and timeouts) and is never reset by revision progress. When exhausted, the session suspends with a distinct total-cap notice (not the consecutive-unproductive wording) naming all three recovery paths.
+**Fix:** Added a total wake budget (totalWakes) alongside the existing consecutive budget, scoped to one process lifetime and running until the durable gate clears via complete/abort — note it deliberately survives the PR_REVIEW → PR_FEEDBACK handoff, which mints a new workflow activation without clearing the gate. The total counter increments on every attempted wake (including failures and timeouts) and is never reset by revision progress. When exhausted, the session suspends with a distinct total-cap notice (not the consecutive-unproductive wording) naming all three recovery paths, and appends a `pr_workflow_wake_suspended` record to `.swarm/events.jsonl` carrying the reason, counters, tier, and ceiling in force.
 
 The ceiling is context-aware (Option C): scaled by the PR-review depth tier, with per-tier values derived from each tier's consolidation-floor workload: Small (S): 12, Medium (M): 54, Large (L): 102 (>=100, above the ~40-55 healthy minimum). Configurable via createPrWorkflowResponseGate({ totalWakeCeiling }). The bound is per-process (in-memory Map, resets on plugin reload).
 
 **Problem B — depth tiers rarely engaged:** The depth-tier thresholds (Small <=50 lines/<=3 files, Medium <=500 lines/<=20 files) were so tight that most real PRs landed at tier Large.
 
 **Fix:** Widened to Small <=100 lines/<=5 files, Medium <=1500 lines/<=50 files. All six base dimensions and all eleven risk families remain mandatory at every tier. Fail-strict-to-Large on unknown stats and submodule changes preserved.
+
+---
+
+### Publish-time obligation (do not copy stale values)
+
+The review of the first attempt at this change found that its PR body carried
+quantitative claims and `src/hooks/pr-workflow-response-gate.ts` line citations
+that were never measured or re-derived at publish time, and were wrong by the
+time it merged. Before publishing any PR that carries this fragment:
+
+1. **Re-measure, do not copy.** Run `bun test` over the explicit list of the 11
+   `tests/unit/hooks/pr-workflow-response-gate*.test.ts` files plus
+   `tests/unit/tools/dispatch-lanes-pr-workflow-gate.test.ts` (explicit list —
+   AGENTS.md invariant 7 forbids `bun test <dir>`), and run `bun run lint:ci`.
+   Put those counts in the PR body. Any count carried over from an earlier
+   revision is stale by construction.
+2. **Re-derive every line citation** in the PR body's invariant audit against
+   the exact publish HEAD. Line numbers shift with every commit, so a citation
+   copied from a prior revision is wrong even when the claim it supports is
+   right.
+
+Delete this section when the fragment is consumed at release time.

--- a/src/hooks/pr-workflow-response-gate.ts
+++ b/src/hooks/pr-workflow-response-gate.ts
@@ -1,3 +1,4 @@
+import * as fsp from 'node:fs/promises';
 import {
 	claimPrFeedbackMonitorEvents,
 	readPrFeedbackMonitorQueue,
@@ -13,6 +14,7 @@ import {
 	type PrReviewDepthTier,
 	readPrWorkflowGateState,
 } from './pr-workflow-gate.js';
+import { validateSwarmPath } from './utils.js';
 
 const DEFAULT_WAKE_TIMEOUT_MS = 5_000;
 
@@ -115,12 +117,16 @@ export const DEFAULT_TOTAL_WAKE_CEILINGS: Record<PrReviewDepthTier, number> = {
 };
 
 /**
- * Bounded FIFO map of tracked wake budgets. Invariant 8 (session/global
- * state): module-level state must have an explicit eviction strategy. Three
- * further per-session maps share this same bound and the same FIFO discipline:
- * `bannerStamps` (instant of the last full banner), `banneredMessages` (the
- * assistant message already carrying a banner), and `fallbackInjections` (the
- * injection count on the messageID-less path).
+ * Bound on the tracked wake budgets. Invariant 8 (session/global state):
+ * module-level state must have an explicit eviction strategy. `wakeBudgets`
+ * evicts LEAST RECENTLY WOKEN — see {@link evictIfOverBound}, which also
+ * refuses to drop suspended or in-flight entries and therefore treats this
+ * bound as best-effort. Three further per-session maps share the same numeric
+ * bound but keep the simpler insertion-order FIFO discipline, because they
+ * hold no enforcement state that is unsafe to lose: `bannerStamps` (instant of
+ * the last full banner), `banneredMessages` (the assistant message already
+ * carrying a banner), and `fallbackInjections` (the injection count on the
+ * messageID-less path).
  */
 export const MAX_TRACKED_WAKE_SESSIONS = 200;
 
@@ -147,13 +153,49 @@ interface WakeBudget {
 	lastWakeAt: number;
 	lastSeenRevision?: number;
 	suspended: boolean;
-	/** Total number of wake attempts across the session lifetime. Never reset by
-	 * revision progress — only the consecutive counter resets on progress. */
+	/** Total number of wake attempts recorded for this budget. NEVER reset by
+	 * revision progress — only the consecutive counter resets on progress; that
+	 * is the guarantee this counter exists to provide. Its SCOPE is the scope of
+	 * the enclosing map (see `wakeBudgets` in
+	 * {@link createPrWorkflowResponseGate}): one PROCESS lifetime, running until
+	 * the durable gate CLEARS. `resetBudget` drops the entry on a gate clear
+	 * (complete/abort) and a plugin reload starts fresh totals — so this is not
+	 * a total across the whole conversation/session lifetime.
+	 *
+	 * Deliberately NOT "one workflow activation": `transitionPrReviewToFeedback`
+	 * (`pr-workflow-gate.ts`) mints a new `workflowInstanceId` WITHOUT clearing
+	 * the gate, so a budget survives the PR_REVIEW -> PR_FEEDBACK handoff and
+	 * keeps accumulating across both activations. See the ceiling note at the
+	 * `totalWakes` increment for why that matters. */
 	totalWakes: number;
 	/** Discriminator for WHY the session was suspended: 'consecutive' means
 	 * the consecutive-unproductive budget was exhausted; 'total' means the
-	 * absolute per-session total-wake ceiling was reached. */
+	 * total-wake ceiling in force for this process, at the tier the gate
+	 * currently reports, was reached (same scope caveat as
+	 * {@link WakeBudget.totalWakes}). */
 	suspendedReason: 'consecutive' | 'total';
+}
+
+/**
+ * A total-wake ceiling is only meaningful as a finite positive integer. Every
+ * other shape silently DISABLES or INVERTS the brake rather than tuning it:
+ * `Infinity` and `NaN` make `totalWakes >= ceiling` never true (so the total
+ * brake never fires), and `0` or a negative value makes it true on the very
+ * first wake (so the session suspends before it can do any work). Fractional
+ * values are accepted by the comparison but describe a ceiling that can never
+ * be hit exactly, which is a configuration mistake rather than an intent.
+ *
+ * Invalid values fall back to {@link DEFAULT_TOTAL_WAKE_CEILINGS} at RESOLVE
+ * time rather than throwing at construction. The sibling options
+ * (`maxConsecutiveUnproductiveWakes`, `wakeCooldownMs`, `bannerCooldownMs`) are
+ * all plain `?? default` reads, so a throw here would be the only option in
+ * this factory able to crash plugin initialization — a strictly worse failure
+ * mode than clamping to a safe default.
+ */
+function isValidTotalWakeCeiling(value: number | undefined): value is number {
+	// Number.isInteger is false for NaN and both Infinities, so this single
+	// predicate covers finiteness, integrality, and positivity.
+	return value !== undefined && Number.isInteger(value) && value > 0;
 }
 
 function canonicalGitHubPrUrl(value: string): string | null {
@@ -225,7 +267,7 @@ function blockedText(
 	if (options.suspended) {
 		if (options.suspendedReason === 'total') {
 			lines.push(
-				'Auto-resume is suspended because the total per-session wake budget has been exhausted. The session will not be re-awoken automatically. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow` to publish normally.',
+				'Auto-resume is suspended because the total wake budget for this workflow has been exhausted. The session will not be re-awoken automatically. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow` to publish normally.',
 			);
 		} else {
 			const max = options.maxConsecutive;
@@ -274,7 +316,7 @@ function workflowBanner(
 	if (options.suspended) {
 		if (options.suspendedReason === 'total') {
 			lines.push(
-				'[Auto-resume is suspended because the total per-session wake budget has been exhausted. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow`.]',
+				'[Auto-resume is suspended because the total wake budget for this workflow has been exhausted. Run `/swarm abort-pr-workflow`, call `abort_pr_workflow`, or complete the workflow with `complete_pr_workflow`.]',
 			);
 		} else {
 			const max = options.maxConsecutive;
@@ -337,13 +379,22 @@ export function createPrWorkflowResponseGate(options: {
 	const wakeCooldownMs = options.wakeCooldownMs ?? DEFAULT_WAKE_COOLDOWN_MS;
 	const bannerCooldownMs =
 		options.bannerCooldownMs ?? DEFAULT_BANNER_COOLDOWN_MS;
+	/**
+	 * Resolve the total-wake ceiling for a tier, validating the caller-supplied
+	 * override (see {@link isValidTotalWakeCeiling}). The check is applied to
+	 * BOTH shapes of the option — the uniform scalar and each looked-up per-tier
+	 * record value — so one bad tier entry degrades to that tier's default
+	 * instead of disabling the brake for it. An absent value (option omitted, or
+	 * a partial record without this tier) takes the same default path.
+	 */
 	const resolveTotalWakeCeiling = (tier: PrReviewDepthTier): number => {
-		if (options.totalWakeCeiling === undefined) {
-			return DEFAULT_TOTAL_WAKE_CEILINGS[tier];
-		}
-		return typeof options.totalWakeCeiling === 'number'
-			? options.totalWakeCeiling
-			: (options.totalWakeCeiling[tier] ?? DEFAULT_TOTAL_WAKE_CEILINGS[tier]);
+		const configured =
+			typeof options.totalWakeCeiling === 'number'
+				? options.totalWakeCeiling
+				: options.totalWakeCeiling?.[tier];
+		return isValidTotalWakeCeiling(configured)
+			? configured
+			: DEFAULT_TOTAL_WAKE_CEILINGS[tier];
 	};
 	/**
 	 * Per-session wake budgets (consecutive counter, suspension flag, and
@@ -379,22 +430,72 @@ export function createPrWorkflowResponseGate(options: {
 	const fallbackInjections = new Map<string, number>();
 	const session = options.client?.session as SessionClient | undefined;
 
-	/** FIFO-evict the oldest NON-suspended budget entry when the map exceeds
-	 * the bound. Suspended budgets are never evicted — they represent bounded
-	 * sessions whose total-wake cap fired. Evicting a suspended budget would
-	 * allow re-entry to recreate it with totalWakes: 0, re-arming auto-resume
-	 * and defeating the total-wake cap. If ALL entries are suspended (unlikely
-	 * but possible), eviction stops as a safety valve. */
-	function evictIfOverBound(): void {
+	/**
+	 * Enforce the {@link MAX_TRACKED_WAKE_SESSIONS} bound on `wakeBudgets`
+	 * (invariant 8) by evicting the LEAST RECENTLY WOKEN entry — LRU by
+	 * `lastWakeAt`, not insertion order. Selection rules, in priority order:
+	 *
+	 *  1. Never evict a SUSPENDED budget. A suspended entry records a session
+	 *     whose consecutive or total cap already fired; recreating it on the
+	 *     next idle would reset `totalWakes` to 0 and re-arm auto-resume,
+	 *     defeating the cap this module exists to enforce.
+	 *  2. Never evict the CURRENT session (`currentSessionID`) or any session
+	 *     whose idle handler is mid-flight (`activeWakeSessions`). Those
+	 *     handlers hold a live reference to their budget object: deleting the
+	 *     map entry detaches it, so their later `totalWakes += 1` / `suspended =
+	 *     true` writes land on an object nothing can read, and the next idle
+	 *     rebuilds a zeroed budget. A rebuilt budget has `lastSeenRevision ===
+	 *     undefined`, which makes `madeProgress` unconditionally true — so the
+	 *     consecutive brake, the cooldown, and the total ceiling all become
+	 *     unreachable for that session.
+	 *  3. Among the survivors, evict the SMALLEST `lastWakeAt`.
+	 *  4. `lastWakeAt === 0` means "created, never woken", which is the NEWEST
+	 *     possible state, not the oldest — a naive minimum would invert the
+	 *     intent and evict the freshest entry first. Never-woken entries are
+	 *     therefore held back as a LAST RESORT, used only when no already-woken
+	 *     candidate exists at all (in insertion order, preserving the previous
+	 *     FIFO tie-break).
+	 *     This branch is defence-in-depth, not the common path: the ordinary
+	 *     create-then-wake window is already covered by rule 2, because
+	 *     `activeWakeSessions` holds the session for exactly as long as its
+	 *     entry sits at `lastWakeAt === 0`, and `lastWakeAt` is assigned
+	 *     unconditionally once the handler reaches its bookkeeping. What
+	 *     remains is the narrow case of a handler that threw between creating
+	 *     the budget and that assignment, which strands a never-woken entry
+	 *     permanently. Do not "simplify" this away by assuming rule 2 covers
+	 *     every zero — it covers every zero that is still in flight.
+	 *
+	 * The bound is best-effort by construction: when suspended entries plus the
+	 * in-flight/current sessions exhaust the candidate set, the map is allowed
+	 * to EXCEED MAX_TRACKED_WAKE_SESSIONS rather than drop state that is unsafe
+	 * to lose. `if (evicted === undefined) break` is the termination guard for
+	 * that case — it also makes an all-suspended map impossible to spin on.
+	 */
+	function evictIfOverBound(currentSessionID: string): void {
 		while (wakeBudgets.size > MAX_TRACKED_WAKE_SESSIONS) {
-			let evicted = false;
+			let lruKey: string | undefined;
+			let lruWakeAt = Number.POSITIVE_INFINITY;
+			let neverWokenKey: string | undefined;
 			for (const [key, budget] of wakeBudgets) {
-				if (budget.suspended) continue;
-				wakeBudgets.delete(key);
-				evicted = true;
-				break;
+				if (
+					budget.suspended ||
+					key === currentSessionID ||
+					activeWakeSessions.has(key)
+				) {
+					continue;
+				}
+				if (budget.lastWakeAt <= 0) {
+					if (neverWokenKey === undefined) neverWokenKey = key;
+					continue;
+				}
+				if (budget.lastWakeAt < lruWakeAt) {
+					lruWakeAt = budget.lastWakeAt;
+					lruKey = key;
+				}
 			}
-			if (!evicted) break;
+			const evicted = lruKey ?? neverWokenKey;
+			if (evicted === undefined) break;
+			wakeBudgets.delete(evicted);
 		}
 	}
 
@@ -434,6 +535,59 @@ export function createPrWorkflowResponseGate(options: {
 		bannerStamps.delete(sessionID);
 		banneredMessages.delete(sessionID);
 		fallbackInjections.delete(sessionID);
+	}
+
+	/**
+	 * Append a machine-readable suspension record to `.swarm/events.jsonl`.
+	 * Auto-resume suspension is otherwise observable only as prose inside a
+	 * chat banner, which no operator tooling can aggregate; this is the audit
+	 * surface for "why did this review stop resuming".
+	 *
+	 * Shape and failure policy mirror the abort-path append in
+	 * `pr-workflow-gate.ts` (`pr_workflow_aborted`): a `type`-tagged JSON line,
+	 * a path resolved through {@link validateSwarmPath}, and a non-fatal
+	 * try/catch. `validateSwarmPath` itself throws synchronously (null bytes,
+	 * traversal, symlinked `.swarm`), so it stays INSIDE the try. A missing
+	 * `.swarm` directory yields ENOENT and is likewise swallowed — the audit
+	 * trail is best-effort and must never break the gate or the wake
+	 * bookkeeping that surrounds this call.
+	 *
+	 * Awaited, never fire-and-forget: this runs inside the async `event`
+	 * handler, and a `queueMicrotask`-style detachment would let the process
+	 * tear down with the record unwritten (a recorded durability lesson in this
+	 * repo).
+	 */
+	async function appendWakeSuspendedEvent(fields: {
+		sessionID: string;
+		mode: string;
+		suspendedReason: 'consecutive' | 'total';
+		consecutiveUnproductive: number;
+		totalWakes: number;
+		tier: PrReviewDepthTier;
+	}): Promise<void> {
+		try {
+			const eventsPath = validateSwarmPath(options.directory, 'events.jsonl');
+			const suspendedEvent = {
+				type: 'pr_workflow_wake_suspended',
+				timestamp: new Date().toISOString(),
+				sessionID: fields.sessionID,
+				mode: fields.mode,
+				suspendedReason: fields.suspendedReason,
+				consecutiveUnproductive: fields.consecutiveUnproductive,
+				totalWakes: fields.totalWakes,
+				tier: fields.tier,
+				maxConsecutiveUnproductiveWakes: maxConsecutive,
+				totalWakeCeiling: resolveTotalWakeCeiling(fields.tier),
+			};
+			await fsp.appendFile(
+				eventsPath,
+				`${JSON.stringify(suspendedEvent)}\n`,
+				'utf-8',
+			);
+		} catch {
+			// Non-fatal: the audit trail is best-effort. A failed write must
+			// never break the gate or abort the suspension bookkeeping.
+		}
 	}
 
 	const textComplete = async (
@@ -596,7 +750,9 @@ export function createPrWorkflowResponseGate(options: {
 			if (isPrWorkflowAutoWakeSuppressed(options.directory, sessionID)) return;
 			if (!session) return;
 
-			evictIfOverBound();
+			// Pass the live session id so eviction can never drop the budget this
+			// handler is about to create or mutate (see evictIfOverBound rule 2).
+			evictIfOverBound(sessionID);
 			let budget = wakeBudgets.get(sessionID);
 			if (!budget) {
 				budget = {
@@ -745,12 +901,31 @@ export function createPrWorkflowResponseGate(options: {
 						sessionID,
 					);
 				} catch {
-					// The pre-wake read already validated the gate exists; a
-					// throw here is a transient fs error. Fall back to the
-					// pre-wake state so the bookkeeping proceeds with the
-					// last-known-good revision. Reserving null exclusively
-					// for a confirmed gate-clear prevents resetBudget from
-					// wiping the just-incremented totalWakes.
+					// Two distinct causes reach this catch, and neither is a
+					// gate-clear. (a) A transient fs error (EBUSY/EMFILE, or a
+					// concurrent writer). (b) A DURABLE validation failure:
+					// readPrWorkflowGateStateFromDisk deliberately throws
+					// `BLOCKED: ... is not valid JSON` / `... is invalid` for a
+					// corrupt or schema-invalid state file
+					// (pr-workflow-gate.ts:6357-6368), and
+					// `_internals.readPrWorkflowGateState` propagates it
+					// unmodified — so a throw here is NOT necessarily transient
+					// and may recur on every subsequent wake.
+					//
+					// Falling back to the pre-wake snapshot is nonetheless the
+					// correct handling for BOTH causes. This catch is nested
+					// inside the `finally` that owns all wake bookkeeping
+					// (lastWakeAt, the consecutive counter, totalWakes, and the
+					// suspension checks below); rethrowing would skip every one
+					// of them and recreate the unbounded-wake hazard this module
+					// exists to prevent — worst under cause (b), where the error
+					// recurs and the loop would never be braked at all.
+					// Continuing with the last-known-good revision instead makes
+					// the wake count as unproductive (a revision that cannot be
+					// re-read cannot advance), so a corrupt gate file suspends
+					// the session through the normal budget path. Reserving null
+					// exclusively for a confirmed gate-clear also prevents
+					// resetBudget from wiping the just-incremented totalWakes.
 					postWakeState = state;
 				}
 				if (
@@ -792,11 +967,20 @@ export function createPrWorkflowResponseGate(options: {
 						(budget.lastSeenRevision !== undefined &&
 							currentRevision > budget.lastSeenRevision);
 					budget.lastSeenRevision = currentRevision;
+					// Set by EITHER suspension branch below; the single audit
+					// append after both branches then reports the FINAL state.
+					// Emitting inside each branch instead would write two
+					// contradicting records for a wake that trips both budgets
+					// (reachable whenever maxConsecutive === totalCeiling), and
+					// the second one would disagree with the `suspendedReason`
+					// the user-facing banner renders.
+					let suspensionTripped = false;
 					if (!effectiveMadeProgress) {
 						budget.consecutiveUnproductive += 1;
 						if (budget.consecutiveUnproductive >= maxConsecutive) {
 							budget.suspended = true;
 							budget.suspendedReason = 'consecutive';
+							suspensionTripped = true;
 						}
 					} else {
 						budget.consecutiveUnproductive = 0;
@@ -806,6 +990,37 @@ export function createPrWorkflowResponseGate(options: {
 					// (success, failure, timeout) and NEVER reset by progress.
 					// Read the depth tier from durable gate state; default to 'L'
 					// when absent (e.g. PR_FEEDBACK mode has no diff-stats tier).
+					//
+					// KNOWN, INTENTIONALLY UNFIXED: the tier is read per-wake
+					// while `totalWakes` is tier-agnostic, so the ceiling a
+					// budget is measured against can CHANGE mid-budget. Two
+					// directions, and they are not symmetric:
+					//
+					//  - TIGHTENING (the common case): wakes accrued before the
+					//    depth tier is bound default to 'L' (102) and are later
+					//    compared against the bound tier. If that turns out to
+					//    be S (12) or M (54), the pre-bind wakes count against
+					//    the smaller ceiling and the brake fires EARLIER. Bind
+					//    happens early and the consecutive brake (5) caps any
+					//    unproductive run, so this is a 0-3 wake skew.
+					//  - LOOSENING (real, do not claim otherwise):
+					//    `transitionPrReviewToFeedback` mints a new
+					//    `workflowInstanceId` WITHOUT clearing the durable gate,
+					//    so `resetBudget` never runs and this budget survives
+					//    into PR_FEEDBACK — where the replacement state carries
+					//    no `prReviewDepthTier` and the `?? 'L'` below therefore
+					//    raises the ceiling to 102. A tier-S review that hands
+					//    off to feedback keeps its accumulated count but gains
+					//    headroom.
+					//
+					// Left as-is deliberately: the loosening is bounded by the
+					// same 102 that a tier-L review gets, the consecutive brake
+					// stays active throughout, and both candidate "fixes"
+					// (per-tier counters, or rebasing the count when the tier
+					// binds) would loosen the FIRST case further while adding
+					// state. Do not "correct" this without re-deriving that
+					// tradeoff — and do not restore the earlier claim that the
+					// skew can only ever tighten, which is false.
 					budget.totalWakes += 1;
 					const tier: PrReviewDepthTier =
 						postWakeState.prReviewDepthTier ?? 'L';
@@ -813,6 +1028,23 @@ export function createPrWorkflowResponseGate(options: {
 					if (budget.totalWakes >= totalCeiling) {
 						budget.suspended = true;
 						budget.suspendedReason = 'total';
+						suspensionTripped = true;
+					}
+					if (suspensionTripped) {
+						// Machine-readable audit record for the suspension. Both
+						// branches above route here, so exactly one line is
+						// written per suspension transition and its
+						// `suspendedReason` is by construction the value the
+						// banner will render. Awaited (never fire-and-forget) and
+						// internally non-fatal.
+						await appendWakeSuspendedEvent({
+							sessionID,
+							mode: postWakeState.mode,
+							suspendedReason: budget.suspendedReason,
+							consecutiveUnproductive: budget.consecutiveUnproductive,
+							totalWakes: budget.totalWakes,
+							tier,
+						});
 					}
 				}
 			}

--- a/tests/unit/hooks/pr-workflow-response-gate-audit-events.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-audit-events.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { _test_exports as autoWakeInternals } from '../../../src/hooks/pr-workflow-auto-wake.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+import { createPrWorkflowResponseGate } from '../../../src/hooks/pr-workflow-response-gate.js';
+import {
+	idleEventFor,
+	makeTempDir,
+	writeStateWithRevision,
+} from './pr-workflow-response-gate-test-helpers.js';
+
+let directory = '';
+
+beforeEach(() => {
+	directory = makeTempDir('pr-response-gate-audit-events-');
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function readEventLines(): Promise<Array<Record<string, unknown>>> {
+	const eventsPath = path.join(directory, '.swarm', 'events.jsonl');
+	const contents = await fs.readFile(eventsPath, 'utf-8');
+	return contents
+		.trim()
+		.split('\n')
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+/**
+ * Regression: F-006. Auto-resume suspension used to be observable only as
+ * prose inside a chat banner, which no operator tooling can aggregate. The
+ * fix appends a `pr_workflow_wake_suspended` record to `.swarm/events.jsonl`
+ * exactly once per suspension TRANSITION, from a single append site placed
+ * after BOTH the consecutive- and total-wake suspension checks — so a single
+ * wake that trips both budgets simultaneously (reachable whenever
+ * `maxConsecutiveUnproductiveWakes === totalWakeCeiling`) still produces one
+ * line, not two contradicting ones.
+ */
+describe('pr_workflow_wake_suspended audit event — regression: exactly one event per suspension transition (F-006)', () => {
+	test('the consecutive-unproductive suspension path appends exactly one event with suspendedReason "consecutive"', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 3,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { L: 999_999 },
+		});
+
+		// Revision never advances — every wake after the first (probe) wake is
+		// unproductive.
+		await writeStateWithRevision(directory, 'consecutive-session', 0, 'L');
+		const idle = idleEventFor('consecutive-session');
+		// Wake 1 is always treated as a probe (madeProgress=true), resetting the
+		// counter to 0. Wakes 2-4 are unproductive: counter reaches 3 (the
+		// configured max) on wake 4.
+		for (let i = 0; i < 4; i++) {
+			await gate.event(idle);
+		}
+		const budget = gate._inspectWakeBudget('consecutive-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('consecutive');
+
+		const events = await readEventLines();
+		const suspendEvents = events.filter(
+			(e) => e.type === 'pr_workflow_wake_suspended',
+		);
+		expect(suspendEvents.length).toBe(1);
+		expect(suspendEvents[0]).toMatchObject({
+			sessionID: 'consecutive-session',
+			suspendedReason: 'consecutive',
+		});
+	});
+
+	test('the total-wake suspension path appends exactly one event with suspendedReason "total"', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 4 },
+		});
+
+		const idle = idleEventFor('total-session');
+		for (let i = 0; i < 4; i++) {
+			await writeStateWithRevision(directory, 'total-session', i + 1, 'S');
+			await gate.event(idle);
+		}
+		const budget = gate._inspectWakeBudget('total-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+
+		const events = await readEventLines();
+		const suspendEvents = events.filter(
+			(e) => e.type === 'pr_workflow_wake_suspended',
+		);
+		expect(suspendEvents.length).toBe(1);
+		expect(suspendEvents[0]).toMatchObject({
+			sessionID: 'total-session',
+			suspendedReason: 'total',
+		});
+	});
+
+	test('a single wake that trips BOTH the consecutive and total budgets writes exactly one event, matching the final suspendedReason the banner renders', async () => {
+		// maxConsecutiveUnproductiveWakes === totalWakeCeiling reproduces the
+		// double-trip window: with no revision progress, wake 3 both crosses
+		// consecutiveUnproductive >= 2 AND totalWakes >= 3 in the same call.
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 2,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { L: 3 },
+		});
+
+		// Revision held constant across all wakes — no progress.
+		await writeStateWithRevision(directory, 'double-trip-session', 0, 'L');
+		const idle = idleEventFor('double-trip-session');
+		for (let i = 0; i < 3; i++) {
+			await gate.event(idle);
+		}
+
+		const budget = gate._inspectWakeBudget('double-trip-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.totalWakes).toBe(3);
+		expect(budget?.consecutiveUnproductive).toBe(2);
+
+		const events = await readEventLines();
+		const suspendEvents = events.filter(
+			(e) => e.type === 'pr_workflow_wake_suspended',
+		);
+		// Exactly one line, even though this wake tripped both budgets.
+		expect(suspendEvents.length).toBe(1);
+		// The recorded reason must match the FINAL budget state — the same
+		// value textComplete's banner will render for this session.
+		expect(suspendEvents[0]?.suspendedReason).toBe(budget?.suspendedReason);
+
+		// Confirm the banner the user actually sees names the same reason.
+		const output = { text: 'still stuck' };
+		await gate.textComplete({ sessionID: 'double-trip-session' }, output);
+		if (budget?.suspendedReason === 'total') {
+			expect(output.text).toContain('total wake budget for this workflow');
+		} else {
+			expect(output.text).toContain('consecutive unproductive retries');
+		}
+	});
+
+	test('a failing events.jsonl write is non-fatal — the gate still suspends and textComplete still renders the suspension banner', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { S: 2 },
+		});
+
+		// Force the events.jsonl append to fail by creating a directory at that
+		// exact path (fs.appendFile rejects with EISDIR). Mirrors
+		// tests/unit/hooks/pr-workflow-gate-abort.test.ts's
+		// "clears the gate even if the audit write would fail" case.
+		const eventsPath = path.join(directory, '.swarm', 'events.jsonl');
+		await fs.mkdir(eventsPath, { recursive: true });
+
+		const idle = idleEventFor('write-fail-session');
+		for (let i = 0; i < 2; i++) {
+			await writeStateWithRevision(directory, 'write-fail-session', i + 1, 'S');
+			// The idle event handler must not throw even though the audit
+			// append underneath it fails.
+			await gate.event(idle);
+		}
+
+		const budget = gate._inspectWakeBudget('write-fail-session');
+		// The gate must still suspend despite the audit-write failure — an
+		// audit-trail problem must never disable the brake it is reporting on.
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+
+		// The suspension banner must still render normally.
+		const output = { text: 'stuck after write failure' };
+		await gate.textComplete({ sessionID: 'write-fail-session' }, output);
+		expect(output.text).toContain('total wake budget for this workflow');
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-ceiling-derivation.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-ceiling-derivation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	PR_REVIEW_BASE_LANE_FLOORS,
+	PR_REVIEW_MICRO_LANE_FLOORS,
+	type PrReviewDepthTier,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { DEFAULT_TOTAL_WAKE_CEILINGS } from '../../../src/hooks/pr-workflow-response-gate.js';
+
+/**
+ * Regression: F-010. `DEFAULT_TOTAL_WAKE_CEILINGS` is documented as derived
+ * proportionally from each tier's lane-floor workload (base + micro lanes)
+ * times a fixed headroom multiplier of 6. That derivation is currently
+ * expressed only in a source comment, not in code — so a future change to
+ * `PR_REVIEW_BASE_LANE_FLOORS` or `PR_REVIEW_MICRO_LANE_FLOORS` (e.g. adding a
+ * new required base dimension or risk family) could silently leave the
+ * ceilings mis-sized relative to the workload they are supposed to bound,
+ * with nothing failing to flag the drift. This test pins the derivation as an
+ * executable invariant instead of prose.
+ */
+describe('DEFAULT_TOTAL_WAKE_CEILINGS — regression: ceilings stay derived from the lane floors (F-010)', () => {
+	test('every tier ceiling equals (base lane floor + micro lane floor) * 6', () => {
+		const HEADROOM_MULTIPLIER = 6;
+		const tiers: PrReviewDepthTier[] = ['S', 'M', 'L'];
+		for (const tier of tiers) {
+			const expected =
+				(PR_REVIEW_BASE_LANE_FLOORS[tier] + PR_REVIEW_MICRO_LANE_FLOORS[tier]) *
+				HEADROOM_MULTIPLIER;
+			expect(DEFAULT_TOTAL_WAKE_CEILINGS[tier]).toBe(expected);
+		}
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-ceiling-validation.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-ceiling-validation.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { _test_exports as autoWakeInternals } from '../../../src/hooks/pr-workflow-auto-wake.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createPrWorkflowResponseGate,
+	DEFAULT_TOTAL_WAKE_CEILINGS,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+import {
+	idleEventFor,
+	makeTempDir,
+	writeStateWithRevision,
+} from './pr-workflow-response-gate-test-helpers.js';
+
+let directory = '';
+
+beforeEach(() => {
+	directory = makeTempDir('pr-response-gate-ceiling-validation-');
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/**
+ * Drive wakes on a tier-S session until suspended, or up to `maxWakes`
+ * (whichever first), asserting revision advances every time so only the
+ * total-wake ceiling (never the consecutive-unproductive one) can trip.
+ * Returns the number of wakes actually driven and the final budget.
+ */
+async function driveUntilSuspendedOrMax(
+	gate: ReturnType<typeof createPrWorkflowResponseGate>,
+	sessionID: string,
+	tier: 'S' | 'M' | 'L',
+	maxWakes: number,
+): Promise<{ wakes: number; suspended: boolean }> {
+	const idle = idleEventFor(sessionID);
+	for (let i = 0; i < maxWakes; i++) {
+		await writeStateWithRevision(directory, sessionID, i + 1, tier);
+		await gate.event(idle);
+		const budget = gate._inspectWakeBudget(sessionID);
+		if (budget?.suspended) return { wakes: i + 1, suspended: true };
+	}
+	return { wakes: maxWakes, suspended: false };
+}
+
+/**
+ * Regression: F-008. A caller-supplied `totalWakeCeiling` that is not a
+ * finite positive integer silently disables or inverts the brake:
+ * `Infinity`/`NaN` make the ceiling comparison never true (brake never
+ * fires — an unbounded loop), and `0`/negative values make it true on the
+ * very first wake (a session suspends before doing any work). The fix
+ * validates every resolved value (both the uniform-scalar shape and each
+ * per-tier record value) and falls back to `DEFAULT_TOTAL_WAKE_CEILINGS` for
+ * that specific value when invalid.
+ */
+describe('resolveTotalWakeCeiling — regression: invalid totalWakeCeiling falls back to the tier default (F-008)', () => {
+	const invalidValues: Array<[string, number]> = [
+		['Infinity', Number.POSITIVE_INFINITY],
+		['-Infinity', Number.NEGATIVE_INFINITY],
+		['NaN', Number.NaN],
+		['0', 0],
+		['negative integer', -5],
+		['non-integer', 3.5],
+	];
+
+	for (const [label, value] of invalidValues) {
+		test(`scalar totalWakeCeiling=${label} falls back to the tier-S default (12)`, async () => {
+			const promptAsync = mock(async () => ({}));
+			const gate = createPrWorkflowResponseGate({
+				directory,
+				client: { session: { prompt: promptAsync, promptAsync } },
+				maxConsecutiveUnproductiveWakes: 999_999,
+				wakeCooldownMs: 0,
+				totalWakeCeiling: value,
+			});
+
+			// A non-fallback (invalid) ceiling would never suspend
+			// (Infinity/NaN) or suspend instantly (0/negative). The default
+			// tier-S ceiling is 12: drive exactly 12 wakes and require
+			// suspension at wake 12 (not before, not never).
+			const result = await driveUntilSuspendedOrMax(
+				gate,
+				`scalar-${label.replace(/[^a-z0-9]/gi, '')}`,
+				'S',
+				DEFAULT_TOTAL_WAKE_CEILINGS.S,
+			);
+			expect(result.suspended).toBe(true);
+			expect(result.wakes).toBe(DEFAULT_TOTAL_WAKE_CEILINGS.S);
+		});
+
+		test(`per-tier totalWakeCeiling.S=${label} falls back to the tier-S default (12)`, async () => {
+			const promptAsync = mock(async () => ({}));
+			const gate = createPrWorkflowResponseGate({
+				directory,
+				client: { session: { prompt: promptAsync, promptAsync } },
+				maxConsecutiveUnproductiveWakes: 999_999,
+				wakeCooldownMs: 0,
+				totalWakeCeiling: { S: value },
+			});
+
+			const result = await driveUntilSuspendedOrMax(
+				gate,
+				`per-tier-${label.replace(/[^a-z0-9]/gi, '')}`,
+				'S',
+				DEFAULT_TOTAL_WAKE_CEILINGS.S,
+			);
+			expect(result.suspended).toBe(true);
+			expect(result.wakes).toBe(DEFAULT_TOTAL_WAKE_CEILINGS.S);
+		});
+	}
+
+	test('a per-tier record with ONE invalid tier still honours the other VALID tiers (fallback is per-value, not whole-record)', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			// S is invalid (must fall back to default 12); M is a valid,
+			// deliberately non-default override (7) that must be HONOURED —
+			// proving one bad tier entry does not disable validation for the
+			// rest of the record.
+			totalWakeCeiling: { S: 0, M: 7 },
+		});
+
+		const sResult = await driveUntilSuspendedOrMax(
+			gate,
+			'mixed-tier-s',
+			'S',
+			DEFAULT_TOTAL_WAKE_CEILINGS.S,
+		);
+		expect(sResult.suspended).toBe(true);
+		expect(sResult.wakes).toBe(DEFAULT_TOTAL_WAKE_CEILINGS.S);
+
+		const mResult = await driveUntilSuspendedOrMax(
+			gate,
+			'mixed-tier-m',
+			'M',
+			20,
+		);
+		expect(mResult.suspended).toBe(true);
+		expect(mResult.wakes).toBe(7);
+	});
+
+	test('positive regression: a valid scalar override IS honoured (not silently replaced by the default)', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: 4, // valid, and deliberately different from every default
+		});
+
+		const result = await driveUntilSuspendedOrMax(
+			gate,
+			'valid-override',
+			'L',
+			20,
+		);
+		expect(result.suspended).toBe(true);
+		expect(result.wakes).toBe(4);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-eviction.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-eviction.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { _test_exports as autoWakeInternals } from '../../../src/hooks/pr-workflow-auto-wake.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createPrWorkflowResponseGate,
+	MAX_TRACKED_WAKE_SESSIONS,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+import { withFrozenClockAsync } from '../../helpers/test-clock.js';
+import {
+	idleEventFor,
+	makeTempDir,
+	writeStateWithRevision,
+} from './pr-workflow-response-gate-test-helpers.js';
+
+let directory = '';
+
+beforeEach(() => {
+	directory = makeTempDir('pr-response-gate-eviction-');
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/**
+ * Regression: F-002. `evictIfOverBound` used to be plain insertion-order FIFO
+ * — the oldest inserted entry was always the eviction victim, with no regard
+ * for suspension state or whether the entry belonged to the session currently
+ * being processed. That meant a live session's own budget could be evicted
+ * and silently recreated (zeroed) on its very next idle wake, once enough
+ * OTHER sessions had been tracked. The rewrite makes eviction LRU-by-
+ * `lastWakeAt`, and it categorically excludes (1) suspended budgets and
+ * (2) the session whose idle handler is currently running.
+ */
+describe('evictIfOverBound — regression: LRU eviction must not delete a live or suspended budget (F-002)', () => {
+	test('a live session survives eviction across its own repeated idle events, even when the bound is saturated entirely by suspended entries', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const promptAsync = mock(async () => ({}));
+				const gate = createPrWorkflowResponseGate({
+					directory,
+					client: { session: { prompt: promptAsync, promptAsync } },
+					maxConsecutiveUnproductiveWakes: 999_999,
+					wakeCooldownMs: 0,
+					// Tier S suspends after exactly one wake (cheap to saturate the
+					// bound); tier L never suspends across the handful of wakes this
+					// test drives.
+					totalWakeCeiling: { S: 1, L: 999_999 },
+				});
+
+				// 1. Wake the "live" session once first, so it is the OLDEST entry by
+				// insertion order — under the old FIFO eviction this made it the
+				// canonical first victim.
+				await writeStateWithRevision(directory, 'live-session', 1, 'L');
+				await gate.event(idleEventFor('live-session'));
+				const afterFirstWake = gate._inspectWakeBudget('live-session');
+				expect(afterFirstWake?.suspended).toBe(false);
+				expect(afterFirstWake?.totalWakes).toBe(1);
+
+				// 2. Saturate the bound with MAX_TRACKED_WAKE_SESSIONS suspended
+				// sessions (tier S, ceiling 1 — each suspends on its own first wake).
+				for (let i = 0; i < MAX_TRACKED_WAKE_SESSIONS; i++) {
+					const sessionID = `suspended-filler-${i}`;
+					await writeStateWithRevision(directory, sessionID, 1, 'S');
+					await gate.event(idleEventFor(sessionID));
+					expect(gate._inspectWakeBudget(sessionID)?.suspended).toBe(true);
+				}
+
+				// 3. Wake the live session several more times. Each call triggers
+				// evictIfOverBound with the map at or over the bound (1 live +
+				// MAX_TRACKED_WAKE_SESSIONS suspended = MAX+1). Every other tracked
+				// entry is suspended, so there is no evictable candidate other than
+				// the live session itself — which must be categorically excluded.
+				for (let i = 0; i < 5; i++) {
+					await writeStateWithRevision(directory, 'live-session', i + 2, 'L');
+					await gate.event(idleEventFor('live-session'));
+				}
+
+				const finalBudget = gate._inspectWakeBudget('live-session');
+				// The live session's budget must have SURVIVED — it was never
+				// evicted-and-recreated. Its totalWakes counter reflects the full
+				// history of 1 + 5 = 6 wakes, not a reset-to-1 that would result
+				// from recreation on any of the later idle events.
+				expect(finalBudget).toBeDefined();
+				expect(finalBudget?.suspended).toBe(false);
+				expect(finalBudget?.totalWakes).toBe(6);
+				// lastSeenRevision must reflect the latest wake's revision (6), which
+				// is only possible if the SAME budget object accumulated state across
+				// every call rather than being torn down and rebuilt.
+				expect(finalBudget?.lastSeenRevision).toBe(6);
+				// Positive lastWakeAt (see the fixedNow note on the sibling test):
+				// keeps the live session on the ordinary LRU path rather than the
+				// never-woken last-resort branch, so its survival is attributable to
+				// the current-session/suspended rules under test.
+				expect(finalBudget?.lastWakeAt).toBeGreaterThan(0);
+			},
+			{ fixedNow: 1_000, tickMs: 1 },
+		);
+	});
+
+	test('among evictable (non-suspended, non-current) entries, the least-recently-woken one is evicted first, and a suspended entry is never the victim even when it has the smallest lastWakeAt', async () => {
+		await withFrozenClockAsync(
+			async () => {
+				const promptAsync = mock(async () => ({}));
+				const gate = createPrWorkflowResponseGate({
+					directory,
+					client: { session: { prompt: promptAsync, promptAsync } },
+					maxConsecutiveUnproductiveWakes: 999_999,
+					wakeCooldownMs: 0,
+					totalWakeCeiling: { S: 1, L: 999_999 },
+				});
+
+				// Wake a tier-S session FIRST so it has the smallest lastWakeAt of
+				// the entire population — and it suspends immediately (ceiling 1).
+				await writeStateWithRevision(directory, 'suspended-oldest', 1, 'S');
+				await gate.event(idleEventFor('suspended-oldest'));
+				expect(gate._inspectWakeBudget('suspended-oldest')?.suspended).toBe(
+					true,
+				);
+
+				// Fill the rest of the bound with non-suspended tier-L fillers,
+				// each woken once, with strictly increasing lastWakeAt (the frozen
+				// clock advances by 1ms per Date.now() call, and each event() call
+				// reads Date.now() exactly once).
+				const fillerCount = MAX_TRACKED_WAKE_SESSIONS - 1;
+				for (let i = 0; i < fillerCount; i++) {
+					const sessionID = `filler-${String(i).padStart(4, '0')}`;
+					await writeStateWithRevision(directory, sessionID, 1, 'L');
+					await gate.event(idleEventFor(sessionID));
+					expect(gate._inspectWakeBudget(sessionID)?.suspended).toBe(false);
+				}
+
+				// Map size is now exactly MAX_TRACKED_WAKE_SESSIONS (1 suspended +
+				// fillerCount non-suspended). Wake a brand-new session: eviction
+				// runs first (size not yet over bound, no-op), then its entry is
+				// inserted, pushing size to MAX+1.
+				await writeStateWithRevision(directory, 'newcomer', 1, 'L');
+				await gate.event(idleEventFor('newcomer'));
+
+				// Wake ANOTHER brand-new session: this time eviction runs with the
+				// map strictly over bound, so it must evict exactly one entry — the
+				// least-recently-woken NON-SUSPENDED one, i.e. filler-0000 (the
+				// oldest filler), never suspended-oldest (which has a smaller
+				// lastWakeAt but is suspended).
+				await writeStateWithRevision(directory, 'trigger', 1, 'L');
+				await gate.event(idleEventFor('trigger'));
+
+				expect(gate._inspectWakeBudget('suspended-oldest')).toBeDefined();
+				expect(gate._inspectWakeBudget('filler-0000')).toBeUndefined();
+				expect(gate._inspectWakeBudget('filler-0001')).toBeDefined();
+
+				// The suspended entry must be spared by the SUSPENDED check, not
+				// incidentally by the never-woken (`lastWakeAt <= 0`) last-resort
+				// branch. `fixedNow` starts the frozen clock above zero precisely
+				// so that every budget in this test carries a positive lastWakeAt
+				// — without it the assertion above would pass for the wrong
+				// reason and the suspended rule would be untested.
+				expect(
+					gate._inspectWakeBudget('suspended-oldest')?.lastWakeAt,
+				).toBeGreaterThan(0);
+			},
+			{ fixedNow: 1_000, tickMs: 1 },
+		);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-postwake-read.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-postwake-read.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { _test_exports as autoWakeInternals } from '../../../src/hooks/pr-workflow-auto-wake.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	_internals,
+	createPrWorkflowResponseGate,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+import {
+	idleEventFor,
+	makeTempDir,
+	writeStateWithRevision,
+} from './pr-workflow-response-gate-test-helpers.js';
+
+let directory = '';
+const originalReadPrWorkflowGateState = _internals.readPrWorkflowGateState;
+
+beforeEach(() => {
+	directory = makeTempDir('pr-response-gate-postwake-read-');
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	_internals.readPrWorkflowGateState = originalReadPrWorkflowGateState;
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/**
+ * Regression: F-003. The `finally` block in the idle handler re-reads durable
+ * gate state AFTER the wake prompt to detect mid-wake progress. That re-read
+ * can throw for two distinct reasons (a transient fs error, or a durable
+ * schema-validation failure) — neither of which is a confirmed gate-clear.
+ * The fix falls back to the PRE-WAKE state snapshot on that throw, so the
+ * wake still counts as an attempted (unproductive) wake. The bug this guards
+ * against: falling back to `null` instead, which is the sentinel this same
+ * finally block uses for a CONFIRMED gate-clear — and a `null` postWakeState
+ * routes into `resetBudget(sessionID)`, silently WIPING the just-incremented
+ * `totalWakes` counter (and the whole budget entry) even though the gate is
+ * still active.
+ */
+describe('idle handler post-wake read — regression: read failure must not wipe totalWakes (F-003)', () => {
+	test('a post-wake readPrWorkflowGateState rejection preserves the pre-wake state snapshot; totalWakes still increments and the budget is not reset', async () => {
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			totalWakeCeiling: { L: 999_999 },
+		});
+
+		await writeStateWithRevision(directory, 'flaky-read-session', 3, 'L');
+
+		let callCount = 0;
+		_internals.readPrWorkflowGateState = mock(async (dir, sessionID) => {
+			callCount += 1;
+			// Odd calls are the pre-wake read of each event() invocation; even
+			// calls are the post-wake re-read in the finally block. Succeed on
+			// pre-wake, fail on post-wake, for every wake this test drives.
+			if (callCount % 2 === 1) {
+				return originalReadPrWorkflowGateState(dir, sessionID);
+			}
+			// Post-wake read: simulate a transient/validation read failure.
+			throw new Error('simulated post-wake read failure');
+		});
+
+		// Must resolve WITHOUT throwing — the failure is caught internally and
+		// does not propagate out of the idle handler.
+		await expect(
+			gate.event(idleEventFor('flaky-read-session')),
+		).resolves.toBeUndefined();
+
+		expect(callCount).toBe(2);
+
+		const budget = gate._inspectWakeBudget('flaky-read-session');
+		// If the fallback were `null` (the gate-clear sentinel) instead of the
+		// pre-wake snapshot, this branch would have called `resetBudget`,
+		// deleting the entry entirely — this assertion would fail with
+		// `undefined`.
+		expect(budget).toBeDefined();
+		// The wake must still count against the total-wake budget: a read
+		// failure that silently drops the counter would let a session whose
+		// gate-state file is corrupt (or a transient fs hiccup recurs on every
+		// wake) auto-resume forever, exactly the unbounded-loop hazard this
+		// module exists to prevent.
+		expect(budget?.totalWakes).toBe(1);
+		// The pre-wake revision (3) must be preserved as lastSeenRevision —
+		// proof that the fallback used the PRE-WAKE snapshot (revision 3), not
+		// a `null`/zeroed budget that would leave lastSeenRevision undefined.
+		expect(budget?.lastSeenRevision).toBe(3);
+		expect(budget?.suspended).toBe(false);
+
+		// A second wake on the same (still-flaky) session must accumulate,
+		// not reset — proving the entry truly survived rather than being torn
+		// down and silently rebuilt with totalWakes back at 1.
+		await writeStateWithRevision(directory, 'flaky-read-session', 3, 'L');
+		await gate.event(idleEventFor('flaky-read-session'));
+		const budgetAfterSecondWake = gate._inspectWakeBudget('flaky-read-session');
+		expect(budgetAfterSecondWake?.totalWakes).toBe(2);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-test-helpers.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-test-helpers.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+	PrReviewDepthTier,
+	PrWorkflowGateState,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+
+/** Create a fresh, symlink-resolved temp directory under a given prefix. */
+export function makeTempDir(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+/** Write a raw gate-state record with a specific revision and optional depth tier. */
+export async function writeStateWithRevision(
+	directory: string,
+	sessionID: string,
+	revision: number,
+	tier?: PrReviewDepthTier,
+): Promise<void> {
+	const relative = workflowInternals.workflowGateStateRelativePath(sessionID);
+	const absolute = path.join(directory, '.swarm', relative);
+	await fs.mkdir(path.dirname(absolute), { recursive: true });
+	const state: PrWorkflowGateState = {
+		schemaVersion: 1,
+		revision,
+		sessionID,
+		mode: 'PR_REVIEW',
+		activatedAt: '2026-07-19T00:00:00.000Z',
+		updatedAt: '2026-07-19T00:00:00.000Z',
+		...(tier !== undefined && { prReviewDepthTier: tier }),
+	};
+	await fs.writeFile(absolute, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/** Write a raw gate-state record, omitting `prReviewDepthTier` entirely
+ * (as opposed to setting it to undefined), so `?? 'L'` fallbacks are
+ * genuinely exercised on an absent field rather than an explicit `undefined`
+ * key that JSON.stringify would drop anyway. */
+export async function writeStateWithoutTier(
+	directory: string,
+	sessionID: string,
+	revision: number,
+): Promise<void> {
+	const relative = workflowInternals.workflowGateStateRelativePath(sessionID);
+	const absolute = path.join(directory, '.swarm', relative);
+	await fs.mkdir(path.dirname(absolute), { recursive: true });
+	const state: Omit<PrWorkflowGateState, 'prReviewDepthTier'> = {
+		schemaVersion: 1,
+		revision,
+		sessionID,
+		mode: 'PR_REVIEW',
+		activatedAt: '2026-07-19T00:00:00.000Z',
+		updatedAt: '2026-07-19T00:00:00.000Z',
+	};
+	await fs.writeFile(absolute, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+export function idleEventFor(sessionID: string): { event: unknown } {
+	return {
+		event: {
+			type: 'session.idle',
+			properties: { sessionID },
+		},
+	};
+}

--- a/tests/unit/hooks/pr-workflow-response-gate-tier-fallback.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-tier-fallback.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { _test_exports as autoWakeInternals } from '../../../src/hooks/pr-workflow-auto-wake.js';
+import { _test_exports as workflowInternals } from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createPrWorkflowResponseGate,
+	DEFAULT_TOTAL_WAKE_CEILINGS,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+import {
+	idleEventFor,
+	makeTempDir,
+	writeStateWithoutTier,
+} from './pr-workflow-response-gate-test-helpers.js';
+
+let directory = '';
+
+beforeEach(() => {
+	directory = makeTempDir('pr-response-gate-tier-fallback-');
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+});
+
+afterEach(async () => {
+	workflowInternals.resetTrackedStateCache();
+	autoWakeInternals.reset();
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/**
+ * Regression: F-012. `prReviewDepthTier` is absent on gate state for modes
+ * (e.g. PR_FEEDBACK) that never compute a diff-stats-derived tier. The idle
+ * handler resolves the total-wake ceiling via `postWakeState.prReviewDepthTier
+ * ?? 'L'`. Before the fix, a missing tier could resolve to `undefined`
+ * (looking up `DEFAULT_TOTAL_WAKE_CEILINGS[undefined]`, which is `undefined`
+ * and makes `totalWakes >= undefined` always `false` — the total brake never
+ * fires for these sessions).
+ */
+describe('idle handler tier resolution — regression: absent prReviewDepthTier falls back to the L ceiling (F-012)', () => {
+	test('a gate-state record with no prReviewDepthTier is governed by the tier-L ceiling (102)', async () => {
+		expect(DEFAULT_TOTAL_WAKE_CEILINGS.L).toBe(102);
+
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 999_999,
+			wakeCooldownMs: 0,
+			// No totalWakeCeiling override: exercise the real DEFAULT_TOTAL_WAKE_CEILINGS.
+		});
+
+		// Never write prReviewDepthTier at all (not even `undefined`).
+		await writeStateWithoutTier(directory, 'no-tier-session', 0);
+
+		const idle = idleEventFor('no-tier-session');
+		// Drive 101 productive wakes (revision advances every time so the
+		// consecutive counter never fires) — must NOT be suspended yet, proving
+		// the ceiling in force is 102 (the L default), not some smaller/absent
+		// value.
+		for (let i = 0; i < 101; i++) {
+			await writeStateWithoutTier(directory, 'no-tier-session', i + 1);
+			await gate.event(idle);
+		}
+		let budget = gate._inspectWakeBudget('no-tier-session');
+		expect(budget?.suspended).toBe(false);
+		expect(budget?.totalWakes).toBe(101);
+
+		// The 102nd wake must hit the ceiling and suspend with reason 'total'.
+		await writeStateWithoutTier(directory, 'no-tier-session', 102);
+		await gate.event(idle);
+		budget = gate._inspectWakeBudget('no-tier-session');
+		expect(budget?.suspended).toBe(true);
+		expect(budget?.suspendedReason).toBe('total');
+		expect(budget?.totalWakes).toBe(102);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate-total-wake-budget.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-total-wake-budget.test.ts
@@ -149,8 +149,12 @@ describe('PR workflow total wake budget', () => {
 		const output = { text: 'still working' };
 		await gate.textComplete({ sessionID: 'notice-session' }, output);
 
-		// Total-cap wording: "total per-session wake budget"
-		expect(output.text).toContain('total per-session wake budget');
+		// Total-cap wording: "total wake budget for this workflow"
+		// (corrected from the earlier "total per-session wake budget" wording,
+		// which overclaimed the counter's scope — WakeBudget.totalWakes is
+		// scoped to one process lifetime, until the durable gate clears, not the
+		// whole session).
+		expect(output.text).toContain('total wake budget for this workflow');
 		// Must NOT contain the consecutive-unproductive wording.
 		expect(output.text).not.toContain('consecutive unproductive retries');
 		// All three recovery paths must be named.


### PR DESCRIPTION
## Summary

Follow-up to the `swarm-pr-review` of #2027, which merged before its review findings were addressed. This closes 12 of the 14 validated findings; the remaining two were corrections to #2027's own body, which is now merged history.

**Behavioural fixes**

- **Eviction could delete a live session's own wake budget.** `evictIfOverBound` is now LRU-by-`lastWakeAt` and refuses to evict the current session or any in-flight one. Previously, once the tracked-budget bound was saturated by suspended entries, a live session's budget was the only eviction candidate and was deleted on each of its own idle events. The recreated budget had no `lastSeenRevision`, so `madeProgress` read true on every wake — and the consecutive brake, the cooldown, and the total ceiling all became unreachable for that session, reproducing the unbounded loop #1967 set out to fix.
- **`Infinity`/`NaN` silently disabled the brake.** `totalWakeCeiling` is now validated at resolve time (finite, integer, `> 0`) for both the scalar and per-tier record forms; invalid values fall back to the tier default. A non-finite ceiling made the `totalWakes >= ceiling` comparison permanently false. Fallback rather than throw, matching the unvalidated sibling options, so a bad value cannot crash plugin init.
- **Suspensions left no machine-readable trace.** Both branches now append a `pr_workflow_wake_suspended` record to `.swarm/events.jsonl` with the reason, both counters, the tier, and the ceiling in force — awaited, and internally non-fatal so a failed audit write cannot break the gate.

**Documentation corrections (no behaviour change)**

- The depth-tier table in `.opencode/skills/swarm-pr-review/SKILL.md` still carried the pre-#2027 thresholds. That table is the tier classifier on Profiles B/C, so #2027's widening had no effect off-controller — the fix was unwired on the default profile.
- The budget's scope was documented as per-session/per-activation. It is neither: it runs for one process lifetime until the durable gate clears, and it deliberately survives the PR_REVIEW → PR_FEEDBACK handoff, which mints a new activation without clearing the gate.
- The post-wake `catch` described a designed `BLOCKED` corruption throw as "a transient fs error". The comment now names both causes and explains why the fallback is still right: the catch is nested inside the `finally` that owns the `totalWakes` increment, so rethrowing would skip the bookkeeping entirely.
- The tier-read comment claimed the pre-bind skew "can only tighten, never leak". That is false — the review→feedback transition raises a tier-S budget's ceiling from 12 to 102 mid-budget. Both directions are now documented, along with why the behaviour is still left as-is.

Findings closed: F-001, F-002, F-003, F-004, F-005, F-006, F-007, F-008, F-009, F-010, F-011, F-012.

## Invariant audit

- 1 (plugin init): not touched — no change to `src/index.ts` or the init path; `bun run build` succeeds and `await import('./dist/index.js')` prints `dist import OK`.
- 2 (runtime portability): touched — added `node:fs/promises` and `validateSwarmPath` imports to `src/hooks/pr-workflow-response-gate.ts`. Both are portable; `grep -nE "from 'bun:|Bun\."` on the changed file returns nothing. `node scripts/repro-704.mjs` passes T1/T2/T3.
- 3 (subprocesses): not touched — `grep -nE "bunSpawn\(|spawn\(|spawnSync\("` on the changed file returns nothing.
- 4 (.swarm containment): touched — the new audit append writes only via `validateSwarmPath(options.directory, 'events.jsonl')` (`pr-workflow-response-gate.ts:569`), mirroring the existing `pr_workflow_aborted` append. No raw path joins, no writes outside `.swarm/`.
- 5 (plan durability): not touched — no plan schema or ledger changes.
- 6 (test_runner safety): not touched — no `test_runner` scope changes; all validation run by hand with explicit file lists.
- 7 (test writing): touched — 7 new test files, all using `bun:test` and the `_internals` DI seam, none using `mock.module`. `bash scripts/check-mock-cleanup.sh` passes; `scripts/check-test-file-cap.sh` reports 0 new-file and 0 ratchet violations (largest new file 198 lines against the 500 cap); `bash scripts/check-test-clock.sh` reports 0 new blocking violations.
- 8 (session state): touched — `wakeBudgets` eviction changed from insertion-order FIFO to LRU with suspended/current/in-flight exclusion (`evictIfOverBound`, `pr-workflow-response-gate.ts:474`); `MAX_TRACKED_WAKE_SESSIONS = 200` (`:131`) unchanged, and the docblock now states plainly that the bound is best-effort when candidates are exhausted. `WakeBudget` at `:151`.
- 9 (guardrails/retry): touched — ceiling validation (`isValidTotalWakeCeiling` `:195`, `resolveTotalWakeCeiling` `:390`), `DEFAULT_TOTAL_WAKE_CEILINGS` `:113`, `totalWakes` increment and ceiling check `:1024`. Behaviour is covered by the eviction, ceiling-validation, tier-fallback, and derivation test files.
- 10 (chat/system msg): touched — corrected total-cap wording in `blockedText` (`:252`) and `workflowBanner` (`:303`); `forceFullBanner` (`:670`) unchanged, so suspended notices still bypass the cooldown while staying per-message deduped.
- 11 (tool registration): not touched — `bun run scripts/check-tool-registration.ts` passes (116 tools, coherent across metadata, handlers, plugin object, `TOOL_NAMES`, `AGENT_TOOL_MAP`).
- 12 (release/cache): touched — updated the existing pending fragment `docs/releases/pending/pr-workflow-total-wake-budget-and-tier-widening.md`. No version file, `CHANGELOG.md`, or `.release-please-manifest.json` edits; `dist/` not staged.

## Test plan

Counts re-measured at this PR's head, not carried over (the fragment's publish-time obligation block requires this — it exists because #2027 shipped stale numbers).

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint:ci` — exit 0, checked 2989 files
- [x] `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` — `dist import OK`
- [x] `node scripts/repro-704.mjs` — T1/T2/T3 all OK
- [x] `bun run test:unit:ci` over the 12 affected files (explicit list; AGENTS.md invariant 7 forbids directory runs) — all 12 exit 0
- [x] Same 12 files under `bun test`: **88 pass, 0 fail, 849 expect()**. The 11 `pr-workflow-response-gate*` files alone: 70 pass / 782 expect. `tests/unit/tools/dispatch-lanes-pr-workflow-gate.test.ts`: 18 pass / 67 expect
- [x] `bun test tests/security` — 163 pass, 4 skip, 0 fail
- [x] `bun test tests/adversarial` — 846 pass, 0 fail
- [x] `bun test tests/smoke` — 10 pass, 0 fail
- [x] `bun run scripts/check-tool-registration.ts`, `scripts/check-mock-cleanup.sh`, `scripts/check-test-clock.sh`, `scripts/check-test-file-cap.sh` — pass
- [x] `bun run drift:check` — no `swarm-pr-review` findings (the 17 reported mirror findings are pre-existing and unrelated)

Every runtime fix was mutation-tested: reverting the guard fails the corresponding test. FIFO revert → eviction tests; removing the suspended skip → eviction test 2; `postWakeState = null` → postwake-read; dropping `await` on the append → audit-events; dropping the ceiling clamp → 13/14 ceiling-validation tests; `?? 'L'` → `?? 'S'` → tier-fallback; ceiling literal 102 → 100 → derivation.

## Pre-existing failures

Both reproduced identically on clean `origin/main` with this branch's changes stashed, so neither is introduced here:

- `bash scripts/check-invariants.sh` — 744 violations, byte-identical count with and without this change; none of the 11 changed files appear in its output.
- `bun test tests/integration ./test` — 749 pass / 215 fail, identical with and without this change. This is the documented bulk-directory `mock.module` cross-file pollution that AGENTS.md invariant 7 warns about; CI runs these files individually.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

