### PR TITLE
fix(pr-workflow-gate): move gate accounting from batch to review item

### DIFF
--- a/.agents/skills/swarm-pr-review/SKILL.md
+++ b/.agents/skills/swarm-pr-review/SKILL.md
@@ -41,13 +41,13 @@ Read and follow `../../../.opencode/skills/swarm-pr-review/SKILL.md` as the cano
   `pr_head_sha`); persist findings and trigger ledgers in working notes,
   never under `.swarm/`.
 - Clean lanes still require a fully populated row, such as
-  `[CLEAN] | workflow_lane | coverage_scope | evidence`; a missing per-family
-  attestation is an unclosed coverage gap — retry it or surface it as BLOCKED
-  rather than emitting a degraded review or partial verdict.
+  `[CLEAN] | workflow_lane | coverage_scope | evidence`; a missing attestation
+  is a coverage gap — retry it or surface BLOCKED, never a degraded review.
 - When a lane result includes an `output_ref`, retrieve the full text before
   extracting candidates; degraded or truncated output is a coverage gap.
-- A newer reviewer batch invalidates all older critic evidence; re-run the
-  critic from the latest complete reviewer inventory before completion.
+- Reviewer and critic verdicts compose per item across passes: a reviewer retry
+  invalidates only the critic evidence for items whose reviewer row changed;
+  re-run the critic for items left without a critic verdict before completion.
 - Where the swarm plugin's structured controller is active (OpenCode hosts),
   the initial base wave is one structured exact-six batch with workflow-lane
   and exact-head provenance at depth tier L, or a smaller consolidated batch

--- a/.claude/skills/swarm-pr-review/SKILL.md
+++ b/.claude/skills/swarm-pr-review/SKILL.md
@@ -40,12 +40,12 @@ Read and follow `../../../.opencode/skills/swarm-pr-review/SKILL.md` as the cano
   persist findings and trigger ledgers as files in the session task workspace,
   never under `.swarm/`.
 - Clean lanes still require a fully populated row, such as
-  `[CLEAN] | workflow_lane | coverage_scope | evidence`; a missing per-family
-  attestation is an unclosed coverage gap — retry it or surface it as BLOCKED
-  rather than emitting a degraded review or partial verdict.
+  `[CLEAN] | workflow_lane | coverage_scope | evidence`; a missing attestation
+  is a coverage gap — retry it or surface BLOCKED, never a degraded review.
 - Use fresh reviewer subagents for candidate validation and fresh critic
-  subagents after review; a newer reviewer batch invalidates older critic
-  evidence. The Pre-Synthesis Gate checklist is the completion gate.
+  subagents after review; settlement composes per item, so a reviewer retry
+  invalidates only the critic claim for an item whose reviewer row changed.
+  The Pre-Synthesis Gate checklist is the completion gate.
 - Only if this session actually exposes the swarm controller tools
   (`dispatch_lanes_async`, `collect_lane_results`, `retrieve_lane_output`),
   run Profile A instead: structured modes, incremental polling, full-text

--- a/.opencode/skills/swarm-pr-feedback/SKILL.md
+++ b/.opencode/skills/swarm-pr-feedback/SKILL.md
@@ -608,7 +608,10 @@ Only exact positive verdict fields pass. A sentence containing “not APPROVE,�
 header without item rows, duplicate rows, missing IDs, degraded/truncated
 artifacts, wrong roles, stale content digests, parallel or out-of-order phases,
 and reused pre-edit approvals all fail closed. Any content change after Stage A
-invalidates Stage A and every later gate; restart at step 1. Publication tools
+invalidates Stage A and every later gate; restart at step 1. See
+"Re-recording Stage A on an unchanged revision" below for the one retention
+exception, which applies only when the revision digest itself did not change.
+Publication tools
 and `git commit`/`git push` remain blocked until all four ordered lane phases
 settle on the Stage-A digest. After they settle, only one standalone `git commit`
 command may create the reviewed commit; push and remote publication remain
@@ -703,6 +706,43 @@ output via `retrieve_summary`; if that persistence fails, the failing check's
 full stdout/stderr is inlined instead so evidence is never lost. A successful
 run persists nothing — there is no failure evidence to recover, and the
 per-check summaries are the useful record.
+
+### Re-recording Stage A on an unchanged revision
+
+Re-recording Stage A always requires a fresh, complete receipt set on the
+current revision digest — that part is unconditional. What happens to the
+already-recorded Stage B and closeout gate batches depends on whether the
+revision digest itself changed. If the digest is unchanged from the prior
+Stage A record **and** the newly declared applicable obligations/categories
+are equal to or a superset of the prior declaration, the already-approved
+independent gate batches are retained: re-recording Stage A to add a
+previously-missed obligation, or to re-attest the same set, does not by
+itself discard Stage B and closeout work that already passed on that
+revision. A narrower obligation set than the prior declaration, or any actual
+digest change, still wipes every recorded gate batch and un-arms publication
+exactly as before — a controller cannot narrow what it declares in order to
+dodge re-verification.
+
+### Why gate evidence is not item-scoped
+
+Stage A, Stage B, and closeout evidence invalidate as whole gate batches, not
+per feedback item, and that is a deliberate design decision, not unfinished
+work:
+
+- **No trustworthy item-to-file mapping exists to key invalidation on.** The
+  file scope a caller declares for a feedback item is caller-asserted and
+  only path-sanitized — it is never intersected with the actual changed-file
+  set, and it carries no persisted binding back to feedback item IDs. Keying
+  invalidation on that declaration would let a controller dodge
+  re-verification by under-declaring scope, turning a fail-closed guarantee
+  into a fail-open one (AGENTS.md invariant 9) — the same failure class that
+  already ruled out keying digest invalidation on `git diff --raw` blob OIDs.
+- **The four gate phases are holistic by contract.** Each recorded batch must
+  own every inventory item exactly once and in declared order. Retaining
+  evidence for a subset of items per gate would re-partition that
+  independent-review contract itself, and would need its own
+  collusion/independence analysis before it could be trusted — it is not a
+  drop-in extension of the revision-level retention above.
 
 ### Stage B — reviewer + test_engineer (mandatory after Stage A passes)
 

--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -775,14 +775,29 @@ cost, or predicted simplicity — permits fewer lanes than the classified tier,
 and no tier permits skipping a dimension or family. Under Profile A the
 controller computes the tier itself from the bound `base_sha...pr_head_sha`
 diff (`--numstat` totals; an uncomputable diff fails strict to tier L) and
-mechanically enforces the matching floors on every base and micro batch —
-initial waves and retries alike: tier L requires the historical
-full fan-out (six singleton base lanes, one micro-lane per family, on every
-batch, not only the first), while
-tiers S and M accept consolidated lanes that declare their complete
-`owned_workflow_lanes` set — every dimension and family still owned exactly
-once and attested per family. Risk triggers remain caller-side escalation on
-every profile: dispatch MORE than the floor whenever a trigger warrants it.
+mechanically enforces the matching floors on every base and micro batch. The
+initial base wave and every micro batch keep the historical tier-L full
+fan-out (six singleton base lanes on the initial base wave; one micro-lane
+per family on every micro batch, not only the first), while tiers S and M
+accept consolidated lanes that declare their complete `owned_workflow_lanes`
+set — every dimension and family still owned exactly once and attested per
+family. A tier-L base **retry** may consolidate dimensions that each have a
+recorded, terminally-failed prior attempt and currently have no successful
+source, subject to two lane floors: no single lane may own all six
+dimensions, and — counted cumulatively across every recorded base batch, not
+per batch, and including batches the capacity GC has since dropped — the six
+dimensions must stay backed by at least four distinct lanes (each dimension
+no consolidated lane claims counts as one, plus the FEWEST declared
+consolidated lanes that suffice to cover the rest). That permits a small
+consolidation as failure recovery and rejects re-doing the whole wave in two
+or three lanes, whether the attempt is split across several batches or
+disguised as overlapping or duplicate consolidations — declaring more lanes
+than the cover needs buys no budget. A dimension that already has a
+successful source, or whose prior attempt is still in flight, still requires
+its own dedicated retry lane, and
+a full six-lane singleton re-dispatch is always accepted. Risk triggers
+remain caller-side escalation on every profile: dispatch MORE than the floor
+whenever a trigger warrants it.
 
 ### Dispatch
 
@@ -1284,23 +1299,47 @@ machine enforcement cannot safely infer every repository-specific trust
 boundary from prose. Completion is blocked until that exact derived inventory
 has valid critic rows.
 
-Reviewer and critic retries cannot be combined as complementary partial verdict
-sets. Each phase requires at least one fully successful exact batch covering its
-entire mechanically assigned inventory on one revision. A later degraded,
-truncated, stale, wrong-identity, or malformed batch cannot replace an earlier
-valid batch or suppress critic routing.
+Reviewer and critic settlement compose across batches, item by item: a phase
+settles once every review item in the current mechanically assigned inventory
+holds a successful verdict, whether that coverage comes from one batch or from
+several complementary partial retries. A later degraded, truncated, stale,
+wrong-identity, or malformed batch never supplies a verdict for the items it
+touches, but it does not discard verdicts other batches already supplied for
+different items.
 
-Any newer reviewer batch invalidates every older critic batch, even when the
-new reviewer rows happen to be identical. Dispatch a fresh critic wave from the
-latest coherent reviewer batch; critic evidence can never predate the reviewer
-evidence it purports to challenge.
+When more than one successful batch covers the same item, the most recent
+successful batch wins that item. This conflict rule is one shared computation,
+so settlement and every downstream verdict use (candidate inventory, critic
+routing, final synthesis) never disagree about which claim is authoritative
+for an item. A batch contributes only when it was validated against the exact
+candidate inventory current at validation time; a batch recorded before that
+binding existed contributes only if it is wholly successful and its item set
+exactly matches the current inventory — the historical all-or-nothing rule,
+preserved unchanged for state that predates composition.
+
+A critic claim is bound per item to the exact reviewer row it was validated
+against, not to the reviewer batch as a whole. A reviewer retry that
+reproduces a byte-identical row for an item retains that item's critic work;
+a reviewer row that changed at all — even one field — invalidates only that
+item's critic claim, not the whole critic wave. Critic batches recorded
+before per-item binding existed keep the old behavior: any newer reviewer
+batch invalidates them wholesale. Dispatch a fresh critic wave to cover
+whatever items composition leaves unclaimed; critic evidence can never
+predate the reviewer evidence it purports to challenge.
+
+Settlement is item completeness, not lane completeness: a declared lane that
+never completes produces a diagnostic naming the abandoned lane, not an
+automatic block, as long as every item in the inventory already holds a
+successful verdict from some lane.
 
 Under Profile A, dispatch critic chunks with `dispatch_lanes_async`,
 `mode: "swarm-pr-review:critic"`, a unique non-empty `workflow_lane` per
 chunk, `review_item_ids` containing the exact finding IDs assigned to that
 chunk, critic-role agents only, and the same exact `pr_head_sha`. The runtime
 requires one parseable `[CRITIC]` row for every structurally assigned ID and
-requires one coherent fully successful exact reviewer batch before a critic wave.
+requires the reviewer phase to have settled — every item in the current
+inventory holding a successful reviewer verdict, composed across batches —
+before a critic wave.
 Under Profile B, dispatch each critic chunk to a fresh subagent that was
 neither the explorer nor the reviewer for those findings; under Profile C, run
 a separate critic pass. The one-parseable-`[CRITIC]`-row-per-assigned-ID

--- a/docs/releases/pending/1968-pr-workflow-composable-gate-accounting.md
+++ b/docs/releases/pending/1968-pr-workflow-composable-gate-accounting.md
@@ -1,0 +1,145 @@
+# PR workflow gate accounting: composable settlement, per-item critic retention, bounded retries
+
+Fixes issue #1968: the PR-workflow gates previously treated the entire
+inventory on the current revision as the atomic unit of validity, so every
+local failure — one lane, one dimension, one feedback item — forced global
+rework with no bounded recovery path.
+
+## What changed
+
+- **Reviewer and critic settlement now compose across batches, item by
+  item.** A reviewer or critic phase settles once every review item in the
+  current inventory holds a successful verdict, whether that coverage comes
+  from a single batch or from several complementary partial retries. One
+  failed lane in an otherwise successful batch no longer forces every item —
+  including the ones that already passed — to be re-run. When more than one
+  successful batch covers the same item, the most recent successful batch
+  wins that item, and this conflict rule is the single computation shared by
+  settlement and every downstream verdict use, so they can never disagree
+  about which claim is authoritative.
+- **The critic gate can no longer be skipped silently.** The gate that
+  decides whether critic coverage is required at all now fails closed if the
+  reviewer phase is not settled, or if a settled reviewer phase somehow
+  yields an empty or incomplete verdict map. Previously either condition
+  produced an empty critic inventory, which read as "nothing needs a critic"
+  and let confirmed critical/high findings ship unchallenged, surfacing only
+  as a later, misleading "no authoritative reviewer verdict" error. Both
+  conditions now block with a message naming the actual cause.
+- **Critic evidence is retained per item, not per batch.** A critic claim is
+  bound to the exact reviewer row it was validated against. A reviewer retry
+  that reproduces a byte-identical row for an item keeps that item's critic
+  work; a reviewer row that changed at all invalidates only that item's
+  critic claim, not the whole critic wave. Critic batches recorded before
+  this per-item binding existed keep the prior behavior: a newer reviewer
+  batch still invalidates them wholesale.
+- **Tier-L base retries no longer require a full six-lane singleton
+  fan-out.** A retry may consolidate dimensions that each have a recorded,
+  terminally-failed prior attempt and currently lack a successful source. Two
+  lane floors bound how much depth consolidation may cost: no single lane may
+  own all six dimensions, and — measured cumulatively across every recorded
+  base batch, not per batch — the six dimensions must stay backed by at least
+  four distinct lanes, counting each dimension no consolidated lane claims as
+  one, plus the *fewest* of the declared consolidated lanes that together cover
+  every dimension consolidated lanes do claim. That floor counts a minimum
+  cover rather than declarations because declaring a lane costs nothing: the
+  four pairwise consolidations `{A,B} {B,C} {D,E} {F,A}` are each individually
+  legal, but three of them already cover all six dimensions, so the wave would
+  settle at three producing lanes and is rejected — a count of declarations
+  would have read four and accepted it. In practice that permits a
+  single two-dimension consolidation, or two of them, and rejects a wholesale
+  re-do of the wave in two or three lanes even when it is split across
+  batches. A dimension that already has a successful source, or whose prior
+  attempt is still in flight, still requires its own dedicated retry lane, and
+  a full singleton re-dispatch of the whole wave is always available. The full
+  fan-out requirement on the initial base wave is unchanged.
+- **The PR_REVIEW batch limits are no longer a dead end.** Sessions that
+  accumulate a large number of base or validation batches now garbage-collect
+  provably inert ones instead of being permanently blocked once the limit is
+  reached. A reviewer batch is dropped only when a full-window recomputation
+  shows it contributes no verdict claim; council and critic batches, the newest
+  batch of each phase, and any base batch carrying a fully successful lane are
+  never dropped. Pruning never changes the computed candidate or critic
+  inventory, never un-forbids a reviewer's child session for the critic reuse
+  ban, and never hands a tier-L wave back consolidation budget it already
+  spent — a dropped base batch's consolidated lane sets move to a retired
+  ledger the cumulative lane floor keeps walking, so that floor is invariant
+  under the GC. Both ledgers are bounded, and a prune that would overflow
+  either one keeps every batch instead of dropping a forbidden child session
+  or a spent consolidation. The prune runs inside the same
+  read-prune-append-persist transaction as the batch that triggered it, so
+  there is no separate, interruptible GC write.
+- **The PR_FEEDBACK verification batch limit is no longer a dead end either.**
+  Verification batches accumulate on retry just as the PR_REVIEW arrays do, so
+  the same reclaim applies. Settlement coverage comes only from lanes that both
+  passed batch integrity and produced an artifact covering their items, so a
+  verification batch whose every lane failed contributes no coverage; what it
+  does hold is its item→lane ownership binding, and those bindings are moved to
+  a retired ledger so the cumulative re-claim rejection — an item may never be
+  re-claimed by a *different* lane — stays in force across the prune. The
+  newest batch is never dropped, the covered-item set is proven unchanged, and
+  a ledger overflow keeps every batch instead.
+- **PR_FEEDBACK Stage A re-recording on an unchanged revision retains
+  already-approved gate evidence.** Re-recording Stage A still always
+  requires a fresh, complete receipt set on the current revision digest. But
+  if the revision digest did not change and the newly declared applicable
+  obligations/categories are equal to or a superset of what was previously
+  declared, the already-approved Stage B and closeout gate batches are
+  retained instead of being wiped. A narrower obligation set, or any actual
+  digest change, still wipes every gate batch and un-arms publication exactly
+  as before.
+- **PR_FEEDBACK's revision-digest computation supports larger diffs with
+  diagnosable limits.** The file-count and byte-size caps that bound digest
+  computation, and the buffer that bounds the underlying `git diff`/`git
+  status` enumeration, were raised together — raising the file cap alone
+  would have been inert, since the enumeration buffer could still overflow
+  first. When a diff still exceeds a bound, the resulting BLOCKED message now
+  names the specific bound that was exceeded (file count, byte size, buffer
+  truncation, timeout, a failed git invocation, or a containment violation)
+  instead of an undifferentiated failure, and truncation is distinguishable
+  from an outright cap.
+
+## Why
+
+The reviewer/critic path enforced settlement as an all-or-nothing property of
+each batch, while the PR-review base-coverage path already unioned successful
+dimensions across batches with no such requirement — the same defect class
+that motivates this change was already fixed once, just not consistently.
+Retrying one failed lane, one failed dimension, or one unresolved feedback item
+should not force revalidation of the sibling work that already passed on the
+same revision — including feedback items already closed. Retention is scoped to
+an unchanged revision digest, so a subsequent edit still invalidates everything;
+the improvement is to the same-revision retry, not to the edit-then-retry case
+(see the design decision below). Composable, item-keyed accounting closes
+that gap while keeping the underlying independent-review contract — an
+`unclaimed` item still blocks completion, and a batch can only contribute
+verdicts for the exact inventory it was validated against.
+
+## Design decision: PR_FEEDBACK gate evidence stays batch-scoped, not item-scoped
+
+Stage A, Stage B, and closeout gate evidence for PR_FEEDBACK still invalidate
+as whole gate batches, not per feedback item. This is a deliberate decision:
+
+- The file scope a caller declares for a feedback item is caller-asserted and
+  only path-sanitized — it is never intersected with the actual changed-file
+  set, and carries no persisted binding back to feedback item IDs. Keying
+  invalidation on that declaration would let a controller dodge
+  re-verification by under-declaring scope, turning a fail-closed guarantee
+  into a fail-open one (the same failure class that already ruled out keying
+  digest invalidation on `git diff --raw` blob OIDs).
+- The four PR_FEEDBACK gate phases are holistic by contract: each batch must
+  own every inventory item exactly once and in declared order. Per-item
+  retention would re-partition that independent-review contract itself and
+  would need its own collusion/independence analysis before it could be
+  trusted.
+
+## Migration and compatibility
+
+All new persisted gate state is additive: four optional top-level keys on the
+existing non-strict PR-workflow gate schema (`prReviewBatchCoherence`,
+`prReviewRetiredReviewerSessionIds`, `prReviewRetiredConsolidatedLanes`, and
+`prFeedbackRetiredItemOwnership` — the last three written only by a capacity
+GC), plus a per-item binding map on critic batch records. A rolled-back plugin
+parses the newer state without
+error and simply ignores the new fields; PR-workflow gate state is
+per-session and cleared at completion, so there is no cross-version data
+migration to run.

--- a/docs/releases/pending/pr-workflow-mechanical-gates.md
+++ b/docs/releases/pending/pr-workflow-mechanical-gates.md
@@ -59,8 +59,9 @@
   count as coverage. Workflow lane, agent, role, child-session, parent-session,
   mode, source, PR head, checkout head, content revision, and output integrity
   must all match the durable delegation record; incompatible output-ref
-  collisions fail closed. Reviewer and critic retries also require one coherent
-  fully successful exact batch rather than complementary partial successes.
+  collisions fail closed. Reviewer and critic settlement composes across
+  batches item by item, so complementary partial retries can jointly satisfy
+  a phase instead of every retry re-covering the full inventory.
   Structured PR-workflow lane prompts also receive a controller-appended,
   caller-non-overridable block binding lane ID, exact head, revision, scope, and
   assigned items. Unresolved or cross-field-incoherent critic rows do not settle.
@@ -77,8 +78,9 @@
   reaches the matching mechanical transition.
 - An active PR workflow also gates architect response completion: final text is
   replaced with a blocked notice, and an idle parent session is automatically
-  resumed until `complete_pr_workflow` clears the durable obligations. A newer
-  reviewer batch invalidates every older critic batch.
+  resumed until `complete_pr_workflow` clears the durable obligations. A
+  reviewer retry invalidates only the critic claims for the items whose
+  reviewer row actually changed, not the whole critic batch.
 - The package smoke budget is raised from 4.9 MiB to 5.4 MiB to accommodate the
   controller and its integrity checks while retaining roughly 350 KB of headroom;
   another 10% increase still fails the guard.

--- a/src/background/workspace-snapshot.ts
+++ b/src/background/workspace-snapshot.ts
@@ -10,11 +10,48 @@ import {
 import type { BackgroundWorkspaceSnapshot } from './pending-delegations.js';
 
 const GIT_SNAPSHOT_TIMEOUT_MS = 3_000;
-const GIT_SNAPSHOT_MAX_BUFFER = 512 * 1024;
-const REVISION_MAX_FILES = 5_000;
-const REVISION_MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+/**
+ * Bounds stdout/stderr for every Git call in this module (issue #1968 P6).
+ * Raised 64x (512 KB -> 32 MB) in lockstep with `REVISION_MAX_FILES`: at an
+ * assumed worst-case average of ~600 bytes/path (NUL-delimited path plus a
+ * generous allowance for deep monorepo directory nesting and the 2-3 byte
+ * porcelain status prefix, doubled again for rename records which emit two
+ * paths per entry), 32 MB covers `REVISION_MAX_FILES` (50,000) paths with
+ * headroom (50,000 * 600 = ~28.6 MB < 32 MB). Raising the file cap alone is
+ * inert without this: `readBoundedGitOutput` (below) truncates the
+ * `git diff --name-only -z` / `git status --porcelain -z` output the digest
+ * enumerates *before* `REVISION_MAX_FILES` is ever consulted.
+ */
+const GIT_SNAPSHOT_MAX_BUFFER = 32 * 1024 * 1024;
+/**
+ * Raised 10x (5,000 -> 50,000). "Cost is time, not correctness": a real bound
+ * remains (unbounded enumeration is forbidden by AGENTS.md invariant 3), but
+ * 50,000 changed paths accommodates large-scale mechanical changes
+ * (repo-wide codemods, vendored dependency bumps) that legitimately touch far
+ * more than 5,000 files without forcing every such revision through the
+ * dead-end `null` this issue exists to fix.
+ */
+const REVISION_MAX_FILES = 50_000;
+/**
+ * Raised 8x (64 MB -> 512 MB). Chunked, cooperatively-yielded reads (see
+ * `REVISION_READ_CHUNK_BYTES`/`REVISION_YIELD_EVERY_CHUNKS` below) make this
+ * a cost-in-time bound, not a correctness bound, so it can move well past
+ * "one big generated asset" without materializing more than one chunk at a
+ * time in memory.
+ */
+const REVISION_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 const REVISION_READ_CHUNK_BYTES = 64 * 1024;
 const REVISION_YIELD_EVERY_CHUNKS = 16;
+/**
+ * Timeout used only for the two path-ENUMERATION Git calls inside the
+ * revision-digest twins (`git diff --name-only` / `git status --porcelain`),
+ * not for `GIT_SNAPSHOT_TIMEOUT_MS`'s default (still 3s) used by every other
+ * Git call in this module. `git status --untracked-files=all` on a huge tree
+ * walks the full working directory and can independently exceed 3s well
+ * before any byte cap is reached; 15s (5x) gives that walk real headroom
+ * while remaining a bounded subprocess call per AGENTS.md invariant 3.
+ */
+const REVISION_ENUMERATION_TIMEOUT_MS = 15_000;
 
 type SpawnSync = typeof child_process.spawnSync;
 
@@ -97,6 +134,17 @@ function runGit(
  * Async equivalent of the bounded snapshot helper. Revision binding runs on
  * tool/hook gates, so it must never monopolize the host event loop while Git
  * is resolving the checked-out state.
+ *
+ * This one deliberately keeps the `timeout` spawn option alongside the
+ * `Promise.race` deadline, unlike `runGitAsyncDetailed`, which had to drop it.
+ * The two-timer arrangement is only a defect when the *reason* for failing is
+ * observable: there, whichever timer won decided whether a timeout was reported
+ * as `timeout` or as a generic `git-failed`. This function returns
+ * `string | null` and has no discriminated reason, so both timers collapse to
+ * the same `null` and there is nothing to misreport.
+ *
+ * If a discriminated failure reason is ever added here, that stops being true —
+ * give the deadline a single owner first (see `runGitAsyncDetailed`).
  */
 async function runGitAsync(
 	directory: string,
@@ -152,6 +200,131 @@ async function runGitAsync(
 		return result.stdout.text.trimEnd();
 	} catch {
 		return null;
+	} finally {
+		if (timeout) clearTimeout(timeout);
+		try {
+			proc?.kill('SIGKILL');
+		} catch {
+			// Best-effort tree cleanup for an already-closed process.
+		}
+	}
+}
+
+/**
+ * Discriminated Git call result used only by the revision-digest twins below
+ * (issue #1968 P6). `resolvePrWorkflowRevisionDigest[Async]` need to know
+ * *why* a Git call failed — timeout, output-buffer overflow, or a genuine
+ * Git failure — to report a diagnosable `RevisionDigestFailureReason`
+ * instead of the bare `null` that made the digest cap a dead end. Unrelated
+ * callers in this module keep using {@link runGit} / {@link runGitAsync},
+ * which stay plain null-on-any-failure helpers; this type and the two
+ * functions below are intentionally scoped to the digest path so no other
+ * call site's behavior changes.
+ */
+type GitCallResult =
+	| { ok: true; text: string }
+	| { ok: false; reason: 'timeout' | 'buffer-truncated' | 'git-failed' };
+
+/**
+ * Sync Git invocation for the revision-digest path. Node's `spawnSync` sets
+ * `error.code` to `'ETIMEDOUT'` when the `timeout` option is exceeded and to
+ * `'ENOBUFS'` when stdout/stderr exceeds `maxBuffer` — both verified against
+ * real `spawnSync` behavior, not assumed — so this distinguishes both from a
+ * generic non-zero-exit Git failure.
+ */
+function runGitDetailed(
+	directory: string,
+	args: string[],
+	timeoutMs: number,
+): GitCallResult {
+	const result = _internals.spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		encoding: 'utf-8',
+		timeout: timeoutMs,
+		maxBuffer: _internals.gitSnapshotMaxBuffer,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
+	if (errorCode === 'ENOBUFS') return { ok: false, reason: 'buffer-truncated' };
+	if (errorCode === 'ETIMEDOUT') return { ok: false, reason: 'timeout' };
+	if (
+		result.error ||
+		result.status !== 0 ||
+		typeof result.stdout !== 'string'
+	) {
+		return { ok: false, reason: 'git-failed' };
+	}
+	return { ok: true, text: result.stdout.trimEnd() };
+}
+
+/**
+ * Async twin of {@link runGitDetailed}, reusing the bounded chunked-read
+ * stream helper so a large permitted revision cannot stall the host event
+ * loop while still surfacing which bound (timeout vs buffer) was hit.
+ *
+ * The deadline has exactly ONE owner: the `Promise.race` below. Passing
+ * `timeout` to `bunSpawn` as well would arm a second timer on the *same*
+ * deadline — `bunSpawn` installs its own `setTimeout` whenever
+ * `killProcessTree` is set, and Bun/Node arm theirs natively otherwise — and
+ * whichever of the two fired first decided the reported reason: the spawn-side
+ * timer SIGKILLs the child, `proc.exited` then resolves non-zero, and the
+ * completion branch below reports `git-failed` ("Verify the checkout is a
+ * healthy Git worktree") for what was in fact a timeout. Relative firing order
+ * of two timers on one deadline is an implementation detail, not a contract, so
+ * this reason must not be decided by it. The `finally` clause performs exactly
+ * the tree-kill the spawn-side timer would have, so dropping it costs no
+ * cleanup.
+ */
+async function runGitAsyncDetailed(
+	directory: string,
+	args: string[],
+	timeoutMs: number,
+): Promise<GitCallResult> {
+	let proc: BunCompatSubprocess | undefined;
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const options: BunCompatSpawnOptions = {
+			cwd: directory,
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			killProcessTree: true,
+		};
+		proc = _internals.bunSpawn(['git', '-C', directory, ...args], options);
+		let overflowed = false;
+		const stopOverflow = () => {
+			overflowed = true;
+			try {
+				proc?.kill('SIGKILL');
+			} catch {
+				// Process already exited or cannot be signalled.
+			}
+		};
+		const maxBuffer = _internals.gitSnapshotMaxBuffer;
+		const completed = Promise.all([
+			proc.exited,
+			readBoundedGitOutput(proc.stdout, maxBuffer, stopOverflow),
+			readBoundedGitOutput(proc.stderr, maxBuffer, stopOverflow),
+		]);
+		const result = await Promise.race([
+			completed.then(([exitCode, stdout, stderr]) => ({
+				kind: 'completed' as const,
+				exitCode,
+				stdout,
+				stderr,
+			})),
+			new Promise<{ kind: 'timeout' }>((resolve) => {
+				timeout = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
+			}),
+		]);
+		if (result.kind === 'timeout') return { ok: false, reason: 'timeout' };
+		if (overflowed || result.stdout.truncated || result.stderr.truncated) {
+			return { ok: false, reason: 'buffer-truncated' };
+		}
+		if (result.exitCode !== 0) return { ok: false, reason: 'git-failed' };
+		return { ok: true, text: result.stdout.text.trimEnd() };
+	} catch {
+		return { ok: false, reason: 'git-failed' };
 	} finally {
 		if (timeout) clearTimeout(timeout);
 		try {
@@ -868,44 +1041,103 @@ export async function switchPrFeedbackTrackingCandidateAsync(
 }
 
 /**
+ * Discriminated result for the revision-digest twins (issue #1968 P6). A
+ * bare `null` on any failure made the digest cap a dead end: a gate consumer
+ * could not tell "revision too large" (a bound the operator can act on) from
+ * "Git failed" or "output truncated" (an environment problem). `detail` is a
+ * best-effort human-readable diagnostic and is not part of the failure
+ * contract; only `reason` is.
+ */
+export type RevisionDigestFailureReason =
+	| 'file-cap'
+	| 'byte-cap'
+	| 'buffer-truncated'
+	| 'timeout'
+	| 'git-failed'
+	| 'containment'
+	| 'read-failed';
+
+export type RevisionDigestResult =
+	| { ok: true; digest: string }
+	| { ok: false; reason: RevisionDigestFailureReason; detail?: string };
+
+function revisionDigestGitCallFailure(
+	call: string,
+	result: Extract<GitCallResult, { ok: false }>,
+): { ok: false; reason: RevisionDigestFailureReason; detail: string } {
+	const description =
+		result.reason === 'timeout'
+			? 'timed out'
+			: result.reason === 'buffer-truncated'
+				? 'output exceeded the bounded buffer'
+				: 'failed';
+	return {
+		ok: false,
+		reason: result.reason,
+		detail: `git ${call} ${description}`,
+	};
+}
+
+/**
  * Bind a mutable working tree to its actual content, not merely porcelain status.
  * This lets PR-feedback approvals fail closed when a same-path edit occurs after a
  * gate. Paths come from Git, are containment-checked, and are hashed without
  * following symlinks outside the project.
+ *
+ * This is the one implementation of the sync digest; {@link
+ * resolvePrWorkflowRevisionDigest} is a thin `.ok ? digest : null` delegate
+ * that preserves the pre-existing signature/behavior for existing callers.
  */
-export function resolvePrWorkflowRevisionDigest(
+export function resolvePrWorkflowRevisionDigestDetailed(
 	directory: string,
 	baseHeadSha: string,
-): string | null {
+): RevisionDigestResult {
 	const projectRoot = path.resolve(directory);
-	const baseHead = runGit(projectRoot, [
-		'rev-parse',
-		'--verify',
-		`${baseHeadSha}^{commit}`,
-	]);
-	const diffNames = runGit(projectRoot, [
-		'diff',
-		'--no-ext-diff',
-		'--name-only',
-		'-z',
-		baseHeadSha,
-	]);
-	const porcelain = runGit(projectRoot, [
-		'status',
-		'--porcelain=v1',
-		'-z',
-		'--untracked-files=all',
-	]);
-	if (!baseHead || diffNames === null || porcelain === null) return null;
-	const porcelainPaths = parsePorcelainPaths(porcelain);
-	if (!porcelainPaths) return null;
+	const baseHeadResult = runGitDetailed(
+		projectRoot,
+		['rev-parse', '--verify', `${baseHeadSha}^{commit}`],
+		_internals.gitTimeoutMs,
+	);
+	if (!baseHeadResult.ok) {
+		return revisionDigestGitCallFailure('rev-parse --verify', baseHeadResult);
+	}
+	const diffResult = runGitDetailed(
+		projectRoot,
+		['diff', '--no-ext-diff', '--name-only', '-z', baseHeadSha],
+		_internals.revisionEnumerationTimeoutMs,
+	);
+	if (!diffResult.ok) {
+		return revisionDigestGitCallFailure('diff --name-only', diffResult);
+	}
+	const porcelainResult = runGitDetailed(
+		projectRoot,
+		['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+		_internals.revisionEnumerationTimeoutMs,
+	);
+	if (!porcelainResult.ok) {
+		return revisionDigestGitCallFailure('status --porcelain', porcelainResult);
+	}
+	const porcelainPaths = parsePorcelainPaths(porcelainResult.text);
+	if (!porcelainPaths) {
+		return {
+			ok: false,
+			reason: 'git-failed',
+			detail: 'malformed git status --porcelain=v1 output',
+		};
+	}
 	const changedPaths = [
-		...new Set([...parseNulPaths(diffNames), ...porcelainPaths]),
+		...new Set([...parseNulPaths(diffResult.text), ...porcelainPaths]),
 	].sort((left, right) => left.localeCompare(right));
-	if (changedPaths.length > REVISION_MAX_FILES) return null;
+	if (changedPaths.length > _internals.revisionMaxFiles) {
+		return {
+			ok: false,
+			reason: 'file-cap',
+			detail: `${changedPaths.length} changed paths exceed the cap of ${_internals.revisionMaxFiles}`,
+		};
+	}
 
 	const hash = createHash('sha256');
-	hash.update(`base\0${baseHead}\0`);
+	hash.update(`base\0${baseHeadResult.text}\0`);
 	let totalBytes = 0;
 	for (const relativePath of changedPaths) {
 		const resolvedPath = path.resolve(projectRoot, relativePath);
@@ -914,8 +1146,13 @@ export function resolvePrWorkflowRevisionDigest(
 			!relativeToRoot ||
 			relativeToRoot.startsWith('..') ||
 			path.isAbsolute(relativeToRoot)
-		)
-			return null;
+		) {
+			return {
+				ok: false,
+				reason: 'containment',
+				detail: `path escapes the project root: ${relativePath}`,
+			};
+		}
 		hash.update(`path\0${relativePath}\0`);
 		let stats: fs.Stats;
 		try {
@@ -925,14 +1162,22 @@ export function resolvePrWorkflowRevisionDigest(
 				hash.update('deleted\0');
 				continue;
 			}
-			return null;
+			return {
+				ok: false,
+				reason: 'read-failed',
+				detail: `lstat failed for ${relativePath}`,
+			};
 		}
 		if (stats.isSymbolicLink()) {
 			try {
 				hash.update(`symlink\0${fs.readlinkSync(resolvedPath)}\0`);
 				continue;
 			} catch {
-				return null;
+				return {
+					ok: false,
+					reason: 'read-failed',
+					detail: `readlink failed for ${relativePath}`,
+				};
 			}
 		}
 		if (!stats.isFile()) {
@@ -940,58 +1185,104 @@ export function resolvePrWorkflowRevisionDigest(
 			continue;
 		}
 		totalBytes += stats.size;
-		if (totalBytes > REVISION_MAX_TOTAL_BYTES) return null;
+		if (totalBytes > _internals.revisionMaxTotalBytes) {
+			return {
+				ok: false,
+				reason: 'byte-cap',
+				detail: `accumulated content bytes ${totalBytes} exceed the cap of ${_internals.revisionMaxTotalBytes} at ${relativePath}`,
+			};
+		}
 		try {
 			hash.update(`file\0${stats.mode}\0`);
-			hash.update(fs.readFileSync(resolvedPath));
+			hash.update(_internals.readChangedFileSync(resolvedPath));
 			hash.update('\0');
 		} catch {
-			return null;
+			return {
+				ok: false,
+				reason: 'read-failed',
+				detail: `read failed for ${relativePath}`,
+			};
 		}
 	}
-	return hash.digest('hex');
+	return { ok: true, digest: hash.digest('hex') };
+}
+
+export function resolvePrWorkflowRevisionDigest(
+	directory: string,
+	baseHeadSha: string,
+): string | null {
+	const result = resolvePrWorkflowRevisionDigestDetailed(
+		directory,
+		baseHeadSha,
+	);
+	return result.ok ? result.digest : null;
 }
 
 /**
  * Asynchronously bind a mutable working tree to its actual content. File
  * reads are chunked with bounded cooperative yields so a large, permitted
  * revision cannot stall the synchronous plugin gate path.
+ *
+ * This is the one implementation of the async digest; {@link
+ * resolvePrWorkflowRevisionDigestAsync} is a thin `.ok ? digest : null`
+ * delegate that preserves the pre-existing signature/behavior for existing
+ * callers. Sequenced after P2 (see issue #1968 05-fix-plan.md P6.4): the sync
+ * twin above has no chunking/yield, so enlarging its `readFileSync` loop
+ * before P2 threads the digest through a single gate-entry-point resolve
+ * would have worsened blocking on the production path.
  */
-export async function resolvePrWorkflowRevisionDigestAsync(
+export async function resolvePrWorkflowRevisionDigestDetailedAsync(
 	directory: string,
 	baseHeadSha: string,
-): Promise<string | null> {
+): Promise<RevisionDigestResult> {
 	const projectRoot = path.resolve(directory);
-	const [baseHead, diffNames, porcelain] = await Promise.all([
-		runGitAsync(projectRoot, [
-			'rev-parse',
-			'--verify',
-			`${baseHeadSha}^{commit}`,
-		]),
-		runGitAsync(projectRoot, [
-			'diff',
-			'--no-ext-diff',
-			'--name-only',
-			'-z',
-			baseHeadSha,
-		]),
-		runGitAsync(projectRoot, [
-			'status',
-			'--porcelain=v1',
-			'-z',
-			'--untracked-files=all',
-		]),
+	const [baseHeadResult, diffResult, porcelainResult] = await Promise.all([
+		runGitAsyncDetailed(
+			projectRoot,
+			['rev-parse', '--verify', `${baseHeadSha}^{commit}`],
+			_internals.gitTimeoutMs,
+		),
+		runGitAsyncDetailed(
+			projectRoot,
+			['diff', '--no-ext-diff', '--name-only', '-z', baseHeadSha],
+			_internals.revisionEnumerationTimeoutMs,
+		),
+		runGitAsyncDetailed(
+			projectRoot,
+			['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+			_internals.revisionEnumerationTimeoutMs,
+		),
 	]);
-	if (!baseHead || diffNames === null || porcelain === null) return null;
-	const porcelainPaths = parsePorcelainPaths(porcelain);
-	if (!porcelainPaths) return null;
+	if (!baseHeadResult.ok) {
+		return revisionDigestGitCallFailure('rev-parse --verify', baseHeadResult);
+	}
+	if (!diffResult.ok) {
+		return revisionDigestGitCallFailure('diff --name-only', diffResult);
+	}
+	if (!porcelainResult.ok) {
+		return revisionDigestGitCallFailure('status --porcelain', porcelainResult);
+	}
+	const porcelainPaths = parsePorcelainPaths(porcelainResult.text);
+	if (!porcelainPaths) {
+		return {
+			ok: false,
+			reason: 'git-failed',
+			detail: 'malformed git status --porcelain=v1 output',
+		};
+	}
 	const changedPaths = [
-		...new Set([...parseNulPaths(diffNames), ...porcelainPaths]),
+		...new Set([...parseNulPaths(diffResult.text), ...porcelainPaths]),
 	].sort((left, right) => left.localeCompare(right));
-	if (changedPaths.length > REVISION_MAX_FILES) return null;
+	if (changedPaths.length > _internals.revisionMaxFiles) {
+		return {
+			ok: false,
+			reason: 'file-cap',
+			detail: `${changedPaths.length} changed paths exceed the cap of ${_internals.revisionMaxFiles}`,
+		};
+	}
 
 	const hash = createHash('sha256');
-	hash.update(`base\0${baseHead}\0`);
+	hash.update(`base\0${baseHeadResult.text}\0`);
 	let totalBytes = 0;
 	let chunksSinceYield = 0;
 	for (const relativePath of changedPaths) {
@@ -1001,8 +1292,13 @@ export async function resolvePrWorkflowRevisionDigestAsync(
 			!relativeToRoot ||
 			relativeToRoot.startsWith('..') ||
 			path.isAbsolute(relativeToRoot)
-		)
-			return null;
+		) {
+			return {
+				ok: false,
+				reason: 'containment',
+				detail: `path escapes the project root: ${relativePath}`,
+			};
+		}
 		hash.update(`path\0${relativePath}\0`);
 		let stats: fs.Stats;
 		try {
@@ -1012,14 +1308,22 @@ export async function resolvePrWorkflowRevisionDigestAsync(
 				hash.update('deleted\0');
 				continue;
 			}
-			return null;
+			return {
+				ok: false,
+				reason: 'read-failed',
+				detail: `lstat failed for ${relativePath}`,
+			};
 		}
 		if (stats.isSymbolicLink()) {
 			try {
 				hash.update(`symlink\0${await fs.promises.readlink(resolvedPath)}\0`);
 				continue;
 			} catch {
-				return null;
+				return {
+					ok: false,
+					reason: 'read-failed',
+					detail: `readlink failed for ${relativePath}`,
+				};
 			}
 		}
 		if (!stats.isFile()) {
@@ -1027,7 +1331,13 @@ export async function resolvePrWorkflowRevisionDigestAsync(
 			continue;
 		}
 		totalBytes += stats.size;
-		if (totalBytes > REVISION_MAX_TOTAL_BYTES) return null;
+		if (totalBytes > _internals.revisionMaxTotalBytes) {
+			return {
+				ok: false,
+				reason: 'byte-cap',
+				detail: `accumulated content bytes ${totalBytes} exceed the cap of ${_internals.revisionMaxTotalBytes} at ${relativePath}`,
+			};
+		}
 		hash.update(`file\0${stats.mode}\0`);
 		let handle: fs.promises.FileHandle | undefined;
 		try {
@@ -1039,7 +1349,13 @@ export async function resolvePrWorkflowRevisionDigestAsync(
 					stats.size - position,
 				);
 				const { bytesRead } = await handle.read(buffer, 0, length, position);
-				if (bytesRead <= 0) return null;
+				if (bytesRead <= 0) {
+					return {
+						ok: false,
+						reason: 'read-failed',
+						detail: `short read for ${relativePath}`,
+					};
+				}
 				hash.update(buffer.subarray(0, bytesRead));
 				position += bytesRead;
 				chunksSinceYield++;
@@ -1050,12 +1366,27 @@ export async function resolvePrWorkflowRevisionDigestAsync(
 			}
 			hash.update('\0');
 		} catch {
-			return null;
+			return {
+				ok: false,
+				reason: 'read-failed',
+				detail: `read failed for ${relativePath}`,
+			};
 		} finally {
 			await handle?.close().catch(() => undefined);
 		}
 	}
-	return hash.digest('hex');
+	return { ok: true, digest: hash.digest('hex') };
+}
+
+export async function resolvePrWorkflowRevisionDigestAsync(
+	directory: string,
+	baseHeadSha: string,
+): Promise<string | null> {
+	const result = await resolvePrWorkflowRevisionDigestDetailedAsync(
+		directory,
+		baseHeadSha,
+	);
+	return result.ok ? result.digest : null;
 }
 
 function parseNulPaths(output: string): string[] {
@@ -1330,10 +1661,38 @@ export const _internals: {
 	gitTimeoutMs: number;
 	yieldControl: () => Promise<void>;
 	parsePorcelainV2Snapshot: typeof parsePorcelainV2Snapshot;
+	/**
+	 * Revision-digest bound seams (issue #1968 P6). Defaults mirror the
+	 * top-level constants; tests lower these to deterministically produce
+	 * `file-cap` / `byte-cap` / `buffer-truncated` against small real temp
+	 * git repos instead of materializing tens of thousands of real files.
+	 */
+	revisionMaxFiles: number;
+	revisionMaxTotalBytes: number;
+	gitSnapshotMaxBuffer: number;
+	revisionEnumerationTimeoutMs: number;
+	/**
+	 * The synchronous digest's changed-file content read, behind the same kind
+	 * of seam as `spawnSync` above. The `read-failed` reason it guards has no
+	 * portable filesystem trigger: Windows normalizes every crafted-path failure
+	 * (nested-under-a-file, reserved characters, over-length) to `ENOENT`, which
+	 * this code deliberately treats as "deleted, keep hashing", and `chmod` is a
+	 * no-op there — so without this seam the sync twin's `read-failed` arm is
+	 * unreachable from a test while remaining reachable in production (EACCES,
+	 * EIO, a vanished mount). The async twin needs no equivalent: its chunked
+	 * reader reaches `read-failed` through the short-read branch, which a test
+	 * drives via the existing `yieldControl` seam.
+	 */
+	readChangedFileSync: (filePath: string) => Buffer;
 } = {
 	spawnSync: child_process.spawnSync,
 	bunSpawn,
 	gitTimeoutMs: GIT_SNAPSHOT_TIMEOUT_MS,
 	yieldControl: () => new Promise<void>((resolve) => setImmediate(resolve)),
 	parsePorcelainV2Snapshot,
+	revisionMaxFiles: REVISION_MAX_FILES,
+	revisionMaxTotalBytes: REVISION_MAX_TOTAL_BYTES,
+	gitSnapshotMaxBuffer: GIT_SNAPSHOT_MAX_BUFFER,
+	revisionEnumerationTimeoutMs: REVISION_ENUMERATION_TIMEOUT_MS,
+	readChangedFileSync: (filePath: string) => fs.readFileSync(filePath),
 };

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -25,6 +25,7 @@ import {
 	validatePrReviewInlineTriggerLedger,
 } from '../background/pr-review-trigger-contract.js';
 import {
+	type RevisionDigestResult,
 	resolveCommitCountSince,
 	resolveCommitCountSinceAsync,
 	resolveCurrentGitHead,
@@ -42,7 +43,8 @@ import {
 	resolvePrReviewDiffStats,
 	resolvePrReviewDiffStatsAsync,
 	resolvePrWorkflowRevisionDigest,
-	resolvePrWorkflowRevisionDigestAsync,
+	resolvePrWorkflowRevisionDigestDetailed,
+	resolvePrWorkflowRevisionDigestDetailedAsync,
 	resolveRemoteRefsContainingHead,
 	resolveRemoteRefsContainingHeadAsync,
 	switchPrFeedbackTrackingCandidateAsync,
@@ -54,6 +56,7 @@ import {
 	type PrWorkflowGitState,
 } from '../git/pr-workflow-state.js';
 import { getPrWorkflowToolCapability } from '../tools/tool-metadata.js';
+import { warn } from '../utils/logger.js';
 import { validateSwarmPath } from './utils.js';
 
 export const PR_REVIEW_BASE_DIMENSION_IDS = [
@@ -119,6 +122,27 @@ export const PR_REVIEW_BASE_LANE_FLOORS: Record<PrReviewDepthTier, number> = {
 	M: 3,
 	L: PR_REVIEW_BASE_DIMENSION_IDS.length,
 };
+
+/**
+ * Cumulative lane floor for a tier-L base wave that used consolidated failure
+ * recovery (issue #1968 MUST-FIX 1).
+ *
+ * `PR_REVIEW_BASE_LANE_FLOORS.L` is the *initial wave* floor and equals the
+ * dimension count, so it cannot also serve as the post-consolidation floor: any
+ * consolidated lane owns at least two dimensions, so a wave that consolidated
+ * even once is backed by at most five lanes. Enforcing six cumulatively would
+ * make the tier-L retry exception unreachable — i.e. delete the feature.
+ *
+ * The bound that *is* enforceable, and is the property worth defending, is that
+ * a tier-L wave may never be reduced by consolidation to a lane count a tier-M
+ * dispatch would already have satisfied: the depth tier chosen for this PR must
+ * not be silently downgraded by failure recovery. Hence "strictly more than the
+ * tier-M floor" — four distinct lanes for six dimensions, a bounded loss of at
+ * most two lanes of depth, versus the unbounded loss (down to two lanes) a
+ * per-batch-only floor permits when a retry is split across batches.
+ */
+export const PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR =
+	PR_REVIEW_BASE_LANE_FLOORS.M + 1;
 
 /**
  * Minimum lane counts for a FULL micro (risk-family) sweep per depth tier. These
@@ -305,6 +329,36 @@ interface PrReviewValidationBatchRecord {
 	validatedAt: string;
 }
 
+/**
+ * Per-batch coherence keys for item-keyed reviewer/critic composition.
+ *
+ * This deliberately lives OUTSIDE `PrReviewValidationBatchRecord`: that record's
+ * schema is `.strict()`, and Zod's unknown-key policy is per-schema — the parent
+ * state schema's `.passthrough()` does not relax a strict child. Adding fields to
+ * the batch record would make a rolled-back plugin fail `safeParse` on every gate
+ * state read, including `requireAnyActiveState`, which `abortPrWorkflow` calls
+ * *before* the clear escape hatch. Keeping this as one new optional TOP-LEVEL key
+ * on the passthrough parent keeps older code at "ignore the field I don't know"
+ * instead of "refuse to read the file at all".
+ */
+interface PrReviewBatchCoherenceRecord {
+	/**
+	 * The exact candidate/critic inventory this batch's ownership was validated
+	 * against at record time (the same set `assertExactStringSet` compared the
+	 * declared lane items to).
+	 */
+	validatedInventory: string[];
+	/**
+	 * Critic batches only: per-item sha256 of the full canonical `[REVIEWED]` row
+	 * that was authoritative for that item when the critic batch was declared. A
+	 * critic claim is admitted only while the current winning reviewer row for
+	 * that item is byte-identical, so a reviewer re-run that changes evidence or
+	 * root cause — not only classification/severity — drops exactly the critic
+	 * claims it invalidated and leaves its siblings intact.
+	 */
+	reviewerItemBindings?: Record<string, string>;
+}
+
 export interface PrWorkflowGateState {
 	schemaVersion: 1;
 	/** Monotonic durable revision used to reject stale same-session transitions. */
@@ -333,6 +387,29 @@ export interface PrWorkflowGateState {
 	prReviewTriggerLedger?: PrReviewInlineTriggerRow[];
 	prReviewTriggerEvalPath?: string;
 	prReviewValidationBatches?: PrReviewValidationBatchRecord[];
+	/** Keyed by validation batch id. See `PrReviewBatchCoherenceRecord`. */
+	prReviewBatchCoherence?: Record<string, PrReviewBatchCoherenceRecord>;
+	/**
+	 * Child session ids that produced a reviewer artifact for a validation batch
+	 * the capacity GC has since dropped (issue #1968 MUST-FIX 3).
+	 *
+	 * `reviewerSubagentSessionIds` derives the critic reuse ban by walking the
+	 * live reviewer batches, so pruning one would silently un-forbid its child
+	 * sessions and let an agent challenge its own review. This ledger carries
+	 * that fail-closed set across the prune.
+	 */
+	prReviewRetiredReviewerSessionIds?: string[];
+	/**
+	 * Canonical dimension-set keys of consolidated base lanes whose batch the
+	 * capacity GC dropped (issue #1968 review round 2, FIX D).
+	 *
+	 * `tierLBackingLaneCount` covers the consolidated lanes it can see, and it can
+	 * only see surviving `prReviewBaseDispatches`. A failed consolidated base
+	 * batch is prunable, so without this ledger a prune would shrink the cover's
+	 * universe and monotonically hand the wave back consolidation budget it had
+	 * already spent.
+	 */
+	prReviewRetiredConsolidatedLanes?: string[];
 	prReviewArtifactRunId?: string;
 	prReviewFindingsPath?: string;
 	prReviewArtifactBoundaries?: PrReviewArtifactBoundary[];
@@ -344,6 +421,16 @@ export interface PrWorkflowGateState {
 	prFeedbackReviewHandoff?: PrFeedbackReviewHandoffRecord;
 	prFeedbackInventory?: string[];
 	prFeedbackVerifications?: PrFeedbackVerificationRecord[];
+	/**
+	 * Item -> lane bindings of verification batches the capacity GC dropped
+	 * (issue #1968 review round 2, MUST-FIX C).
+	 *
+	 * `enforcePrFeedbackVerificationOwnership` rejects a re-claim of an inventory
+	 * item by a different lane using a ledger rebuilt from every live batch.
+	 * Pruning a batch would silently un-claim its items; this carries the binding
+	 * across the prune so the rejection stays cumulative.
+	 */
+	prFeedbackRetiredItemOwnership?: Record<string, string>;
 	/** @deprecated Compatibility projection of the most recent verification dispatch. */
 	prFeedbackVerification?: PrFeedbackVerificationRecord;
 	prFeedbackStageA?: PrFeedbackStageARecord;
@@ -361,6 +448,42 @@ interface SessionStateMutationLock {
 const GATE_SCHEMA_VERSION = 1 as const;
 const MAX_TRACKED_SESSIONS = 200;
 const MAX_WORKFLOW_BATCHES = 128;
+/**
+ * Ceiling on the retired-reviewer-session ledger the capacity GC maintains,
+ * sized at eight child sessions per pruned batch across a full cap. If a prune
+ * would exceed it, the GC keeps every batch instead of dropping a forbidden
+ * session id — losing the ban is a fail-open, losing the reclaim is only a dead
+ * end, and the schema bound must never be the thing that decides which.
+ */
+const MAX_RETIRED_REVIEWER_SESSION_IDS = 1024;
+/**
+ * Ceiling on the retired-consolidated-lane ledger. Every entry this code
+ * *writes* is a canonical subset of the six base dimensions with at least two
+ * members — `PrReviewBaseDispatchRecordSchema` constrains both `workflowLane`
+ * and `ownedWorkflowLanes` to `PrReviewBaseDimensionIdSchema` — so there are
+ * exactly 2^6 - 6 - 1 = 57 such values and self-written state can never reach
+ * 64.
+ *
+ * The guard is nonetheless live, because the ledger is *seeded from disk* and
+ * its own schema is `z.array(z.string().min(1)).max(64)`, not the dimension
+ * enum: a state file carrying up to 64 non-canonical entries plus the canonical
+ * keys a prune contributes exceeds the bound. That is precisely the case a
+ * fail-closed guard is for — the same reasoning as `MAX_COVER_UNIVERSE_BITS`,
+ * which also refuses to assume disk state is enum-shaped. As with the
+ * reviewer-session ledger, an overflowing prune keeps every batch rather than
+ * dropping an entry: losing the ledger is a fail-open, losing the reclaim is
+ * only a dead end.
+ */
+const MAX_RETIRED_CONSOLIDATED_LANES = 64;
+/**
+ * Ceiling on the retired feedback item-ownership ledger. An entry can only exist
+ * for an item that passed the `inventorySet` membership check, so the ledger is
+ * bounded by the declared feedback inventory; this is the schema's independent
+ * backstop for an inventory the schema itself does not bound. A prune that would
+ * exceed it keeps every batch rather than dropping a binding, on the same
+ * reasoning as the reviewer-session ledger.
+ */
+const MAX_RETIRED_FEEDBACK_ITEM_OWNERS = 4096;
 const WINDOWS_RENAME_MAX_RETRIES = 3;
 const RENAME_RETRY_DELAY_MS = 10;
 const STATE_MUTATION_LOCK_MAX_ATTEMPTS = 50;
@@ -534,6 +657,18 @@ const PrReviewValidationBatchRecordSchema = z
 	})
 	.strict();
 
+// Intentionally NOT .strict(): this record is the newest persisted shape and is
+// the most likely to gain fields. Passthrough keeps a future field opaque but
+// present through any read-modify-write cycle instead of bricking a rollback.
+const PrReviewBatchCoherenceRecordSchema = z
+	.object({
+		validatedInventory: z.array(z.string().min(1)),
+		reviewerItemBindings: z
+			.record(z.string().min(1), z.string().regex(/^[0-9a-f]{64}$/))
+			.optional(),
+	})
+	.passthrough();
+
 const PrFeedbackScopeDeclarationRecordSchema = z
 	.object({
 		taskId: z.string().regex(/^\d+\.\d+(?:\.\d+)*$/),
@@ -625,6 +760,21 @@ const PrWorkflowGateStateSchema = z
 			.array(PrReviewValidationBatchRecordSchema)
 			.max(MAX_WORKFLOW_BATCHES)
 			.optional(),
+		prReviewBatchCoherence: z
+			.record(z.string().min(1), PrReviewBatchCoherenceRecordSchema)
+			.refine(
+				(entries) => Object.keys(entries).length <= MAX_WORKFLOW_BATCHES,
+				`prReviewBatchCoherence may not exceed ${MAX_WORKFLOW_BATCHES} entries`,
+			)
+			.optional(),
+		prReviewRetiredReviewerSessionIds: z
+			.array(z.string().min(1))
+			.max(MAX_RETIRED_REVIEWER_SESSION_IDS)
+			.optional(),
+		prReviewRetiredConsolidatedLanes: z
+			.array(z.string().min(1))
+			.max(MAX_RETIRED_CONSOLIDATED_LANES)
+			.optional(),
 		prReviewArtifactRunId: z.string().min(1).optional(),
 		prReviewFindingsPath: z.string().min(1).optional(),
 		prReviewArtifactBoundaries: z
@@ -640,6 +790,14 @@ const PrWorkflowGateStateSchema = z
 		prFeedbackVerifications: z
 			.array(PrFeedbackVerificationRecordSchema)
 			.max(MAX_WORKFLOW_BATCHES)
+			.optional(),
+		prFeedbackRetiredItemOwnership: z
+			.record(z.string().min(1), z.string().min(1))
+			.refine(
+				(entries) =>
+					Object.keys(entries).length <= MAX_RETIRED_FEEDBACK_ITEM_OWNERS,
+				`prFeedbackRetiredItemOwnership may not exceed ${MAX_RETIRED_FEEDBACK_ITEM_OWNERS} entries`,
+			)
 			.optional(),
 		prFeedbackVerification: PrFeedbackVerificationRecordSchema.optional(),
 		prFeedbackStageA: PrFeedbackStageARecordSchema.optional(),
@@ -1301,13 +1459,9 @@ export async function enforcePrReviewBaseDimensions(
 	directory: string,
 	sessionID: string,
 	lanes: readonly PrWorkflowLaneSpec[],
-	options: { batchId: string; prHeadSha: string },
+	options: { batchId: string; prHeadSha: string; revisionDigest?: string },
 ): Promise<PrWorkflowGateState> {
-	const state = await bindPrWorkflowHead(
-		directory,
-		sessionID,
-		options.prHeadSha,
-	);
+	let state = await bindPrWorkflowHead(directory, sessionID, options.prHeadSha);
 	if (state.mode !== 'PR_REVIEW') {
 		throw wrongModeError(state, 'PR_REVIEW');
 	}
@@ -1329,24 +1483,60 @@ export async function enforcePrReviewBaseDimensions(
 	// Tier L requires one dedicated lane per dimension on every base batch, not
 	// only the initial wave — a later retry/supplementary batch may not use a
 	// consolidated lane to settle multiple dimensions from a single artifact
-	// that never went through the initial-wave tier check.
+	// that never went through the initial-wave tier check. The one exception is
+	// narrow, and every clause of it is load-bearing (issue #1968 P3.1).
 	if (
 		(state.prReviewDepthTier ?? 'L') === 'L' &&
 		normalizedLanes.some((lane) => (lane.ownedWorkflowLanes?.length ?? 1) !== 1)
 	) {
-		throw new Error(
-			'BLOCKED: PR_REVIEW base dispatch at depth tier L requires one dedicated lane per dimension; consolidated owned_workflow_lanes are allowed only at tiers S and M',
+		const rejection = await tierLConsolidationRejection(
+			directory,
+			state,
+			normalizedLanes,
+			options.revisionDigest,
 		);
+		if (rejection) {
+			throw new Error(
+				'BLOCKED: PR_REVIEW base dispatch at depth tier L requires one dedicated lane per dimension; ' +
+					'consolidated owned_workflow_lanes are allowed only at tiers S and M, or on a retry batch that ' +
+					'satisfies all five of: (1) every consolidated dimension already has a recorded lane that ' +
+					'reached a terminal non-successful state; (2) no consolidated dimension already has a ' +
+					`successful source; (3) no single lane owns all ${PR_REVIEW_BASE_DIMENSION_IDS.length} ` +
+					`dimensions; (4) a batch claiming all ${PR_REVIEW_BASE_DIMENSION_IDS.length} dimensions uses ` +
+					`at least ${PR_REVIEW_BASE_LANE_FLOORS.L} lanes; and (5) across every recorded base batch the ` +
+					`six dimensions stay backed by at least ${PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR} distinct ` +
+					'lanes, counting each dimension no consolidated lane claims as one plus the FEWEST declared ' +
+					'consolidated lanes that suffice to cover every dimension consolidated lanes do claim. ' +
+					'Clause 5 is cumulative over every base batch this wave recorded, including batches the ' +
+					'capacity GC has since dropped, and it counts a minimum cover rather than declarations — so ' +
+					'neither splitting one consolidation across several batches nor declaring overlapping or ' +
+					'duplicate consolidations evades it. ' +
+					rejection,
+			);
+		}
 	}
 	const batchId = normalizeBatchId(options.batchId);
-	const previous = state.prReviewBaseDispatches ?? [];
+	let previous = state.prReviewBaseDispatches ?? [];
 	if (previous.some((record) => record.batchId === batchId)) {
 		throw new Error(
 			`BLOCKED: PR_REVIEW base batch id "${batchId}" is already recorded`,
 		);
 	}
 	if (previous.length >= MAX_WORKFLOW_BATCHES) {
-		throw new Error('BLOCKED: PR_REVIEW base batch limit reached');
+		// The cap used to be a permanent dead end with no recovery path. Prune
+		// provably-inert batches from the in-memory state FIRST, then re-read
+		// `previous` from the pruned object, so the append below and the single
+		// persistState downstream both operate on the same state — a separate GC
+		// write would be undone by `[...previous, record]` and would trip the CAS.
+		state = await prunePrWorkflowBatchesForCapacity(
+			directory,
+			state,
+			options.revisionDigest,
+		);
+		previous = state.prReviewBaseDispatches ?? [];
+		if (previous.length >= MAX_WORKFLOW_BATCHES) {
+			throw new Error('BLOCKED: PR_REVIEW base batch limit reached');
+		}
 	}
 	const record: PrReviewBaseDispatchRecord = {
 		batchId,
@@ -1373,16 +1563,670 @@ export async function enforcePrReviewBaseDimensions(
 	return nextState;
 }
 
+/**
+ * Delegation statuses that prove a lane will produce nothing further.
+ *
+ * Enumerated here rather than reusing `isTerminal`
+ * (`src/background/pending-delegations.ts:1829`) because that helper is private
+ * to its module and because the two sets deliberately differ: `consumed` is a
+ * *successfully ingested* terminal state, so treating it as a failure would let
+ * a healthy lane be consolidated over. `pending` / `running` / `ingesting` /
+ * `ingestion_error` are in flight or retryable. Any unrecognized (future) status
+ * is treated as "not proven failed" and denies consolidation — default-deny.
+ *
+ * `completed` is included because completion alone is not success: a completed
+ * record whose artifact is degraded, truncated, empty or identity-mismatched
+ * fails `recordsPassingBatchIntegrity` and is exactly the ran-and-failed case
+ * the tier-L retry exception exists for. This set is therefore only ever
+ * consulted for lanes that already failed that integrity chain.
+ */
+const TERMINAL_FAILED_DELEGATION_STATUSES: ReadonlySet<string> = new Set([
+	'completed',
+	'error',
+	'cancelled',
+	'stale',
+]);
+
+interface PrReviewBaseDimensionAttempts {
+	/** Dimensions with a currently authoritative successful artifact. */
+	successful: Set<string>;
+	/**
+	 * The subset of `successful` supplied by a lane that owns that dimension
+	 * alone. Used by the cumulative tier-L lane floor to decide when an earlier
+	 * consolidated lane has been superseded and no longer spends lane budget.
+	 */
+	dedicatedSuccessful: Set<string>;
+	/** Dimensions whose recorded lane ran to a terminal, non-successful end. */
+	terminallyFailed: Set<string>;
+}
+
+/**
+ * Per-dimension success/failure across every recorded base batch.
+ *
+ * The two halves deliberately use different evidence:
+ *
+ * - **successful** is revision-aware (`successfulObligationsFromExactBatch`
+ *   compares each artifact's `revisionDigest` against the current worktree), so
+ *   a stale artifact is correctly not a current source.
+ * - **terminallyFailed** is revision-INdependent on purpose.
+ *   `recordsPassingBatchIntegrity` takes no digest and checks only
+ *   session-immutable identity plus the delegation outcome. If failure were
+ *   derived from the revision-aware set instead, any working-tree edit would
+ *   make all six dimensions read as "failed" at once and a caller could then
+ *   consolidate the whole base wave into two lanes — re-opening the tier-L lane
+ *   floor by a second route (issue #1968 BL-4).
+ */
+function summarizePrReviewBaseDimensionAttempts(
+	directory: string,
+	state: PrWorkflowGateState,
+	revisionDigest: string,
+): PrReviewBaseDimensionAttempts {
+	const successful = new Set<string>();
+	const dedicatedSuccessful = new Set<string>();
+	const terminallyFailed = new Set<string>();
+	for (const batch of state.prReviewBaseDispatches ?? []) {
+		const batchSuccessful = successfulObligationsFromExactBatch(
+			directory,
+			state,
+			batch.batchId,
+			batch.lanes,
+			'swarm-pr-review:base',
+			batch.validatedAt,
+			true,
+			new Set(),
+			revisionDigest,
+		);
+		for (const obligation of batchSuccessful) {
+			successful.add(obligation);
+		}
+		for (const lane of batch.lanes) {
+			if ((lane.ownedWorkflowLanes?.length ?? 1) !== 1) continue;
+			const dimension = lane.ownedWorkflowLanes?.[0] ?? lane.workflowLane;
+			if (batchSuccessful.has(dimension)) dedicatedSuccessful.add(dimension);
+		}
+		const integrityPassingLaneIds = new Set(
+			recordsPassingBatchIntegrity(
+				directory,
+				state,
+				batch.batchId,
+				batch.lanes,
+				'swarm-pr-review:base',
+				batch.validatedAt,
+			).map((qualified) => qualified.record.laneId),
+		);
+		const records = findByBatchId(directory, batch.batchId, {
+			parentSessionId: state.sessionID,
+		});
+		for (const lane of batch.lanes) {
+			if (integrityPassingLaneIds.has(lane.laneId)) continue;
+			const laneRecords = records.filter(
+				(record) => record.laneId === lane.laneId,
+			);
+			// No record at all: never dispatched. Any record not in the terminal
+			// failure set: still in flight or retryable. Both deny consolidation.
+			if (
+				laneRecords.length === 0 ||
+				!laneRecords.every((record) =>
+					TERMINAL_FAILED_DELEGATION_STATUSES.has(record.status),
+				)
+			) {
+				continue;
+			}
+			for (const dimension of lane.ownedWorkflowLanes?.length
+				? lane.ownedWorkflowLanes
+				: [lane.workflowLane]) {
+				terminallyFailed.add(dimension);
+			}
+		}
+	}
+	return { successful, dedicatedSuccessful, terminallyFailed };
+}
+
+/**
+ * Fewest of these consolidated lane sets that together cover their own union.
+ *
+ * This is the "how many agents actually have to produce a review" number, and it
+ * is deliberately a **minimum cover** rather than a count of declared lanes
+ * (issue #1968 review round 2, MUST-FIX A). Declaring a lane costs nothing, so a
+ * count of declarations inflates without bound while the union of the dimensions
+ * they own saturates at six: four pairwise consolidations
+ * `{A,B} {B,C} {D,E} {F,A}` are each individually legal, yet three of them
+ * ({B,C}, {D,E}, {F,A}) already cover all six dimensions, and the wave settles at
+ * three producing lanes — precisely `PR_REVIEW_BASE_LANE_FLOORS.M`, the tier-M
+ * dispatch shape the tier-L floor exists to forbid. Re-declaring one identical
+ * set several times is the same defect in its simplest form.
+ *
+ * Exact, not greedy. Greedy subset-elimination is order-dependent — on the four
+ * pairs above it counts 4 in declaration order and 3 with `{A,B}` considered
+ * last — and declaration order is chosen by the very controller being gated, so
+ * an order-dependent count is not a floor.
+ *
+ * Cost is a bitmask DP over `2^|universe|` states. The universe is the set of
+ * dimensions consolidated lanes own, which `enforcePrReviewBaseDimensions`
+ * constrains to `PR_REVIEW_BASE_DIMENSION_IDS` before this ever runs, so it is
+ * six in practice. State is nonetheless read from disk, so a universe wider than
+ * `MAX_COVER_UNIVERSE_BITS` falls back to `ceil(|universe| / largest set size)` —
+ * a valid lower bound on any cover, hence still fail-closed: it can only make the
+ * floor reject more.
+ */
+const MAX_COVER_UNIVERSE_BITS = 12;
+
+/**
+ * Canonical key for a consolidated lane's owned dimension set. Sorted so two
+ * declarations of the same set collapse, and `|`-joined because
+ * `enforcePrReviewBaseDimensions` constrains every dimension to
+ * `PR_REVIEW_BASE_DIMENSION_IDS`, none of which contains that character.
+ */
+function encodeConsolidatedLaneKey(owned: readonly string[]): string {
+	return [...new Set(owned)].sort().join('|');
+}
+
+function decodeConsolidatedLaneKey(key: string): string[] {
+	return key.split('|').filter((dimension) => dimension.length > 0);
+}
+
+function minimumConsolidatedLaneCover(
+	sets: ReadonlyArray<readonly string[]>,
+): number {
+	const bitOf = new Map<string, number>();
+	for (const set of sets) {
+		for (const dimension of set) {
+			if (!bitOf.has(dimension)) bitOf.set(dimension, bitOf.size);
+		}
+	}
+	const universeSize = bitOf.size;
+	if (universeSize === 0) return 0;
+	const distinctMasks = new Set<number>();
+	let largestSetSize = 1;
+	for (const set of sets) {
+		let mask = 0;
+		let size = 0;
+		for (const dimension of set) {
+			const bit = 1 << (bitOf.get(dimension) as number);
+			if ((mask & bit) === 0) size += 1;
+			mask |= bit;
+		}
+		if (mask === 0) continue;
+		distinctMasks.add(mask);
+		largestSetSize = Math.max(largestSetSize, size);
+	}
+	if (universeSize > MAX_COVER_UNIVERSE_BITS) {
+		return Math.ceil(universeSize / largestSetSize);
+	}
+	const full = (1 << universeSize) - 1;
+	// Forward DP in increasing mask order. `mask | setMask` is strictly greater
+	// than `mask` whenever it differs, so ascending order is a valid topological
+	// order and one pass suffices. `full` is always reachable because the union
+	// of every set is the universe by construction.
+	const unreachable = universeSize + 1;
+	const best: number[] = new Array<number>(full + 1).fill(unreachable);
+	best[0] = 0;
+	for (let mask = 0; mask < full; mask += 1) {
+		const steps = best[mask] as number;
+		if (steps === unreachable) continue;
+		for (const setMask of distinctMasks) {
+			const next = mask | setMask;
+			if (next === mask) continue;
+			if ((best[next] as number) > steps + 1) best[next] = steps + 1;
+		}
+	}
+	return best[full] as number;
+}
+
+/**
+ * Distinct lanes that would still back the six base dimensions once this batch
+ * is recorded (issue #1968 MUST-FIX 1, refined by review round 2 MUST-FIX A).
+ *
+ * Counting rule: every dimension no consolidated lane claims contributes one
+ * lane (it has, or will need, a dedicated lane of its own at tier L), plus the
+ * MINIMUM number of the declared consolidated lanes needed to cover every
+ * dimension consolidated lanes do claim — see `minimumConsolidatedLaneCover` for
+ * why a count of declarations is not a floor. That sum is exactly "how many
+ * agents actually produce the six-dimension base review".
+ *
+ * The cover is taken over lanes as **declared**, not as produced. Covering only
+ * lanes that currently supply a source would let a controller declare every
+ * consolidated retry batch before any of them lands — each one measured against
+ * a wave that still looks un-consolidated — and land them all afterwards. A
+ * consolidated lane that was later superseded by a successful *dedicated* lane
+ * for every dimension it owned is dropped, so a failed consolidation followed by
+ * singleton re-dispatch does not spend budget forever.
+ *
+ * `prReviewRetiredConsolidatedLanes` is walked alongside the live batches so the
+ * cover is invariant under the capacity GC (issue #1968 review round 2, FIX D):
+ * a failed consolidated base batch is prunable, and without the ledger dropping
+ * it would shrink the cover's universe and hand the wave its consolidation
+ * budget back.
+ */
+function tierLBackingLaneCount(
+	state: PrWorkflowGateState,
+	normalizedLanes: readonly PrWorkflowLaneSpec[],
+	dedicatedSuccessful: ReadonlySet<string>,
+): { backingLanes: number; consolidatedDimensions: string[] } {
+	const consolidatedDimensions = new Set<string>();
+	const consolidatedSets: string[][] = [];
+	const consider = (
+		owned: readonly (string | undefined)[],
+		allowSupersede: boolean,
+	): void => {
+		const declared = owned.filter((dimension): dimension is string =>
+			Boolean(dimension),
+		);
+		if (declared.length < 2) return;
+		const live = allowSupersede
+			? declared.filter((dimension) => !dedicatedSuccessful.has(dimension))
+			: declared;
+		if (live.length === 0) return;
+		consolidatedSets.push([...new Set(live)]);
+		for (const dimension of live) consolidatedDimensions.add(dimension);
+	};
+	const considerLane = (
+		lane: { workflowLane?: string; ownedWorkflowLanes?: readonly string[] },
+		allowSupersede: boolean,
+	): void =>
+		consider(
+			lane.ownedWorkflowLanes?.length
+				? lane.ownedWorkflowLanes
+				: [lane.workflowLane],
+			allowSupersede,
+		);
+	for (const batch of state.prReviewBaseDispatches ?? []) {
+		for (const lane of batch.lanes) considerLane(lane, true);
+	}
+	for (const key of state.prReviewRetiredConsolidatedLanes ?? []) {
+		consider(decodeConsolidatedLaneKey(key), true);
+	}
+	for (const lane of normalizedLanes) considerLane(lane, false);
+	const dedicatedDimensions = PR_REVIEW_BASE_DIMENSION_IDS.filter(
+		(dimension) => !consolidatedDimensions.has(dimension),
+	).length;
+	return {
+		backingLanes:
+			dedicatedDimensions + minimumConsolidatedLaneCover(consolidatedSets),
+		consolidatedDimensions: [...consolidatedDimensions],
+	};
+}
+
+/**
+ * Why this tier-L batch may not consolidate, or `null` when it may.
+ *
+ * Every clause of the retry exception must hold (issue #1968 P3.1, MUST-FIX 1).
+ * The purely structural clauses — initial wave, one lane owning everything, and
+ * the per-batch all-six floor — run first, so those rejections still cost no
+ * artifact reads and no digest resolution. The remaining clauses, including the
+ * cumulative wave floor, all read from the one `attempts` summary; the
+ * cumulative floor adds no read the success/failure clauses did not already do.
+ */
+async function tierLConsolidationRejection(
+	directory: string,
+	state: PrWorkflowGateState,
+	normalizedLanes: readonly PrWorkflowLaneSpec[],
+	revisionDigest: string | undefined,
+): Promise<string | null> {
+	if ((state.prReviewBaseDispatches?.length ?? 0) === 0) {
+		return 'This is the initial base wave, which may never consolidate at tier L.';
+	}
+	const dimensionCount = PR_REVIEW_BASE_DIMENSION_IDS.length;
+	const consolidatedLanes = normalizedLanes.filter(
+		(lane) => (lane.ownedWorkflowLanes?.length ?? 1) !== 1,
+	);
+	const wholeWaveLane = consolidatedLanes.find(
+		(lane) => (lane.ownedWorkflowLanes?.length ?? 1) >= dimensionCount,
+	);
+	if (wholeWaveLane) {
+		return `Lane "${wholeWaveLane.laneId}" owns all ${dimensionCount} dimensions on its own.`;
+	}
+	const claimedDimensions = new Set(
+		normalizedLanes.flatMap(
+			(lane) => lane.ownedWorkflowLanes ?? [lane.workflowLane],
+		),
+	);
+	if (
+		claimedDimensions.size >= dimensionCount &&
+		normalizedLanes.length < PR_REVIEW_BASE_LANE_FLOORS.L
+	) {
+		return `This batch claims all ${dimensionCount} dimensions with only ${normalizedLanes.length} lanes.`;
+	}
+	let digest = revisionDigest;
+	if (!digest) {
+		// Dispatch always threads the digest it already resolved, so this branch
+		// only serves direct callers (focused tests, future entry points). It is
+		// the gate's single memoized resolve, never a per-record one.
+		digest = (await createPrReviewGateContext(directory, state)).revisionDigest;
+	}
+	const attempts = summarizePrReviewBaseDimensionAttempts(
+		directory,
+		state,
+		digest,
+	);
+	const consolidatedDimensions = [
+		...new Set(
+			consolidatedLanes.flatMap(
+				(lane) => lane.ownedWorkflowLanes ?? [lane.workflowLane],
+			),
+		),
+	].filter((dimension): dimension is string => Boolean(dimension));
+	const alreadySuccessful = consolidatedDimensions.filter((dimension) =>
+		attempts.successful.has(dimension),
+	);
+	if (alreadySuccessful.length > 0) {
+		return `These consolidated dimensions already have a successful source: ${alreadySuccessful.join(', ')}.`;
+	}
+	const notTerminallyFailed = consolidatedDimensions.filter(
+		(dimension) => !attempts.terminallyFailed.has(dimension),
+	);
+	if (notTerminallyFailed.length > 0) {
+		return `These consolidated dimensions have no recorded lane that reached a terminal non-successful state (never dispatched, still in flight, or awaiting ingestion): ${notTerminallyFailed.join(', ')}.`;
+	}
+	// The cumulative floor. The per-batch clause above is defeated by splitting
+	// one consolidation across two batches (claim five dimensions in one batch,
+	// the sixth in a singleton batch that never reaches this predicate at all),
+	// so the floor has to be measured over the whole base wave.
+	const backing = tierLBackingLaneCount(
+		state,
+		normalizedLanes,
+		attempts.dedicatedSuccessful,
+	);
+	if (backing.backingLanes < PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR) {
+		return (
+			`Across every base batch this wave would be backed by only ${backing.backingLanes} distinct ` +
+			`lanes (each dimension no consolidated lane claims counts as one, plus the fewest declared ` +
+			`consolidated lanes that cover the rest), and dimensions ` +
+			`${backing.consolidatedDimensions.join(', ')} would be covered by consolidated lanes.`
+		);
+	}
+	return null;
+}
+
+/**
+ * Reclaim `MAX_WORKFLOW_BATCHES` capacity by dropping provably-inert batches.
+ *
+ * Pure with respect to durable state: it reads artifacts, returns a new state
+ * object, and never persists. The caller re-reads its batch array from the
+ * returned object and performs the one `persistState` for the whole
+ * read-prune-append transaction — a separate GC write would be undone by the
+ * subsequent `[...previous, record]` and would leave the local `revision` stale,
+ * tripping the optimistic-concurrency check (issue #1968 BL-6).
+ *
+ * Fail-closed: the discharge of "pruning changed nothing observable" is
+ * **inventory equality only** — `derivePrReviewCandidateInventory` and
+ * `derivePrReviewCriticInventory`, the two pure `(directory, state)` derivations
+ * the downstream gates consume. A past artifact-boundary exact-cover verdict is
+ * deliberately NOT recomputed: `prReviewArtifactBoundaries` persists boundary
+ * names only and the `findingIds` that check compares are caller-supplied and
+ * never persisted, so that verdict is not a property of state and never was
+ * (issue #1968 BL-5). If either inventory changes, or anything at all throws,
+ * every batch is kept and the caller's cap error stands.
+ */
+async function prunePrWorkflowBatchesForCapacity(
+	directory: string,
+	state: PrWorkflowGateState,
+	revisionDigest: string | undefined,
+): Promise<PrWorkflowGateState> {
+	try {
+		const digest =
+			revisionDigest ??
+			(await createPrReviewGateContext(directory, state)).revisionDigest;
+		const before = {
+			candidate: derivePrReviewCandidateInventory(directory, state, {
+				revisionDigest: digest,
+			}),
+			critic: derivePrReviewCriticInventory(directory, state, {
+				revisionDigest: digest,
+			}),
+		};
+		const pruned = pruneWorkflowBatches(directory, state, digest);
+		if (!pruned) return state;
+		const after = {
+			candidate: derivePrReviewCandidateInventory(directory, pruned, {
+				revisionDigest: digest,
+			}),
+			critic: derivePrReviewCriticInventory(directory, pruned, {
+				revisionDigest: digest,
+			}),
+		};
+		if (
+			!sameStringSet(before.candidate, after.candidate) ||
+			!sameStringSet(before.critic, after.critic)
+		) {
+			warn(
+				'PR_REVIEW batch GC aborted: pruning would have changed the derived inventory; every batch was kept',
+			);
+			return state;
+		}
+		// The newest batch of every kind is unprunable, so the singular "latest"
+		// pointers must survive. Assert rather than assume: a pointer left dangling
+		// past its array entry would silently misreport the active dispatch.
+		const survivingBaseIds = new Set(
+			(pruned.prReviewBaseDispatches ?? []).map((batch) => batch.batchId),
+		);
+		if (
+			state.prReviewBaseDispatch &&
+			!survivingBaseIds.has(state.prReviewBaseDispatch.batchId)
+		) {
+			warn(
+				'PR_REVIEW batch GC aborted: the latest base dispatch pointer would have been orphaned',
+			);
+			return state;
+		}
+		return pruned;
+	} catch (error) {
+		warn(
+			`PR_REVIEW batch GC aborted: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return state;
+	}
+}
+
+/**
+ * The pure prune itself. Returns `null` when nothing is prunable.
+ *
+ * Never pruned:
+ * - every `council` batch. `assertPrReviewValidationSettled` derives
+ *   `declaredPhases` from the whole array and `prReviewPhaseWindow('reviewer')`
+ *   scopes itself with `slice(latestCouncilIndex + 1)`, so council membership is
+ *   load-bearing. Non-council batches are position-independent: removing one
+ *   never changes *which* batches sit after the last council batch, only their
+ *   indices, so the reviewer window is preserved by keeping council intact;
+ * - every `critic` batch. `prReviewPhaseWindow('critic')` is **not** council
+ *   scoped — it returns every critic batch in the array — so no critic batch is
+ *   inert, including one recorded before the latest council. The fix plan's
+ *   never-prune list omits this; dropping a pre-council critic batch would
+ *   silently remove claims from critic settlement, which the inventory-equality
+ *   proof below does not cover (critic settlement is not an inventory);
+ * - the newest batch of each kind/phase, which keeps the singular latest-dispatch
+ *   pointer and `declaredPhases` intact;
+ * - any base batch carrying a fully-successful lane. The fix plan says "a current
+ *   authoritative source for a dimension"; this protects the strict superset,
+ *   because `derivePrReviewCandidateInventory` picks its authoritative source
+ *   per *lane* under the tier-L singleton-first precedence, and a reverse
+ *   per-batch scan here would not always agree. A superset can only under-prune;
+ * - any reviewer batch that contributed at least one claim to the **exhaustive**
+ *   composition. Contribution is read from a full-window scan rather than from
+ *   the memoized early-exit pass, so this durable decision never rests on the
+ *   composition's performance heuristic (issue #1968 MUST-FIX 3 / FIX 5; the two
+ *   agree under today's exit condition — see `composePrReviewPhaseVerdicts`).
+ *   A non-contributing reviewer batch is provably unable to change any verdict —
+ *   composition is
+ *   first-write-wins over a reverse scan, so a batch that claimed nothing at its
+ *   own position cannot claim anything once the batches ahead of it are still
+ *   there. That is a stronger warrant than inventory inequality and subsumes it:
+ *   a batch validated against a different inventory contributes nothing anyway.
+ *   The warrant is about the composition as it stands now; if a later inventory
+ *   change made a dropped batch eligible again, its claims are simply absent,
+ *   which can only leave an item unclaimed and BLOCK — never admit a verdict.
+ *
+ * Pruning a reviewer batch would otherwise loosen one fail-closed check —
+ * `reviewerSubagentSessionIds`, the ban on a critic lane reusing a reviewer's
+ * child session, which walks the live reviewer batches. Their child sessions are
+ * therefore moved to `prReviewRetiredReviewerSessionIds`, which that function
+ * unions in; if the ledger would overflow its bound the prune is abandoned.
+ *
+ * Pruning a base batch would loosen the other cumulative check the same way:
+ * `tierLBackingLaneCount` covers the consolidated lanes it can see, and dropping
+ * a failed consolidated batch would shrink that cover's universe and hand the
+ * wave back consolidation budget it had already spent (issue #1968 review round
+ * 2, FIX D). A dropped batch's consolidated lanes are therefore recorded in
+ * `prReviewRetiredConsolidatedLanes` as canonical dimension-set keys, under the
+ * same overflow-abandons-the-prune rule. Keys, not batches: the cover dedupes
+ * identical sets anyway, so the ledger is bounded by the 57 non-singleton
+ * subsets of six dimensions no matter how many batches retire.
+ *
+ * `prFeedbackVerifications` is not touched here — it belongs to the PR_FEEDBACK
+ * mode, which never reaches this function — but it is no longer uncollected:
+ * `prunePrFeedbackVerificationsForCapacity` reclaims it under the same
+ * fail-closed contract (issue #1968 review round 2, MUST-FIX C).
+ *
+ * Survivor order is preserved, and an orphaned `prReviewBatchCoherence` entry is
+ * always pruned with its batch.
+ */
+function pruneWorkflowBatches(
+	directory: string,
+	state: PrWorkflowGateState,
+	revisionDigest: string,
+): PrWorkflowGateState | null {
+	const baseBatches = state.prReviewBaseDispatches ?? [];
+	const validationBatches = state.prReviewValidationBatches ?? [];
+	const ctx: PrReviewGateContext = { revisionDigest };
+
+	const contributingBaseBatchIds = new Set<string>();
+	for (const batch of baseBatches) {
+		const successful = successfulObligationsFromExactBatch(
+			directory,
+			state,
+			batch.batchId,
+			batch.lanes,
+			'swarm-pr-review:base',
+			batch.validatedAt,
+			true,
+			new Set(),
+			revisionDigest,
+		);
+		const hasFullySuccessfulLane = batch.lanes.some((lane) =>
+			(lane.ownedWorkflowLanes?.length
+				? lane.ownedWorkflowLanes
+				: [lane.workflowLane]
+			).every((dimension) => successful.has(dimension)),
+		);
+		if (hasFullySuccessfulLane) contributingBaseBatchIds.add(batch.batchId);
+	}
+	const newestBaseBatchId = baseBatches.at(-1)?.batchId;
+	const survivingBase = baseBatches.filter(
+		(batch) =>
+			batch.batchId === newestBaseBatchId ||
+			contributingBaseBatchIds.has(batch.batchId),
+	);
+
+	const newestBatchIdByPhase = new Map<string, string>();
+	for (const batch of validationBatches) {
+		newestBatchIdByPhase.set(batch.phase, batch.batchId);
+	}
+	// Exhaustive on purpose: the hot path stops as soon as every item is claimed,
+	// and "was not reached before the early exit" is not evidence of inertness.
+	const contributingReviewerBatchIds = new Set(
+		composePrReviewPhaseVerdicts(directory, state, 'reviewer', ctx, true)
+			.contributingBatchIds,
+	);
+	const survivingValidation = validationBatches.filter((batch) => {
+		if (batch.phase === 'council' || batch.phase === 'critic') return true;
+		if (newestBatchIdByPhase.get(batch.phase) === batch.batchId) return true;
+		return contributingReviewerBatchIds.has(batch.batchId);
+	});
+
+	if (
+		survivingBase.length === baseBatches.length &&
+		survivingValidation.length === validationBatches.length
+	) {
+		return null;
+	}
+	const survivingValidationIds = new Set(
+		survivingValidation.map((batch) => batch.batchId),
+	);
+	const retiredReviewerSessionIds = new Set(
+		state.prReviewRetiredReviewerSessionIds ?? [],
+	);
+	for (const batch of validationBatches) {
+		if (batch.phase !== 'reviewer') continue;
+		if (survivingValidationIds.has(batch.batchId)) continue;
+		for (const record of findByBatchId(directory, batch.batchId, {
+			parentSessionId: state.sessionID,
+		})) {
+			const subagentSessionId = record.subagentSessionId?.trim();
+			if (subagentSessionId) retiredReviewerSessionIds.add(subagentSessionId);
+		}
+	}
+	if (retiredReviewerSessionIds.size > MAX_RETIRED_REVIEWER_SESSION_IDS) {
+		warn(
+			'PR_REVIEW batch GC aborted: retiring these reviewer batches would overflow the forbidden child-session ledger; every batch was kept',
+		);
+		return null;
+	}
+	// Same shape, for the other fail-closed check a prune would loosen: the
+	// tier-L cumulative consolidation floor covers the consolidated lanes it can
+	// see, and it can only see surviving base batches (issue #1968 FIX D).
+	const survivingBaseIds = new Set(survivingBase.map((batch) => batch.batchId));
+	const retiredConsolidatedLanes = new Set(
+		state.prReviewRetiredConsolidatedLanes ?? [],
+	);
+	for (const batch of baseBatches) {
+		if (survivingBaseIds.has(batch.batchId)) continue;
+		for (const lane of batch.lanes) {
+			const owned = lane.ownedWorkflowLanes?.length
+				? lane.ownedWorkflowLanes
+				: [lane.workflowLane];
+			if (new Set(owned).size < 2) continue;
+			retiredConsolidatedLanes.add(encodeConsolidatedLaneKey(owned));
+		}
+	}
+	if (retiredConsolidatedLanes.size > MAX_RETIRED_CONSOLIDATED_LANES) {
+		warn(
+			'PR_REVIEW batch GC aborted: retiring these base batches would overflow the retired consolidated-lane ledger; every batch was kept',
+		);
+		return null;
+	}
+	const survivingBatchIds = new Set([
+		...survivingBaseIds,
+		...survivingValidationIds,
+	]);
+	const coherence = Object.fromEntries(
+		Object.entries(state.prReviewBatchCoherence ?? {}).filter(([batchId]) =>
+			survivingBatchIds.has(batchId),
+		),
+	);
+	return {
+		...state,
+		...(state.prReviewBaseDispatches
+			? { prReviewBaseDispatches: survivingBase }
+			: {}),
+		...(state.prReviewValidationBatches
+			? { prReviewValidationBatches: survivingValidation }
+			: {}),
+		prReviewBatchCoherence:
+			Object.keys(coherence).length > 0 ? coherence : undefined,
+		prReviewRetiredReviewerSessionIds:
+			retiredReviewerSessionIds.size > 0
+				? [...retiredReviewerSessionIds]
+				: undefined,
+		prReviewRetiredConsolidatedLanes:
+			retiredConsolidatedLanes.size > 0
+				? [...retiredConsolidatedLanes]
+				: undefined,
+	};
+}
+
 /** Validate durable exact-six PR review evidence across all base and retry batches. */
 export async function assertPrReviewBaseCoverageSettled(
 	directory: string,
 	sessionID: string,
+	gateContext?: PrReviewGateContext,
 ): Promise<PrWorkflowGateState> {
 	const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
 	const batches = state.prReviewBaseDispatches ?? [];
 	if (batches.length === 0) {
 		throw new Error('BLOCKED: PR_REVIEW requires at least one base batch');
 	}
+	const ctx =
+		gateContext ?? (await createPrReviewGateContext(directory, state));
 	const covered = new Set<PrReviewBaseDimensionId>();
 	const malformedDiagnostics: string[] = [];
 	for (const batch of batches) {
@@ -1395,7 +2239,7 @@ export async function assertPrReviewBaseCoverageSettled(
 			batch.validatedAt,
 			true,
 			new Set(),
-			undefined,
+			ctx.revisionDigest,
 			malformedDiagnostics,
 		);
 		for (const obligation of successful) {
@@ -1435,6 +2279,7 @@ export async function recordPrReviewValidationBatch(
 			'BLOCKED: PR_REVIEW validation dispatch requires a completed trigger evaluation',
 		);
 	}
+	let ctx = await createPrReviewGateContext(directory, state);
 	if (
 		phase === 'reviewer' &&
 		(state.prReviewValidationBatches ?? []).some(
@@ -1445,14 +2290,21 @@ export async function recordPrReviewValidationBatch(
 			directory,
 			sessionID,
 			'council',
+			ctx,
 		);
 	} else if (phase === 'critic') {
 		state = await assertPrReviewValidationSettled(
 			directory,
 			sessionID,
 			'reviewer',
+			ctx,
 		);
 	}
+	// requireBoundState re-reads through the same snapshot, but the returned
+	// object identity changed; the memoized compositions were computed against
+	// the pre-reload object, so keep the digest and re-memoize against the state
+	// this function actually persists from.
+	ctx = { revisionDigest: ctx.revisionDigest };
 	const normalizedLanes = normalizeWorkflowLanes(lanes);
 	if (
 		(phase === 'reviewer' || phase === 'critic') &&
@@ -1462,6 +2314,7 @@ export async function recordPrReviewValidationBatch(
 			`BLOCKED: PR_REVIEW ${phase} lanes require non-empty review_item_ids ownership`,
 		);
 	}
+	let validatedInventory: string[] | undefined;
 	if (phase === 'reviewer' || phase === 'critic') {
 		assertNoDuplicates(
 			normalizedLanes.flatMap((lane) => lane.reviewItemIds ?? []),
@@ -1470,21 +2323,36 @@ export async function recordPrReviewValidationBatch(
 		const assigned = normalizedLanes.flatMap(
 			(lane) => lane.reviewItemIds ?? [],
 		);
-		const required =
+		validatedInventory =
 			phase === 'reviewer'
-				? derivePrReviewCandidateInventory(directory, state)
-				: derivePrReviewCriticInventory(directory, state);
-		assertExactStringSet(assigned, required, `PR_REVIEW ${phase} ownership`);
+				? derivePrReviewCandidateInventory(directory, state, ctx)
+				: derivePrReviewCriticInventory(directory, state, ctx);
+		assertExactStringSet(
+			assigned,
+			validatedInventory,
+			`PR_REVIEW ${phase} ownership`,
+		);
 	}
 	const batchId = normalizeBatchId(options.batchId);
-	const previous = state.prReviewValidationBatches ?? [];
+	let previous = state.prReviewValidationBatches ?? [];
 	if (previous.some((batch) => batch.batchId === batchId)) {
 		throw new Error(
 			`BLOCKED: PR_REVIEW validation batch id "${batchId}" is already recorded`,
 		);
 	}
 	if (previous.length >= MAX_WORKFLOW_BATCHES) {
-		throw new Error('BLOCKED: PR_REVIEW validation batch limit reached');
+		// Prune inside this same read-prune-append transaction, before `previous`
+		// and `retained` are derived, so the single persistState below writes the
+		// pruned array (issue #1968 BL-6).
+		state = await prunePrWorkflowBatchesForCapacity(
+			directory,
+			state,
+			ctx.revisionDigest,
+		);
+		previous = state.prReviewValidationBatches ?? [];
+		if (previous.length >= MAX_WORKFLOW_BATCHES) {
+			throw new Error('BLOCKED: PR_REVIEW validation batch limit reached');
+		}
 	}
 	const record: PrReviewValidationBatchRecord = {
 		batchId,
@@ -1492,29 +2360,73 @@ export async function recordPrReviewValidationBatch(
 		lanes: normalizedLanes,
 		validatedAt: isoNow(),
 	};
-	// Any new reviewer verdict set invalidates every prior critic receipt. A
-	// critic is meaningful only for the reviewer inventory that immediately
-	// precedes it; stale critic batches must never certify later severities.
+	// A critic batch is meaningful only for the exact reviewer rows it was
+	// launched against. Pin each owned item to the sha256 of the full canonical
+	// [REVIEWED] row that was authoritative right now; composition drops exactly
+	// the claims whose reviewer row later changed and keeps the rest.
+	const reviewerItemBindings =
+		phase === 'critic'
+			? criticReviewerItemBindings(directory, state, normalizedLanes, ctx)
+			: undefined;
+	// Legacy critic batches carry no bindings, so nothing can decide per item
+	// whether they went stale; for those the pre-existing blanket prune on every
+	// new reviewer batch is retained verbatim. Bound critic batches survive and
+	// are filtered per item at composition time instead.
 	const retained =
 		phase === 'reviewer'
-			? previous.filter((batch) => batch.phase !== 'critic')
+			? previous.filter(
+					(batch) =>
+						batch.phase !== 'critic' ||
+						Boolean(
+							state.prReviewBatchCoherence?.[batch.batchId]
+								?.reviewerItemBindings,
+						),
+				)
 			: previous;
-	const nextState = {
+	const retainedIds = new Set(retained.map((batch) => batch.batchId));
+	const coherence: Record<string, PrReviewBatchCoherenceRecord> =
+		Object.fromEntries(
+			Object.entries(state.prReviewBatchCoherence ?? {}).filter(([id]) =>
+				retainedIds.has(id),
+			),
+		);
+	if (validatedInventory) {
+		coherence[batchId] = {
+			validatedInventory,
+			...(reviewerItemBindings ? { reviewerItemBindings } : {}),
+		};
+	}
+	const nextState: PrWorkflowGateState = {
 		...state,
 		updatedAt: isoNow(),
 		prReviewValidationBatches: [...retained, record],
+		// Always reassigned, never spread-inherited: a pruned critic batch must
+		// take its coherence entry with it.
+		prReviewBatchCoherence:
+			Object.keys(coherence).length > 0 ? coherence : undefined,
 	};
 	await persistState(directory, nextState);
 	return nextState;
 }
 
-/** Validate that every declared council/reviewer/critic obligation has a successful retry. */
+/**
+ * Validate that every declared council obligation has a successful retry, and
+ * that every reviewer/critic *item* carries an authenticated verdict.
+ *
+ * Council keeps lane-level accounting (council lanes carry no item ownership).
+ * Reviewer and critic settle through `composePrReviewPhaseVerdicts`, so
+ * settlement and every verdict derivation are literally the same computation —
+ * settlement can never pass while derivation is empty.
+ */
 export async function assertPrReviewValidationSettled(
 	directory: string,
 	sessionID: string,
 	phase?: PrReviewValidationPhase,
+	gateContext?: PrReviewGateContext,
 ): Promise<PrWorkflowGateState> {
 	const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+	const ctx =
+		gateContext ?? (await createPrReviewGateContext(directory, state));
 	const declaredPhases = new Set(
 		(state.prReviewValidationBatches ?? []).map((batch) => batch.phase),
 	);
@@ -1525,37 +2437,13 @@ export async function assertPrReviewValidationSettled(
 			);
 	for (const requiredPhase of phases) {
 		const validationBatches = state.prReviewValidationBatches ?? [];
-		const forbiddenSubagentSessionIds = new Set<string>();
-		if (requiredPhase === 'critic') {
-			for (const reviewerBatch of validationBatches.filter(
-				(batch) => batch.phase === 'reviewer',
-			)) {
-				for (const record of findByBatchId(directory, reviewerBatch.batchId, {
-					parentSessionId: state.sessionID,
-				})) {
-					const subagentSessionId = record.subagentSessionId?.trim();
-					if (subagentSessionId) {
-						forbiddenSubagentSessionIds.add(subagentSessionId);
-					}
-				}
-			}
-		}
-		let batches = validationBatches.filter(
-			(batch) => batch.phase === requiredPhase,
-		);
-		if (requiredPhase === 'reviewer') {
-			let latestCouncilIndex = -1;
-			for (let index = 0; index < validationBatches.length; index++) {
-				if (validationBatches[index]?.phase === 'council') {
-					latestCouncilIndex = index;
-				}
-			}
-			if (latestCouncilIndex >= 0) {
-				batches = validationBatches
-					.slice(latestCouncilIndex + 1)
-					.filter((batch) => batch.phase === 'reviewer');
-			}
-		}
+		const batches =
+			requiredPhase === 'council'
+				? validationBatches.filter((batch) => batch.phase === 'council')
+				: prReviewPhaseWindow(state, requiredPhase);
+		// Ordering is load-bearing: the "no batch at all" diagnostic must fire
+		// before composition, which derives the candidate inventory and can raise
+		// its own (less useful, here) provenance errors.
 		if (batches.length === 0) {
 			throw new Error(
 				requiredPhase === 'reviewer' && declaredPhases.has('council')
@@ -1563,46 +2451,72 @@ export async function assertPrReviewValidationSettled(
 					: `BLOCKED: PR_REVIEW requires at least one ${requiredPhase} batch`,
 			);
 		}
-		const allObligations = new Set(
-			batches.flatMap((batch) => batch.lanes.map((lane) => lane.workflowLane)),
-		);
-		const settled = new Set<string>();
-		let hasFullySuccessfulExactBatch = false;
-		for (const batch of batches) {
-			const successful = successfulObligationsFromExactBatch(
-				directory,
-				state,
-				batch.batchId,
-				batch.lanes,
-				`swarm-pr-review:${requiredPhase}`,
-				batch.validatedAt,
-				true,
-				forbiddenSubagentSessionIds,
-			);
-			if (
-				successful.size === batch.lanes.length &&
-				batch.lanes.every((lane) => successful.has(lane.workflowLane))
-			) {
-				hasFullySuccessfulExactBatch = true;
+		if (requiredPhase === 'council') {
+			const settled = new Set<string>();
+			for (const batch of batches) {
+				for (const obligation of successfulObligationsFromExactBatch(
+					directory,
+					state,
+					batch.batchId,
+					batch.lanes,
+					'swarm-pr-review:council',
+					batch.validatedAt,
+					true,
+					new Set(),
+					ctx.revisionDigest,
+				)) {
+					settled.add(obligation);
+				}
 			}
-			for (const obligation of successful) {
-				settled.add(obligation);
+			const missing = [
+				...new Set(
+					batches.flatMap((batch) =>
+						batch.lanes.map((lane) => lane.workflowLane),
+					),
+				),
+			].filter((obligation) => !settled.has(obligation));
+			if (missing.length > 0) {
+				throw new Error(
+					`BLOCKED: PR_REVIEW council obligations lack successful exact artifacts: ${missing.join(', ')}`,
+				);
 			}
+			continue;
 		}
-		if (
-			(requiredPhase === 'reviewer' || requiredPhase === 'critic') &&
-			!hasFullySuccessfulExactBatch
-		) {
+		const composed = composePrReviewPhaseVerdicts(
+			directory,
+			state,
+			requiredPhase,
+			ctx,
+		);
+		if (composed.unclaimed.length > 0) {
+			const named = composed.unclaimed.slice(0, MAX_UNCLAIMED_ITEMS_IN_MESSAGE);
+			const overflow = composed.unclaimed.length - named.length;
 			throw new Error(
-				`BLOCKED: PR_REVIEW ${requiredPhase} requires one fully successful exact batch; complementary partial retries are not a coherent verdict set`,
+				`BLOCKED: PR_REVIEW ${requiredPhase} items lack an authenticated verdict from any successful lane: ${named.join(', ')}` +
+					(overflow > 0 ? ` (+${overflow} more)` : '') +
+					(composed.diagnostics.length > 0
+						? `; diagnostics: ${composed.diagnostics.join(' | ')}`
+						: ''),
 			);
 		}
-		const missing = [...allObligations].filter(
-			(obligation) => !settled.has(obligation),
+		// B1 (issue #1968): reaching here means this phase is now *treated as
+		// settled*. Settling is only meaningful if the authoritative verdict map
+		// every downstream gate reads is actually populated over the same
+		// inventory — a settled-but-empty reviewer map skips critic coverage
+		// silently. Same memoized composition, so this costs one filter and adds
+		// no digest resolution or artifact read.
+		assertSettledPhaseHasAuthoritativeVerdicts(
+			requiredPhase,
+			composed,
+			requiredPhase === 'reviewer'
+				? deriveLatestPrReviewReviewerVerdicts(directory, state, ctx)
+				: deriveLatestPrReviewCriticVerdicts(directory, state, ctx),
+			`assertPrReviewValidationSettled(${requiredPhase})`,
 		);
-		if (missing.length > 0) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW ${requiredPhase} obligations lack successful exact artifacts: ${missing.join(', ')}`,
+		if (composed.diagnostics.length > 0) {
+			warn(
+				`PR_REVIEW ${requiredPhase} settled by composition across batches [${composed.contributingBatchIds.join(', ')}] with abandoned or ineligible lanes`,
+				composed.diagnostics,
 			);
 		}
 	}
@@ -1652,17 +2566,114 @@ export async function declarePrFeedbackInventory(
 	return nextState;
 }
 
+/**
+ * Reclaim `MAX_WORKFLOW_BATCHES` capacity for `prFeedbackVerifications` (issue
+ * #1968 review round 2, MUST-FIX C).
+ *
+ * Same contract as `prunePrWorkflowBatchesForCapacity`: pure with respect to
+ * durable state (reads artifacts, returns a new object, never persists), so the
+ * caller performs the one `persistState` for the whole read-prune-append
+ * transaction and the optimistic-concurrency revision stays consistent.
+ *
+ * A verification batch holds exactly two things a later call reads:
+ * - its contribution to settlement coverage, which is only ever the items of a
+ *   lane that both passed batch integrity and produced an artifact covering
+ *   them. `assertPrFeedbackVerificationSettled` unions coverage from those lanes
+ *   alone, so a batch whose every lane failed contributes nothing at all — the
+ *   retry-driven accumulation this cap suffers from is made entirely of such
+ *   batches;
+ * - its item->lane ownership bindings, which `enforcePrFeedbackVerificationOwnership`
+ *   rebuilds cumulatively to reject a re-claim of an item by a *different* lane.
+ *   Those are moved to `prFeedbackRetiredItemOwnership`, which that function
+ *   seeds from, so the fail-closed re-claim rejection survives the prune. If the
+ *   ledger would overflow its bound, every batch is kept instead.
+ *
+ * Fail-closed like its PR_REVIEW sibling: the covered-item set is recomputed
+ * over the pruned state and must be identical, the newest batch is never
+ * dropped (so the singular `prFeedbackVerification` pointer cannot dangle), and
+ * anything that throws keeps every batch and lets the caller's cap error stand.
+ *
+ * Batch ids of dropped batches become reusable, which is safe for the same
+ * reason it is in the PR_REVIEW GC: `recordsPassingBatchIntegrity` requires
+ * `record.createdAt >= validatedAt`, so a new batch reusing a retired id cannot
+ * inherit the retired batch's older delegation records.
+ */
+async function prunePrFeedbackVerificationsForCapacity(
+	directory: string,
+	state: PrWorkflowGateState,
+): Promise<PrWorkflowGateState> {
+	try {
+		const digest = await currentPrFeedbackRevisionDigest(directory, state);
+		const batches = state.prFeedbackVerifications ?? [];
+		const before = prFeedbackCoveredItems(directory, state, digest);
+		const newestBatchId = batches.at(-1)?.batchId;
+		const surviving = batches.filter(
+			(batch) =>
+				batch.batchId === newestBatchId ||
+				prFeedbackBatchCoveredItems(directory, state, batch, digest).size > 0,
+		);
+		if (surviving.length === batches.length) return state;
+		const retiredItemOwnership: Record<string, string> = {
+			...(state.prFeedbackRetiredItemOwnership ?? {}),
+		};
+		const survivingIds = new Set(surviving.map((batch) => batch.batchId));
+		for (const batch of batches) {
+			if (survivingIds.has(batch.batchId)) continue;
+			for (const lane of batch.ownership) {
+				for (const itemId of lane.ownedItemIds) {
+					retiredItemOwnership[itemId] = lane.laneId;
+				}
+			}
+		}
+		if (
+			Object.keys(retiredItemOwnership).length >
+			MAX_RETIRED_FEEDBACK_ITEM_OWNERS
+		) {
+			warn(
+				'PR_FEEDBACK verification GC aborted: retiring these batches would overflow the item-ownership ledger; every batch was kept',
+			);
+			return state;
+		}
+		const pruned: PrWorkflowGateState = {
+			...state,
+			prFeedbackVerifications: surviving,
+			prFeedbackRetiredItemOwnership:
+				Object.keys(retiredItemOwnership).length > 0
+					? retiredItemOwnership
+					: undefined,
+		};
+		const after = prFeedbackCoveredItems(directory, pruned, digest);
+		if (!sameStringSet([...before], [...after])) {
+			warn(
+				'PR_FEEDBACK verification GC aborted: pruning would have changed the covered inventory; every batch was kept',
+			);
+			return state;
+		}
+		if (
+			state.prFeedbackVerification &&
+			!survivingIds.has(state.prFeedbackVerification.batchId)
+		) {
+			warn(
+				'PR_FEEDBACK verification GC aborted: the latest verification pointer would have been orphaned',
+			);
+			return state;
+		}
+		return pruned;
+	} catch (error) {
+		warn(
+			`PR_FEEDBACK verification GC aborted: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return state;
+	}
+}
+
 export async function enforcePrFeedbackVerificationOwnership(
 	directory: string,
 	sessionID: string,
 	ownership: readonly PrFeedbackLaneOwnership[],
 	options: { batchId: string; prHeadSha: string },
 ): Promise<PrWorkflowGateState> {
-	const state = await bindPrWorkflowHead(
-		directory,
-		sessionID,
-		options.prHeadSha,
-	);
+	let state = await bindPrWorkflowHead(directory, sessionID, options.prHeadSha);
 	if (state.mode !== 'PR_FEEDBACK') {
 		throw wrongModeError(state, 'PR_FEEDBACK');
 	}
@@ -1676,7 +2687,7 @@ export async function enforcePrFeedbackVerificationOwnership(
 	const normalizedOwnership = normalizeOwnership(ownership);
 	const inventorySet = new Set(inventory);
 	const claimedByItemId = new Map<string, string>();
-	const previous = state.prFeedbackVerifications ?? [];
+	let previous = state.prFeedbackVerifications ?? [];
 	const batchId = normalizeBatchId(options.batchId);
 	if (previous.some((record) => record.batchId === batchId)) {
 		throw new Error(
@@ -1684,7 +2695,25 @@ export async function enforcePrFeedbackVerificationOwnership(
 		);
 	}
 	if (previous.length >= MAX_WORKFLOW_BATCHES) {
-		throw new Error('BLOCKED: PR_FEEDBACK verification batch limit reached');
+		// Feedback verification accumulates on retry exactly as the PR_REVIEW
+		// arrays do — `dispatch-lanes.ts` appends a batch on EVERY verification
+		// dispatch, retries included — so this cap needs the same reclaim (issue
+		// #1968 review round 2, MUST-FIX C). What a dropped batch would otherwise
+		// take with it is the cumulative item->lane ownership ledger rebuilt just
+		// below; `prFeedbackRetiredItemOwnership` carries those bindings across the
+		// prune so the re-claim rejection is preserved. Same transaction shape as
+		// the PR_REVIEW GC: prune the in-memory state first, re-read `previous`
+		// from it, and let the single persistState downstream commit both.
+		state = await prunePrFeedbackVerificationsForCapacity(directory, state);
+		previous = state.prFeedbackVerifications ?? [];
+		if (previous.length >= MAX_WORKFLOW_BATCHES) {
+			throw new Error('BLOCKED: PR_FEEDBACK verification batch limit reached');
+		}
+	}
+	for (const [itemId, laneId] of Object.entries(
+		state.prFeedbackRetiredItemOwnership ?? {},
+	)) {
+		claimedByItemId.set(itemId, laneId);
 	}
 	for (const record of previous) {
 		for (const lane of record.ownership) {
@@ -1727,6 +2756,71 @@ export async function enforcePrFeedbackVerificationOwnership(
 	return nextState;
 }
 
+/**
+ * Inventory items a verification batch settles: the items of every lane that is
+ * both successful under batch integrity and whose artifact actually covers them.
+ *
+ * Shared with the capacity GC so "what this batch contributes to coverage" is
+ * one computation rather than two that can drift (issue #1968 review round 2,
+ * MUST-FIX C). A batch with no such lane contributes nothing to settlement.
+ */
+function prFeedbackBatchCoveredItems(
+	directory: string,
+	state: PrWorkflowGateState,
+	batch: PrFeedbackVerificationRecord,
+	currentDigest: string,
+): Set<string> {
+	const covered = new Set<string>();
+	const successfulLaneIds = successfulObligationsFromExactBatch(
+		directory,
+		state,
+		batch.batchId,
+		batch.ownership.map((lane) => ({
+			laneId: lane.laneId,
+			workflowLane: lane.laneId,
+		})),
+		'swarm-pr-feedback:verification',
+		batch.validatedAt,
+		false,
+		new Set(),
+		currentDigest,
+	);
+	for (const lane of batch.ownership) {
+		if (!successfulLaneIds.has(lane.laneId)) continue;
+		if (
+			!feedbackArtifactCoversItems(
+				directory,
+				state,
+				batch.batchId,
+				lane.laneId,
+				lane.ownedItemIds,
+			)
+		)
+			continue;
+		for (const itemId of lane.ownedItemIds) covered.add(itemId);
+	}
+	return covered;
+}
+
+function prFeedbackCoveredItems(
+	directory: string,
+	state: PrWorkflowGateState,
+	currentDigest: string,
+): Set<string> {
+	const covered = new Set<string>();
+	for (const batch of state.prFeedbackVerifications ?? []) {
+		for (const itemId of prFeedbackBatchCoveredItems(
+			directory,
+			state,
+			batch,
+			currentDigest,
+		)) {
+			covered.add(itemId);
+		}
+	}
+	return covered;
+}
+
 /** Validate cumulative exact inventory ownership and settled verification artifacts. */
 export async function assertPrFeedbackVerificationSettled(
 	directory: string,
@@ -1741,37 +2835,7 @@ export async function assertPrFeedbackVerificationSettled(
 			'BLOCKED: PR_FEEDBACK requires an immutable inventory and verification batches',
 		);
 	}
-	const covered = new Set<string>();
-	for (const batch of batches) {
-		const successfulLaneIds = successfulObligationsFromExactBatch(
-			directory,
-			state,
-			batch.batchId,
-			batch.ownership.map((lane) => ({
-				laneId: lane.laneId,
-				workflowLane: lane.laneId,
-			})),
-			'swarm-pr-feedback:verification',
-			batch.validatedAt,
-			false,
-			new Set(),
-			currentDigest,
-		);
-		for (const lane of batch.ownership) {
-			if (!successfulLaneIds.has(lane.laneId)) continue;
-			if (
-				!feedbackArtifactCoversItems(
-					directory,
-					state,
-					batch.batchId,
-					lane.laneId,
-					lane.ownedItemIds,
-				)
-			)
-				continue;
-			for (const itemId of lane.ownedItemIds) covered.add(itemId);
-		}
-	}
+	const covered = prFeedbackCoveredItems(directory, state, currentDigest);
 	const missing = inventory.filter((itemId) => !covered.has(itemId));
 	if (missing.length > 0 || covered.size !== inventory.length) {
 		throw new Error(
@@ -1967,6 +3031,23 @@ export async function recordPrFeedbackStageA(
 			'BLOCKED: PR_FEEDBACK Stage A reproduction must map every immutable feedback item exactly once and in declared order',
 		);
 	}
+	const normalizedCategories = optionalCategoryOrder.filter((category) =>
+		applicableCategories.includes(category),
+	);
+	// Issue #1968 P5a: a re-record on the SAME revision with an equal-or-wider
+	// attestation invalidates nothing the already-recorded independent gate
+	// batches proved, so those batches are retained instead of forcing a full
+	// four-phase re-dispatch. An unchanged digest is NOT sufficient on its own:
+	// `applicableObligations` / `applicableCategories` are caller-supplied and
+	// validated only for internal self-consistency, so a re-record may narrow the
+	// attestation, and a gate batch proved on the wider one is then no longer
+	// evidence for what is being attested now. Narrower (or a changed revision)
+	// wipes exactly as before.
+	const retainsGateBatches = stageARetainsGateBatches(state.prFeedbackStageA, {
+		revisionDigest: currentDigest,
+		applicableCategories: normalizedCategories,
+		applicableObligations,
+	});
 	const nextState: PrWorkflowGateState = {
 		...state,
 		updatedAt: isoNow(),
@@ -1974,17 +3055,90 @@ export async function recordPrFeedbackStageA(
 			revisionDigest: currentDigest,
 			checks: [...checks],
 			feedbackItemIds: reproductionFeedbackItemIds,
-			applicableCategories: optionalCategoryOrder.filter((category) =>
-				applicableCategories.includes(category),
-			),
+			applicableCategories: normalizedCategories,
 			applicableObligations,
 			validatedAt: isoNow(),
 		},
-		prFeedbackGateBatches: [],
+		prFeedbackGateBatches: retainsGateBatches
+			? [...(state.prFeedbackGateBatches ?? [])]
+			: [],
+		// Always disarmed, even when the gate batches are retained: re-arming is
+		// one `complete_pr_workflow` call that re-verifies every retained phase,
+		// so keeping an armed publication alive across a Stage A re-record would
+		// widen the publication window for no saving worth having.
 		prFeedbackReadyToPublish: undefined,
 	};
 	await persistState(directory, nextState);
 	return nextState;
+}
+
+/**
+ * Canonical identity of one Stage A workspace obligation.
+ *
+ * Field-ordered by construction rather than `JSON.stringify`-ed, because a fresh
+ * caller object and a schema-parsed round-trip do not agree on key order. Every
+ * field the obligation is validated against at `recordPrFeedbackStageA` time
+ * participates: the same `id` carrying a different `source` or
+ * `validatorContract` is a *different* obligation and must not read as retained.
+ */
+function canonicalStageAObligation(obligation: {
+	id: string;
+	category: string;
+	workingDirectory: string;
+	source: string;
+	validatorContract?: { path: string; id: string };
+}): string {
+	return [
+		obligation.id,
+		obligation.category,
+		obligation.workingDirectory,
+		obligation.source,
+		obligation.validatorContract?.path ?? '',
+		obligation.validatorContract?.id ?? '',
+	].join('\0');
+}
+
+/**
+ * May the already-recorded PR_FEEDBACK gate batches survive this Stage A
+ * re-record? Only when the revision is unchanged AND the incoming attestation is
+ * equal to or a superset of the prior one.
+ *
+ * A previous record that carries neither attestation field is a *legacy* record
+ * (both keys are optional in the schema and were absent before this retention
+ * rule existed). Defaulting them to `[]` would make the superset check
+ * vacuously true and retain gate approvals straight across a narrowed
+ * re-attestation — the exact fail-open this function exists to close (issue
+ * #1968 FIX 6). Unprovable therefore means wipe. `recordPrFeedbackStageA` always
+ * writes both fields, so no record this code writes can take that branch.
+ */
+function stageARetainsGateBatches(
+	previous: PrWorkflowGateState['prFeedbackStageA'],
+	next: {
+		revisionDigest: string;
+		applicableCategories: ReadonlyArray<'build' | 'typecheck' | 'lint'>;
+		applicableObligations: ReadonlyArray<
+			Parameters<typeof canonicalStageAObligation>[0]
+		>;
+	},
+): boolean {
+	if (!previous || previous.revisionDigest !== next.revisionDigest)
+		return false;
+	if (!previous.applicableCategories || !previous.applicableObligations)
+		return false;
+	const nextCategories = new Set<string>(next.applicableCategories);
+	if (
+		!previous.applicableCategories.every((category) =>
+			nextCategories.has(category),
+		)
+	) {
+		return false;
+	}
+	const nextObligations = new Set(
+		next.applicableObligations.map(canonicalStageAObligation),
+	);
+	return previous.applicableObligations.every((obligation) =>
+		nextObligations.has(canonicalStageAObligation(obligation)),
+	);
 }
 
 /** Record one ordered, single-lane feedback validation phase before launch. */
@@ -2337,19 +3491,39 @@ export async function assertPrReviewArtifactBoundary(
 			`BLOCKED: PR_REVIEW ${boundary} findings cannot be persisted after a later checkpoint`,
 		);
 	}
+	// One digest resolution and one composed verdict map for this whole gate
+	// call: the settlement pass, the critic-inventory derivation and the
+	// candidate-inventory check below must all see the same verdicts.
+	const ctx = await createPrReviewGateContext(directory, state);
 	if (boundary === 'post_reviewer') {
 		state = await assertPrReviewValidationSettled(
 			directory,
 			sessionID,
 			'reviewer',
+			ctx,
 		);
 	} else if (boundary === 'post_critic') {
-		await assertPrReviewValidationSettled(directory, sessionID, 'reviewer');
-		if (derivePrReviewCriticInventory(directory, state).length > 0) {
+		await assertPrReviewValidationSettled(
+			directory,
+			sessionID,
+			'reviewer',
+			ctx,
+		);
+		// Empty here must mean "no CONFIRMED CRITICAL/HIGH/MEDIUM verdict exists",
+		// never "the reviewer map was empty" or "reviewer never settled".
+		if (
+			derivePrReviewCriticInventoryForCoverageGate(
+				directory,
+				state,
+				ctx,
+				'assertPrReviewArtifactBoundary(post_critic)',
+			).length > 0
+		) {
 			state = await assertPrReviewValidationSettled(
 				directory,
 				sessionID,
 				'critic',
+				ctx,
 			);
 		}
 	}
@@ -2358,7 +3532,11 @@ export async function assertPrReviewArtifactBoundary(
 			`BLOCKED: PR_REVIEW artifacts are already bound to run "${state.prReviewArtifactRunId}"`,
 		);
 	}
-	const expectedFindingIds = derivePrReviewCandidateInventory(directory, state);
+	const expectedFindingIds = derivePrReviewCandidateInventory(
+		directory,
+		state,
+		ctx,
+	);
 	const normalizedFindingIds = [...new Set(findingIds)].sort();
 	if (
 		normalizedFindingIds.length !== findingIds.length ||
@@ -2398,13 +3576,24 @@ export async function assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
 		return;
 	}
 
-	const reviewerVerdicts = deriveLatestPrReviewReviewerVerdicts(
+	const ctx = await createPrReviewGateContext(directory, state);
+	// B1: this is the gate that emits the misleading "no authoritative reviewer
+	// verdict" per record. When the real cause is a settled-but-empty verdict
+	// map, the guarded accessors name that cause instead.
+	const reviewerVerdicts = authoritativeReviewerVerdictsForGate(
 		directory,
 		state,
+		ctx,
+		`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
 	);
 	const criticVerdicts =
 		boundary === 'post_critic'
-			? deriveLatestPrReviewCriticVerdicts(directory, state)
+			? authoritativeCriticVerdictsForGate(
+					directory,
+					state,
+					ctx,
+					`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
+				)
 			: undefined;
 	for (const record of records) {
 		const reviewer = reviewerVerdicts.get(record.finding_id);
@@ -2883,7 +4072,9 @@ async function assertPrReviewTerminalReady(
 			`BLOCKED: PR_REVIEW transition has ${open.length} unsettled PR workflow lane(s)`,
 		);
 	}
-	await assertPrReviewBaseCoverageSettled(directory, sessionID);
+	// One digest + one composed verdict map for the entire terminal check.
+	const ctx = await createPrReviewGateContext(directory, state);
+	await assertPrReviewBaseCoverageSettled(directory, sessionID, ctx);
 	if (!state.prReviewTriggerEvalPath) {
 		throw new Error(
 			'BLOCKED: PR_REVIEW transition requires a persisted trigger evaluation artifact',
@@ -2894,10 +4085,19 @@ async function assertPrReviewTerminalReady(
 			(batch) => batch.phase === 'council',
 		)
 	) {
-		await assertPrReviewValidationSettled(directory, sessionID, 'council');
+		await assertPrReviewValidationSettled(directory, sessionID, 'council', ctx);
 	}
-	await assertPrReviewValidationSettled(directory, sessionID, 'reviewer');
-	const criticInventory = derivePrReviewCriticInventory(directory, state);
+	await assertPrReviewValidationSettled(directory, sessionID, 'reviewer', ctx);
+	// The critic-coverage gate. `length === 0` skips the critic phase entirely,
+	// so it must provably mean "no CONFIRMED CRITICAL/HIGH/MEDIUM reviewer
+	// verdict exists" — not "reviewer never settled" and not "the authoritative
+	// reviewer map came back empty". Both pathologies BLOCK inside this call.
+	const criticInventory = derivePrReviewCriticInventoryForCoverageGate(
+		directory,
+		state,
+		ctx,
+		'completePrWorkflow critic-coverage gate',
+	);
 	if (criticInventory.length > 0) {
 		if (
 			!(state.prReviewValidationBatches ?? []).some(
@@ -2908,7 +4108,7 @@ async function assertPrReviewTerminalReady(
 				`BLOCKED: PR_REVIEW reviewer verdicts require critic coverage for: ${criticInventory.join(', ')}`,
 			);
 		}
-		await assertPrReviewValidationSettled(directory, sessionID, 'critic');
+		await assertPrReviewValidationSettled(directory, sessionID, 'critic', ctx);
 	}
 	const requiredBoundaries: PrReviewArtifactBoundary[] = [
 		'post_explorer',
@@ -3689,6 +4889,8 @@ export async function completePrWorkflow(
 }
 
 export const _test_exports = {
+	minimumConsolidatedLaneCover,
+	MAX_COVER_UNIVERSE_BITS,
 	workflowGateStateRelativePath,
 	workflowGateStateLockRelativePath,
 	workflowCheckoutMutationLockRelativePath,
@@ -3752,9 +4954,94 @@ export const _test_exports = {
 	resolvePrReviewDiffStats,
 	resolvePrReviewDiffStatsAsync,
 	resolvePrWorkflowRevisionDigest,
+	/**
+	 * The batch cap the capacity GC reclaims against. Exposed so the GC suite
+	 * builds its fixture from the real bound instead of a hand-copied literal
+	 * that would silently drift if the cap ever moved.
+	 */
+	MAX_WORKFLOW_BATCHES,
+	/**
+	 * The three ledger ceilings whose overflow makes the capacity GC abandon a
+	 * prune and keep every batch. Exposed on the same reasoning as
+	 * `MAX_WORKFLOW_BATCHES`: the overflow suite seeds a ledger to exactly its
+	 * bound from the real constant, so a hand-copied literal cannot drift away
+	 * from the branch it is meant to reach.
+	 */
+	MAX_RETIRED_REVIEWER_SESSION_IDS,
+	MAX_RETIRED_CONSOLIDATED_LANES,
+	MAX_RETIRED_FEEDBACK_ITEM_OWNERS,
+	/**
+	 * Issue #1968 P2.2: lets a focused test drive one specific bounded-snapshot
+	 * failure reason so the BLOCKED diagnostic can be asserted per bound. The
+	 * pre-existing `resolvePrWorkflowRevisionDigest` seam above still takes
+	 * priority-two precedence and is unchanged for every existing fixture.
+	 */
+	resolvePrWorkflowRevisionDigestDetailed,
 	resolveRemoteRefsContainingHead,
 	resolveRemoteRefsContainingHeadAsync,
 	parseCriticVerdict,
+	/**
+	 * Read-only view of the item-keyed composition for one session, including
+	 * the diagnostics that settlement only logs (abandoned declared lanes,
+	 * batches skipped for inventory incoherence). Production callers reach the
+	 * same computation through settlement and the verdict derivations.
+	 */
+	composePrReviewPhaseVerdicts: async (
+		directory: string,
+		sessionID: string,
+		phase: PrReviewComposablePhase,
+	): Promise<PrReviewPhaseComposition> => {
+		const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+		const ctx = await createPrReviewGateContext(directory, state);
+		return composePrReviewPhaseVerdicts(directory, state, phase, ctx);
+	},
+	/**
+	 * Issue #1968 B1 guardrail, exposed directly.
+	 *
+	 * Production reaches it from `assertPrReviewValidationSettled`, both
+	 * critic-coverage gates and the artifact-record projection check. Item-keyed
+	 * composition makes a real violation unreachable by construction, so the only
+	 * way to exercise the assertion's own behaviour (and its cause-naming
+	 * message) without mutating production code is to hand it the divergent pair
+	 * a future re-split would produce.
+	 */
+	assertSettledPhaseHasAuthoritativeVerdicts,
+	/**
+	 * The critic-coverage gate's guarded input, exposed for the same reason as
+	 * the assertion above: production reaches its unsettled-reviewer branch only
+	 * if a caller stops settling reviewer first, which is precisely the future
+	 * regression it exists to catch, so the branch is otherwise untestable.
+	 */
+	derivePrReviewCriticInventoryForCoverageGate: async (
+		directory: string,
+		sessionID: string,
+		origin = '_test_exports',
+	): Promise<string[]> => {
+		const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+		const ctx = await createPrReviewGateContext(directory, state);
+		return derivePrReviewCriticInventoryForCoverageGate(
+			directory,
+			state,
+			ctx,
+			origin,
+		);
+	},
+	/**
+	 * Read-only view of the mandatory candidate inventory for one session.
+	 * Production reaches the same derivation through validation-batch ownership
+	 * validation, the composition, and the artifact-boundary checks; this seam
+	 * lets a focused test observe *which* base lane won a dimension (the tier-L
+	 * singleton-over-consolidated precedence) without standing up the full
+	 * micro-sweep and trigger-ledger prerequisites those entry points require.
+	 */
+	derivePrReviewCandidateInventory: async (
+		directory: string,
+		sessionID: string,
+	): Promise<string[]> => {
+		const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+		const ctx = await createPrReviewGateContext(directory, state);
+		return derivePrReviewCandidateInventory(directory, state, ctx);
+	},
 	isProcessAlive,
 	// Exposed for the `-c` config-injection regression test. The publication
 	// path that calls this needs a fully-armed ready-to-publish state, so the
@@ -4668,38 +5955,166 @@ async function currentPrFeedbackRevisionDigest(
 			'BLOCKED: PR_FEEDBACK revision binding requires pr_head_sha',
 		);
 	}
-	const digest = await resolvePrWorkflowRevisionDigestForGate(
+	const resolved = await resolvePrWorkflowRevisionDigestForGate(
 		directory,
 		state.prHeadSha,
 	);
-	if (!digest) {
+	if (!resolved.ok) {
 		throw new Error(
-			'BLOCKED: PR_FEEDBACK could not compute a bounded current-revision digest',
+			'BLOCKED: PR_FEEDBACK could not compute a bounded current-revision digest' +
+				` for pr_head_sha "${state.prHeadSha}"; ${describePrWorkflowRevisionDigestFailure(resolved)}`,
 		);
 	}
-	return digest;
+	return resolved.digest;
 }
 
 /**
- * Production gate calls use the non-blocking, chunked digest implementation.
- * Keep the synchronous seam for existing focused tests and explicit test
- * injection; it is never selected while the production implementation is in
- * place.
+ * The gate's view of a digest failure. Everything the bounded-snapshot resolver
+ * can report, plus one test-only case: an injected `string | null` seam returned
+ * `null`, which carries no reason at all. Modelled explicitly rather than folded
+ * into one of the real reasons so a diagnostic never claims a bound fired when
+ * nothing proved it did.
+ */
+type GateRevisionDigestResult =
+	| RevisionDigestResult
+	| { ok: false; reason: 'seam-unavailable'; detail?: string };
+
+/**
+ * Name the exact bound that fired, plus what to do about it.
+ *
+ * Exported because `dispatch_lanes_async` resolves the same bounded revision
+ * digest before any gate entry point runs, and must produce the same
+ * bound-naming diagnostic rather than the pre-fix "could not compute" with no
+ * indication of which of six limits was hit (issue #1968 P2.2 / criterion 6).
+ */
+export function describePrWorkflowRevisionDigestFailure(
+	failure: Extract<GateRevisionDigestResult, { ok: false }>,
+): string {
+	const detail = failure.detail ? ` (${failure.detail})` : '';
+	switch (failure.reason) {
+		case 'file-cap':
+			return `the changed-file snapshot exceeded REVISION_MAX_FILES${detail}. Reduce the changed-path count (commit or stash generated/vendored output) before retrying`;
+		case 'byte-cap':
+			return `the changed-file snapshot exceeded REVISION_MAX_TOTAL_BYTES${detail}. Reduce the changed content size before retrying`;
+		case 'buffer-truncated':
+			return `a bounded git enumeration exceeded GIT_SNAPSHOT_MAX_BUFFER${detail}. The changed-path list is too large to enumerate`;
+		case 'timeout':
+			return `a bounded git enumeration timed out${detail}. Retry once the working tree is quiescent`;
+		case 'git-failed':
+			return `a bounded git enumeration failed${detail}. Verify the checkout is a healthy Git worktree at the recorded head`;
+		case 'containment':
+			return `git reported a changed path outside the project root${detail}. Nothing outside the project root may be hashed`;
+		case 'read-failed':
+			return `a changed path could not be read${detail}. Resolve the filesystem error before retrying`;
+		default:
+			return `an injected revision-digest seam returned no digest${detail}; production names one of REVISION_MAX_FILES / REVISION_MAX_TOTAL_BYTES / GIT_SNAPSHOT_MAX_BUFFER, a bounded git enumeration timeout, or a read failure`;
+	}
+}
+
+/**
+ * Production gate calls use the non-blocking, chunked digest implementation, and
+ * consume its discriminated failure reason so a BLOCKED message can name the one
+ * bound that actually fired instead of listing every bound that might have.
+ *
+ * Two synchronous seams are kept for focused tests, in priority order. The
+ * detailed seam lets a test drive a specific failure reason; the pre-existing
+ * `string | null` seam is preserved verbatim so every existing fixture keeps
+ * working, and its `null` maps to the reasonless `seam-unavailable` case rather
+ * than being attributed to a bound no test proved. Neither is selected while the
+ * production implementation is in place.
  */
 async function resolvePrWorkflowRevisionDigestForGate(
 	directory: string,
 	baseHeadSha: string,
-): Promise<string | null> {
+): Promise<GateRevisionDigestResult> {
 	if (
-		_test_exports.resolvePrWorkflowRevisionDigest !==
-		resolvePrWorkflowRevisionDigest
+		_test_exports.resolvePrWorkflowRevisionDigestDetailed !==
+		resolvePrWorkflowRevisionDigestDetailed
 	) {
-		return _test_exports.resolvePrWorkflowRevisionDigest(
+		return _test_exports.resolvePrWorkflowRevisionDigestDetailed(
 			directory,
 			baseHeadSha,
 		);
 	}
-	return resolvePrWorkflowRevisionDigestAsync(directory, baseHeadSha);
+	if (
+		_test_exports.resolvePrWorkflowRevisionDigest !==
+		resolvePrWorkflowRevisionDigest
+	) {
+		const digest = _test_exports.resolvePrWorkflowRevisionDigest(
+			directory,
+			baseHeadSha,
+		);
+		return digest
+			? { ok: true, digest }
+			: { ok: false, reason: 'seam-unavailable' };
+	}
+	return resolvePrWorkflowRevisionDigestDetailedAsync(directory, baseHeadSha);
+}
+
+/**
+ * One PR_REVIEW gate entry point's memoized derivation context.
+ *
+ * Two properties, both load-bearing:
+ *
+ * 1. **One revision digest per gate call.** Every artifact-integrity check below
+ *    compares the persisted artifact's `revisionDigest` against the current
+ *    worktree revision. Resolving that per record costs three blocking `git`
+ *    calls plus a full re-read of every changed file, once per record. Both
+ *    callers of the marker check already require
+ *    `record.workspace.prHeadSha === state.prHeadSha` earlier in the same
+ *    predicate, so every record reaching the comparison shares one head and one
+ *    resolution is equivalent to N.
+ *
+ *    **Honest equivalence statement:** one digest is equivalent to N per-record
+ *    resolves *absent concurrent worktree mutation during a gate call*. The
+ *    resolver reads the live worktree, so this narrows a TOCTOU window rather
+ *    than being a pure cost change. It adopts the precedent already set by the
+ *    PR_FEEDBACK verification path, which resolves once and threads.
+ *
+ * 2. **One composed verdict map per gate call.** Settlement, critic-inventory
+ *    derivation, the artifact-record projection check and the legacy-eligibility
+ *    marker check are separate passes over the same state. They must never hold
+ *    two different notions of "the current reviewer verdict", so the composition
+ *    is computed once here and the same object is handed to all of them.
+ *
+ * A context is valid for exactly one gate entry-point call over one state
+ * snapshot. Never cache it across calls.
+ */
+interface PrReviewGateContext {
+	readonly revisionDigest: string;
+	reviewer?: PrReviewPhaseComposition;
+	critic?: PrReviewPhaseComposition;
+	candidateInventory?: string[];
+}
+
+/**
+ * Resolve the single current-revision digest this gate call will thread.
+ *
+ * A failed resolution is a hard BLOCK, never a silently-threaded `undefined`:
+ * `undefined` restores the per-record synchronous fallback inside the marker
+ * check, which would make the gate quietly do 1+N blocking resolutions and
+ * would make a "resolved once" guardrail assert something production does not
+ * do. The resolver reports a discriminated failure reason, so the message names
+ * the one bound that actually fired rather than every bound that might have.
+ */
+async function createPrReviewGateContext(
+	directory: string,
+	state: PrWorkflowGateState,
+): Promise<PrReviewGateContext> {
+	if (!state.prHeadSha) {
+		throw new Error('BLOCKED: PR_REVIEW revision binding requires pr_head_sha');
+	}
+	const resolved = await resolvePrWorkflowRevisionDigestForGate(
+		directory,
+		state.prHeadSha,
+	);
+	if (!resolved.ok) {
+		throw new Error(
+			'BLOCKED: PR_REVIEW could not compute a bounded current-revision digest for ' +
+				`pr_head_sha "${state.prHeadSha}"; ${describePrWorkflowRevisionDigestFailure(resolved)}`,
+		);
+	}
+	return { revisionDigest: resolved.digest };
 }
 
 function normalizeBatchId(batchId: string): string {
@@ -4717,6 +6132,18 @@ function sameStringArray(
 	return (
 		left.length === right.length &&
 		left.every((value, index) => value === right[index])
+	);
+}
+
+/** Order- and duplicate-insensitive set equality over two id lists. */
+function sameStringSet(
+	left: readonly string[],
+	right: readonly string[],
+): boolean {
+	const leftSet = new Set(left);
+	const rightSet = new Set(right);
+	return (
+		leftSet.size === rightSet.size && [...leftSet].every((v) => rightSet.has(v))
 	);
 }
 
@@ -4744,7 +6171,9 @@ function assertExactStringSet(
 function derivePrReviewCandidateInventory(
 	directory: string,
 	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
 ): string[] {
+	if (ctx.candidateInventory) return ctx.candidateInventory;
 	const sources: Array<{
 		batchId: string;
 		laneId: string;
@@ -4779,34 +6208,64 @@ function derivePrReviewCandidateInventory(
 	>();
 	const baseSourceCreditedDimensions = new Map<string, string[]>();
 	const baseSourceFullOwnershipCount = new Map<string, number>();
-	for (const batch of [...(state.prReviewBaseDispatches ?? [])].reverse()) {
-		const successful = successfulObligationsFromExactBatch(
-			directory,
-			state,
+	const reversedBaseBatches = [
+		...(state.prReviewBaseDispatches ?? []),
+	].reverse();
+	const successfulByBaseBatchId = new Map<string, Set<string>>();
+	for (const batch of reversedBaseBatches) {
+		successfulByBaseBatchId.set(
 			batch.batchId,
-			batch.lanes,
-			'swarm-pr-review:base',
-			batch.validatedAt,
+			successfulObligationsFromExactBatch(
+				directory,
+				state,
+				batch.batchId,
+				batch.lanes,
+				'swarm-pr-review:base',
+				batch.validatedAt,
+				true,
+				new Set(),
+				ctx.revisionDigest,
+			),
 		);
-		for (const lane of batch.lanes) {
-			const ownedDimensions = lane.ownedWorkflowLanes?.length
-				? lane.ownedWorkflowLanes
-				: [lane.workflowLane];
-			if (!ownedDimensions.every((dimension) => successful.has(dimension)))
-				continue;
-			const key = `${batch.batchId}\0${lane.laneId}`;
-			baseSourceFullOwnershipCount.set(key, ownedDimensions.length);
-			for (const dimension of ownedDimensions) {
-				if (!baseDimensionSources.has(dimension)) {
-					baseDimensionSources.set(dimension, {
-						batchId: batch.batchId,
-						laneId: lane.laneId,
-					});
-					const credited = baseSourceCreditedDimensions.get(key);
-					if (credited) {
-						credited.push(dimension);
-					} else {
-						baseSourceCreditedDimensions.set(key, [dimension]);
+	}
+	// Tier L only (issue #1968 P3.2): a successful SINGLETON source outranks a
+	// consolidated one for the same dimension, with most-recent-wins applying
+	// within each class. Tier L's contract is per-dimension depth
+	// (PR_REVIEW_BASE_LANE_FLOORS.L), and consolidation is permitted there only
+	// as failure recovery — so when both exist, the singleton is the lane that
+	// actually satisfied the tier's contract. This closes the residual race where
+	// a singleton's record completes only after a consolidated retry was already
+	// declared against it. Tiers S and M keep plain most-recent-wins, where
+	// consolidation is a first-class dispatch shape rather than a fallback.
+	const laneClassPasses: Array<(ownedCount: number) => boolean> =
+		(state.prReviewDepthTier ?? 'L') === 'L'
+			? [(ownedCount) => ownedCount === 1, (ownedCount) => ownedCount !== 1]
+			: [() => true];
+	for (const laneIsInClass of laneClassPasses) {
+		for (const batch of reversedBaseBatches) {
+			const successful =
+				successfulByBaseBatchId.get(batch.batchId) ?? new Set<string>();
+			for (const lane of batch.lanes) {
+				const ownedDimensions = lane.ownedWorkflowLanes?.length
+					? lane.ownedWorkflowLanes
+					: [lane.workflowLane];
+				if (!laneIsInClass(ownedDimensions.length)) continue;
+				if (!ownedDimensions.every((dimension) => successful.has(dimension)))
+					continue;
+				const key = `${batch.batchId}\0${lane.laneId}`;
+				baseSourceFullOwnershipCount.set(key, ownedDimensions.length);
+				for (const dimension of ownedDimensions) {
+					if (!baseDimensionSources.has(dimension)) {
+						baseDimensionSources.set(dimension, {
+							batchId: batch.batchId,
+							laneId: lane.laneId,
+						});
+						const credited = baseSourceCreditedDimensions.get(key);
+						if (credited) {
+							credited.push(dimension);
+						} else {
+							baseSourceCreditedDimensions.set(key, [dimension]);
+						}
 					}
 				}
 			}
@@ -4846,6 +6305,9 @@ function derivePrReviewCandidateInventory(
 			batch.lanes,
 			'swarm-pr-review:council',
 			batch.validatedAt,
+			true,
+			new Set(),
+			ctx.revisionDigest,
 		);
 		for (const lane of batch.lanes) {
 			if (
@@ -4935,7 +6397,7 @@ function derivePrReviewCandidateInventory(
 					source.mode,
 					record.workflowLane ?? source.workflowLane ?? source.laneId,
 					undefined,
-					undefined,
+					ctx.revisionDigest,
 					recordOwnedLanes,
 				)
 			)
@@ -4972,7 +6434,9 @@ function derivePrReviewCandidateInventory(
 		}
 	}
 	assertNoDuplicates(candidateIds, 'PR_REVIEW discovery candidate ids');
-	return candidateIds.length > 0 ? candidateIds.sort() : ['CLEAN-REVIEW'];
+	ctx.candidateInventory =
+		candidateIds.length > 0 ? candidateIds.sort() : ['CLEAN-REVIEW'];
+	return ctx.candidateInventory;
 }
 
 /**
@@ -5067,11 +6531,459 @@ function extractCandidateIds(
 		.map((row) => row.candidateId);
 }
 
+type PrReviewComposablePhase = 'reviewer' | 'critic';
+
+/** One item's admitted verdict plus the lane provenance that admitted it. */
+interface PrReviewItemClaim {
+	batchId: string;
+	laneId: string;
+	workflowLane: string;
+	/** Reviewer classification, or critic status. */
+	classification: string;
+	severity: string;
+	/**
+	 * sha256 of the full canonical `[REVIEWED]` row this claim was parsed from.
+	 * Reviewer claims only — this is what a critic batch binds to per item.
+	 */
+	rowDigest?: string;
+}
+
+interface PrReviewPhaseComposition {
+	/** Item id -> winning claim. Most recent successful lane per item wins. */
+	claims: Map<string, PrReviewItemClaim>;
+	requiredInventory: string[];
+	unclaimed: string[];
+	contributingBatchIds: string[];
+	diagnostics: string[];
+}
+
+const MAX_COMPOSITION_DIAGNOSTICS = 16;
+/** Item ids named in one BLOCKED message before it degrades to a count. */
+const MAX_UNCLAIMED_ITEMS_IN_MESSAGE = 50;
+
+function appendCompositionDiagnostic(
+	diagnostics: string[],
+	message: string,
+): void {
+	if (diagnostics.length >= MAX_COMPOSITION_DIAGNOSTICS) return;
+	diagnostics.push(message.slice(0, MAX_BASE_COVERAGE_DIAGNOSTIC_CHARS));
+}
+
+/**
+ * The batches a phase composes over.
+ *
+ * Reviewer is scoped to everything after the latest council batch (a council
+ * verdict re-opens the reviewer question). Critic spans every critic batch;
+ * critic staleness is enforced per item by the reviewer row binding rather than
+ * positionally. Note this makes reviewer *derivation* council-scoped, which it
+ * was not before — derivation and settlement previously disagreed on the window,
+ * and one computation cannot hold two windows.
+ */
+function prReviewPhaseWindow(
+	state: PrWorkflowGateState,
+	phase: PrReviewComposablePhase,
+): PrReviewValidationBatchRecord[] {
+	const all = state.prReviewValidationBatches ?? [];
+	if (phase === 'critic') {
+		return all.filter((batch) => batch.phase === 'critic');
+	}
+	let latestCouncilIndex = -1;
+	for (let index = 0; index < all.length; index++) {
+		if (all[index]?.phase === 'council') latestCouncilIndex = index;
+	}
+	return (
+		latestCouncilIndex >= 0 ? all.slice(latestCouncilIndex + 1) : all
+	).filter((batch) => batch.phase === 'reviewer');
+}
+
+/**
+ * Child sessions that already produced a reviewer artifact. A critic lane may
+ * never reuse one — an agent cannot independently challenge its own review.
+ *
+ * Seeded from `prReviewRetiredReviewerSessionIds` so the ban survives the
+ * capacity GC: a pruned reviewer batch is gone from the array this walks, and
+ * without the ledger its child sessions would silently become reusable.
+ */
+function reviewerSubagentSessionIds(
+	directory: string,
+	state: PrWorkflowGateState,
+): Set<string> {
+	const forbidden = new Set<string>(
+		state.prReviewRetiredReviewerSessionIds ?? [],
+	);
+	for (const reviewerBatch of (state.prReviewValidationBatches ?? []).filter(
+		(batch) => batch.phase === 'reviewer',
+	)) {
+		for (const record of findByBatchId(directory, reviewerBatch.batchId, {
+			parentSessionId: state.sessionID,
+		})) {
+			const subagentSessionId = record.subagentSessionId?.trim();
+			if (subagentSessionId) forbidden.add(subagentSessionId);
+		}
+	}
+	return forbidden;
+}
+
+/**
+ * May this batch contribute claims at all?
+ *
+ * Two live paths, deliberately different in granularity:
+ *
+ * - **Coherent (has a `prReviewBatchCoherence` entry).** Reviewer batches must
+ *   have been validated against exactly the inventory in force now: a reviewer
+ *   verdict set is only meaningful for the candidate inventory it was assigned,
+ *   and nothing else pins it. Critic batches are admitted at batch level and
+ *   filtered *per item* by `reviewerItemBindings`, which is the finer and
+ *   strictly stronger check — batch-level inventory equality for critics would
+ *   discard every sibling item's still-valid claim the moment one item left the
+ *   critic inventory, reintroducing exactly the batch-granularity failure this
+ *   composition exists to remove.
+ * - **Legacy (no entry, written by an older plugin).** Exactly today's rule: the
+ *   batch must be wholly successful and its declared item set must equal the
+ *   current inventory. Expressed as a stricter predicate inside the same
+ *   algorithm, so legacy state can never loosen.
+ */
+function batchMayContributeClaims(
+	directory: string,
+	state: PrWorkflowGateState,
+	batch: PrReviewValidationBatchRecord,
+	phase: PrReviewComposablePhase,
+	requiredInventory: readonly string[],
+	forbiddenSubagentSessionIds: ReadonlySet<string>,
+	reviewerClaims: ReadonlyMap<string, PrReviewItemClaim> | undefined,
+	ctx: PrReviewGateContext,
+): boolean {
+	const coherence = state.prReviewBatchCoherence?.[batch.batchId];
+	if (coherence) {
+		return (
+			phase === 'critic' ||
+			sameStringSet(coherence.validatedInventory, requiredInventory)
+		);
+	}
+	const declaredItems = batch.lanes.flatMap((lane) => lane.reviewItemIds ?? []);
+	if (!sameStringSet(declaredItems, requiredInventory)) return false;
+	const successful = successfulObligationsFromExactBatch(
+		directory,
+		state,
+		batch.batchId,
+		batch.lanes,
+		`swarm-pr-review:${phase}`,
+		batch.validatedAt,
+		true,
+		forbiddenSubagentSessionIds,
+		ctx.revisionDigest,
+		undefined,
+		reviewerClaims,
+	);
+	return (
+		successful.size === batch.lanes.length &&
+		batch.lanes.every((lane) => successful.has(lane.workflowLane))
+	);
+}
+
+/**
+ * The single item-keyed computation behind reviewer/critic settlement AND every
+ * reviewer/critic verdict derivation.
+ *
+ * Settlement *is* `unclaimed.length === 0` over this map, so settlement can never
+ * pass while derivation returns nothing — the failure mode that would let
+ * CONFIRMED CRITICAL/HIGH findings ship without critic coverage.
+ *
+ * Scanning the window reverse-chronologically and claiming only *unclaimed*
+ * items makes first-write-wins equal "most recent successful lane per item wins",
+ * which is the explicit conflict rule for the case where two batches both carry a
+ * parseable verdict for one item. Memoized per gate context so two passes never
+ * hold two different verdict maps.
+ *
+ * The scan stops as soon as every required item is claimed (issue #1968 FIX 5).
+ * `readLaneOutput` is a synchronous `readFileSync` per lane per batch, and the
+ * window can hold up to `MAX_WORKFLOW_BATCHES` batches, so scanning past a
+ * complete claim set is unbounded blocking I/O for no verdict change — first
+ * write wins, and every required item has already been written.
+ *
+ * `exhaustive` turns the exit off for the batch GC, which prunes a reviewer
+ * batch on "it contributed no claim". Being precise about what that buys: with
+ * *this* exit condition the two scans yield the same `contributingBatchIds`,
+ * because the exit fires only when every required item is claimed and a batch
+ * reached after that point could never have claimed anything anyway. The flag is
+ * therefore not fixing a live divergence — it decouples a durable-state decision
+ * from a performance heuristic, so that weakening the exit condition later
+ * cannot silently turn "not examined" into "proven inert". It also keeps the
+ * whole-window abandoned-lane diagnostics intact for the GC's scan.
+ */
+function composePrReviewPhaseVerdicts(
+	directory: string,
+	state: PrWorkflowGateState,
+	phase: PrReviewComposablePhase,
+	ctx: PrReviewGateContext,
+	exhaustive = false,
+): PrReviewPhaseComposition {
+	const memoized = phase === 'reviewer' ? ctx.reviewer : ctx.critic;
+	if (memoized && !exhaustive) return memoized;
+
+	const requiredInventory =
+		phase === 'reviewer'
+			? derivePrReviewCandidateInventory(directory, state, ctx)
+			: derivePrReviewCriticInventory(directory, state, ctx);
+	const reviewerClaims =
+		phase === 'critic'
+			? authoritativeReviewerClaims(directory, state, ctx)
+			: undefined;
+	const forbiddenSubagentSessionIds =
+		phase === 'critic'
+			? reviewerSubagentSessionIds(directory, state)
+			: new Set<string>();
+	const expectedMode = `swarm-pr-review:${phase}`;
+	const window = prReviewPhaseWindow(state, phase);
+	const requiredSet = new Set(requiredInventory);
+	const claims = new Map<string, PrReviewItemClaim>();
+	const contributingBatchIds: string[] = [];
+	const diagnostics: string[] = [];
+	const satisfiedObligations = new Set<string>();
+	const scannedBatches: PrReviewValidationBatchRecord[] = [];
+
+	for (const batch of [...window].reverse()) {
+		scannedBatches.push(batch);
+		if (
+			!batchMayContributeClaims(
+				directory,
+				state,
+				batch,
+				phase,
+				requiredInventory,
+				forbiddenSubagentSessionIds,
+				reviewerClaims,
+				ctx,
+			)
+		) {
+			appendCompositionDiagnostic(
+				diagnostics,
+				`${phase} batch "${batch.batchId}" was validated against a different inventory or is not wholly successful legacy state; it contributes no claims`,
+			);
+			continue;
+		}
+		const coherence = state.prReviewBatchCoherence?.[batch.batchId];
+		let contributed = false;
+		for (const qualified of recordsPassingBatchIntegrity(
+			directory,
+			state,
+			batch.batchId,
+			batch.lanes,
+			expectedMode,
+			batch.validatedAt,
+			true,
+			forbiddenSubagentSessionIds,
+		)) {
+			const artifact = loadArtifactPassingLaneIntegrity(
+				directory,
+				state,
+				qualified.record,
+				expectedMode,
+				qualified.expectedWorkflowLane,
+				ctx.revisionDigest,
+			);
+			if (!artifact) continue;
+			const declaredItems = qualified.expectedLane.reviewItemIds ?? [];
+			const parsed = parseLaneItemVerdicts(
+				artifact.text,
+				declaredItems,
+				phase,
+				reviewerClaims,
+			);
+			if (declaredItems.length > 0 && parsed.size === declaredItems.length) {
+				satisfiedObligations.add(qualified.expectedWorkflowLane);
+			}
+			for (const [itemId, verdict] of parsed) {
+				if (!requiredSet.has(itemId) || claims.has(itemId)) continue;
+				// Defense in depth: the persisted inventory this batch was
+				// validated against must still list the item. Declaration time
+				// already makes the lane item set equal to it, so a mismatch here
+				// means the persisted state was mutated out of band.
+				if (coherence && !coherence.validatedInventory.includes(itemId)) {
+					continue;
+				}
+				if (
+					phase === 'critic' &&
+					coherence &&
+					!criticClaimIsBoundToCurrentReviewerRow(
+						coherence,
+						itemId,
+						reviewerClaims,
+					)
+				) {
+					continue;
+				}
+				claims.set(itemId, {
+					batchId: batch.batchId,
+					laneId: qualified.expectedLane.laneId,
+					workflowLane: qualified.expectedWorkflowLane,
+					...verdict,
+				});
+				contributed = true;
+			}
+		}
+		if (contributed) contributingBatchIds.push(batch.batchId);
+		if (!exhaustive && claims.size === requiredSet.size) break;
+	}
+
+	// The lane-level "every declared obligation across every batch in the window
+	// must be settled" requirement was deliberately dropped: it is part of the
+	// all-or-nothing accounting that forces a full re-run for one failed lane,
+	// and it re-blocks exactly the composed-retry case. Item completeness
+	// (`unclaimed.length === 0`) is the stronger property for what actually
+	// ships — verdicts are per item; lane ids are bookkeeping. An abandoned
+	// declared lane is now a named diagnostic, not a block.
+	//
+	// Scoped to the batches actually scanned: an unscanned batch's lanes were
+	// never examined, so reporting them as "produced no successful exact
+	// artifact" would be an unevidenced claim. Nothing is lost — the early exit
+	// only fires once every required item is claimed, and the diagnostic exists
+	// to explain a settlement that succeeded despite abandoned lanes.
+	for (const obligation of new Set(
+		scannedBatches.flatMap((batch) =>
+			batch.lanes.map((lane) => lane.workflowLane),
+		),
+	)) {
+		if (satisfiedObligations.has(obligation)) continue;
+		appendCompositionDiagnostic(
+			diagnostics,
+			`declared ${phase} lane "${obligation}" produced no successful exact artifact`,
+		);
+	}
+
+	const composition: PrReviewPhaseComposition = {
+		claims,
+		requiredInventory,
+		unclaimed: requiredInventory.filter((itemId) => !claims.has(itemId)),
+		contributingBatchIds,
+		diagnostics,
+	};
+	// An exhaustive pass is a superset of the memoizable one, but it is computed
+	// for a different question (which batches are inert) and its diagnostics
+	// cover a wider window; never let it become the map the gates read.
+	if (!exhaustive) {
+		if (phase === 'reviewer') ctx.reviewer = composition;
+		else ctx.critic = composition;
+	}
+	return composition;
+}
+
+/**
+ * A critic claim survives only while the reviewer row it challenged is
+ * byte-identical.
+ *
+ * What this guarantees: the critic verdict was produced against reviewer row
+ * *content* identical to the content authoritative now. A reviewer verdict keeps
+ * only 2 of the 10 required row fields, so a classification/severity tuple would
+ * still match after the evidence and root cause changed entirely; the full-row
+ * digest does not. That also closes the `DOWNGRADED` hole in
+ * `parseCriticVerdict`, where a reviewer severity *increase* leaves a stale
+ * DOWNGRADED row still parseable.
+ *
+ * What this does NOT guarantee (issue #1968 FIX 8; the fix plan's claim that it
+ * "closes the leave-and-return readmission path" is retracted as false):
+ * `reviewerVerdictRowDigest` hashes the ten parsed `[REVIEWED]` fields and
+ * nothing else — no lane, session, or batch identity. So a byte-identical row
+ * emitted by a *different* lane or session re-admits the bound critic claim, and
+ * an item that leaves the critic inventory and later returns with an identical
+ * row re-admits the original critic verdict rather than requiring a fresh one.
+ * Both are content-equivalent by construction, and the artifact behind the claim
+ * is still pinned to the current revision digest and to its own lane identity by
+ * `loadArtifactPassingLaneIntegrity`, so neither admits a verdict about
+ * different content — but neither is prevented, and the binding is not the thing
+ * that prevents them.
+ */
+function criticClaimIsBoundToCurrentReviewerRow(
+	coherence: PrReviewBatchCoherenceRecord,
+	itemId: string,
+	reviewerClaims: ReadonlyMap<string, PrReviewItemClaim> | undefined,
+): boolean {
+	// A coherent critic batch always carries bindings; absent bindings on a
+	// coherent entry means out-of-band mutation, so fail closed.
+	const bound = coherence.reviewerItemBindings?.[itemId];
+	const current = reviewerClaims?.get(itemId)?.rowDigest;
+	return Boolean(bound && current && bound === current);
+}
+
+/**
+ * Reviewer claims only when the reviewer phase is item-complete. Preserves the
+ * pre-existing fail-closed "empty map" semantics for an unsettled reviewer
+ * phase, now derived from the same computation settlement uses.
+ */
+function authoritativeReviewerClaims(
+	directory: string,
+	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
+): ReadonlyMap<string, PrReviewItemClaim> {
+	const composed = composePrReviewPhaseVerdicts(
+		directory,
+		state,
+		'reviewer',
+		ctx,
+	);
+	return composed.unclaimed.length === 0 ? composed.claims : new Map();
+}
+
+/**
+ * Pin every item a critic batch owns to the sha256 of the reviewer row that is
+ * authoritative for it right now.
+ *
+ * The throw is unreachable defense in depth, kept deliberately: callers reach
+ * here only via `recordPrReviewValidationBatch`, which first asserts reviewer
+ * settlement and then requires the assigned items to exactly equal
+ * `derivePrReviewCriticInventory` — an inventory derived *from* the reviewer
+ * claims — so every assigned item necessarily has an authoritative row. It
+ * throws rather than emitting a partial binding set so that a future caller
+ * reaching it out of that order fails loudly instead of recording a critic
+ * batch with silently missing bindings.
+ *
+ * It is NOT protecting against an `undefined === undefined` admission: an
+ * earlier version of this comment claimed that, and it was wrong.
+ * `criticClaimIsBoundToCurrentReviewerRow` requires
+ * `Boolean(bound && current && bound === current)`, so a missing binding
+ * already blocks. Both the throw and its absence are fail-closed.
+ */
+function criticReviewerItemBindings(
+	directory: string,
+	state: PrWorkflowGateState,
+	lanes: ReadonlyArray<{ reviewItemIds?: string[] }>,
+	ctx: PrReviewGateContext,
+): Record<string, string> {
+	const reviewerClaims = authoritativeReviewerClaims(directory, state, ctx);
+	const bindings: Record<string, string> = {};
+	for (const itemId of lanes.flatMap((lane) => lane.reviewItemIds ?? [])) {
+		const rowDigest = reviewerClaims.get(itemId)?.rowDigest;
+		if (!rowDigest) {
+			throw new Error(
+				`BLOCKED: PR_REVIEW critic dispatch cannot bind item "${itemId}" to an authoritative reviewer verdict row`,
+			);
+		}
+		bindings[itemId] = rowDigest;
+	}
+	return bindings;
+}
+
+/**
+ * Items whose reviewer verdict obliges critic coverage.
+ *
+ * The reviewer map is read through the B1-guarded accessor: an empty or partial
+ * map after a *settled* reviewer phase is a hard BLOCK here rather than an
+ * empty critic inventory that silently disables the critic gate. The
+ * complementary "reviewer never settled" case is rejected at the coverage gates
+ * by `derivePrReviewCriticInventoryForCoverageGate`; this function stays usable
+ * on unsettled states because batch GC derives it there.
+ */
 function derivePrReviewCriticInventory(
 	directory: string,
 	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
 ): string[] {
-	const verdicts = deriveLatestPrReviewReviewerVerdicts(directory, state);
+	const verdicts = authoritativeReviewerVerdictsForGate(
+		directory,
+		state,
+		ctx,
+		'derivePrReviewCriticInventory',
+	);
 	return [...verdicts.entries()]
 		.filter(
 			([, verdict]) =>
@@ -5082,129 +6994,233 @@ function derivePrReviewCriticInventory(
 		.sort();
 }
 
+/** Thin projection of the composed critic phase. Empty unless item-complete. */
 function deriveLatestPrReviewCriticVerdicts(
 	directory: string,
 	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
 ): Map<string, { status: string; severity: string }> {
-	const reviewerVerdicts = deriveLatestPrReviewReviewerVerdicts(
+	const composed = composePrReviewPhaseVerdicts(
 		directory,
 		state,
+		'critic',
+		ctx,
 	);
-	const criticBatches = (state.prReviewValidationBatches ?? []).filter(
-		(batch) => batch.phase === 'critic',
+	if (composed.unclaimed.length > 0) return new Map();
+	return new Map(
+		[...composed.claims].map(([itemId, claim]) => [
+			itemId,
+			{ status: claim.classification, severity: claim.severity },
+		]),
 	);
-	for (const batch of [...criticBatches].reverse()) {
-		const successful = successfulObligationsFromExactBatch(
-			directory,
-			state,
-			batch.batchId,
-			batch.lanes,
-			'swarm-pr-review:critic',
-			batch.validatedAt,
-		);
-		if (
-			batch.lanes.some((lane) => !successful.has(lane.workflowLane)) ||
-			successful.size !== batch.lanes.length
-		) {
-			continue;
-		}
-		const required = batch.lanes.flatMap((lane) => lane.reviewItemIds ?? []);
-		const verdicts = new Map<string, { status: string; severity: string }>();
-		for (const lane of batch.lanes) {
-			const record = findByBatchId(directory, batch.batchId, {
-				parentSessionId: state.sessionID,
-			}).find((candidate) => candidate.laneId === lane.laneId);
-			const ref = record?.result?.outputRef?.trim();
-			const artifact = ref
-				? readLaneOutput(directory, ref)?.artifact
-				: undefined;
-			if (!artifact) continue;
-			for (const itemId of lane.reviewItemIds ?? []) {
-				const verdict = parseCriticVerdict(
-					artifact.text,
-					itemId,
-					reviewerVerdicts.get(itemId)?.severity,
-				);
-				if (verdict) verdicts.set(itemId, verdict);
-			}
-		}
-		if (required.every((itemId) => verdicts.has(itemId))) return verdicts;
-	}
-	return new Map();
 }
 
+/** Thin projection of the composed reviewer phase. Empty unless item-complete. */
 function deriveLatestPrReviewReviewerVerdicts(
 	directory: string,
 	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
 ): Map<string, ReviewerVerdict> {
-	const reviewerBatches = (state.prReviewValidationBatches ?? []).filter(
-		(batch) => batch.phase === 'reviewer',
+	return new Map(
+		[...authoritativeReviewerClaims(directory, state, ctx)].map(
+			([itemId, claim]) => [
+				itemId,
+				{ classification: claim.classification, severity: claim.severity },
+			],
+		),
 	);
-	for (const batch of [...reviewerBatches].reverse()) {
-		const successful = successfulObligationsFromExactBatch(
-			directory,
-			state,
-			batch.batchId,
-			batch.lanes,
-			'swarm-pr-review:reviewer',
-			batch.validatedAt,
-		);
-		if (
-			batch.lanes.some((lane) => !successful.has(lane.workflowLane)) ||
-			successful.size !== batch.lanes.length
-		) {
-			continue;
-		}
-		const required = batch.lanes.flatMap((lane) => lane.reviewItemIds ?? []);
-		const verdicts = new Map<string, ReviewerVerdict>();
-		for (const lane of batch.lanes) {
-			const record = findByBatchId(directory, batch.batchId, {
-				parentSessionId: state.sessionID,
-			}).find((candidate) => candidate.laneId === lane.laneId);
-			const ref = record?.result?.outputRef?.trim();
-			const artifact = ref
-				? readLaneOutput(directory, ref)?.artifact
-				: undefined;
-			if (!artifact) continue;
-			for (const itemId of lane.reviewItemIds ?? []) {
-				const verdict = parseReviewerVerdict(artifact.text, itemId);
-				if (verdict) verdicts.set(itemId, verdict);
-			}
-		}
-		if (required.every((itemId) => verdicts.has(itemId))) {
-			return verdicts;
-		}
-	}
-	return new Map();
 }
 
-function successfulObligationsFromExactBatch(
+/**
+ * **B1 invariant — the accounting defect class's most dangerous recurrence.**
+ *
+ * Issue #1968's defect class treats the whole inventory on the current revision
+ * as the atomic unit of validity. Its worst recurrence is not a false BLOCK, it
+ * is a silent PASS: a phase treated as *settled* while the authoritative verdict
+ * map every downstream gate reads is empty or partial. For the reviewer phase
+ * that chain is `derivePrReviewCriticInventory` -> `[]` ->
+ * `completePrWorkflow`'s `criticInventory.length > 0` is false -> **critic
+ * coverage is skipped entirely** and CONFIRMED CRITICAL/HIGH findings ship
+ * unchallenged, with the only surface symptom a downstream
+ * `no authoritative reviewer verdict` that names a consequence, not the cause.
+ *
+ * Composition currently makes this unreachable by construction: settlement *is*
+ * `unclaimed.length === 0` over the very map derivation projects, and claims are
+ * filtered to `requiredInventory`, so `unclaimed === []` implies the map covers
+ * every required item. This assertion deliberately does **not** rely on that
+ * adjacency. It states the property directly so a future refactor that re-splits
+ * settlement from derivation fails loudly at the gate instead of silently
+ * skipping the critic phase.
+ *
+ * Fail-closed and always on; never downgraded to a warning, because the failure
+ * it catches is invisible in the passing direction. Pure over values the caller
+ * already computed: no digest resolution, no artifact reads, no subprocess work.
+ */
+function assertSettledPhaseHasAuthoritativeVerdicts(
+	phase: PrReviewComposablePhase,
+	// Narrowed to the two fields the property is stated over, so the check can
+	// never come to depend on the rest of the composition.
+	composed: Pick<PrReviewPhaseComposition, 'requiredInventory' | 'unclaimed'>,
+	authoritative: ReadonlyMap<string, unknown>,
+	origin: string,
+): void {
+	// Antecedent, both halves load-bearing: an *unsettled* phase is supposed to
+	// project an empty map (that is the pre-existing fail-closed semantics), and
+	// an empty required inventory legitimately yields an empty map.
+	if (composed.unclaimed.length > 0) return;
+	if (composed.requiredInventory.length === 0) return;
+	const missing = composed.requiredInventory.filter(
+		(itemId) => !authoritative.has(itemId),
+	);
+	if (missing.length === 0) return;
+	const named = missing.slice(0, MAX_UNCLAIMED_ITEMS_IN_MESSAGE);
+	const overflow = missing.length - named.length;
+	throw new Error(
+		`BLOCKED: PR_REVIEW internal invariant violated at ${origin}: the ${phase} phase settled over ` +
+			`${composed.requiredInventory.length} required item(s), but its authoritative ${phase} verdict map is ` +
+			(authoritative.size === 0
+				? 'EMPTY'
+				: `PARTIAL (${authoritative.size} of ${composed.requiredInventory.length} items)`) +
+			' after successful settlement' +
+			(phase === 'reviewer'
+				? '; an empty or partial reviewer verdict map empties the critic inventory, which silently skips the critic-coverage gate and lets CONFIRMED CRITICAL/HIGH findings ship unchallenged'
+				: '; an empty or partial critic verdict map silently drops challenges the gate already accepted') +
+			`; missing ${phase} verdicts for: ${named.join(', ')}` +
+			(overflow > 0 ? ` (+${overflow} more)` : ''),
+	);
+}
+
+/**
+ * The reviewer verdict map downstream gates consume, with the B1 invariant
+ * checked at the point of use. Reuses the caller's memoized composition, so the
+ * check costs one array filter and adds no digest or artifact work.
+ */
+function authoritativeReviewerVerdictsForGate(
+	directory: string,
+	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
+	origin: string,
+): Map<string, ReviewerVerdict> {
+	const verdicts = deriveLatestPrReviewReviewerVerdicts(directory, state, ctx);
+	assertSettledPhaseHasAuthoritativeVerdicts(
+		'reviewer',
+		composePrReviewPhaseVerdicts(directory, state, 'reviewer', ctx),
+		verdicts,
+		origin,
+	);
+	return verdicts;
+}
+
+/** Critic twin of `authoritativeReviewerVerdictsForGate`. */
+function authoritativeCriticVerdictsForGate(
+	directory: string,
+	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
+	origin: string,
+): Map<string, { status: string; severity: string }> {
+	const verdicts = deriveLatestPrReviewCriticVerdicts(directory, state, ctx);
+	assertSettledPhaseHasAuthoritativeVerdicts(
+		'critic',
+		composePrReviewPhaseVerdicts(directory, state, 'critic', ctx),
+		verdicts,
+		origin,
+	);
+	return verdicts;
+}
+
+/**
+ * The critic-coverage gate's input, with the "empty" case made provable.
+ *
+ * `completePrWorkflow` and the `post_critic` artifact boundary both branch on
+ * `length > 0` to decide whether the critic phase is required *at all*, so an
+ * empty result there must provably mean "no CONFIRMED CRITICAL/HIGH/MEDIUM
+ * reviewer verdict exists" and never "the reviewer verdict map came back empty".
+ * Two distinct pathologies produce the same `[]`:
+ *
+ * 1. the reviewer phase was never settled — rejected here explicitly;
+ * 2. the reviewer phase settled but its verdict map is empty or partial —
+ *    rejected by `assertSettledPhaseHasAuthoritativeVerdicts` (B1).
+ *
+ * Past both, `[]` is a filter result over a map that covers every required
+ * reviewer item. This cannot newly block any state reachable today: both call
+ * sites run `assertPrReviewValidationSettled(..., 'reviewer', ctx)` on the same
+ * context immediately beforehand, which already throws on `unclaimed > 0`. The
+ * point is that the guarantee stops depending on that adjacency.
+ *
+ * Deliberately NOT folded into `derivePrReviewCriticInventory` itself:
+ * `prunePrWorkflowBatchesForCapacity` derives the critic inventory on states
+ * whose reviewer phase is legitimately unsettled, and its fail-closed try/catch
+ * would convert the throw into "keep every batch", silently disabling GC.
+ */
+function derivePrReviewCriticInventoryForCoverageGate(
+	directory: string,
+	state: PrWorkflowGateState,
+	ctx: PrReviewGateContext,
+	origin: string,
+): string[] {
+	const reviewer = composePrReviewPhaseVerdicts(
+		directory,
+		state,
+		'reviewer',
+		ctx,
+	);
+	if (reviewer.unclaimed.length > 0) {
+		const named = reviewer.unclaimed.slice(0, MAX_UNCLAIMED_ITEMS_IN_MESSAGE);
+		const overflow = reviewer.unclaimed.length - named.length;
+		throw new Error(
+			`BLOCKED: PR_REVIEW internal invariant violated at ${origin}: the critic-coverage decision requires a settled reviewer phase, ` +
+				`but ${reviewer.unclaimed.length} reviewer item(s) lack an authenticated verdict; an unsettled reviewer phase derives an empty ` +
+				`critic inventory, which would skip critic coverage instead of demanding it; unsettled reviewer items: ${named.join(', ')}` +
+				(overflow > 0 ? ` (+${overflow} more)` : ''),
+		);
+	}
+	return derivePrReviewCriticInventory(directory, state, ctx);
+}
+
+interface ExpectedWorkflowLane {
+	laneId: string;
+	workflowLane: string;
+	reviewItemIds?: string[];
+	ownedWorkflowLanes?: string[];
+}
+
+interface QualifiedBatchRecord {
+	record: ReturnType<typeof findByBatchId>[number];
+	expectedLane: ExpectedWorkflowLane;
+	expectedWorkflowLane: string;
+	expectedOwnedLanes: string[];
+}
+
+/**
+ * Every record of a batch that passes the record-level integrity chain: exactly
+ * one record per declared lane, exactly one record per child session, no reuse
+ * of a forbidden child session, recorded after the batch was declared, exact
+ * lane/ownership/mode/head match, and a complete non-degraded result.
+ *
+ * Extracted so the per-item composition can reuse the identical chain instead of
+ * re-deriving it. `successfulObligationsFromExactBatch` composes this with the
+ * contract-marker check and keeps its exact prior semantics.
+ */
+function recordsPassingBatchIntegrity(
 	directory: string,
 	state: PrWorkflowGateState,
 	batchId: string,
-	expectedLanes: ReadonlyArray<{
-		laneId: string;
-		workflowLane: string;
-		reviewItemIds?: string[];
-		ownedWorkflowLanes?: string[];
-	}>,
+	expectedLanes: ReadonlyArray<ExpectedWorkflowLane>,
 	expectedMode: string,
 	validatedAt: string,
 	checkWorkflowLane = true,
 	forbiddenSubagentSessionIds: ReadonlySet<string> = new Set(),
-	expectedRevisionDigest?: string,
-	diagnostics?: string[],
-): Set<string> {
-	const records = findByBatchId(directory, batchId, {
-		parentSessionId: state.sessionID,
-	});
-	const successful = new Set<string>();
+): QualifiedBatchRecord[] {
+	const qualified: QualifiedBatchRecord[] = [];
 	const validatedAtMs = Date.parse(validatedAt);
-	if (!Number.isFinite(validatedAtMs)) return successful;
+	if (!Number.isFinite(validatedAtMs)) return qualified;
 	const expectedByLaneId = new Map(
 		expectedLanes.map((lane) => [lane.laneId, lane]),
 	);
-	if (expectedByLaneId.size !== expectedLanes.length) return successful;
+	if (expectedByLaneId.size !== expectedLanes.length) return qualified;
+	const records = findByBatchId(directory, batchId, {
+		parentSessionId: state.sessionID,
+	});
 	const recordCountByLaneId = new Map<string, number>();
 	const recordCountBySubagentSessionId = new Map<string, number>();
 	for (const record of records) {
@@ -5233,6 +7249,7 @@ function successfulObligationsFromExactBatch(
 				: undefined;
 		const subagentSessionId = record.subagentSessionId?.trim();
 		if (
+			expectedLane !== undefined &&
 			expectedWorkflowLane !== undefined &&
 			expectedOwnedLanes !== undefined &&
 			record.laneId !== undefined &&
@@ -5253,20 +7270,58 @@ function successfulObligationsFromExactBatch(
 			record.result?.truncated !== true &&
 			(record.result?.chars ?? 0) > 0 &&
 			Boolean(record.result?.digest?.trim()) &&
-			Boolean(record.result?.outputRef?.trim()) &&
+			Boolean(record.result?.outputRef?.trim())
+		) {
+			qualified.push({
+				record,
+				expectedLane,
+				expectedWorkflowLane,
+				expectedOwnedLanes,
+			});
+		}
+	}
+	return qualified;
+}
+
+function successfulObligationsFromExactBatch(
+	directory: string,
+	state: PrWorkflowGateState,
+	batchId: string,
+	expectedLanes: ReadonlyArray<ExpectedWorkflowLane>,
+	expectedMode: string,
+	validatedAt: string,
+	checkWorkflowLane = true,
+	forbiddenSubagentSessionIds: ReadonlySet<string> = new Set(),
+	expectedRevisionDigest?: string,
+	diagnostics?: string[],
+	reviewerClaims?: ReadonlyMap<string, PrReviewItemClaim>,
+): Set<string> {
+	const successful = new Set<string>();
+	for (const qualified of recordsPassingBatchIntegrity(
+		directory,
+		state,
+		batchId,
+		expectedLanes,
+		expectedMode,
+		validatedAt,
+		checkWorkflowLane,
+		forbiddenSubagentSessionIds,
+	)) {
+		if (
 			workflowArtifactHasContractMarker(
 				directory,
 				state,
-				record,
+				qualified.record,
 				expectedMode,
-				expectedWorkflowLane,
-				expectedLane?.reviewItemIds,
+				qualified.expectedWorkflowLane,
+				qualified.expectedLane.reviewItemIds,
 				expectedRevisionDigest,
-				expectedOwnedLanes,
+				qualified.expectedOwnedLanes,
 				diagnostics,
+				reviewerClaims,
 			)
 		) {
-			for (const obligation of expectedOwnedLanes) {
+			for (const obligation of qualified.expectedOwnedLanes) {
 				successful.add(obligation);
 			}
 		}
@@ -5302,32 +7357,41 @@ function ownedLaneSetsEqual(
 	return recordOwned.every((owned) => expectedSet.has(owned));
 }
 
-function workflowArtifactHasContractMarker(
+type LaneArtifact = NonNullable<ReturnType<typeof readLaneOutput>>['artifact'];
+
+/**
+ * The mode-independent half of the contract-marker check: load the lane artifact
+ * and prove it is the exact artifact this delegation record produced, on this
+ * revision, for this identity. Returns the artifact when the lane passes, `null`
+ * otherwise.
+ *
+ * Split out of `workflowArtifactHasContractMarker` so the item-keyed composition
+ * can admit *individual items* from a lane. The marker function itself still
+ * ends in an all-items-or-nothing verdict, which is what base, council, micro
+ * and every PR_FEEDBACK caller require and continue to get unchanged.
+ *
+ * `expectedRevisionDigest` is required (issue #1968 FIX 7). It used to fall back
+ * to a per-record synchronous `resolvePrWorkflowRevisionDigest`, which was dead
+ * in production — every entry point threads a digest resolved once per gate call
+ * from a context that hard-throws when it cannot be resolved — while keeping an
+ * unchunked `readFileSync` snapshot loop reachable under the raised 512 MB cap.
+ * An empty digest still fails closed below rather than matching an artifact.
+ */
+function loadArtifactPassingLaneIntegrity(
 	directory: string,
 	state: PrWorkflowGateState,
 	record: ReturnType<typeof findByBatchId>[number],
 	expectedMode: string,
 	expectedWorkflowLane: string,
-	reviewItemIds?: readonly string[],
-	expectedRevisionDigest?: string,
-	ownedWorkflowLanes?: readonly string[],
-	diagnostics?: string[],
-): boolean {
+	expectedRevisionDigest: string,
+): LaneArtifact | null {
 	const ref = record.result?.outputRef?.trim();
-	if (!ref) return false;
+	if (!ref) return null;
 	const loaded = readLaneOutput(directory, ref);
-	if (!loaded) return false;
+	if (!loaded) return null;
 	const artifact = loaded.artifact;
 	const recordPrHeadSha = record.workspace?.prHeadSha;
 	const recordGitHead = record.workspace?.gitHead;
-	const resolvedRevisionDigest =
-		expectedRevisionDigest ??
-		(recordPrHeadSha
-			? _test_exports.resolvePrWorkflowRevisionDigest(
-					directory,
-					recordPrHeadSha,
-				)
-			: null);
 	const expectedReviewScope =
 		state.mode === 'PR_REVIEW' && state.prReviewBaseSha && state.prHeadSha
 			? `complete PR diff ${state.prReviewBaseSha}...${state.prHeadSha}`
@@ -5347,40 +7411,66 @@ function workflowArtifactHasContractMarker(
 		artifact.prHeadSha !== recordPrHeadSha ||
 		!recordGitHead ||
 		artifact.gitHead !== recordGitHead ||
-		!resolvedRevisionDigest ||
-		artifact.revisionDigest !== resolvedRevisionDigest ||
+		!expectedRevisionDigest ||
+		artifact.revisionDigest !== expectedRevisionDigest ||
 		(expectedReviewScope !== undefined &&
 			(record.workspace?.scope !== expectedReviewScope ||
 				artifact.scope !== expectedReviewScope)) ||
 		artifact.digest !== record.result?.digest ||
 		artifact.chars !== record.result?.chars
 	) {
-		return false;
+		return null;
 	}
-	if (expectedMode === 'swarm-pr-review:reviewer') {
+	return artifact;
+}
+
+function workflowArtifactHasContractMarker(
+	directory: string,
+	state: PrWorkflowGateState,
+	record: ReturnType<typeof findByBatchId>[number],
+	expectedMode: string,
+	expectedWorkflowLane: string,
+	reviewItemIds?: readonly string[],
+	expectedRevisionDigest?: string,
+	ownedWorkflowLanes?: readonly string[],
+	diagnostics?: string[],
+	// Reviewer claims for the critic branch. The only production caller that
+	// reaches that branch is the legacy-eligibility predicate in the composition,
+	// which always passes the memoized map. Absent, the critic branch degrades to
+	// the pre-existing "reviewer map was empty" behaviour rather than inventing a
+	// second reviewer derivation with its own digest cost.
+	reviewerClaims?: ReadonlyMap<string, PrReviewItemClaim>,
+): boolean {
+	const ref = record.result?.outputRef?.trim();
+	// Fail closed rather than resolving a digest here (issue #1968 FIX 7): every
+	// production path threads the gate's single memoized digest, so an absent one
+	// means a caller skipped the resolve, not that a per-record resolve is owed.
+	const artifact = expectedRevisionDigest
+		? loadArtifactPassingLaneIntegrity(
+				directory,
+				state,
+				record,
+				expectedMode,
+				expectedWorkflowLane,
+				expectedRevisionDigest,
+			)
+		: null;
+	if (!artifact) return false;
+	if (
+		expectedMode === 'swarm-pr-review:reviewer' ||
+		expectedMode === 'swarm-pr-review:critic'
+	) {
+		const phase: PrReviewComposablePhase =
+			expectedMode === 'swarm-pr-review:reviewer' ? 'reviewer' : 'critic';
+		const parsed = parseLaneItemVerdicts(
+			artifact.text,
+			reviewItemIds ?? [],
+			phase,
+			reviewerClaims,
+		);
 		return Boolean(
 			reviewItemIds?.length &&
-				reviewItemIds.every((itemId) =>
-					Boolean(parseReviewerVerdict(artifact.text, itemId)),
-				),
-		);
-	}
-	if (expectedMode === 'swarm-pr-review:critic') {
-		const reviewerVerdicts = deriveLatestPrReviewReviewerVerdicts(
-			directory,
-			state,
-		);
-		return Boolean(
-			reviewItemIds?.length &&
-				reviewItemIds.every((itemId) =>
-					Boolean(
-						parseCriticVerdict(
-							artifact.text,
-							itemId,
-							reviewerVerdicts.get(itemId)?.severity,
-						),
-					),
-				),
+				reviewItemIds.every((itemId) => parsed.has(itemId)),
 		);
 	}
 	if (expectedMode === 'swarm-pr-feedback:verification') {
@@ -5632,10 +7722,11 @@ interface ReviewerVerdict {
 	severity: string;
 }
 
-function parseReviewerVerdict(
+/** The validated 10 canonical fields of the single `[REVIEWED]` row for an item. */
+function parseReviewerVerdictFields(
 	text: string,
 	itemId: string,
-): ReviewerVerdict | null {
+): string[] | null {
 	const rows = text
 		.split(/\r?\n/)
 		.map(pipeFields)
@@ -5655,7 +7746,61 @@ function parseReviewerVerdict(
 		return null;
 	if (fields[7].length < 8 || fields[8].length < 5 || fields[9].length < 3)
 		return null;
-	return { classification: fields[2], severity: fields[4] };
+	return fields;
+}
+
+/**
+ * Digest of the FULL canonical reviewer row, not the classification/severity
+ * pair a reviewer verdict projects to. Only 2 of the 10 required fields survive
+ * that projection, so a tuple binding would still match a row whose evidence,
+ * file:line and root cause all changed. Fields are joined on NUL, which
+ * `pipeFields` can never produce, so no field boundary is forgeable.
+ */
+function reviewerVerdictRowDigest(fields: readonly string[]): string {
+	return createHash('sha256').update(fields.join('\0')).digest('hex');
+}
+
+/**
+ * Per-item verdicts an artifact actually carries, as a map rather than a
+ * boolean. This is the granularity the composition needs: one unparseable item
+ * must not discard its healthy siblings in the same lane.
+ */
+function parseLaneItemVerdicts(
+	text: string,
+	itemIds: readonly string[],
+	phase: PrReviewComposablePhase,
+	reviewerClaims?: ReadonlyMap<string, PrReviewItemClaim>,
+): Map<
+	string,
+	{ classification: string; severity: string; rowDigest?: string }
+> {
+	const parsed = new Map<
+		string,
+		{ classification: string; severity: string; rowDigest?: string }
+	>();
+	for (const itemId of itemIds) {
+		if (phase === 'reviewer') {
+			const fields = parseReviewerVerdictFields(text, itemId);
+			if (!fields) continue;
+			parsed.set(itemId, {
+				classification: fields[2],
+				severity: fields[4],
+				rowDigest: reviewerVerdictRowDigest(fields),
+			});
+			continue;
+		}
+		const verdict = parseCriticVerdict(
+			text,
+			itemId,
+			reviewerClaims?.get(itemId)?.severity,
+		);
+		if (!verdict) continue;
+		parsed.set(itemId, {
+			classification: verdict.status,
+			severity: verdict.severity,
+		});
+	}
+	return parsed;
 }
 
 function parseCriticVerdict(

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -18,6 +18,7 @@ import {
 import {
 	resolveExactMergeBaseAsync,
 	resolvePrWorkflowRevisionDigestAsync,
+	resolvePrWorkflowRevisionDigestDetailedAsync,
 } from '../background/workspace-snapshot.js';
 import { WRITE_TOOL_NAMES } from '../config/constants.js';
 import {
@@ -31,6 +32,7 @@ import {
 	bindPrReviewBase,
 	bindPrReviewTriggerLedger,
 	declarePrFeedbackInventory,
+	describePrWorkflowRevisionDigestFailure,
 	enforcePrFeedbackVerificationOwnership,
 	enforcePrReviewBaseDimensions,
 	enforcePrWorkflowDispatchLanesAsync,
@@ -903,16 +905,35 @@ export async function executeDispatchLanesAsync(
 					? 'PR_FEEDBACK'
 					: 'PR_REVIEW',
 			);
-			workflowRevisionDigest =
-				(await _internals.resolvePrWorkflowRevisionDigestAsync(
-					directory,
-					parsed.data.pr_head_sha,
-				)) ?? undefined;
-			if (!workflowRevisionDigest) {
+			// Issue #1968 P2.2: name the exact bound that fired. The pre-existing
+			// `string | null` seam keeps priority when a test injected it, so every
+			// existing fixture drives this path unchanged; production takes the
+			// discriminated twin and gets a diagnosable reason.
+			const resolvedDigest =
+				_internals.resolvePrWorkflowRevisionDigestAsync !==
+				resolvePrWorkflowRevisionDigestAsync
+					? await _internals
+							.resolvePrWorkflowRevisionDigestAsync(
+								directory,
+								parsed.data.pr_head_sha,
+							)
+							.then((digest) =>
+								digest
+									? ({ ok: true, digest } as const)
+									: ({ ok: false, reason: 'seam-unavailable' } as const),
+							)
+					: await resolvePrWorkflowRevisionDigestDetailedAsync(
+							directory,
+							parsed.data.pr_head_sha,
+						);
+			if (!resolvedDigest.ok) {
 				throw new Error(
-					'BLOCKED: PR workflow could not compute a bounded current-revision digest',
+					'BLOCKED: PR workflow could not compute a bounded current-revision digest for ' +
+						`pr_head_sha "${parsed.data.pr_head_sha}"; ` +
+						describePrWorkflowRevisionDigestFailure(resolvedDigest),
 				);
 			}
+			workflowRevisionDigest = resolvedDigest.digest;
 			if (parsed.data.mode?.startsWith('swarm-pr-review:')) {
 				if (!parsed.data.base_sha || !parsed.data.base_ref) {
 					throw new Error(
@@ -1116,7 +1137,15 @@ export async function executeDispatchLanesAsync(
 						directory,
 						context.sessionID,
 						laneSpecs,
-						{ batchId, prHeadSha: headSha },
+						{
+							batchId,
+							prHeadSha: headSha,
+							// Reuse the digest already resolved above (issue #1968 MS-5).
+							// The tier-L retry predicate and the batch GC both need
+							// per-dimension artifact state; neither may add a fresh
+							// synchronous digest resolution to the dispatch path.
+							revisionDigest: workflowRevisionDigest,
+						},
 					);
 				} else if (parsed.data.mode === 'swarm-pr-review:micro') {
 					await assertPrReviewBaseCoverageSettled(directory, context.sessionID);

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -14,6 +14,7 @@ import {
 import {
 	resolveExactMergeBase,
 	resolvePrWorkflowRevisionDigest,
+	resolvePrWorkflowRevisionDigestAsync,
 } from '../background/workspace-snapshot.js';
 import {
 	assertPrReviewBaseCoverageSettled,
@@ -29,8 +30,30 @@ export { PR_REVIEW_TRIGGER_DEFINITIONS } from '../background/pr-review-trigger-c
 
 export const _internals = {
 	resolvePrWorkflowRevisionDigest,
+	resolvePrWorkflowRevisionDigestAsync,
 	resolveMergeBase: resolveExactMergeBase,
 };
+
+/**
+ * Production uses the non-blocking, chunked digest implementation; the three
+ * blocking `spawnSync` git calls plus a full re-read of every changed file do
+ * not belong on a tool call's synchronous path. The synchronous member stays as
+ * the injection seam existing focused tests stub, and is selected only while it
+ * is overridden — mirroring `resolvePrWorkflowRevisionDigestForGate` in the
+ * gate itself.
+ */
+async function resolveCurrentRevisionDigest(
+	directory: string,
+	prHeadSha: string,
+): Promise<string | null> {
+	if (
+		_internals.resolvePrWorkflowRevisionDigest !==
+		resolvePrWorkflowRevisionDigest
+	) {
+		return _internals.resolvePrWorkflowRevisionDigest(directory, prHeadSha);
+	}
+	return _internals.resolvePrWorkflowRevisionDigestAsync(directory, prHeadSha);
+}
 
 const WritePrReviewTriggerEvalArgsSchema = z
 	.object({
@@ -151,7 +174,7 @@ export async function executeWritePrReviewTriggerEval(
 			'PR_REVIEW trigger evaluation differs from the canonical ledger frozen across micro dispatches',
 		);
 	}
-	const currentRevisionDigest = _internals.resolvePrWorkflowRevisionDigest(
+	const currentRevisionDigest = await resolveCurrentRevisionDigest(
 		directory,
 		parsed.data.pr_head_sha,
 	);

--- a/tests/unit/background/workspace-snapshot-digest-bounds.test.ts
+++ b/tests/unit/background/workspace-snapshot-digest-bounds.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	_internals,
+	resolveCurrentGitHead,
+	resolvePrWorkflowRevisionDigest,
+	resolvePrWorkflowRevisionDigestAsync,
+	resolvePrWorkflowRevisionDigestDetailed,
+	resolvePrWorkflowRevisionDigestDetailedAsync,
+} from '../../../src/background/workspace-snapshot';
+
+// issue #1968 P6 — the digest caps stop being a dead end: this file proves
+// the discriminated `RevisionDigestResult` reasons are actually produced and
+// distinguishable, and that the pre-existing sync/async twins stay
+// byte-for-byte backward compatible (`null` on any failure, never a throw).
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			result.stderr || result.stdout || `git ${args.join(' ')} failed`,
+		);
+	}
+}
+
+const original = {
+	revisionMaxFiles: _internals.revisionMaxFiles,
+	revisionMaxTotalBytes: _internals.revisionMaxTotalBytes,
+	gitSnapshotMaxBuffer: _internals.gitSnapshotMaxBuffer,
+	revisionEnumerationTimeoutMs: _internals.revisionEnumerationTimeoutMs,
+	spawnSync: _internals.spawnSync,
+};
+
+describe('revision digest bounds (issue #1968 P6)', () => {
+	let directory: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'revision-digest-bounds-'),
+		);
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.writeFileSync(path.join(directory, 'base.txt'), 'base\n');
+		git(directory, ['add', 'base.txt']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+		_internals.revisionMaxFiles = original.revisionMaxFiles;
+		_internals.revisionMaxTotalBytes = original.revisionMaxTotalBytes;
+		_internals.gitSnapshotMaxBuffer = original.gitSnapshotMaxBuffer;
+		_internals.revisionEnumerationTimeoutMs =
+			original.revisionEnumerationTimeoutMs;
+		_internals.spawnSync = original.spawnSync;
+	});
+
+	test('happy path: detailed ok+digest equals the legacy sync/async strings', async () => {
+		const head = resolveCurrentGitHead(directory);
+		expect(head).not.toBeNull();
+		fs.writeFileSync(path.join(directory, 'base.txt'), 'edited\n');
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head!);
+		const legacy = resolvePrWorkflowRevisionDigest(directory, head!);
+		expect(detailed).toEqual({ ok: true, digest: expect.any(String) });
+		expect(detailed.ok && detailed.digest).toBe(legacy!);
+
+		const detailedAsync = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head!,
+		);
+		const legacyAsync = await resolvePrWorkflowRevisionDigestAsync(
+			directory,
+			head!,
+		);
+		expect(detailedAsync).toEqual({ ok: true, digest: expect.any(String) });
+		expect(detailedAsync.ok && detailedAsync.digest).toBe(legacyAsync!);
+
+		// Sync and async twins agree on the same repo state.
+		expect(detailedAsync.ok && detailed.ok && detailedAsync.digest).toBe(
+			detailed.ok ? detailed.digest : undefined,
+		);
+	});
+
+	test('file-cap: too many changed paths is reason "file-cap", distinguishable from other bounds', async () => {
+		_internals.revisionMaxFiles = 1;
+		const head = resolveCurrentGitHead(directory);
+		expect(head).not.toBeNull();
+		fs.writeFileSync(path.join(directory, 'untracked-a.txt'), 'a\n');
+		fs.writeFileSync(path.join(directory, 'untracked-b.txt'), 'b\n');
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head!);
+		expect(detailed).toMatchObject({ ok: false, reason: 'file-cap' });
+		expect(resolvePrWorkflowRevisionDigest(directory, head!)).toBeNull();
+
+		const detailedAsync = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head!,
+		);
+		expect(detailedAsync).toMatchObject({ ok: false, reason: 'file-cap' });
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, head!),
+		).resolves.toBeNull();
+	});
+
+	test('byte-cap: content exceeding the total-bytes bound is reason "byte-cap"', async () => {
+		_internals.revisionMaxTotalBytes = 10;
+		const head = resolveCurrentGitHead(directory);
+		expect(head).not.toBeNull();
+		fs.writeFileSync(
+			path.join(directory, 'base.txt'),
+			Buffer.alloc(1_000, 'x'),
+		);
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head!);
+		expect(detailed).toMatchObject({ ok: false, reason: 'byte-cap' });
+		expect(resolvePrWorkflowRevisionDigest(directory, head!)).toBeNull();
+
+		const detailedAsync = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head!,
+		);
+		expect(detailedAsync).toMatchObject({ ok: false, reason: 'byte-cap' });
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, head!),
+		).resolves.toBeNull();
+	});
+
+	test('buffer-truncated: an oversized enumeration call is reason "buffer-truncated", not "file-cap"', async () => {
+		// A real `rev-parse --verify` hash line is ~41 bytes (40 hex chars + \n).
+		// 100 bytes comfortably fits that single call but not the untracked-file
+		// `status --porcelain -z` enumeration created below (untracked files
+		// never appear in `diff --name-only` output), so the overflow is pinned
+		// to a real path-enumeration call, not baseHead.
+		_internals.gitSnapshotMaxBuffer = 100;
+		const head = resolveCurrentGitHead(directory);
+		expect(head).not.toBeNull();
+		for (let index = 0; index < 10; index++) {
+			fs.writeFileSync(
+				path.join(directory, `long-enough-file-name-${index}.txt`),
+				`content ${index}\n`,
+			);
+		}
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head!);
+		expect(detailed).toMatchObject({ ok: false, reason: 'buffer-truncated' });
+		// Reason must be distinguishable from a mere cap — the whole point of
+		// this change (05-fix-plan.md P6.2).
+		expect(detailed).not.toMatchObject({ reason: 'file-cap' });
+		expect(resolvePrWorkflowRevisionDigest(directory, head!)).toBeNull();
+
+		const detailedAsync = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head!,
+		);
+		expect(detailedAsync).toMatchObject({
+			ok: false,
+			reason: 'buffer-truncated',
+		});
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, head!),
+		).resolves.toBeNull();
+	});
+
+	test('git-failed: a base revision that cannot be verified is reason "git-failed"', async () => {
+		const nonExistentSha = '0'.repeat(40);
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(
+			directory,
+			nonExistentSha,
+		);
+		expect(detailed).toMatchObject({ ok: false, reason: 'git-failed' });
+		expect(
+			resolvePrWorkflowRevisionDigest(directory, nonExistentSha),
+		).toBeNull();
+
+		const detailedAsync = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			nonExistentSha,
+		);
+		expect(detailedAsync).toMatchObject({ ok: false, reason: 'git-failed' });
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, nonExistentSha),
+		).resolves.toBeNull();
+	});
+
+	test('containment: a path resolving outside the project root is reason "containment"', () => {
+		const head = resolveCurrentGitHead(directory);
+		expect(head).not.toBeNull();
+
+		_internals.spawnSync = ((_command, args) => {
+			const joined = args.join(' ');
+			if (joined.includes('rev-parse')) {
+				return {
+					status: 0,
+					signal: null,
+					pid: 1,
+					output: [],
+					stdout: `${head}\n`,
+					stderr: '',
+				};
+			}
+			if (joined.includes('diff')) {
+				return {
+					status: 0,
+					signal: null,
+					pid: 1,
+					output: [],
+					// Escapes the project root; real Git never emits this, but the
+					// digest must fail closed rather than hash outside the repo.
+					stdout: '../outside.txt\0',
+					stderr: '',
+				};
+			}
+			return {
+				status: 0,
+				signal: null,
+				pid: 1,
+				output: [],
+				stdout: '',
+				stderr: '',
+			};
+		}) as typeof _internals.spawnSync;
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head!);
+		expect(detailed).toMatchObject({ ok: false, reason: 'containment' });
+		expect(resolvePrWorkflowRevisionDigest(directory, head!)).toBeNull();
+	});
+});

--- a/tests/unit/background/workspace-snapshot-digest-failure-reasons.test.ts
+++ b/tests/unit/background/workspace-snapshot-digest-failure-reasons.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	_internals,
+	resolveCurrentGitHead,
+	resolvePrWorkflowRevisionDigest,
+	resolvePrWorkflowRevisionDigestAsync,
+	resolvePrWorkflowRevisionDigestDetailed,
+	resolvePrWorkflowRevisionDigestDetailedAsync,
+} from '../../../src/background/workspace-snapshot';
+import type {
+	BunCompatSpawnOptions,
+	BunCompatSubprocess,
+} from '../../../src/utils/bun-compat';
+
+/**
+ * Issue #1968 acceptance criterion 6, the two reasons its own bounds suite left
+ * unproduced: `timeout` and `read-failed`. Both are asserted on BOTH twins,
+ * because the sync and async digests are independent implementations of the
+ * same discriminated contract and a reason that only one of them can emit is a
+ * message the other silently downgrades.
+ *
+ * `timeout` additionally pins the fix for a real defect: `runGitAsyncDetailed`
+ * used to arm the spawn helper's timer AND its own on the same deadline, so a
+ * timed-out enumeration was reported as `git-failed` — "Verify the checkout is
+ * a healthy Git worktree" — whenever the spawn-side timer won the race.
+ */
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdio: 'pipe',
+		encoding: 'utf-8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			result.stderr || result.stdout || `git ${args.join(' ')} failed`,
+		);
+	}
+}
+
+const original = {
+	revisionEnumerationTimeoutMs: _internals.revisionEnumerationTimeoutMs,
+	readChangedFileSync: _internals.readChangedFileSync,
+	yieldControl: _internals.yieldControl,
+	bunSpawn: _internals.bunSpawn,
+};
+
+/** A closed stream carrying `text`, in the shape `readBoundedGitOutput` reads. */
+function fakeStream(text: string): BunCompatSubprocess['stdout'] {
+	const encoded = new TextEncoder().encode(text);
+	return {
+		text: async () => text,
+		bytes: async () => encoded,
+		getReader: () =>
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					if (encoded.byteLength > 0) controller.enqueue(encoded);
+					controller.close();
+				},
+			}).getReader(),
+	};
+}
+
+/**
+ * Stand-in for `bunSpawn` that reproduces the one contract detail the race
+ * turned on: **when the caller passes `timeout`, the spawn helper arms its own
+ * kill timer at that deadline** (`src/utils/bun-compat.ts` does exactly this
+ * whenever `killProcessTree` is set, and delegates to the runtime's native
+ * timeout otherwise). `rev-parse` always succeeds so the failure is pinned to a
+ * path-enumeration call; the enumeration child never exits on its own.
+ */
+function spawnWithHelperOwnedTimeout(
+	headSha: string,
+): typeof _internals.bunSpawn {
+	return ((cmd: string[], options?: BunCompatSpawnOptions) => {
+		const isRevParse = cmd.includes('rev-parse');
+		let settle: (code: number) => void = () => undefined;
+		const exited = isRevParse
+			? Promise.resolve(0)
+			: new Promise<number>((resolve) => {
+					settle = resolve;
+				});
+		if (!isRevParse && options?.timeout && options.timeout > 0) {
+			// SIGKILL by the helper's own timer: the child is reaped and `exited`
+			// resolves with a kill code, which the completion branch reads as a
+			// plain non-zero exit.
+			setTimeout(() => settle(137), options.timeout);
+		}
+		return {
+			stdout: fakeStream(isRevParse ? `${headSha}\n` : ''),
+			stderr: fakeStream(''),
+			exited,
+			exitCode: null,
+			kill: () => settle(137),
+		} satisfies BunCompatSubprocess;
+	}) as typeof _internals.bunSpawn;
+}
+
+describe('revision digest timeout and read-failed reasons (issue #1968)', () => {
+	let directory: string;
+	let head: string;
+
+	beforeEach(() => {
+		directory = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'revision-digest-reasons-'),
+		);
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.writeFileSync(path.join(directory, 'base.txt'), 'base\n');
+		git(directory, ['add', 'base.txt']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+		const resolved = resolveCurrentGitHead(directory);
+		expect(resolved).not.toBeNull();
+		head = resolved as string;
+	});
+
+	afterEach(() => {
+		_internals.revisionEnumerationTimeoutMs =
+			original.revisionEnumerationTimeoutMs;
+		_internals.readChangedFileSync = original.readChangedFileSync;
+		_internals.yieldControl = original.yieldControl;
+		_internals.bunSpawn = original.bunSpawn;
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('async: the enumeration deadline has one owner, so a timeout is never reported as "git-failed"', async () => {
+		_internals.revisionEnumerationTimeoutMs = 25;
+		_internals.bunSpawn = spawnWithHelperOwnedTimeout(head);
+
+		// Arming the deadline in BOTH places is what made the reported reason
+		// depend on which of two equal-deadline timers fired first. The spawn
+		// helper's timer is armed first (inside the spawn call, before the race
+		// is constructed), so when it exists it wins: the child is reaped, the
+		// completion branch sees a non-zero exit, and a timeout is reported as
+		// "a bounded git enumeration failed ... Verify the checkout is a healthy
+		// Git worktree". Passing no `timeout` to the spawn helper leaves the race
+		// as the sole owner of the deadline, which is what this asserts.
+		const detailed = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head,
+		);
+		expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
+		expect(detailed).not.toMatchObject({ reason: 'git-failed' });
+	});
+
+	test('sync: a path enumeration that exceeds its deadline is reason "timeout"', () => {
+		fs.writeFileSync(path.join(directory, 'changed.txt'), 'changed\n');
+		// Only the ENUMERATION deadline is lowered; `gitTimeoutMs` still governs
+		// the `rev-parse --verify` that runs first, so the base-head resolution
+		// still succeeds and the timeout is pinned to a path-enumeration call.
+		_internals.revisionEnumerationTimeoutMs = 1;
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head);
+		expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
+		expect(detailed.ok === false && detailed.detail).toContain('timed out');
+		// Not misreported as a broken worktree.
+		expect(detailed).not.toMatchObject({ reason: 'git-failed' });
+		expect(resolvePrWorkflowRevisionDigest(directory, head)).toBeNull();
+	});
+
+	test('async: a path enumeration that exceeds its deadline is reason "timeout"', async () => {
+		fs.writeFileSync(path.join(directory, 'changed.txt'), 'changed\n');
+		_internals.revisionEnumerationTimeoutMs = 1;
+
+		// Real git, real child process. Tearing down a killed process tree costs
+		// hundreds of milliseconds on Windows, so this gets an explicit budget
+		// rather than racing bun's 5s default.
+		const detailed = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head,
+		);
+		expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
+		expect(detailed.ok === false && detailed.detail).toContain('timed out');
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, head),
+		).resolves.toBeNull();
+	}, 60_000);
+
+	test('sync: a changed path whose content cannot be read is reason "read-failed"', () => {
+		fs.writeFileSync(path.join(directory, 'unreadable.txt'), 'content\n');
+		_internals.readChangedFileSync = () => {
+			const error = new Error('permission denied') as NodeJS.ErrnoException;
+			error.code = 'EACCES';
+			throw error;
+		};
+
+		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head);
+		expect(detailed).toMatchObject({ ok: false, reason: 'read-failed' });
+		expect(detailed.ok === false && detailed.detail).toContain(
+			'read failed for unreadable.txt',
+		);
+		expect(resolvePrWorkflowRevisionDigest(directory, head)).toBeNull();
+	});
+
+	test('async: a changed path that shrinks mid-read is reason "read-failed"', async () => {
+		// The async twin reads in bounded chunks and yields between them, so a
+		// file that is truncated after `lstat` sized it reads short. No seam of
+		// its own is needed: the existing `yieldControl` seam is the point at
+		// which the file can change under the reader, which is exactly the
+		// real-world race this arm exists for.
+		const unstable = path.join(directory, 'unstable.bin');
+		let truncated = false;
+		// 2 MB is past the reader's first yield point (64 KB chunks, yielding
+		// every 16), so the truncation lands mid-file with reads still to come.
+		const arm = (): void => {
+			fs.writeFileSync(unstable, Buffer.alloc(2 * 1024 * 1024, 'x'));
+			truncated = false;
+		};
+		_internals.yieldControl = async () => {
+			if (!truncated) {
+				truncated = true;
+				fs.truncateSync(unstable, 0);
+			}
+			await original.yieldControl();
+		};
+
+		arm();
+		const detailed = await resolvePrWorkflowRevisionDigestDetailedAsync(
+			directory,
+			head,
+		);
+		expect(truncated).toBe(true);
+		expect(detailed).toMatchObject({ ok: false, reason: 'read-failed' });
+		expect(detailed.ok === false && detailed.detail).toContain('unstable.bin');
+
+		// The legacy twin must collapse the same failure to `null`, never throw.
+		arm();
+		await expect(
+			resolvePrWorkflowRevisionDigestAsync(directory, head),
+		).resolves.toBeNull();
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-b1-invariant.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-b1-invariant.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts,
+	assertPrReviewValidationSettled,
+	completePrWorkflow,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const BASE_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+
+const assertB1 = gateInternals.assertSettledPhaseHasAuthoritativeVerdicts;
+
+const reviewed = (
+	ids: readonly string[],
+	classification = 'CONFIRMED',
+	severity = 'HIGH',
+): string =>
+	ids
+		.map(
+			(id) =>
+				`[REVIEWED] | ${id} | ${classification} | STRUCTURALLY_PROVEN | ${severity} | YES | file.ts:1 | rationale | probe | reviewer`,
+		)
+		.join('\n');
+
+const criticised = (ids: readonly string[]): string =>
+	ids
+		.map((id) => `[CRITIC] | ${id} | UPHELD | HIGH | reason | required change`)
+		.join('\n');
+
+/** Declare a reviewer batch over one lane owning every id, then settle it. */
+async function settleReviewerPhase(
+	batchId: string,
+	rows: string,
+	itemIds: readonly string[] = BASE_IDS,
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+		[
+			{
+				laneId: `${batchId}-a`,
+				workflowLane: `${batchId}-a`,
+				reviewItemIds: [...itemIds],
+			},
+		],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		batchId,
+		'swarm-pr-review:reviewer',
+		[{ laneId: `${batchId}-a`, workflowLane: `${batchId}-a` }],
+		{ textOverride: rows, subagentSessionId: `${batchId}-a` },
+	);
+}
+
+async function settleCriticPhase(
+	batchId: string,
+	itemIds: readonly string[],
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'critic',
+		[
+			{
+				laneId: batchId,
+				workflowLane: batchId,
+				reviewItemIds: [...itemIds],
+			},
+		],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		batchId,
+		'swarm-pr-review:critic',
+		[{ laneId: batchId, workflowLane: batchId }],
+		{ textOverride: criticised(itemIds), subagentSessionId: batchId },
+	);
+}
+
+function errorFrom(promise: Promise<unknown>): Promise<Error | null> {
+	return promise.then(
+		() => null,
+		(reason: unknown) => reason as Error,
+	);
+}
+
+describe('pr-workflow-gate B1 invariant: settled phase implies a covering verdict map', () => {
+	test('an EMPTY reviewer map after settlement blocks and names the real cause', () => {
+		let thrown: Error | null = null;
+		try {
+			assertB1(
+				'reviewer',
+				{ requiredInventory: [...BASE_IDS], unclaimed: [] },
+				new Map(),
+				'unit(reviewer)',
+			);
+		} catch (error) {
+			thrown = error as Error;
+		}
+		expect(thrown).not.toBeNull();
+		const message = thrown?.message ?? '';
+		// Names the phase, the emptiness, that settlement succeeded, and the
+		// consequence — instead of the misleading downstream "no authoritative
+		// reviewer verdict" that names a symptom.
+		expect(message).toContain('BLOCKED: PR_REVIEW internal invariant violated');
+		expect(message).toContain('unit(reviewer)');
+		expect(message).toContain(
+			'the reviewer phase settled over 6 required item',
+		);
+		expect(message).toContain(
+			'verdict map is EMPTY after successful settlement',
+		);
+		expect(message).toContain('skips the critic-coverage gate');
+		expect(message).toContain(
+			`missing reviewer verdicts for: ${BASE_IDS.join(', ')}`,
+		);
+		expect(message).not.toContain('no authoritative reviewer verdict');
+	});
+
+	test('a PARTIAL reviewer map blocks and names only the uncovered items', () => {
+		const covered = BASE_IDS.slice(0, 4);
+		const missing = BASE_IDS.slice(4);
+		const error = (() => {
+			try {
+				assertB1(
+					'reviewer',
+					{ requiredInventory: [...BASE_IDS], unclaimed: [] },
+					new Map(covered.map((id) => [id, {}])),
+					'unit(partial)',
+				);
+				return null;
+			} catch (reason) {
+				return reason as Error;
+			}
+		})();
+		expect(error?.message).toContain('PARTIAL (4 of 6 items)');
+		expect(error?.message).toContain(
+			`missing reviewer verdicts for: ${missing.join(', ')}`,
+		);
+		for (const claimed of covered) {
+			expect(error?.message).not.toContain(`${claimed},`);
+		}
+	});
+
+	test('the critic phase is covered by the same invariant, with its own cause', () => {
+		const error = (() => {
+			try {
+				assertB1(
+					'critic',
+					{ requiredInventory: [...BASE_IDS], unclaimed: [] },
+					new Map(),
+					'unit(critic)',
+				);
+				return null;
+			} catch (reason) {
+				return reason as Error;
+			}
+		})();
+		expect(error?.message).toContain(
+			'the critic phase settled over 6 required',
+		);
+		expect(error?.message).toContain(
+			'verdict map is EMPTY after successful settlement',
+		);
+		expect(error?.message).toContain(
+			'silently drops challenges the gate already accepted',
+		);
+		expect(error?.message).toContain(
+			`missing critic verdicts for: ${BASE_IDS.join(', ')}`,
+		);
+	});
+
+	test('an UNSETTLED phase legitimately projects an empty map and is allowed', () => {
+		// Pre-existing fail-closed semantics: derivation returns an empty map
+		// until the phase is item-complete. The invariant must not fire there or
+		// it would break every mid-flight gate call.
+		expect(() =>
+			assertB1(
+				'reviewer',
+				{ requiredInventory: [...BASE_IDS], unclaimed: [BASE_IDS[5]] },
+				new Map(),
+				'unit(unsettled)',
+			),
+		).not.toThrow();
+	});
+
+	test('an empty required inventory legitimately yields an empty map', () => {
+		expect(() =>
+			assertB1(
+				'reviewer',
+				{ requiredInventory: [], unclaimed: [] },
+				new Map(),
+				'unit(empty)',
+			),
+		).not.toThrow();
+		expect(() =>
+			assertB1(
+				'critic',
+				{ requiredInventory: [], unclaimed: [] },
+				new Map(),
+				'unit(empty)',
+			),
+		).not.toThrow();
+	});
+
+	test('the violation message is bounded and degrades to a count', () => {
+		const many = Array.from({ length: 64 }, (_value, index) => `I-${index}`);
+		const error = (() => {
+			try {
+				assertB1(
+					'reviewer',
+					{ requiredInventory: many, unclaimed: [] },
+					new Map(),
+					'unit(bounded)',
+				);
+				return null;
+			} catch (reason) {
+				return reason as Error;
+			}
+		})();
+		// MAX_UNCLAIMED_ITEMS_IN_MESSAGE names 50; the rest collapse to a count.
+		expect(error?.message).toContain('I-49');
+		expect(error?.message).not.toContain('I-50');
+		expect(error?.message).toContain('(+14 more)');
+	});
+});
+
+describe('pr-workflow-gate B1 invariant: no false positives on the settled path', () => {
+	test('a normally settled reviewer phase yields a map covering the full inventory', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewerPhase('rv-1', reviewed(BASE_IDS));
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		// Production entry point that reads the authoritative reviewer map for
+		// every item. It resolves only if the map covers all six ids, so this is
+		// the positive statement of the B1 property through real code.
+		await expect(
+			assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+				tempDir,
+				SESSION_ID,
+				'post_reviewer',
+				BASE_IDS.map((findingId) => ({
+					finding_id: findingId,
+					status: 'CONFIRMED',
+					next_action: 'route_to_critic',
+					severity: 'HIGH',
+				})),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('a normally settled critic phase does not trigger the invariant', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewerPhase('rv-1', reviewed(BASE_IDS));
+		await settleCriticPhase('critic-all', BASE_IDS);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		await expect(
+			assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+				tempDir,
+				SESSION_ID,
+				'post_critic',
+				BASE_IDS.map((findingId) => ({
+					finding_id: findingId,
+					status: 'CONFIRMED',
+					next_action: 'report',
+					severity: 'HIGH',
+				})),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('an unsettled reviewer phase still reports settlement, not the invariant', async () => {
+		await establishReviewPrerequisites();
+		// One item never gets a verdict: the phase is not settled, so the
+		// antecedent is false and the pre-existing diagnostics must survive.
+		await settleReviewerPhase('rv-short', reviewed(BASE_IDS.slice(0, -1)));
+		const settlement = await errorFrom(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		);
+		expect(settlement?.message).toContain(
+			`reviewer items lack an authenticated verdict from any successful lane: ${BASE_IDS.at(-1)}`,
+		);
+		expect(settlement?.message).not.toContain('internal invariant violated');
+		// The critic-coverage gate is never reached silently: completion blocks on
+		// reviewer settlement first, so critic coverage cannot be skipped.
+		const completion = await errorFrom(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		);
+		expect(completion?.message).toContain(
+			'reviewer items lack an authenticated verdict',
+		);
+		// The artifact-record gate does not settle first, so its per-record
+		// message is still the correct diagnostic for an unsettled phase.
+		const projection = await errorFrom(
+			assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+				tempDir,
+				SESSION_ID,
+				'post_reviewer',
+				[
+					{
+						finding_id: BASE_IDS[0],
+						status: 'CONFIRMED',
+						next_action: 'route_to_critic',
+					},
+				],
+			),
+		);
+		// Third case, distinct from both empty-inventory outcomes: if a future
+		// refactor stops settling reviewer before the critic-coverage decision,
+		// the resulting empty critic inventory BLOCKS naming reviewer
+		// unsettledness rather than silently skipping critic coverage.
+		const coverage = await errorFrom(
+			gateInternals.derivePrReviewCriticInventoryForCoverageGate(
+				tempDir,
+				SESSION_ID,
+				'unit(coverage-gate)',
+			),
+		);
+		expect(coverage?.message).toContain(
+			'BLOCKED: PR_REVIEW internal invariant violated at unit(coverage-gate)',
+		);
+		expect(coverage?.message).toContain(
+			'the critic-coverage decision requires a settled reviewer phase',
+		);
+		expect(coverage?.message).toContain(
+			`unsettled reviewer items: ${BASE_IDS.at(-1)}`,
+		);
+		// Not confusable with the B1 empty-map message.
+		expect(coverage?.message).not.toContain('after successful settlement');
+		expect(projection?.message).toContain(
+			`record ${BASE_IDS[0]} has no authoritative reviewer verdict`,
+		);
+		expect(projection?.message).not.toContain('internal invariant violated');
+	});
+});
+
+describe('pr-workflow-gate B1 invariant: a legitimately empty critic inventory', () => {
+	test('no CONFIRMED CRITICAL/HIGH/MEDIUM verdict means critic coverage is genuinely not required', async () => {
+		await establishReviewPrerequisites();
+		// Every item is DISPROVED/LOW: the reviewer map is fully populated, and
+		// the critic inventory is empty because the *filter* excluded everything.
+		await settleReviewerPhase(
+			'rv-clean',
+			reviewed(BASE_IDS, 'DISPROVED', 'LOW'),
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const error = await errorFrom(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		);
+		// It passed the critic-coverage gate (no critic-related block, no
+		// invariant violation) and stopped at the next unrelated obligation.
+		expect(error?.message).toContain('requires durable findings checkpoints');
+		expect(error?.message).not.toContain('internal invariant violated');
+		expect(error?.message).not.toContain('require critic coverage');
+		// Distinguishable from the pathological case: the reviewer map that
+		// produced the empty inventory covers every required item, which this
+		// gate resolving proves.
+		await expect(
+			assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+				tempDir,
+				SESSION_ID,
+				'post_reviewer',
+				BASE_IDS.map((findingId) => ({
+					finding_id: findingId,
+					status: 'DISPROVED',
+					next_action: 'suppress_with_reason',
+					severity: 'LOW',
+				})),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('a mixed inventory keeps only the qualifying items in critic coverage', async () => {
+		await establishReviewPrerequisites();
+		const challenged = BASE_IDS.slice(0, 2);
+		const suppressed = BASE_IDS.slice(2);
+		await settleReviewerPhase(
+			'rv-mixed',
+			`${reviewed(challenged)}\n${reviewed(suppressed, 'DISPROVED', 'LOW')}`,
+		);
+		const error = await errorFrom(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		);
+		// Non-empty critic inventory: coverage is demanded for exactly the two
+		// CONFIRMED/HIGH items and nothing else.
+		expect(error?.message).toBe(
+			`BLOCKED: PR_REVIEW reviewer verdicts require critic coverage for: ${challenged.join(', ')}`,
+		);
+		await settleCriticPhase('critic-two', challenged);
+		const next = await errorFrom(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		);
+		expect(next?.message).toContain('requires durable findings checkpoints');
+		expect(next?.message).not.toContain('internal invariant violated');
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-base-coverage.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-base-coverage.test.ts
@@ -184,6 +184,40 @@ describe('pr-workflow-gate base coverage', () => {
 		).rejects.toThrow('depth tier L requires one dedicated lane per dimension');
 	});
 
+	test('a retry base batch MAY consolidate dimensions whose lanes ran and failed at tier L', async () => {
+		// The mirror of the rejection above (issue #1968 P3.1): the ban is lifted
+		// only once every consolidated dimension has a recorded lane that reached a
+		// terminal non-successful state, none of them has a successful source, and
+		// the batch keeps the tier-L lane floor.
+		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
+		const singletonLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+			laneId: workflowLane,
+			workflowLane,
+		}));
+		await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, singletonLanes, {
+			batchId: 'base-initial',
+			prHeadSha: HEAD_SHA,
+		});
+		const failedLanes = singletonLanes.slice(0, 2);
+		await persistBatch('base-initial', 'swarm-pr-review:base', failedLanes, {
+			status: 'error',
+		});
+
+		const state = await enforcePrReviewBaseDimensions(
+			tempDir,
+			SESSION_ID,
+			[
+				{
+					laneId: 'retry-consolidated',
+					workflowLane: failedLanes[0].workflowLane,
+					ownedWorkflowLanes: failedLanes.map((lane) => lane.workflowLane),
+				},
+			],
+			{ batchId: 'base-retry-consolidated', prHeadSha: HEAD_SHA },
+		);
+		expect(state.prReviewBaseDispatch?.batchId).toBe('base-retry-consolidated');
+	});
+
 	test('at depth tier S/M, a later base batch may consolidate ownership and settles all-or-none', async () => {
 		const originalResolveDiffStats = _test_exports.resolvePrReviewDiffStats;
 		_test_exports.resolvePrReviewDiffStats = () => ({

--- a/tests/unit/hooks/pr-workflow-gate-batch-gc.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-batch-gc.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+import {
+	activatePrWorkflow,
+	assertPrReviewValidationSettled,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	prWorkflowSessionFileStem,
+	readPrWorkflowGateState,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+/**
+ * Issue #1968 P4: `MAX_WORKFLOW_BATCHES` used to be a permanent dead end — once
+ * a session accumulated 128 batches of a kind, every further dispatch was
+ * blocked with no recovery path. The GC reclaims capacity by dropping provably
+ * inert batches inside the same read-prune-append transaction, and fails closed
+ * (keeping every batch) whenever it cannot prove the derived inventory is
+ * unchanged.
+ */
+
+/**
+ * Every test here builds a full cap's worth of batches, which is inherently
+ * slow: ~4s against bun's 5000ms default, i.e. flaky by construction, and a
+ * timeout mid-transaction poisons the *next* test (its continuation writes into
+ * a temp directory teardown already replaced, surfacing as "PR workflow state
+ * mutation lock changed or escaped .swarm"). A generous explicit budget is the
+ * fix; the work itself cannot be shrunk without making the cap injectable.
+ */
+const CAP_TEST_TIMEOUT_MS = 60_000;
+const { MAX_WORKFLOW_BATCHES } = gateInternals;
+const [DIM_A] = PR_REVIEW_BASE_DIMENSION_IDS;
+const REVIEW_ITEM_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+const REVIEWED_ROWS = REVIEW_ITEM_IDS.map(
+	(id) =>
+		`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
+).join('\n');
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+/** Declare one reviewer batch owning the whole candidate inventory. */
+async function recordReviewerBatch(batchId: string): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+		[
+			{
+				laneId: `${batchId}-lane`,
+				workflowLane: `${batchId}-lane`,
+				reviewItemIds: REVIEW_ITEM_IDS,
+			},
+		],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+}
+
+/** Land a full, successful reviewer artifact for an already-declared batch. */
+async function landReviewerArtifact(batchId: string): Promise<void> {
+	await persistBatch(
+		batchId,
+		'swarm-pr-review:reviewer',
+		[{ laneId: `${batchId}-lane`, workflowLane: `${batchId}-lane` }],
+		{ textOverride: REVIEWED_ROWS, subagentSessionId: `${batchId}-session` },
+	);
+}
+
+async function validationBatchIds(): Promise<string[]> {
+	gateInternals.resetTrackedStateCache();
+	const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+	return (state?.prReviewValidationBatches ?? []).map((batch) => batch.batchId);
+}
+
+/** Declare `count` base batches that never produce a delegation record. */
+async function recordInertBaseBatches(
+	count: number,
+	prefix = 'inert',
+): Promise<string[]> {
+	const batchIds: string[] = [];
+	for (let index = 0; index < count; index += 1) {
+		const batchId = `${prefix}-${index}`;
+		await enforcePrReviewBaseDimensions(
+			tempDir,
+			SESSION_ID,
+			[{ laneId: `${batchId}-lane`, workflowLane: DIM_A }],
+			{ batchId, prHeadSha: HEAD_SHA },
+		);
+		batchIds.push(batchId);
+	}
+	return batchIds;
+}
+
+async function baseBatchIds(): Promise<string[]> {
+	gateInternals.resetTrackedStateCache();
+	const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+	return (state?.prReviewBaseDispatches ?? []).map((batch) => batch.batchId);
+}
+
+describe('pr-workflow-gate workflow batch GC', () => {
+	test(
+		'the base batch cap is no longer a dead end',
+		async () => {
+			await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
+			const sourceLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+				laneId: workflowLane,
+				workflowLane,
+			}));
+			await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, sourceLanes, {
+				batchId: 'base-source',
+				prHeadSha: HEAD_SHA,
+			});
+			await persistBatch('base-source', 'swarm-pr-review:base', sourceLanes);
+			await recordInertBaseBatches(MAX_WORKFLOW_BATCHES - 1);
+			expect(await baseBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+
+			// Pre-fix this threw `PR_REVIEW base batch limit reached` forever.
+			await enforcePrReviewBaseDimensions(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'after-gc-lane', workflowLane: DIM_A }],
+				{ batchId: 'after-gc', prHeadSha: HEAD_SHA },
+			);
+
+			// Survivors, in their original relative order: the one batch carrying a
+			// fully-successful lane, the newest pre-existing batch, and the append.
+			expect(await baseBatchIds()).toEqual([
+				'base-source',
+				`inert-${MAX_WORKFLOW_BATCHES - 2}`,
+				'after-gc',
+			]);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'the singular latest-dispatch pointer survives the prune',
+		async () => {
+			await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
+			await recordInertBaseBatches(MAX_WORKFLOW_BATCHES);
+			const state = await enforcePrReviewBaseDimensions(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'pointer-lane', workflowLane: DIM_A }],
+				{ batchId: 'pointer-batch', prHeadSha: HEAD_SHA },
+			);
+			expect(state.prReviewBaseDispatch?.batchId).toBe('pointer-batch');
+			expect(
+				state.prReviewBaseDispatches?.some(
+					(batch) => batch.batchId === state.prReviewBaseDispatch?.batchId,
+				),
+			).toBe(true);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'pruning never changes the derived candidate inventory',
+		async () => {
+			await establishReviewPrerequisites();
+			const before = await gateInternals.derivePrReviewCandidateInventory(
+				tempDir,
+				SESSION_ID,
+			);
+			expect(before.length).toBeGreaterThan(0);
+			await recordInertBaseBatches(MAX_WORKFLOW_BATCHES - 1);
+			await enforcePrReviewBaseDimensions(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'post-gc-lane', workflowLane: DIM_A }],
+				{ batchId: 'post-gc', prHeadSha: HEAD_SHA },
+			);
+			const surviving = await baseBatchIds();
+			expect(surviving).toContain('base-all');
+			expect(surviving.length).toBeLessThan(MAX_WORKFLOW_BATCHES);
+			expect(
+				await gateInternals.derivePrReviewCandidateInventory(
+					tempDir,
+					SESSION_ID,
+				),
+			).toEqual(before);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'the GC aborts and keeps every batch when the inventory cannot be derived',
+		async () => {
+			await establishReviewPrerequisites();
+			await recordInertBaseBatches(MAX_WORKFLOW_BATCHES - 1);
+			// The trigger receipt is an input to derivePrReviewCandidateInventory; with
+			// it gone the equality proof cannot be computed at all, so the GC must keep
+			// every batch and let the pre-existing cap error stand.
+			await fs.rm(
+				path.join(
+					tempDir,
+					'.swarm',
+					'pr-review',
+					'test-run',
+					'trigger-eval.json',
+				),
+			);
+			await expect(
+				enforcePrReviewBaseDimensions(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: 'blocked-lane', workflowLane: DIM_A }],
+					{ batchId: 'blocked', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow('PR_REVIEW base batch limit reached');
+			expect(await baseBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'council batches are never pruned, so the validation cap stays closed',
+		async () => {
+			await establishReviewPrerequisites();
+			for (let index = 0; index < MAX_WORKFLOW_BATCHES; index += 1) {
+				await recordPrReviewValidationBatch(
+					tempDir,
+					SESSION_ID,
+					'council',
+					[{ laneId: `council-lane-${index}`, workflowLane: 'council-sweep' }],
+					{ batchId: `council-${index}`, prHeadSha: HEAD_SHA },
+				);
+			}
+			await expect(
+				recordPrReviewValidationBatch(
+					tempDir,
+					SESSION_ID,
+					'council',
+					[{ laneId: 'council-lane-extra', workflowLane: 'council-sweep' }],
+					{ batchId: 'council-extra', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow('PR_REVIEW validation batch limit reached');
+			gateInternals.resetTrackedStateCache();
+			const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+			expect(state?.prReviewValidationBatches).toHaveLength(
+				MAX_WORKFLOW_BATCHES,
+			);
+			expect(
+				state?.prReviewValidationBatches?.every(
+					(batch) => batch.phase === 'council',
+				),
+			).toBe(true);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'the validation batch cap is reclaimed in a reviewer retry loop',
+		async () => {
+			await establishReviewPrerequisites();
+			// The issue's own scenario: one session, a FIXED candidate inventory, and
+			// reviewer retries piling up. Pre-fix the validation GC kept every batch
+			// with `index > latestCouncilIndex` — and with no council batch at all
+			// `latestCouncilIndex` is -1, so it kept everything and the cap was a
+			// permanent dead end no matter how many batches were provably inert.
+			await recordReviewerBatch('rv-first');
+			await landReviewerArtifact('rv-first');
+			await expect(
+				assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+			).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+
+			for (let index = 1; index < MAX_WORKFLOW_BATCHES - 1; index += 1) {
+				await recordReviewerBatch(`rv-${index}`);
+			}
+			// A later batch lands the same rows, so it — not `rv-first` — is the
+			// first-write-wins source for every item, and `rv-first` becomes inert
+			// while still holding a delegation record.
+			await recordReviewerBatch('rv-winner');
+			await landReviewerArtifact('rv-winner');
+			expect(await validationBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+			const before = await gateInternals.derivePrReviewCandidateInventory(
+				tempDir,
+				SESSION_ID,
+			);
+
+			// Pre-fix this threw `PR_REVIEW validation batch limit reached`.
+			await recordReviewerBatch('rv-after-gc');
+
+			const surviving = await validationBatchIds();
+			expect(surviving).toEqual(['rv-winner', 'rv-after-gc']);
+			expect(
+				await gateInternals.derivePrReviewCandidateInventory(
+					tempDir,
+					SESSION_ID,
+				),
+			).toEqual(before);
+			// The verdicts the surviving batch carries still settle the phase.
+			await expect(
+				assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+			).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+
+			// Pruning a reviewer batch must not un-forbid its child session for the
+			// critic reuse ban: the ids move to the retired ledger instead.
+			gateInternals.resetTrackedStateCache();
+			const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+			expect(state?.prReviewRetiredReviewerSessionIds).toContain(
+				'rv-first-session',
+			);
+
+			// Rollback: the ledger is a second optional TOP-LEVEL key, and only a GC
+			// ever writes it, so this is the one place the rolled-back-plugin claim
+			// can be asserted against a file a v2 plugin actually produced.
+			const persisted = JSON.parse(
+				await fs.readFile(
+					path.join(
+						tempDir,
+						'.swarm',
+						'pr-workflow-gates',
+						`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+					),
+					'utf-8',
+				),
+			);
+			expect(persisted.prReviewRetiredReviewerSessionIds).toBeDefined();
+			const v1Schema = z
+				.object({
+					schemaVersion: z.literal(1),
+					sessionID: z.string().min(1),
+					mode: z.enum(['PR_REVIEW', 'PR_FEEDBACK']),
+				})
+				.passthrough();
+			expect(v1Schema.safeParse(persisted).success).toBe(true);
+
+			// The ledger is only worth writing if it is still ENFORCED, so drive the
+			// ban through settlement rather than through the state field: a critic
+			// lane run from the RETIRED reviewer's child session may not claim any
+			// item, exactly as if its reviewer batch had never been pruned. Asserting
+			// the field alone leaves `reviewerSubagentSessionIds`' seed free to be
+			// deleted with every suite still green — a fail-OPEN the new GC would
+			// introduce (issue #1968 review round 2, MUST-FIX B).
+			await recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'critic',
+				[
+					{
+						laneId: 'critic-retired',
+						workflowLane: 'critic-retired',
+						reviewItemIds: REVIEW_ITEM_IDS,
+					},
+				],
+				{ batchId: 'critic-retired', prHeadSha: HEAD_SHA },
+			);
+			const criticRows = REVIEW_ITEM_IDS.map(
+				(id) => `[CRITIC] | ${id} | UPHELD | HIGH | reason | no change`,
+			).join('\n');
+			await persistBatch(
+				'critic-retired',
+				'swarm-pr-review:critic',
+				[{ laneId: 'critic-retired', workflowLane: 'critic-retired' }],
+				{ subagentSessionId: 'rv-first-session', textOverride: criticRows },
+			);
+			await expect(
+				assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+			).rejects.toThrow(
+				`critic items lack an authenticated verdict from any successful lane: ${REVIEW_ITEM_IDS.join(', ')}`,
+			);
+
+			// Positive control: the identical critic batch from a child session that
+			// never produced a reviewer artifact settles, so the rejection above
+			// isolates the retired-session ban and nothing else about this state.
+			await recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'critic',
+				[
+					{
+						laneId: 'critic-independent',
+						workflowLane: 'critic-independent',
+						reviewItemIds: REVIEW_ITEM_IDS,
+					},
+				],
+				{ batchId: 'critic-independent', prHeadSha: HEAD_SHA },
+			);
+			await persistBatch(
+				'critic-independent',
+				'swarm-pr-review:critic',
+				[{ laneId: 'critic-independent', workflowLane: 'critic-independent' }],
+				{ subagentSessionId: 'independent-critic', textOverride: criticRows },
+			);
+			await expect(
+				assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+			).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+});

--- a/tests/unit/hooks/pr-workflow-gate-critic-batch-eligibility.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-critic-batch-eligibility.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	assertPrReviewValidationSettled,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	prWorkflowSessionFileStem,
+	readPrWorkflowGateState,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+/**
+ * Issue #1968 MUST-FIX 2 — `batchMayContributeClaims` exempts critic batches
+ * from batch-level `validatedInventory` set-equality on purpose, because a
+ * critic batch is filtered per item by `reviewerItemBindings` instead.
+ *
+ * That exemption had zero discriminating coverage: deleting `phase === 'critic'
+ * ||` left every PR-workflow test green. The discriminating state is a critic
+ * batch whose `validatedInventory` is a strict SUPERSET of the live critic
+ * inventory — one item left the inventory while its siblings' reviewer rows
+ * stayed byte-identical. Batch-level equality discards the whole batch there,
+ * which is precisely the batch-granularity failure the item-keyed composition
+ * exists to remove.
+ */
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const BASE_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+
+const reviewed = (
+	ids: readonly string[],
+	classification = 'CONFIRMED',
+	severity = 'HIGH',
+	rationale = 'rationale',
+): string =>
+	ids
+		.map(
+			(id) =>
+				`[REVIEWED] | ${id} | ${classification} | STRUCTURALLY_PROVEN | ${severity} | YES | file.ts:1 | ${rationale} | probe | reviewer`,
+		)
+		.join('\n');
+
+const criticised = (ids: readonly string[]): string =>
+	ids
+		.map((id) => `[CRITIC] | ${id} | UPHELD | HIGH | reason | required change`)
+		.join('\n');
+
+/** Declare a single-lane reviewer batch owning every item and land its rows. */
+async function reviewerBatch(batchId: string, rows: string): Promise<void> {
+	const laneId = `${batchId}-a`;
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+		[{ laneId, workflowLane: laneId, reviewItemIds: BASE_IDS }],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		batchId,
+		'swarm-pr-review:reviewer',
+		[{ laneId, workflowLane: laneId }],
+		{ textOverride: rows, subagentSessionId: `${batchId}-${laneId}` },
+	);
+}
+
+/**
+ * Reviewer settles all six CONFIRMED/HIGH, a critic batch covers all six and
+ * settles. Leaves the critic batch's `validatedInventory` equal to all six.
+ */
+async function settleSixThenCritic(): Promise<void> {
+	await establishReviewPrerequisites();
+	await reviewerBatch('rv-1', reviewed(BASE_IDS));
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'critic',
+		[
+			{
+				laneId: 'critic-all',
+				workflowLane: 'critic-all',
+				reviewItemIds: BASE_IDS,
+			},
+		],
+		{ batchId: 'critic-all', prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		'critic-all',
+		'swarm-pr-review:critic',
+		[{ laneId: 'critic-all', workflowLane: 'critic-all' }],
+		{ textOverride: criticised(BASE_IDS) },
+	);
+	await expect(
+		assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+	).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+}
+
+function gateStatePath(): string {
+	return path.join(
+		tempDir,
+		'.swarm',
+		'pr-workflow-gates',
+		`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+	);
+}
+
+/**
+ * Strip a batch's coherence entry so it is indistinguishable from state an
+ * older plugin wrote: no `validatedInventory`, and — the part that matters
+ * here — no `reviewerItemBindings`, so nothing can decide per item whether its
+ * critic claims went stale.
+ */
+async function makeBatchLegacy(batchId: string): Promise<void> {
+	const persisted = JSON.parse(await fs.readFile(gateStatePath(), 'utf-8'));
+	delete (persisted.prReviewBatchCoherence as Record<string, unknown>)[batchId];
+	await fs.writeFile(gateStatePath(), JSON.stringify(persisted), 'utf-8');
+	gateInternals.resetTrackedStateCache();
+}
+
+/** Declare a single-lane critic batch owning every item and land its rows. */
+async function criticBatch(batchId: string): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'critic',
+		[{ laneId: batchId, workflowLane: batchId, reviewItemIds: BASE_IDS }],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		batchId,
+		'swarm-pr-review:critic',
+		[{ laneId: batchId, workflowLane: batchId }],
+		{ textOverride: criticised(BASE_IDS), subagentSessionId: batchId },
+	);
+}
+
+async function validationBatchIds(): Promise<string[]> {
+	gateInternals.resetTrackedStateCache();
+	const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+	return (state?.prReviewValidationBatches ?? []).map((batch) => batch.batchId);
+}
+
+describe('pr-workflow-gate critic batch eligibility', () => {
+	test('a critic batch survives an item leaving the critic inventory', async () => {
+		await settleSixThenCritic();
+
+		// Re-review: C-0 drops to DISPROVED/LOW and therefore leaves the critic
+		// inventory; C-1..C-5 rows are re-emitted BYTE-IDENTICALLY, so their row
+		// digests still match the critic batch's bindings.
+		await reviewerBatch(
+			'rv-2',
+			`${reviewed([BASE_IDS[0]], 'DISPROVED', 'LOW')}\n${reviewed(BASE_IDS.slice(1))}`,
+		);
+		// The critic batch was validated against all six, so its recorded
+		// `validatedInventory` is now a strict superset of the live inventory.
+		// Batch-level set-equality would discard the whole batch and block the
+		// critic phase; the per-item bindings admit the five survivors.
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'critic',
+		);
+		expect(composed.requiredInventory).toEqual(BASE_IDS.slice(1));
+		expect([...composed.claims.keys()].sort()).toEqual(BASE_IDS.slice(1));
+		expect(composed.contributingBatchIds).toEqual(['critic-all']);
+	});
+
+	test('a sibling whose reviewer row changed is still rejected', async () => {
+		await settleSixThenCritic();
+
+		// The negative twin of the case above, in the same superset-inventory
+		// state: C-0 leaves the inventory AND C-1's reviewer row changes (same
+		// classification and severity, revised rationale — so `parseCriticVerdict`
+		// alone would still accept the stale critic row). Only the full-row digest
+		// distinguishes it.
+		await reviewerBatch(
+			'rv-2',
+			[
+				reviewed([BASE_IDS[0]], 'DISPROVED', 'LOW'),
+				reviewed([BASE_IDS[1]], 'CONFIRMED', 'HIGH', 'revised root cause'),
+				reviewed(BASE_IDS.slice(2)),
+			].join('\n'),
+		);
+		const error = await assertPrReviewValidationSettled(
+			tempDir,
+			SESSION_ID,
+			'critic',
+		).then(
+			() => null,
+			(reason: unknown) => reason as Error,
+		);
+		expect(error?.message).toContain(
+			`critic items lack an authenticated verdict from any successful lane: ${BASE_IDS[1]}`,
+		);
+		for (const survivor of BASE_IDS.slice(2)) {
+			expect(error?.message).not.toContain(survivor);
+		}
+	});
+
+	test('a newer reviewer batch invalidates legacy critic batches and keeps bound ones', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch('rv-1', reviewed(BASE_IDS));
+		await criticBatch('critic-bound');
+		await criticBatch('critic-legacy');
+		await makeBatchLegacy('critic-legacy');
+		expect(await validationBatchIds()).toEqual([
+			'rv-1',
+			'critic-bound',
+			'critic-legacy',
+		]);
+
+		// Byte-identical re-review, so the BOUND batch's per-item row digests all
+		// still match and it stays authoritative. The LEGACY batch carries no
+		// bindings, so nothing could decide that per item — the pre-existing
+		// blanket rule (any new reviewer batch invalidates it) is the only thing
+		// standing between it and the binding-free legacy admission path.
+		await reviewerBatch('rv-2', reviewed(BASE_IDS));
+		expect(await validationBatchIds()).toEqual([
+			'rv-1',
+			'critic-bound',
+			'rv-2',
+		]);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'critic',
+		);
+		expect(composed.contributingBatchIds).toEqual(['critic-bound']);
+	});
+
+	test('a retained legacy critic batch would survive reviewer rows it never challenged', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch('rv-1', reviewed(BASE_IDS));
+		await criticBatch('critic-legacy');
+		await makeBatchLegacy('critic-legacy');
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+
+		// Every reviewer row is re-emitted with a revised rationale — same
+		// classification and severity, so `parseCriticVerdict` alone still accepts
+		// the stale critic rows, and the legacy admission path has no row digest to
+		// notice with. Only dropping the batch outright keeps this fail-closed.
+		await reviewerBatch(
+			'rv-2',
+			reviewed(BASE_IDS, 'CONFIRMED', 'HIGH', 'revised root cause'),
+		);
+		const error = await assertPrReviewValidationSettled(
+			tempDir,
+			SESSION_ID,
+			'critic',
+		).then(
+			() => null,
+			(reason: unknown) => reason as Error,
+		);
+		expect(error?.message ?? 'settled on unchallenged reviewer rows').toContain(
+			'BLOCKED: PR_REVIEW requires at least one critic batch',
+		);
+		expect(await validationBatchIds()).not.toContain('critic-legacy');
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-digest-diagnostics.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-digest-diagnostics.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import type { RevisionDigestFailureReason } from '../../../src/background/workspace-snapshot.js';
+import { describePrWorkflowRevisionDigestFailure } from '../../../src/hooks/pr-workflow-gate.js';
+
+/**
+ * Issue #1968 acceptance criterion 6: when a bounded revision digest fails, the
+ * BLOCKED message must name the ONE bound that actually fired instead of
+ * listing every bound that might have. That makes each arm of
+ * `describePrWorkflowRevisionDigestFailure` a user-facing contract in its own
+ * right — three of the eight were previously asserted only for their `reason`,
+ * never for the text a maintainer actually reads, so five message bodies could
+ * be replaced with any string at all and the suite stayed green.
+ *
+ * Every arm is pinned here on three axes: the exact bound or cause it names,
+ * the remediation it offers, and mutual distinctness — a diagnostic that names
+ * a bound is worthless if two bounds produce the same sentence.
+ */
+
+/** `seam-unavailable` is gate-local (an injected test seam returned null). */
+type DescribedReason = RevisionDigestFailureReason | 'seam-unavailable';
+
+const ARMS: ReadonlyArray<{
+	reason: DescribedReason;
+	/** The bound or cause the message must name. */
+	names: string;
+	/** The remediation clause the message must carry. */
+	remediation: string;
+}> = [
+	{
+		reason: 'file-cap',
+		names: 'the changed-file snapshot exceeded REVISION_MAX_FILES',
+		remediation:
+			'Reduce the changed-path count (commit or stash generated/vendored output) before retrying',
+	},
+	{
+		reason: 'byte-cap',
+		names: 'the changed-file snapshot exceeded REVISION_MAX_TOTAL_BYTES',
+		remediation: 'Reduce the changed content size before retrying',
+	},
+	{
+		reason: 'buffer-truncated',
+		names: 'a bounded git enumeration exceeded GIT_SNAPSHOT_MAX_BUFFER',
+		remediation: 'The changed-path list is too large to enumerate',
+	},
+	{
+		reason: 'timeout',
+		names: 'a bounded git enumeration timed out',
+		remediation: 'Retry once the working tree is quiescent',
+	},
+	{
+		reason: 'git-failed',
+		names: 'a bounded git enumeration failed',
+		remediation:
+			'Verify the checkout is a healthy Git worktree at the recorded head',
+	},
+	{
+		reason: 'containment',
+		names: 'git reported a changed path outside the project root',
+		remediation: 'Nothing outside the project root may be hashed',
+	},
+	{
+		reason: 'read-failed',
+		names: 'a changed path could not be read',
+		remediation: 'Resolve the filesystem error before retrying',
+	},
+	{
+		reason: 'seam-unavailable',
+		names: 'an injected revision-digest seam returned no digest',
+		remediation:
+			'production names one of REVISION_MAX_FILES / REVISION_MAX_TOTAL_BYTES / GIT_SNAPSHOT_MAX_BUFFER, a bounded git enumeration timeout, or a read failure',
+	},
+];
+
+const describe_ = (reason: DescribedReason, detail?: string): string =>
+	describePrWorkflowRevisionDigestFailure({
+		ok: false,
+		reason,
+		...(detail === undefined ? {} : { detail }),
+	} as Parameters<typeof describePrWorkflowRevisionDigestFailure>[0]);
+
+describe('describePrWorkflowRevisionDigestFailure', () => {
+	for (const { reason, names, remediation } of ARMS) {
+		test(`"${reason}" names its own bound and remediation`, () => {
+			const message = describe_(reason);
+			expect(message).toContain(names);
+			expect(message).toContain(remediation);
+		});
+
+		test(`"${reason}" interpolates the detail in parentheses`, () => {
+			// The detail carries the concrete numbers ("1234 changed paths exceed
+			// the cap of 512"), which is what turns "a bound fired" into an
+			// actionable message.
+			expect(describe_(reason, `detail for ${reason}`)).toContain(
+				`(detail for ${reason})`,
+			);
+			// ...and an absent detail must not leave an empty pair of parens.
+			expect(describe_(reason)).not.toContain('()');
+		});
+	}
+
+	test('no two arms produce the same message', () => {
+		const messages = ARMS.map(({ reason }) => describe_(reason));
+		expect(new Set(messages).size).toBe(ARMS.length);
+	});
+
+	test('every RevisionDigestFailureReason the resolver can emit is covered', () => {
+		// This list IS hand-copied; the `RevisionDigestFailureReason[]`
+		// annotation is what gives it teeth. Removing or renaming a member of
+		// the union breaks the build here, so this cannot silently rot in that
+		// direction. It does NOT catch a newly *added* reason — that would
+		// fall through to the `seam-unavailable` default, claiming a test seam
+		// misbehaved when a real bound actually fired. Add the arm and the row
+		// together when introducing a reason.
+		const producedReasons: RevisionDigestFailureReason[] = [
+			'file-cap',
+			'byte-cap',
+			'buffer-truncated',
+			'timeout',
+			'git-failed',
+			'containment',
+			'read-failed',
+		];
+		const covered = new Set(ARMS.map(({ reason }) => reason));
+		for (const reason of producedReasons)
+			expect(covered.has(reason)).toBe(true);
+		expect(covered.has('seam-unavailable')).toBe(true);
+		expect(covered.size).toBe(producedReasons.length + 1);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-digest-threading.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-digest-threading.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	assertPrReviewBaseCoverageSettled,
+	assertPrReviewValidationSettled,
+	completePrWorkflow,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	REVISION_DIGEST,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const CANDIDATE_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+
+/**
+ * Replace the digest seam with a counting stub. `setupPrWorkflowGateFixtures`
+ * already routes the gate's async resolver through this synchronous member, so
+ * the counter observes exactly the resolutions production performs.
+ */
+function countDigestResolutions(result: string | null = REVISION_DIGEST): {
+	calls: () => number;
+	reset: () => void;
+} {
+	let calls = 0;
+	gateInternals.resolvePrWorkflowRevisionDigest = () => {
+		calls += 1;
+		return result;
+	};
+	return { calls: () => calls, reset: () => (calls = 0) };
+}
+
+async function settleReviewer(
+	classification = 'DISPROVED',
+	severity = 'LOW',
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+		[
+			{
+				laneId: 'review-all',
+				workflowLane: 'review-all',
+				reviewItemIds: CANDIDATE_IDS,
+			},
+		],
+		{ batchId: 'review-all', prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		'review-all',
+		'swarm-pr-review:reviewer',
+		[{ laneId: 'review-all', workflowLane: 'review-all' }],
+		{
+			textOverride: CANDIDATE_IDS.map(
+				(id) =>
+					`[REVIEWED] | ${id} | ${classification} | STRUCTURALLY_PROVEN | ${severity} | NO | file.ts:1 | rationale | probe | reviewer`,
+			).join('\n'),
+		},
+	);
+}
+
+describe('pr-workflow-gate revision digest threading', () => {
+	test('base coverage resolves the current revision digest exactly once', async () => {
+		await establishReviewPrerequisites();
+		const counter = countDigestResolutions();
+		await assertPrReviewBaseCoverageSettled(tempDir, SESSION_ID);
+		// Six base dimension records plus eleven micro records were checked; the
+		// pre-fix per-record fallback resolved once per record.
+		expect(counter.calls()).toBe(1);
+	});
+
+	test('reviewer settlement resolves the current revision digest exactly once', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewer();
+		const counter = countDigestResolutions();
+		await assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer');
+		expect(counter.calls()).toBe(1);
+	});
+
+	test('the terminal completion chain shares one digest across every pass', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewer();
+		const counter = countDigestResolutions();
+		// Base coverage, council/reviewer settlement, the critic-inventory
+		// derivation and the candidate-inventory scan all run under this call.
+		await expect(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		).rejects.toThrow('durable findings checkpoints');
+		expect(counter.calls()).toBe(1);
+	});
+
+	test('a batch record dispatch resolves one digest per gate entry point', async () => {
+		await establishReviewPrerequisites();
+		const counter = countDigestResolutions();
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[
+				{
+					laneId: 'review-all',
+					workflowLane: 'review-all',
+					reviewItemIds: CANDIDATE_IDS,
+				},
+			],
+			{ batchId: 'review-all', prHeadSha: HEAD_SHA },
+		);
+		expect(counter.calls()).toBe(1);
+	});
+
+	test('a critic dispatch resolves one digest across settle-then-recompose', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewer('CONFIRMED', 'HIGH');
+		const counter = countDigestResolutions();
+		// This entry point settles the reviewer phase with a threaded context,
+		// then re-derives the critic inventory and the per-item reviewer row
+		// bindings against the re-read state. All of it shares one digest.
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'critic',
+			[
+				{
+					laneId: 'critic-all',
+					workflowLane: 'critic-all',
+					reviewItemIds: CANDIDATE_IDS,
+				},
+			],
+			{ batchId: 'critic-all', prHeadSha: HEAD_SHA },
+		);
+		expect(counter.calls()).toBe(1);
+	});
+
+	test('a bounded-snapshot failure names the exact bound that fired', async () => {
+		await establishReviewPrerequisites();
+		const original = gateInternals.resolvePrWorkflowRevisionDigestDetailed;
+		try {
+			// P2.2: the detailed seam takes priority over the legacy `string | null`
+			// one, so a focused test can drive one specific reason.
+			gateInternals.resolvePrWorkflowRevisionDigestDetailed = () => ({
+				ok: false,
+				reason: 'file-cap',
+				detail: '61234 changed paths exceed the cap of 50000',
+			});
+			const capError = await assertPrReviewBaseCoverageSettled(
+				tempDir,
+				SESSION_ID,
+			).then(
+				() => null,
+				(reason: unknown) => reason as Error,
+			);
+			expect(capError?.message).toContain('REVISION_MAX_FILES');
+			expect(capError?.message).toContain(
+				'61234 changed paths exceed the cap of 50000',
+			);
+			// The old message listed every bound at once, so it could not have been
+			// distinguished from a truncated enumeration.
+			expect(capError?.message).not.toContain('GIT_SNAPSHOT_MAX_BUFFER');
+
+			gateInternals.resolvePrWorkflowRevisionDigestDetailed = () => ({
+				ok: false,
+				reason: 'buffer-truncated',
+				detail: 'git diff --name-only output exceeded the bounded buffer',
+			});
+			const truncationError = await assertPrReviewBaseCoverageSettled(
+				tempDir,
+				SESSION_ID,
+			).then(
+				() => null,
+				(reason: unknown) => reason as Error,
+			);
+			expect(truncationError?.message).toContain('GIT_SNAPSHOT_MAX_BUFFER');
+			expect(truncationError?.message).not.toContain('REVISION_MAX_FILES');
+		} finally {
+			gateInternals.resolvePrWorkflowRevisionDigestDetailed = original;
+		}
+	});
+
+	test('an unresolvable digest blocks with the bounds it could not satisfy', async () => {
+		await establishReviewPrerequisites();
+		await settleReviewer();
+		countDigestResolutions(null);
+		// Never threaded as `undefined`: that would silently restore the
+		// per-record synchronous fallback inside the marker check.
+		for (const entryPoint of [
+			() => assertPrReviewBaseCoverageSettled(tempDir, SESSION_ID),
+			() => assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+			() => completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		]) {
+			const error = await entryPoint().then(
+				() => null,
+				(reason: unknown) => reason as Error,
+			);
+			expect(error?.message).toContain(
+				'BLOCKED: PR_REVIEW could not compute a bounded current-revision digest',
+			);
+			expect(error?.message).toContain('REVISION_MAX_FILES');
+			expect(error?.message).toContain('REVISION_MAX_TOTAL_BYTES');
+			expect(error?.message).toContain('GIT_SNAPSHOT_MAX_BUFFER');
+		}
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-feedback-batch-gc.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-feedback-batch-gc.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+import {
+	activatePrWorkflow,
+	assertPrFeedbackVerificationSettled,
+	declarePrFeedbackInventory,
+	enforcePrFeedbackVerificationOwnership,
+	_test_exports as gateInternals,
+	prWorkflowSessionFileStem,
+	readPrWorkflowGateState,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+/**
+ * Issue #1968 review round 2, MUST-FIX C — `MAX_WORKFLOW_BATCHES` was a
+ * permanent dead end for `prFeedbackVerifications`.
+ *
+ * The shipped justification was that no verification batch is inert because
+ * every one claims an inventory item. That confused the two things a batch
+ * holds. Coverage comes only from lanes that passed batch integrity AND produced
+ * an artifact covering their items, so an all-failed verification batch
+ * contributes nothing to settlement; what it does hold is its item->lane
+ * ownership binding. Moving those bindings to `prFeedbackRetiredItemOwnership`
+ * makes the non-contributing batches genuinely inert, and
+ * `src/tools/dispatch-lanes.ts` appends one on every verification dispatch
+ * including retries, so this accumulation is retry-driven exactly like the
+ * PR_REVIEW arrays.
+ */
+
+const CAP_TEST_TIMEOUT_MS = 120_000;
+const { MAX_WORKFLOW_BATCHES } = gateInternals;
+const COVERED_ITEM = 'FB-001';
+const ORPHAN_ITEM = 'FB-002';
+/** What a rolled-back plugin's non-strict reader accepts. */
+const V1_PASSTHROUGH_SCHEMA = z
+	.object({
+		schemaVersion: z.literal(1),
+		sessionID: z.string().min(1),
+		mode: z.enum(['PR_REVIEW', 'PR_FEEDBACK']),
+	})
+	.passthrough();
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+async function verificationBatchIds(): Promise<string[]> {
+	gateInternals.resetTrackedStateCache();
+	const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+	return (state?.prFeedbackVerifications ?? []).map((batch) => batch.batchId);
+}
+
+/**
+ * A full cap of verification batches: one that settles `COVERED_ITEM`, one that
+ * is the sole owner of `ORPHAN_ITEM` and never produces an artifact, and filler
+ * retries of the covered lane. Only the first contributes coverage.
+ */
+async function fillVerificationCap(): Promise<void> {
+	await activatePrWorkflow(tempDir, SESSION_ID, 'PR_FEEDBACK');
+	await declarePrFeedbackInventory(
+		tempDir,
+		SESSION_ID,
+		[COVERED_ITEM, ORPHAN_ITEM],
+		{ prHeadSha: HEAD_SHA },
+	);
+	await enforcePrFeedbackVerificationOwnership(
+		tempDir,
+		SESSION_ID,
+		[{ laneId: 'verify-a', ownedItemIds: [COVERED_ITEM] }],
+		{ batchId: 'covering', prHeadSha: HEAD_SHA },
+	);
+	await persistBatch(
+		'covering',
+		'swarm-pr-feedback:verification',
+		[{ laneId: 'verify-a', workflowLane: 'verify-a' }],
+		{
+			textOverride: `[FEEDBACK-VERIFIED] | ${COVERED_ITEM} | CONFIRMED | evidence`,
+		},
+	);
+	// The only batch that ever binds ORPHAN_ITEM -> verify-b, and it dies without
+	// an artifact. Post-prune this binding exists nowhere but the retired ledger.
+	await enforcePrFeedbackVerificationOwnership(
+		tempDir,
+		SESSION_ID,
+		[{ laneId: 'verify-b', ownedItemIds: [ORPHAN_ITEM] }],
+		{ batchId: 'orphan-owner', prHeadSha: HEAD_SHA },
+	);
+	for (let index = 2; index < MAX_WORKFLOW_BATCHES; index += 1) {
+		await enforcePrFeedbackVerificationOwnership(
+			tempDir,
+			SESSION_ID,
+			[{ laneId: 'verify-a', ownedItemIds: [COVERED_ITEM] }],
+			{ batchId: `retry-${index}`, prHeadSha: HEAD_SHA },
+		);
+	}
+	expect(await verificationBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+}
+
+describe('pr-workflow-gate feedback verification batch GC', () => {
+	test(
+		'the feedback verification cap is no longer a dead end',
+		async () => {
+			await fillVerificationCap();
+			// Coverage that already settled must be untouched by the reclaim, so
+			// pin it on both sides of the prune rather than only after.
+			await expect(
+				assertPrFeedbackVerificationSettled(tempDir, SESSION_ID),
+			).rejects.toThrow(`missing inventory items: ${ORPHAN_ITEM}`);
+
+			// Pre-fix this threw `PR_FEEDBACK verification batch limit reached` with
+			// no recovery path for the rest of the session.
+			await enforcePrFeedbackVerificationOwnership(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'verify-b', ownedItemIds: [ORPHAN_ITEM] }],
+				{ batchId: 'after-gc', prHeadSha: HEAD_SHA },
+			);
+
+			// Survivors in original order: the one batch carrying settled coverage,
+			// the newest pre-existing batch, and the append.
+			expect(await verificationBatchIds()).toEqual([
+				'covering',
+				`retry-${MAX_WORKFLOW_BATCHES - 1}`,
+				'after-gc',
+			]);
+
+			// The reclaim is real progress, not just a shorter array: the dispatch
+			// that was previously impossible now lands an artifact and settles the
+			// whole inventory.
+			await persistBatch(
+				'after-gc',
+				'swarm-pr-feedback:verification',
+				[{ laneId: 'verify-b', workflowLane: 'verify-b' }],
+				{
+					textOverride: `[FEEDBACK-VERIFIED] | ${ORPHAN_ITEM} | CONFIRMED | evidence`,
+				},
+			);
+			await expect(
+				assertPrFeedbackVerificationSettled(tempDir, SESSION_ID),
+			).resolves.toMatchObject({ mode: 'PR_FEEDBACK' });
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'the cumulative ownership re-claim rejection survives the prune',
+		async () => {
+			await fillVerificationCap();
+			// This dispatch trips the cap, so the GC runs and drops `orphan-owner` —
+			// the only live batch binding ORPHAN_ITEM to `verify-b`. The re-claim by a
+			// different lane must still be rejected, from the retired ledger alone.
+			await expect(
+				enforcePrFeedbackVerificationOwnership(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: 'verify-c', ownedItemIds: [ORPHAN_ITEM] }],
+					{ batchId: 'reclaim-attempt', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow(
+				`PR_FEEDBACK verification item "${ORPHAN_ITEM}" is owned by both "verify-b" and "verify-c"`,
+			);
+			// A rejected dispatch persists nothing, cap included.
+			expect(await verificationBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+
+			// Positive control: the ledger rejects a DIFFERENT lane, not every lane.
+			// The original owner may still re-dispatch, which is the retry loop this
+			// reclaim exists to unblock.
+			await enforcePrFeedbackVerificationOwnership(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'verify-b', ownedItemIds: [ORPHAN_ITEM] }],
+				{ batchId: 'owner-retry', prHeadSha: HEAD_SHA },
+			);
+			gateInternals.resetTrackedStateCache();
+			const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+			expect(state?.prFeedbackRetiredItemOwnership).toMatchObject({
+				[ORPHAN_ITEM]: 'verify-b',
+			});
+
+			// Rollback: the ledger is an optional TOP-LEVEL key written only by this
+			// GC, so this is the one file a v2 plugin actually produced that can be
+			// parsed against the v1 passthrough schema the release note claims.
+			const persisted = JSON.parse(
+				await fs.readFile(
+					path.join(
+						tempDir,
+						'.swarm',
+						'pr-workflow-gates',
+						`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+					),
+					'utf-8',
+				),
+			);
+			expect(persisted.prFeedbackRetiredItemOwnership).toBeDefined();
+			expect(V1_PASSTHROUGH_SCHEMA.safeParse(persisted).success).toBe(true);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'the GC aborts and keeps every batch when the revision digest cannot be resolved',
+		async () => {
+			await fillVerificationCap();
+			const original = gateInternals.resolvePrWorkflowRevisionDigest;
+			try {
+				// An unresolvable digest makes `currentPrFeedbackRevisionDigest` throw,
+				// which the prune's outer catch must convert into "keep every batch" so
+				// the caller's pre-existing cap error stands. A partial prune landing
+				// here would drop ownership bindings on the strength of a coverage
+				// comparison that was never computed.
+				gateInternals.resolvePrWorkflowRevisionDigest = () => '';
+				await expect(
+					enforcePrFeedbackVerificationOwnership(
+						tempDir,
+						SESSION_ID,
+						[{ laneId: 'verify-a', ownedItemIds: [COVERED_ITEM] }],
+						{ batchId: 'blocked', prHeadSha: HEAD_SHA },
+					),
+				).rejects.toThrow('PR_FEEDBACK verification batch limit reached');
+			} finally {
+				gateInternals.resolvePrWorkflowRevisionDigest = original;
+			}
+			expect(await verificationBatchIds()).toHaveLength(MAX_WORKFLOW_BATCHES);
+			gateInternals.resetTrackedStateCache();
+			const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
+			expect(state?.prFeedbackRetiredItemOwnership).toBeUndefined();
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+});

--- a/tests/unit/hooks/pr-workflow-gate-gc-ledger-overflow.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-gc-ledger-overflow.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	activatePrWorkflow,
+	declarePrFeedbackInventory,
+	enforcePrFeedbackVerificationOwnership,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	prWorkflowSessionFileStem,
+	readPrWorkflowGateState,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+/**
+ * Issue #1968 — the three "abandon the prune" branches of the capacity GC.
+ *
+ * Each ledger carries a fail-closed control across a prune that would otherwise
+ * loosen it (the critic reuse ban, the tier-L cumulative consolidation floor,
+ * the feedback re-claim rejection). When retiring a batch would push a ledger
+ * past its schema bound, the GC must keep EVERY batch and let the pre-existing
+ * cap error stand: losing the control is a fail-open, losing the reclaim is
+ * only a dead end. Every one of the three branches was reachable but unproven —
+ * raising all three constants to `Number.MAX_SAFE_INTEGER` left the GC suite
+ * green.
+ *
+ * No production constant is injected. Each ledger is a top-level optional key
+ * whose own schema admits arbitrary strings up to its bound, so seeding a state
+ * file to exactly that bound and then triggering a prune that must add at least
+ * one entry reaches the branch through the real code path.
+ */
+
+const CAP_TEST_TIMEOUT_MS = 120_000;
+const {
+	MAX_WORKFLOW_BATCHES,
+	MAX_RETIRED_REVIEWER_SESSION_IDS,
+	MAX_RETIRED_CONSOLIDATED_LANES,
+	MAX_RETIRED_FEEDBACK_ITEM_OWNERS,
+} = gateInternals;
+const [DIM_A, DIM_B] = PR_REVIEW_BASE_DIMENSION_IDS;
+const REVIEW_ITEM_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+const REVIEWED_ROWS = REVIEW_ITEM_IDS.map(
+	(id) =>
+		`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
+).join('\n');
+const COVERED_ITEM = 'FB-001';
+const ORPHAN_ITEM = 'FB-002';
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+function gateStatePath(): string {
+	return path.join(
+		tempDir,
+		'.swarm',
+		'pr-workflow-gates',
+		`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+	);
+}
+
+/** Edit the persisted gate state in place and drop the in-memory cache. */
+async function patchPersistedState(
+	mutate: (state: Record<string, unknown>) => void,
+): Promise<void> {
+	const persisted = JSON.parse(await fs.readFile(gateStatePath(), 'utf-8'));
+	mutate(persisted);
+	await fs.writeFile(gateStatePath(), JSON.stringify(persisted), 'utf-8');
+	gateInternals.resetTrackedStateCache();
+}
+
+/** `count` filler entries that can never collide with a real ledger key. */
+function fillerEntries(count: number, prefix: string): string[] {
+	return Array.from({ length: count }, (_value, index) => `${prefix}-${index}`);
+}
+
+async function currentState() {
+	gateInternals.resetTrackedStateCache();
+	return readPrWorkflowGateState(tempDir, SESSION_ID);
+}
+
+describe('pr-workflow-gate capacity GC ledger overflow', () => {
+	test(
+		'a reviewer-session ledger overflow keeps every validation batch',
+		async () => {
+			await establishReviewPrerequisites();
+			// The exact scenario the reclaim test proves succeeds: `rv-first` becomes
+			// inert once `rv-winner` lands the same rows, so the GC wants to drop it —
+			// and dropping it means retiring its child session for the critic ban.
+			for (const batchId of ['rv-first', 'rv-winner']) {
+				await recordPrReviewValidationBatch(
+					tempDir,
+					SESSION_ID,
+					'reviewer',
+					[
+						{
+							laneId: `${batchId}-lane`,
+							workflowLane: `${batchId}-lane`,
+							reviewItemIds: REVIEW_ITEM_IDS,
+						},
+					],
+					{ batchId, prHeadSha: HEAD_SHA },
+				);
+			}
+			for (let index = 2; index < MAX_WORKFLOW_BATCHES; index += 1) {
+				await recordPrReviewValidationBatch(
+					tempDir,
+					SESSION_ID,
+					'reviewer',
+					[
+						{
+							laneId: `rv-${index}-lane`,
+							workflowLane: `rv-${index}-lane`,
+							reviewItemIds: REVIEW_ITEM_IDS,
+						},
+					],
+					{ batchId: `rv-${index}`, prHeadSha: HEAD_SHA },
+				);
+			}
+			for (const batchId of ['rv-first', 'rv-winner']) {
+				await persistBatch(
+					batchId,
+					'swarm-pr-review:reviewer',
+					[{ laneId: `${batchId}-lane`, workflowLane: `${batchId}-lane` }],
+					{
+						textOverride: REVIEWED_ROWS,
+						subagentSessionId: `${batchId}-session`,
+					},
+				);
+			}
+			await patchPersistedState((state) => {
+				state.prReviewRetiredReviewerSessionIds = fillerEntries(
+					MAX_RETIRED_REVIEWER_SESSION_IDS,
+					'retired-session',
+				);
+			});
+
+			// Retiring `rv-first` would add a 1025th forbidden session id.
+			await expect(
+				recordPrReviewValidationBatch(
+					tempDir,
+					SESSION_ID,
+					'reviewer',
+					[
+						{
+							laneId: 'blocked-lane',
+							workflowLane: 'blocked-lane',
+							reviewItemIds: REVIEW_ITEM_IDS,
+						},
+					],
+					{ batchId: 'blocked', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow('PR_REVIEW validation batch limit reached');
+			const state = await currentState();
+			expect(state?.prReviewValidationBatches).toHaveLength(
+				MAX_WORKFLOW_BATCHES,
+			);
+			// Kept whole: not one batch dropped, and the ledger untouched.
+			expect(state?.prReviewRetiredReviewerSessionIds).toHaveLength(
+				MAX_RETIRED_REVIEWER_SESSION_IDS,
+			);
+			expect(state?.prReviewRetiredReviewerSessionIds).not.toContain(
+				'rv-first-session',
+			);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'a consolidated-lane ledger overflow keeps every base batch',
+		async () => {
+			await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
+			const sourceLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+				laneId: workflowLane,
+				workflowLane,
+			}));
+			await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, sourceLanes, {
+				batchId: 'base-source',
+				prHeadSha: HEAD_SHA,
+			});
+			await persistBatch('base-source', 'swarm-pr-review:base', sourceLanes);
+			for (let index = 0; index < MAX_WORKFLOW_BATCHES - 1; index += 1) {
+				await enforcePrReviewBaseDimensions(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: `inert-${index}-lane`, workflowLane: DIM_A }],
+					{ batchId: `inert-${index}`, prHeadSha: HEAD_SHA },
+				);
+			}
+			await patchPersistedState((state) => {
+				// `inert-0` is prunable (no delegation record, not the newest), and now
+				// carries a consolidated lane, so retiring it must spend a ledger slot.
+				const batches = state.prReviewBaseDispatches as Array<{
+					batchId: string;
+					lanes: Array<Record<string, unknown>>;
+				}>;
+				const target = batches.find((batch) => batch.batchId === 'inert-0');
+				expect(target).toBeDefined();
+				(
+					target as { lanes: Array<Record<string, unknown>> }
+				).lanes[0].ownedWorkflowLanes = [DIM_A, DIM_B];
+				state.prReviewRetiredConsolidatedLanes = fillerEntries(
+					MAX_RETIRED_CONSOLIDATED_LANES,
+					'retired-lane',
+				);
+			});
+
+			await expect(
+				enforcePrReviewBaseDimensions(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: 'blocked-lane', workflowLane: DIM_A }],
+					{ batchId: 'blocked', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow('PR_REVIEW base batch limit reached');
+			const state = await currentState();
+			expect(state?.prReviewBaseDispatches).toHaveLength(MAX_WORKFLOW_BATCHES);
+			expect(state?.prReviewRetiredConsolidatedLanes).toHaveLength(
+				MAX_RETIRED_CONSOLIDATED_LANES,
+			);
+			expect(state?.prReviewRetiredConsolidatedLanes).not.toContain(
+				[DIM_A, DIM_B].sort().join('|'),
+			);
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+
+	test(
+		'a feedback item-ownership ledger overflow keeps every verification batch',
+		async () => {
+			await activatePrWorkflow(tempDir, SESSION_ID, 'PR_FEEDBACK');
+			await declarePrFeedbackInventory(
+				tempDir,
+				SESSION_ID,
+				[COVERED_ITEM, ORPHAN_ITEM],
+				{ prHeadSha: HEAD_SHA },
+			);
+			await enforcePrFeedbackVerificationOwnership(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'verify-a', ownedItemIds: [COVERED_ITEM] }],
+				{ batchId: 'covering', prHeadSha: HEAD_SHA },
+			);
+			await persistBatch(
+				'covering',
+				'swarm-pr-feedback:verification',
+				[{ laneId: 'verify-a', workflowLane: 'verify-a' }],
+				{
+					textOverride: `[FEEDBACK-VERIFIED] | ${COVERED_ITEM} | CONFIRMED | evidence`,
+				},
+			);
+			await enforcePrFeedbackVerificationOwnership(
+				tempDir,
+				SESSION_ID,
+				[{ laneId: 'verify-b', ownedItemIds: [ORPHAN_ITEM] }],
+				{ batchId: 'orphan-owner', prHeadSha: HEAD_SHA },
+			);
+			for (let index = 2; index < MAX_WORKFLOW_BATCHES; index += 1) {
+				await enforcePrFeedbackVerificationOwnership(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: 'verify-a', ownedItemIds: [COVERED_ITEM] }],
+					{ batchId: `retry-${index}`, prHeadSha: HEAD_SHA },
+				);
+			}
+			await patchPersistedState((state) => {
+				state.prFeedbackRetiredItemOwnership = Object.fromEntries(
+					fillerEntries(MAX_RETIRED_FEEDBACK_ITEM_OWNERS, 'retired-item').map(
+						(itemId) => [itemId, 'retired-lane'],
+					),
+				);
+			});
+
+			await expect(
+				enforcePrFeedbackVerificationOwnership(
+					tempDir,
+					SESSION_ID,
+					[{ laneId: 'verify-b', ownedItemIds: [ORPHAN_ITEM] }],
+					{ batchId: 'blocked', prHeadSha: HEAD_SHA },
+				),
+			).rejects.toThrow('PR_FEEDBACK verification batch limit reached');
+			const state = await currentState();
+			expect(state?.prFeedbackVerifications).toHaveLength(MAX_WORKFLOW_BATCHES);
+			expect(
+				Object.keys(state?.prFeedbackRetiredItemOwnership ?? {}),
+			).toHaveLength(MAX_RETIRED_FEEDBACK_ITEM_OWNERS);
+			// The binding the prune would have retired is still nowhere but its batch.
+			expect(
+				state?.prFeedbackRetiredItemOwnership?.[ORPHAN_ITEM],
+			).toBeUndefined();
+		},
+		CAP_TEST_TIMEOUT_MS,
+	);
+});

--- a/tests/unit/hooks/pr-workflow-gate-review-item-coherence.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-review-item-coherence.test.ts
@@ -1,0 +1,494 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+import {
+	assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts,
+	assertPrReviewValidationSettled,
+	completePrWorkflow,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	prWorkflowSessionFileStem,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const BASE_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+const CANDIDATE_HEADER =
+	'[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence';
+
+const reviewed = (
+	ids: readonly string[],
+	classification = 'CONFIRMED',
+	severity = 'HIGH',
+	rationale = 'rationale',
+): string =>
+	ids
+		.map(
+			(id) =>
+				`[REVIEWED] | ${id} | ${classification} | STRUCTURALLY_PROVEN | ${severity} | YES | file.ts:1 | ${rationale} | probe | reviewer`,
+		)
+		.join('\n');
+
+const criticised = (ids: readonly string[]): string =>
+	ids
+		.map((id) => `[CRITIC] | ${id} | UPHELD | HIGH | reason | required change`)
+		.join('\n');
+
+function gateStatePath(): string {
+	return path.join(
+		tempDir,
+		'.swarm',
+		'pr-workflow-gates',
+		`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+	);
+}
+
+async function readPersistedState(): Promise<Record<string, unknown>> {
+	return JSON.parse(await fs.readFile(gateStatePath(), 'utf-8'));
+}
+
+/** Strip coherence entries so the batch is indistinguishable from v1 state. */
+async function makeBatchesLegacy(...batchIds: string[]): Promise<void> {
+	const state = await readPersistedState();
+	const entries = state.prReviewBatchCoherence as Record<string, unknown>;
+	for (const batchId of batchIds) delete entries[batchId];
+	await fs.writeFile(gateStatePath(), JSON.stringify(state), 'utf-8');
+	gateInternals.resetTrackedStateCache();
+}
+
+/** Declare a reviewer batch and persist only the named lanes' artifacts. */
+async function reviewerBatch(
+	batchId: string,
+	lanes: ReadonlyArray<{ laneId: string; reviewItemIds: string[] }>,
+	successful: ReadonlyArray<{ laneId: string; rows: string }>,
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+		lanes.map((lane) => ({ ...lane, workflowLane: lane.laneId })),
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	for (const { laneId, rows } of successful) {
+		await persistBatch(
+			batchId,
+			'swarm-pr-review:reviewer',
+			[{ laneId, workflowLane: laneId }],
+			{ textOverride: rows, subagentSessionId: `${batchId}-${laneId}` },
+		);
+	}
+}
+
+/**
+ * Fifty candidates. A base retry re-claims dimension 0 with 45 fresh
+ * candidates, superseding `base-all`'s dimension-0 lane — which therefore loses
+ * its authoritative source and its `C-0` — leaving C-1..C-5 plus I-01..I-45.
+ */
+async function establishFiftyItemInventory(): Promise<string[]> {
+	await establishReviewPrerequisites();
+	const [dimension] = PR_REVIEW_BASE_DIMENSION_IDS;
+	const lane = { laneId: 'retry-dim0', workflowLane: dimension };
+	await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, [lane], {
+		batchId: 'base-retry-dim0',
+		prHeadSha: HEAD_SHA,
+	});
+	await persistBatch('base-retry-dim0', 'swarm-pr-review:base', [lane], {
+		textOverride: [
+			CANDIDATE_HEADER,
+			...Array.from({ length: 45 }, (_value, index) => {
+				const id = `I-${String(index + 1).padStart(2, '0')}`;
+				return `${id} | ${dimension} | HIGH | correctness | file.ts:${index + 1} | claim ${id} | evidence ${id} | impact ${id} | HIGH`;
+			}),
+		].join('\n'),
+	});
+	const composed = await gateInternals.composePrReviewPhaseVerdicts(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+	);
+	expect(composed.requiredInventory).toHaveLength(50);
+	// Falsifies the supersession claim above rather than trusting it.
+	expect(composed.requiredInventory).not.toContain('C-0');
+	expect(composed.requiredInventory).toContain('C-1');
+	expect(composed.requiredInventory).toContain('I-45');
+	return composed.requiredInventory;
+}
+
+describe('pr-workflow-gate item-keyed reviewer/critic coherence', () => {
+	test('composition blocks on the admitted gap two partial batches leave', async () => {
+		const items = await establishFiftyItemInventory();
+		const first = items.slice(0, 25);
+		const gap = items.slice(25, 45);
+		const last = items.slice(45);
+		await reviewerBatch(
+			'rv-1',
+			[
+				{ laneId: 'rv-1-a', reviewItemIds: first },
+				{ laneId: 'rv-1-b', reviewItemIds: [...gap, ...last] },
+			],
+			[{ laneId: 'rv-1-a', rows: reviewed(first) }],
+		);
+		await reviewerBatch(
+			'rv-2',
+			[
+				{ laneId: 'rv-2-a', reviewItemIds: [...first, ...gap] },
+				{ laneId: 'rv-2-b', reviewItemIds: last },
+			],
+			[{ laneId: 'rv-2-b', rows: reviewed(last) }],
+		);
+		const error = await assertPrReviewValidationSettled(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		).then(
+			() => null,
+			(reason: unknown) => reason as Error,
+		);
+		expect(error?.message).toContain(
+			`reviewer items lack an authenticated verdict from any successful lane: ${gap.join(', ')}`,
+		);
+		for (const claimed of [...first, ...last]) {
+			expect(error?.message).not.toContain(`${claimed},`);
+		}
+	});
+
+	test('the most recent successful lane wins, and derivation agrees', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch(
+			'rv-old',
+			[{ laneId: 'rv-old-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-old-a', rows: reviewed(BASE_IDS) }],
+		);
+		// A later batch re-reviews everything but only its C-0 lane succeeds.
+		await reviewerBatch(
+			'rv-new',
+			[
+				{ laneId: 'rv-new-a', reviewItemIds: [BASE_IDS[0]] },
+				{ laneId: 'rv-new-b', reviewItemIds: BASE_IDS.slice(1) },
+			],
+			[
+				{
+					laneId: 'rv-new-a',
+					rows: reviewed([BASE_IDS[0]], 'DISPROVED', 'LOW'),
+				},
+			],
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		// Provenance names the exact winning lane, not just the batch.
+		expect(composed.claims.get(BASE_IDS[0])).toMatchObject({
+			batchId: 'rv-new',
+			laneId: 'rv-new-a',
+			workflowLane: 'rv-new-a',
+			classification: 'DISPROVED',
+			severity: 'LOW',
+		});
+		expect(composed.claims.get(BASE_IDS[1])).toMatchObject({
+			batchId: 'rv-old',
+			laneId: 'rv-old-a',
+			workflowLane: 'rv-old-a',
+			classification: 'CONFIRMED',
+		});
+		// Derivation must pick the same winner: C-0 is DISPROVED/LOW, so it is
+		// out of the critic inventory while its five siblings stay in.
+		await expect(
+			recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'critic',
+				[
+					{
+						laneId: 'critic-all',
+						workflowLane: 'critic-all',
+						reviewItemIds: BASE_IDS,
+					},
+				],
+				{ batchId: 'critic-all', prHeadSha: HEAD_SHA },
+			),
+		).rejects.toThrow(`extra: ${BASE_IDS[0]}`);
+		await expect(
+			recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'critic',
+				[
+					{
+						laneId: 'critic-rest',
+						workflowLane: 'critic-rest',
+						reviewItemIds: BASE_IDS.slice(1),
+					},
+				],
+				{ batchId: 'critic-rest', prHeadSha: HEAD_SHA },
+			),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+	});
+
+	test('a composed reviewer phase can never settle with an empty critic inventory', async () => {
+		await establishReviewPrerequisites();
+		const halves = [BASE_IDS.slice(0, 3), BASE_IDS.slice(3)];
+		for (const [index, half] of halves.entries()) {
+			await reviewerBatch(
+				`rv-${index}`,
+				[
+					{ laneId: `rv-${index}-a`, reviewItemIds: halves[0] },
+					{ laneId: `rv-${index}-b`, reviewItemIds: halves[1] },
+				],
+				[
+					{
+						laneId: `rv-${index}-${index === 0 ? 'a' : 'b'}`,
+						rows: reviewed(half),
+					},
+				],
+			);
+		}
+		// Neither batch is wholly successful, so the pre-fix derivation returned
+		// an empty map while settlement blocked. Settlement is now the same
+		// computation, so it cannot pass without CONFIRMED/HIGH verdicts being
+		// visible to the critic-inventory derivation.
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		await expect(
+			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
+		).rejects.toThrow(`require critic coverage for: ${BASE_IDS.join(', ')}`);
+	});
+
+	test('one item losing its reviewer row leaves its critic lane siblings intact', async () => {
+		await establishReviewPrerequisites();
+		const challenged = BASE_IDS.slice(0, 3);
+		const suppressed = BASE_IDS.slice(3);
+		const rows = (rationale: string) =>
+			`${reviewed(challenged, 'CONFIRMED', 'HIGH', rationale)}\n${reviewed(suppressed, 'DISPROVED', 'LOW')}`;
+		await reviewerBatch(
+			'rv-1',
+			[{ laneId: 'rv-1-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-1-a', rows: rows('rationale') }],
+		);
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'critic',
+			[
+				{
+					laneId: 'critic-three',
+					workflowLane: 'critic-three',
+					reviewItemIds: challenged,
+				},
+			],
+			{ batchId: 'critic-three', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'critic-three',
+			'swarm-pr-review:critic',
+			[{ laneId: 'critic-three', workflowLane: 'critic-three' }],
+			{ textOverride: criticised(challenged) },
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+
+		// Re-review: only C-0's row changes, and only in its rationale — same
+		// classification, same severity, so parseCriticVerdict still accepts the
+		// old critic row and a CLASSIFICATION|SEVERITY tuple would still match.
+		await reviewerBatch(
+			'rv-2',
+			[{ laneId: 'rv-2-a', reviewItemIds: BASE_IDS }],
+			[
+				{
+					laneId: 'rv-2-a',
+					rows: `${reviewed([challenged[0]], 'CONFIRMED', 'HIGH', 'revised root cause')}\n${reviewed(challenged.slice(1))}\n${reviewed(suppressed, 'DISPROVED', 'LOW')}`,
+				},
+			],
+		);
+		const error = await assertPrReviewValidationSettled(
+			tempDir,
+			SESSION_ID,
+			'critic',
+		).then(
+			() => null,
+			(reason: unknown) => reason as Error,
+		);
+		expect(error?.message).toContain(
+			`critic items lack an authenticated verdict from any successful lane: ${challenged[0]}`,
+		);
+		for (const survivor of challenged.slice(1)) {
+			expect(error?.message).not.toContain(survivor);
+		}
+	});
+
+	test('an abandoned declared lane is a diagnostic, not a block', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch(
+			'rv-covered',
+			[{ laneId: 'rv-covered-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-covered-a', rows: reviewed(BASE_IDS) }],
+		);
+		// A later batch declares a second lane over the whole inventory and never
+		// completes it. Every item is already covered, so settlement passes.
+		await reviewerBatch(
+			'rv-abandoned',
+			[{ laneId: 'rv-abandoned-a', reviewItemIds: BASE_IDS }],
+			[],
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		expect(composed.unclaimed).toEqual([]);
+		expect(composed.diagnostics).toContain(
+			'declared reviewer lane "rv-abandoned-a" produced no successful exact artifact',
+		);
+		expect(composed.contributingBatchIds).toEqual(['rv-covered']);
+	});
+
+	test('an unclaimed item blocks settlement and empties every derivation', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch(
+			'rv-short',
+			[{ laneId: 'rv-short-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-short-a', rows: reviewed(BASE_IDS.slice(0, -1)) }],
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).rejects.toThrow(
+			`reviewer items lack an authenticated verdict from any successful lane: ${BASE_IDS.at(-1)}`,
+		);
+		// This gate is exported and does NOT settle first, so the derivation
+		// itself must stay empty rather than project the five claims that did
+		// parse onto artifact records.
+		await expect(
+			assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
+				tempDir,
+				SESSION_ID,
+				'post_reviewer',
+				[
+					{
+						finding_id: BASE_IDS[0],
+						status: 'CONFIRMED',
+						next_action: 'route_to_critic',
+					},
+				],
+			),
+		).rejects.toThrow(
+			`record ${BASE_IDS[0]} has no authoritative reviewer verdict`,
+		);
+	});
+
+	test('legacy batches without coherence keys stay on the stricter old rule', async () => {
+		await establishReviewPrerequisites();
+		const halves = [BASE_IDS.slice(0, 3), BASE_IDS.slice(3)];
+		await reviewerBatch(
+			'rv-legacy',
+			[{ laneId: 'rv-legacy-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-legacy-a', rows: reviewed(BASE_IDS) }],
+		);
+		await reviewerBatch(
+			'rv-modern',
+			[
+				{ laneId: 'rv-modern-a', reviewItemIds: halves[0] },
+				{ laneId: 'rv-modern-b', reviewItemIds: halves[1] },
+			],
+			[
+				{
+					laneId: 'rv-modern-a',
+					rows: reviewed(halves[0], 'DISPROVED', 'LOW'),
+				},
+			],
+		);
+		// Mixed state: the legacy batch is wholly successful over the exact
+		// inventory, so it stays eligible; the modern partial batch contributes
+		// its one successful lane and wins those items.
+		await makeBatchesLegacy('rv-legacy');
+		let composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		expect(composed.unclaimed).toEqual([]);
+		expect(composed.claims.get(halves[0][0])?.batchId).toBe('rv-modern');
+		expect(composed.claims.get(halves[1][0])?.batchId).toBe('rv-legacy');
+
+		// Demote the modern partial batch to legacy too: it is no longer wholly
+		// successful, so the legacy predicate refuses it entirely and the legacy
+		// full batch wins every item. Legacy state can never loosen.
+		await makeBatchesLegacy('rv-modern');
+		composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		expect(composed.unclaimed).toEqual([]);
+		expect(composed.contributingBatchIds).toEqual(['rv-legacy']);
+		expect(composed.claims.get(halves[0][0])?.classification).toBe('CONFIRMED');
+	});
+
+	test('a v1 plugin still parses state a v2 plugin wrote', async () => {
+		await establishReviewPrerequisites();
+		await reviewerBatch(
+			'rv-1',
+			[{ laneId: 'rv-1-a', reviewItemIds: BASE_IDS }],
+			[{ laneId: 'rv-1-a', rows: reviewed(BASE_IDS) }],
+		);
+		const persisted = await readPersistedState();
+		expect(persisted.prReviewBatchCoherence).toBeDefined();
+		// Exactly the pre-change shape: a .strict() batch record under a
+		// .passthrough() parent. A rolled-back plugin reads this file on every
+		// gate call, including the abort escape hatch.
+		const v1Lane = z
+			.object({
+				laneId: z.string().min(1),
+				workflowLane: z.string().min(1),
+				reviewItemIds: z.array(z.string().min(1)).min(1).optional(),
+			})
+			.strict();
+		const v1Batch = z
+			.object({
+				batchId: z.string().min(1),
+				phase: z.enum(['council', 'reviewer', 'critic']),
+				lanes: z.array(v1Lane).min(1),
+				validatedAt: z.string().min(1),
+			})
+			.strict();
+		const v1Schema = z
+			.object({
+				schemaVersion: z.literal(1),
+				revision: z.number().int().nonnegative().default(0),
+				sessionID: z.string().min(1),
+				mode: z.enum(['PR_REVIEW', 'PR_FEEDBACK']),
+				activatedAt: z.string().min(1),
+				updatedAt: z.string().min(1),
+				prReviewValidationBatches: z.array(v1Batch).optional(),
+			})
+			.passthrough();
+		const parsed = v1Schema.safeParse(persisted);
+		expect(parsed.success).toBe(true);
+		expect(
+			(parsed.data as Record<string, unknown>).prReviewBatchCoherence,
+		).toBeDefined();
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-review-validation.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-review-validation.test.ts
@@ -6,7 +6,6 @@ import {
 	completePrWorkflow,
 	_test_exports as gateInternals,
 	PR_REVIEW_BASE_DIMENSION_IDS,
-	readPrWorkflowGateState,
 	recordPrReviewValidationBatch,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import {
@@ -21,6 +20,22 @@ import {
 
 beforeEach(setupPrWorkflowGateFixtures);
 afterEach(teardownPrWorkflowGateFixtures);
+
+/** Canonical CONFIRMED/HIGH reviewer rows; `rationale` varies the row digest. */
+const reviewedRows = (
+	ids: readonly string[],
+	rationale = 'rationale',
+): string =>
+	ids
+		.map(
+			(id) =>
+				`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | ${rationale} | probe | reviewer`,
+		)
+		.join('\n');
+
+/** Settlement now blocks on the exact items that lack an authenticated verdict. */
+const unclaimed = (ids: readonly string[]): string =>
+	`items lack an authenticated verdict from any successful lane: ${ids.join(', ')}`;
 
 describe('pr-workflow-gate review validation', () => {
 	test('PR review completion cannot clear with zero reviewer obligations', async () => {
@@ -143,12 +158,7 @@ describe('pr-workflow-gate review validation', () => {
 			],
 			{ batchId: 'review-all', prHeadSha: HEAD_SHA },
 		);
-		const reviewerRows = candidateIds
-			.map(
-				(id) =>
-					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
-			)
-			.join('\n');
+		const reviewerRows = reviewedRows(candidateIds);
 		await persistBatch(
 			'review-all',
 			'swarm-pr-review:reviewer',
@@ -235,7 +245,7 @@ describe('pr-workflow-gate review validation', () => {
 		);
 		await expect(
 			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
-		).rejects.toThrow('one fully successful exact batch');
+		).rejects.toThrow(unclaimed(candidateIds));
 	});
 
 	test('semantic verdict enums reject structurally populated nonsense', async () => {
@@ -270,7 +280,7 @@ describe('pr-workflow-gate review validation', () => {
 		);
 		await expect(
 			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
-		).rejects.toThrow('one fully successful exact batch');
+		).rejects.toThrow(unclaimed(candidateIds));
 	});
 
 	test('critic verdicts reject unresolved and incoherent terminal rows', () => {
@@ -315,17 +325,12 @@ describe('pr-workflow-gate review validation', () => {
 		).toBeNull();
 	});
 
-	test('a new reviewer batch invalidates every older critic batch', async () => {
+	test('a reviewer row that changed at all invalidates its critic claims', async () => {
 		await establishReviewPrerequisites();
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
 		);
-		const reviewerRows = candidateIds
-			.map(
-				(id) =>
-					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
-			)
-			.join('\n');
+		const reviewerRows = reviewedRows(candidateIds);
 		await recordPrReviewValidationBatch(
 			tempDir,
 			SESSION_ID,
@@ -388,24 +393,25 @@ describe('pr-workflow-gate review validation', () => {
 			],
 			{ batchId: 'review-after-critic', prHeadSha: HEAD_SHA },
 		);
+		// Identical classification AND severity, entirely different rationale: a
+		// CLASSIFICATION|SEVERITY tuple binding would still admit the old critic
+		// rows, and parseCriticVerdict alone still accepts them. Only the
+		// full-row digest drops them.
 		await persistBatch(
 			'review-after-critic',
 			'swarm-pr-review:reviewer',
 			[{ laneId: 'review-after-critic', workflowLane: 'review-all' }],
-			{ textOverride: reviewerRows },
+			{ textOverride: reviewedRows(candidateIds, 'revised root cause') },
 		);
-		const state = await readPrWorkflowGateState(tempDir, SESSION_ID);
-		expect(
-			state?.prReviewValidationBatches?.some(
-				(batch) => batch.phase === 'critic',
-			),
-		).toBe(false);
 		await expect(
-			completePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW', HEAD_SHA),
-		).rejects.toThrow('require critic coverage');
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).rejects.toThrow(unclaimed(candidateIds));
 	});
 
-	test('reviewer settlement rejects complementary partial retry batches', async () => {
+	test('reviewer settlement composes complementary partial retry batches', async () => {
 		await establishReviewPrerequisites();
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
@@ -433,12 +439,6 @@ describe('pr-workflow-gate review validation', () => {
 				{ batchId, prHeadSha: HEAD_SHA },
 			);
 			const successfulLane = lanes[index];
-			const rows = successfulHalf
-				.map(
-					(id) =>
-						`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
-				)
-				.join('\n');
 			await persistBatch(
 				batchId,
 				'swarm-pr-review:reviewer',
@@ -448,13 +448,15 @@ describe('pr-workflow-gate review validation', () => {
 						workflowLane: successfulLane.workflowLane,
 					},
 				],
-				{ textOverride: rows },
+				{ textOverride: reviewedRows(successfulHalf) },
 			);
 		}
 
+		// Each batch has one failed lane, so neither is a "fully successful exact
+		// batch"; between them every item has exactly one authenticated verdict.
 		await expect(
 			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
-		).rejects.toThrow('one fully successful exact batch');
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
 	});
 
 	test('workflow artifacts must match the exact delegation role identity', async () => {
@@ -475,21 +477,17 @@ describe('pr-workflow-gate review validation', () => {
 			],
 			{ batchId: 'review-wrong-role', prHeadSha: HEAD_SHA },
 		);
-		const rows = candidateIds
-			.map(
-				(id) =>
-					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
-			)
-			.join('\n');
 		await persistBatch(
 			'review-wrong-role',
 			'swarm-pr-review:reviewer',
 			[{ laneId: 'review-wrong-role', workflowLane: 'review-wrong-role' }],
-			{ textOverride: rows, artifactRole: 'critic' },
+			{ textOverride: reviewedRows(candidateIds), artifactRole: 'critic' },
 		);
 
+		// The verdict rows themselves are perfectly valid; only the artifact's
+		// role identity is wrong, so no item may be claimed from this lane.
 		await expect(
 			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
-		).rejects.toThrow('one fully successful exact batch');
+		).rejects.toThrow(unclaimed(candidateIds));
 	});
 });

--- a/tests/unit/hooks/pr-workflow-gate-reviewer-inventory-binding.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-reviewer-inventory-binding.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	assertPrReviewValidationSettled,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+/**
+ * Issue #1968, the headline fail-closed guarantee of the composable accounting:
+ * "a batch can only contribute verdicts for the exact inventory it was validated
+ * against". Item-keyed composition means a reviewer batch's rows are matched by
+ * candidate id, so without the inventory-equality clause in
+ * `batchMayContributeClaims` a reviewer wave that reviewed a WIDER inventory
+ * would silently keep settling a narrower one — the reviewer never saw the
+ * narrowing, and per-item matching alone cannot notice, because every surviving
+ * item does have a row.
+ *
+ * The narrowing here is driven entirely through real gate entry points: a base
+ * retry re-claims one dimension and emits fresh candidates, then a second retry
+ * on the same dimension comes back clean and withdraws them.
+ */
+
+const [DIM_0] = PR_REVIEW_BASE_DIMENSION_IDS;
+const CANDIDATE_HEADER =
+	'[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence';
+/** The five candidates `base-all` contributes for dimensions 1..5. */
+const SURVIVING_IDS = PR_REVIEW_BASE_DIMENSION_IDS.slice(1).map(
+	(_dimension, index) => `C-${index + 1}`,
+);
+const WITHDRAWN_IDS = ['X-1', 'X-2', 'X-3'];
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const reviewed = (ids: readonly string[]): string =>
+	ids
+		.map(
+			(id) =>
+				`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale ${id} | probe | reviewer`,
+		)
+		.join('\n');
+
+/** Re-dispatch dimension 0 alone, superseding whatever claimed it before. */
+async function retryDimensionZero(
+	batchId: string,
+	text: string,
+): Promise<void> {
+	const lane = { laneId: `${batchId}-lane`, workflowLane: DIM_0 };
+	await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, [lane], {
+		batchId,
+		prHeadSha: HEAD_SHA,
+	});
+	await persistBatch(batchId, 'swarm-pr-review:base', [lane], {
+		textOverride: text,
+	});
+}
+
+async function reviewerInventory(): Promise<string[]> {
+	const composed = await gateInternals.composePrReviewPhaseVerdicts(
+		tempDir,
+		SESSION_ID,
+		'reviewer',
+	);
+	return composed.requiredInventory;
+}
+
+describe('pr-workflow-gate reviewer batch inventory binding', () => {
+	test('a reviewer batch stops contributing once the inventory it was validated against shrinks', async () => {
+		await establishReviewPrerequisites();
+
+		// Widen: dimension 0 comes back with three fresh candidates, superseding
+		// `base-all`'s dimension-0 lane (and so its C-0).
+		await retryDimensionZero(
+			'base-widen',
+			[
+				CANDIDATE_HEADER,
+				...WITHDRAWN_IDS.map(
+					(id, index) =>
+						`${id} | ${DIM_0} | HIGH | correctness | file.ts:${index + 1} | claim ${id} | evidence ${id} | impact ${id} | HIGH`,
+				),
+			].join('\n'),
+		);
+		const wide = await reviewerInventory();
+		expect([...wide].sort()).toEqual(
+			[...SURVIVING_IDS, ...WITHDRAWN_IDS].sort(),
+		);
+
+		// One reviewer lane reviews all eight and fully succeeds.
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[{ laneId: 'rv-wide-a', workflowLane: 'rv-wide-a', reviewItemIds: wide }],
+			{ batchId: 'rv-wide', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'rv-wide',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'rv-wide-a', workflowLane: 'rv-wide-a' }],
+			{ textOverride: reviewed(wide), subagentSessionId: 'rv-wide-session' },
+		);
+		// Positive control: against the inventory it WAS validated against, this
+		// same batch settles. Everything that changes below is the inventory.
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+
+		// Narrow: dimension 0 is re-dispatched once more and comes back clean, so
+		// X-1..X-3 leave the candidate inventory. `rv-wide` still holds a
+		// byte-identical [REVIEWED] row for every one of the five survivors, so
+		// per-item matching alone cannot tell that anything changed.
+		await retryDimensionZero(
+			'base-narrow',
+			[
+				CANDIDATE_HEADER,
+				`[CLEAN] | ${DIM_0} | exact reviewed diff | no finding after focused invariant review`,
+			].join('\n'),
+		);
+		expect([...(await reviewerInventory())].sort()).toEqual(
+			[...SURVIVING_IDS].sort(),
+		);
+
+		const error = await assertPrReviewValidationSettled(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		).then(
+			() => null,
+			(reason: unknown) => reason as Error,
+		);
+		// Named explicitly so a regression that lets `rv-wide` keep contributing
+		// reports "settled against the narrowed inventory" rather than an opaque
+		// undefined-message mismatch.
+		expect(
+			error?.message ?? 'settled against the narrowed inventory',
+		).toContain(
+			`reviewer items lack an authenticated verdict from any successful lane: ${SURVIVING_IDS.join(', ')}`,
+		);
+		expect(error?.message ?? '').toContain(
+			'reviewer batch "rv-wide" was validated against a different inventory',
+		);
+		// And the batch really is excluded from the composition, not merely
+		// reported: no surviving item may carry a claim from it.
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		expect(composed.contributingBatchIds).toEqual([]);
+		for (const id of SURVIVING_IDS) {
+			expect(composed.claims.get(id)).toBeUndefined();
+		}
+	});
+
+	test('a reviewer batch re-validated against the narrowed inventory contributes again', async () => {
+		await establishReviewPrerequisites();
+		await retryDimensionZero(
+			'base-widen',
+			[
+				CANDIDATE_HEADER,
+				...WITHDRAWN_IDS.map(
+					(id, index) =>
+						`${id} | ${DIM_0} | HIGH | correctness | file.ts:${index + 1} | claim ${id} | evidence ${id} | impact ${id} | HIGH`,
+				),
+			].join('\n'),
+		);
+		const wide = await reviewerInventory();
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[{ laneId: 'rv-wide-a', workflowLane: 'rv-wide-a', reviewItemIds: wide }],
+			{ batchId: 'rv-wide', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'rv-wide',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'rv-wide-a', workflowLane: 'rv-wide-a' }],
+			{ textOverride: reviewed(wide), subagentSessionId: 'rv-wide-session' },
+		);
+		await retryDimensionZero(
+			'base-narrow',
+			[
+				CANDIDATE_HEADER,
+				`[CLEAN] | ${DIM_0} | exact reviewed diff | no finding after focused invariant review`,
+			].join('\n'),
+		);
+
+		// The recovery path the clause leaves open: re-declare a reviewer batch
+		// against the inventory in force now. Nothing about the artifact content
+		// changes — only what the batch was validated against — so this isolates
+		// the inventory binding from every other admission rule.
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[
+				{
+					laneId: 'rv-narrow-a',
+					workflowLane: 'rv-narrow-a',
+					reviewItemIds: SURVIVING_IDS,
+				},
+			],
+			{ batchId: 'rv-narrow', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'rv-narrow',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'rv-narrow-a', workflowLane: 'rv-narrow-a' }],
+			{
+				textOverride: reviewed(SURVIVING_IDS),
+				subagentSessionId: 'rv-narrow-session',
+			},
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		const composed = await gateInternals.composePrReviewPhaseVerdicts(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+		);
+		expect(composed.contributingBatchIds).toEqual(['rv-narrow']);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-session-provenance.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-session-provenance.test.ts
@@ -73,8 +73,37 @@ describe('pr-workflow-gate independent session provenance', () => {
 			{ ...shared, textOverride: criticRows },
 		);
 
+		// Every critic row parses and the batch covers the whole inventory; the
+		// ONLY defect is the reused child session, so no item may be claimed.
 		await expect(
 			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
-		).rejects.toThrow('one fully successful exact batch');
+		).rejects.toThrow(
+			`critic items lack an authenticated verdict from any successful lane: ${ids.join(', ')}`,
+		);
+
+		// Positive control: the identical critic batch from an independent child
+		// session settles, proving the rejection above isolates session reuse.
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'critic',
+			[
+				{
+					laneId: 'critic-independent',
+					workflowLane: 'critic-independent',
+					reviewItemIds: ids,
+				},
+			],
+			{ batchId: 'critic-independent', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'critic-independent',
+			'swarm-pr-review:critic',
+			[{ laneId: 'critic-independent', workflowLane: 'critic-independent' }],
+			{ subagentSessionId: 'independent-critic', textOverride: criticRows },
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
 	});
 });

--- a/tests/unit/hooks/pr-workflow-gate-stage-a-retention.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-stage-a-retention.test.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store.js';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	activatePrWorkflow,
+	declarePrFeedbackInventory,
+	enforcePrFeedbackVerificationOwnership,
+	_test_exports as gateInternals,
+	prWorkflowSessionFileStem,
+	recordPrFeedbackGateBatch,
+	recordPrFeedbackStageA,
+} from '../../../src/hooks/pr-workflow-gate.js';
+
+/**
+ * Issue #1968 P5a: re-recording Stage A used to wipe every already-proven
+ * independent gate batch unconditionally, so a re-attestation on an unchanged
+ * revision forced all four PR_FEEDBACK phases to re-dispatch. Retention is bound
+ * to Stage A *equivalence*, not to the digest alone — `applicableObligations`
+ * and `applicableCategories` are caller-supplied and validated only for internal
+ * self-consistency, so an unchanged digest can still carry a NARROWER
+ * attestation, and a gate proved against the wider one is no longer evidence for
+ * what is being attested now.
+ */
+
+const SESSION_ID = 'feedback-stage-a-retention';
+const HEAD_SHA = 'abc123';
+const REVISION = 'revision-1';
+const NEXT_REVISION = 'revision-2';
+const ITEM_ID = 'FB-001';
+
+let directory = '';
+let currentRevision = REVISION;
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveRevision = gateInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+const originalResolveCurrentUpstreamPushTarget =
+	gateInternals.resolveCurrentUpstreamPushTarget;
+const originalResolveCurrentUpstreamPushTargetAsync =
+	gateInternals.resolveCurrentUpstreamPushTargetAsync;
+const originalResolveRemoteRefsContainingHead =
+	gateInternals.resolveRemoteRefsContainingHead;
+const originalResolveRemoteRefsContainingHeadAsync =
+	gateInternals.resolveRemoteRefsContainingHeadAsync;
+
+beforeEach(() => {
+	directory = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'pr-gate-stage-a-')),
+	);
+	currentRevision = REVISION;
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolvePrWorkflowRevisionDigest = () => currentRevision;
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+	gateInternals.resolveCurrentUpstreamPushTarget = () => ({
+		remoteName: 'origin',
+		remoteBranchRef: 'refs/heads/pr-branch',
+		remoteTrackingRef: 'refs/remotes/origin/pr-branch',
+	});
+	gateInternals.resolveCurrentUpstreamPushTargetAsync = async (dir) =>
+		gateInternals.resolveCurrentUpstreamPushTarget(dir);
+	gateInternals.resolveRemoteRefsContainingHead = () => [
+		'refs/remotes/origin/pr-branch',
+	];
+	gateInternals.resolveRemoteRefsContainingHeadAsync = async (...args) =>
+		gateInternals.resolveRemoteRefsContainingHead(...args);
+});
+
+afterEach(async () => {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolvePrWorkflowRevisionDigest = originalResolveRevision;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	gateInternals.resolveCurrentUpstreamPushTarget =
+		originalResolveCurrentUpstreamPushTarget;
+	gateInternals.resolveCurrentUpstreamPushTargetAsync =
+		originalResolveCurrentUpstreamPushTargetAsync;
+	gateInternals.resolveRemoteRefsContainingHead =
+		originalResolveRemoteRefsContainingHead;
+	gateInternals.resolveRemoteRefsContainingHeadAsync =
+		originalResolveRemoteRefsContainingHeadAsync;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function persistLaneArtifact(options: {
+	batchId: string;
+	laneId: string;
+	mode: string;
+	role: string;
+	text: string;
+	revisionDigest: string;
+}): Promise<void> {
+	const correlationId = `${options.batchId}--${options.laneId}`;
+	await recordPendingDelegation(directory, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `call-${correlationId}`,
+		normalizedAgent: options.role,
+		swarmPrefixedAgent: options.role,
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: options.batchId,
+		laneId: options.laneId,
+		mode: options.mode,
+		workflowLane: options.laneId,
+		workspace: {
+			directory,
+			gitHead: HEAD_SHA,
+			dirtyHash: options.revisionDigest,
+			prHeadSha: HEAD_SHA,
+			scope: null,
+		},
+	});
+	const stored = storeLaneOutput(directory, {
+		batchId: options.batchId,
+		laneId: options.laneId,
+		agent: options.role,
+		role: options.role,
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: options.mode,
+		workflowLane: options.laneId,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: options.revisionDigest,
+		source: 'collect_lane_results',
+		text: options.text,
+	});
+	await appendDelegationTransition(directory, correlationId, {
+		status: 'completed',
+		result: {
+			text: options.text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			outputRef: stored.ref,
+		},
+	});
+}
+
+async function settleVerification(
+	batchId: string,
+	revisionDigest: string,
+): Promise<void> {
+	await enforcePrFeedbackVerificationOwnership(
+		directory,
+		SESSION_ID,
+		[{ laneId: 'verify', ownedItemIds: [ITEM_ID] }],
+		{ batchId, prHeadSha: HEAD_SHA },
+	);
+	await persistLaneArtifact({
+		batchId,
+		laneId: 'verify',
+		mode: 'swarm-pr-feedback:verification',
+		role: 'reviewer',
+		text: `[FEEDBACK-VERIFIED] | ${ITEM_ID} | CONFIRMED | evidence`,
+		revisionDigest,
+	});
+}
+
+interface StageAObligation {
+	id: string;
+	category: 'build';
+	workingDirectory: string;
+	source: string;
+	validatorContract?: { path: string; id: string };
+}
+
+function obligations(ids: readonly string[]): StageAObligation[] {
+	return ids.map((id) => ({
+		id,
+		category: 'build' as const,
+		workingDirectory: '.',
+		source: `manual:${id}`,
+	}));
+}
+
+/**
+ * Receipts that exactly satisfy `declared`. `recordPrFeedbackStageA` demands
+ * that each receipt's category, working directory and validator contract match
+ * its obligation, so this is derived from the obligations rather than hardcoded
+ * — otherwise a test that varies an obligation field would be rejected by that
+ * consistency check long before retention was consulted.
+ */
+function checksForObligations(declared: readonly StageAObligation[]) {
+	return [
+		{
+			category: 'diff-check' as const,
+			command: ['git', 'diff', '--check'],
+			durationMs: 1,
+		},
+		{
+			category: 'reproduction' as const,
+			command: ['test', 'regression'],
+			targets: ['regression'],
+			feedbackTargets: [
+				{
+					feedbackItemId: ITEM_ID,
+					target: 'regression',
+					expectedBehavior: 'regression stays fixed',
+				},
+			],
+			durationMs: 1,
+		},
+		...declared.map((obligation) => ({
+			category: obligation.category,
+			command: ['build', obligation.id],
+			obligationId: obligation.id,
+			workingDirectory: obligation.workingDirectory,
+			...(obligation.validatorContract
+				? { validatorContract: obligation.validatorContract }
+				: {}),
+			durationMs: 1,
+		})),
+	];
+}
+
+function checks(obligationIds: readonly string[]) {
+	return checksForObligations(obligations(obligationIds));
+}
+
+async function recordStageAWith(
+	revisionDigest: string,
+	declared: readonly StageAObligation[],
+) {
+	return recordPrFeedbackStageA(
+		directory,
+		SESSION_ID,
+		revisionDigest,
+		checksForObligations(declared),
+		{
+			applicableCategories: ['build'],
+			applicableObligations: declared,
+		},
+	);
+}
+
+async function recordStageA(
+	revisionDigest: string,
+	obligationIds: readonly string[],
+) {
+	return recordStageAWith(revisionDigest, obligations(obligationIds));
+}
+
+/** Activate, settle verification, record Stage A, and prove one gate phase. */
+async function armOneGateBatchWith(
+	declared: readonly StageAObligation[],
+): Promise<void> {
+	await activatePrWorkflow(directory, SESSION_ID, 'PR_FEEDBACK');
+	await declarePrFeedbackInventory(directory, SESSION_ID, [ITEM_ID], {
+		prHeadSha: HEAD_SHA,
+	});
+	await settleVerification('verify-1', REVISION);
+	await recordStageAWith(REVISION, declared);
+	await recordPrFeedbackGateBatch(
+		directory,
+		SESSION_ID,
+		'stage-b-reviewer',
+		{ laneId: 'stage-b-reviewer', ownedItemIds: [ITEM_ID] },
+		{
+			batchId: 'gate-review',
+			prHeadSha: HEAD_SHA,
+			revisionDigest: REVISION,
+		},
+	);
+	await persistLaneArtifact({
+		batchId: 'gate-review',
+		laneId: 'stage-b-reviewer',
+		mode: 'swarm-pr-feedback:stage-b-reviewer',
+		role: 'reviewer',
+		text: `[STAGE-B-REVIEW] | ${ITEM_ID} | APPROVE | evidence`,
+		revisionDigest: REVISION,
+	});
+}
+
+async function armOneGateBatch(
+	obligationIds: readonly string[],
+): Promise<void> {
+	await armOneGateBatchWith(obligations(obligationIds));
+}
+
+const BASE_OBLIGATION: StageAObligation = {
+	id: 'OBL-A',
+	category: 'build',
+	workingDirectory: '.',
+	source: 'manual:OBL-A',
+};
+const CONTRACTED_OBLIGATION: StageAObligation = {
+	...BASE_OBLIGATION,
+	validatorContract: { path: 'contracts/validators.json', id: 'build-a' },
+};
+
+/**
+ * Every field `canonicalStageAObligation` folds in besides `id` and `category`
+ * — `category` is separately pinned by the receipt-consistency check above, so
+ * it cannot be varied here in isolation. Each row keeps the obligation `id`
+ * FIXED and changes exactly one other field: identity by id alone would read
+ * every one of these as "the same obligation, still attested" and retain gate
+ * evidence proved against an obligation that no longer exists.
+ */
+const NON_ID_IDENTITY_FIELDS: ReadonlyArray<{
+	field: string;
+	before: StageAObligation;
+	after: StageAObligation;
+}> = [
+	{
+		field: 'source',
+		before: BASE_OBLIGATION,
+		after: { ...BASE_OBLIGATION, source: 'pr-validation:OBL-A' },
+	},
+	{
+		field: 'workingDirectory',
+		before: BASE_OBLIGATION,
+		after: { ...BASE_OBLIGATION, workingDirectory: 'packages/app' },
+	},
+	{
+		field: 'validatorContract.path',
+		before: CONTRACTED_OBLIGATION,
+		after: {
+			...CONTRACTED_OBLIGATION,
+			validatorContract: { path: 'contracts/other.json', id: 'build-a' },
+		},
+	},
+	{
+		field: 'validatorContract.id',
+		before: CONTRACTED_OBLIGATION,
+		after: {
+			...CONTRACTED_OBLIGATION,
+			validatorContract: { path: 'contracts/validators.json', id: 'build-b' },
+		},
+	},
+	{
+		field: 'validatorContract (added)',
+		before: BASE_OBLIGATION,
+		after: CONTRACTED_OBLIGATION,
+	},
+	{
+		field: 'validatorContract (removed)',
+		before: CONTRACTED_OBLIGATION,
+		after: BASE_OBLIGATION,
+	},
+];
+
+describe('PR_FEEDBACK Stage A gate-batch retention', () => {
+	for (const { field, before, after } of NON_ID_IDENTITY_FIELDS) {
+		test(`the same obligation id with a different ${field} wipes gate batches`, async () => {
+			await armOneGateBatchWith([before]);
+			const state = await recordStageAWith(REVISION, [after]);
+			expect(state.prFeedbackGateBatches).toEqual([]);
+		});
+	}
+
+	test('an obligation identical in every canonical field retains gate batches', async () => {
+		// Positive control for the table above: a fresh object with the same
+		// values retains, so each wipe there is attributable to the one field
+		// that changed and not to object identity or re-recording itself.
+		await armOneGateBatchWith([CONTRACTED_OBLIGATION]);
+		const state = await recordStageAWith(REVISION, [
+			{
+				...CONTRACTED_OBLIGATION,
+				validatorContract: { ...CONTRACTED_OBLIGATION.validatorContract! },
+			},
+		]);
+		expect(state.prFeedbackGateBatches?.map((batch) => batch.batchId)).toEqual([
+			'gate-review',
+		]);
+	});
+
+	test('an identical re-attestation on the same revision retains gate batches', async () => {
+		await armOneGateBatch(['OBL-A']);
+		const state = await recordStageA(REVISION, ['OBL-A']);
+		expect(state.prFeedbackGateBatches?.map((batch) => batch.batchId)).toEqual([
+			'gate-review',
+		]);
+	});
+
+	test('a widened re-attestation on the same revision retains gate batches', async () => {
+		await armOneGateBatch(['OBL-A']);
+		const state = await recordStageA(REVISION, ['OBL-A', 'OBL-B']);
+		expect(state.prFeedbackGateBatches?.map((batch) => batch.batchId)).toEqual([
+			'gate-review',
+		]);
+		expect(state.prFeedbackStageA?.applicableObligations).toHaveLength(2);
+	});
+
+	test('a NARROWED re-attestation on the same revision wipes gate batches', async () => {
+		await armOneGateBatch(['OBL-A', 'OBL-B']);
+		const state = await recordStageA(REVISION, ['OBL-A']);
+		expect(state.prFeedbackGateBatches).toEqual([]);
+	});
+
+	test('a narrowed applicable-category set on the same revision wipes gate batches', async () => {
+		await armOneGateBatch(['OBL-A']);
+		// Same obligations, but the caller no longer attests the lint category.
+		// The prior gate batch was proved against the wider attestation.
+		const state = await recordPrFeedbackStageA(
+			directory,
+			SESSION_ID,
+			REVISION,
+			[
+				...checks(['OBL-A']),
+				{ category: 'lint' as const, command: ['lint'], durationMs: 1 },
+			],
+			{
+				applicableCategories: ['build', 'lint'],
+				applicableObligations: obligations(['OBL-A']),
+			},
+		);
+		expect(state.prFeedbackGateBatches?.map((batch) => batch.batchId)).toEqual([
+			'gate-review',
+		]);
+		const narrowed = await recordStageA(REVISION, ['OBL-A']);
+		expect(narrowed.prFeedbackGateBatches).toEqual([]);
+	});
+
+	test('a changed revision wipes gate batches even with an identical attestation', async () => {
+		await armOneGateBatch(['OBL-A']);
+		currentRevision = NEXT_REVISION;
+		await settleVerification('verify-2', NEXT_REVISION);
+		const state = await recordStageA(NEXT_REVISION, ['OBL-A']);
+		expect(state.prFeedbackGateBatches).toEqual([]);
+	});
+
+	test('retention never keeps an armed publication', async () => {
+		await armOneGateBatch(['OBL-A']);
+		const state = await recordStageA(REVISION, ['OBL-A']);
+		expect(state.prFeedbackReadyToPublish).toBeUndefined();
+	});
+
+	test('a legacy Stage A record without an attestation cannot prove non-narrowing', async () => {
+		// Issue #1968 FIX 6. Both attestation keys are optional in the schema, so a
+		// record written by an older plugin carries neither. Defaulting them to []
+		// made the superset check vacuously true and retained gate approvals across
+		// an attestation that may have narrowed arbitrarily.
+		await armOneGateBatch(['OBL-A', 'OBL-B']);
+		const statePath = path.join(
+			directory,
+			'.swarm',
+			'pr-workflow-gates',
+			`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+		);
+		const persisted = JSON.parse(await fs.readFile(statePath, 'utf-8'));
+		delete persisted.prFeedbackStageA.applicableCategories;
+		delete persisted.prFeedbackStageA.applicableObligations;
+		await fs.writeFile(statePath, JSON.stringify(persisted), 'utf-8');
+		gateInternals.resetTrackedStateCache();
+
+		// Same revision, and an attestation that is a superset of nothing — but the
+		// prior one is unknown, so non-narrowing is unprovable and the gate batches
+		// must be wiped rather than carried across.
+		const state = await recordStageA(REVISION, ['OBL-A', 'OBL-B']);
+		expect(state.prFeedbackGateBatches).toEqual([]);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
@@ -389,9 +389,14 @@ describe('PR review council mechanical dispatch', () => {
 				outputRef: stored.ref,
 			},
 		});
+		// The artifact carries exactly one well-formed [REVIEWED] row, for an id
+		// the lane does not own; every structurally assigned item must be named
+		// as lacking an authenticated verdict.
 		await expect(
 			assertPrReviewValidationSettled(directory, SESSION_ID, 'reviewer'),
-		).rejects.toThrow('one fully successful exact batch');
+		).rejects.toThrow(
+			`reviewer items lack an authenticated verdict from any successful lane: ${reviewItems.join(', ')}`,
+		);
 	});
 
 	test('accepts structured council mode and blocks reviewer dispatch until council settles', async () => {

--- a/tests/unit/tools/dispatch-lanes-pr-review-tier-l-gc.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-tier-l-gc.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { z } from 'zod';
+import {
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR,
+	prWorkflowSessionFileStem,
+	readPrWorkflowGateState,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	attemptBaseBatch,
+	attemptConsolidatedRetry,
+	failEntireInitialWave,
+	persistBaseLane,
+	recordInitialWave,
+	SESSION_ID,
+	setupTierLFixtures,
+	singleton,
+	TIER_L_MESSAGE,
+	teardownTierLFixtures,
+	tierLDirectory,
+} from './dispatch-lanes-pr-review-tier-l.test-fixtures.js';
+
+/**
+ * Issue #1968 review round 2, FIX D — the tier-L cumulative consolidation
+ * floor must be invariant under the capacity GC.
+ *
+ * `tierLBackingLaneCount` computes a MINIMUM SET COVER of every consolidated
+ * lane a wave has ever declared. Before `prReviewRetiredConsolidatedLanes`
+ * existed, that cover could only see LIVE `prReviewBaseDispatches` — so once
+ * the capacity GC dropped a failed consolidated base batch (which it is
+ * entitled to: the batch never produced a successful lane, so it is
+ * provably inert by the GC's own inventory-equality proof), the cover's
+ * universe shrank and the wave got back consolidation budget it had already
+ * spent. This suite drives that exact sequence end-to-end: fill the base
+ * batch array to `MAX_WORKFLOW_BATCHES` with a consolidated retry already
+ * declared, force a real prune that drops it, and prove the ledger — not the
+ * live array — still backs the floor afterwards.
+ */
+
+const [DIM_A, DIM_B, DIM_C, DIM_D, DIM_E, DIM_F] = PR_REVIEW_BASE_DIMENSION_IDS;
+const { MAX_WORKFLOW_BATCHES } = gateInternals;
+
+/** Mirrors the production `encodeConsolidatedLaneKey` contract exactly: sort
+ * the owned dimensions and join with `|`. Computed independently here rather
+ * than imported so the assertion pins the durable on-disk key SHAPE, not an
+ * implementation dependency the production module happens to expose. */
+function expectedConsolidatedLaneKey(owned: readonly string[]): string {
+	return [...new Set(owned)].sort().join('|');
+}
+
+beforeEach(setupTierLFixtures);
+afterEach(teardownTierLFixtures);
+
+describe('PR_REVIEW tier-L consolidation floor survives the capacity GC', () => {
+	test('a pruned consolidated batch still counts against the cumulative floor via the retired-lane ledger', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+
+		// Declare and accept a consolidated retry owning {A, B}. Per-batch this
+		// is legal: A and B are both terminally failed with no successful
+		// source, and the wave (six dedicated dims minus two consolidated, plus
+		// one covering lane = five backing lanes) clears the floor.
+		expect(
+			await attemptConsolidatedRetry([DIM_A, DIM_B], 'retry-ab'),
+		).toBeNull();
+
+		// Fill the base batch array to one below the cap with cheap inert
+		// singleton filler batches — never persisted, so none ever supplies a
+		// successful lane and every one of them is prunable.
+		const fillerCount = MAX_WORKFLOW_BATCHES - 3;
+		for (let index = 0; index < fillerCount; index += 1) {
+			expect(
+				await attemptBaseBatch(
+					[{ laneId: `filler-${index}-lane`, workflowLane: DIM_A }],
+					`filler-${index}`,
+				),
+			).toBeNull();
+		}
+
+		// The batch that lands exactly at the cap re-establishes terminal
+		// failure for C, D, E, F under a NEW batch id. It is the newest base
+		// batch when the GC runs moments from now, so the "newest batch is
+		// never pruned" rule keeps it alive — which is exactly what lets the
+		// {C,D} and {E,F} attempts below still see C/D/E/F as terminally
+		// failed even though `base-initial` (their original failure evidence)
+		// is about to be pruned out from under them.
+		expect(
+			await attemptBaseBatch(
+				[DIM_C, DIM_D, DIM_E, DIM_F].map((dimension) =>
+					singleton(dimension, 'final'),
+				),
+				'final-cdef',
+			),
+		).toBeNull();
+		for (const dimension of [DIM_C, DIM_D, DIM_E, DIM_F]) {
+			await persistBaseLane({
+				batchId: 'final-cdef',
+				laneId: `final-${dimension}`,
+				workflowLane: dimension,
+				status: 'error',
+			});
+		}
+
+		const beforeGc = await readPrWorkflowGateState(
+			tierLDirectory(),
+			SESSION_ID,
+		);
+		expect(beforeGc?.prReviewBaseDispatches).toHaveLength(MAX_WORKFLOW_BATCHES);
+		expect(
+			beforeGc?.prReviewBaseDispatches?.some(
+				(batch) => batch.batchId === 'retry-ab',
+			),
+		).toBe(true);
+		expect(beforeGc?.prReviewRetiredConsolidatedLanes ?? []).toEqual([]);
+
+		// One more base dispatch pushes the array to `previous.length >=
+		// MAX_WORKFLOW_BATCHES`, which is the ONLY thing that makes
+		// `enforcePrReviewBaseDimensions` invoke the capacity GC.
+		expect(
+			await attemptBaseBatch([singleton(DIM_A, 'trigger')], 'trigger-gc'),
+		).toBeNull();
+
+		// EMPIRICAL PROOF the prune actually ran and actually dropped the
+		// consolidated batch — never assumed.
+		const afterGc = await readPrWorkflowGateState(tierLDirectory(), SESSION_ID);
+		const survivingIds = (afterGc?.prReviewBaseDispatches ?? []).map(
+			(batch) => batch.batchId,
+		);
+		expect(survivingIds.length).toBeLessThan(MAX_WORKFLOW_BATCHES);
+		expect(survivingIds).not.toContain('retry-ab');
+		expect(survivingIds).not.toContain('base-initial');
+		expect(survivingIds).toContain('final-cdef');
+		expect(survivingIds).toContain('trigger-gc');
+		const expectedKey = expectedConsolidatedLaneKey([DIM_A, DIM_B]);
+		expect(afterGc?.prReviewRetiredConsolidatedLanes).toEqual([expectedKey]);
+
+		// Rollback: this optional top-level key is written only by the GC, so this
+		// is a file a v2 plugin actually produced that carries it. A rolled-back
+		// plugin's non-strict reader must still parse it, which is the release
+		// note's compatibility claim for every key this change adds.
+		const persisted = JSON.parse(
+			await fs.readFile(
+				path.join(
+					tierLDirectory(),
+					'.swarm',
+					'pr-workflow-gates',
+					`${prWorkflowSessionFileStem(SESSION_ID)}.json`,
+				),
+				'utf-8',
+			),
+		);
+		expect(persisted.prReviewRetiredConsolidatedLanes).toEqual([expectedKey]);
+		expect(
+			z
+				.object({
+					schemaVersion: z.literal(1),
+					sessionID: z.string().min(1),
+					mode: z.enum(['PR_REVIEW', 'PR_FEEDBACK']),
+				})
+				.passthrough()
+				.safeParse(persisted).success,
+		).toBe(true);
+
+		// {C, D}: with the retired {A,B} lane still counted, the cover is
+		// {A,B} + {C,D} = 2, dedicated E/F = 2, backing = 4 — exactly the
+		// floor. Accepted.
+		expect(
+			await attemptConsolidatedRetry([DIM_C, DIM_D], 'retry-cd'),
+		).toBeNull();
+
+		// {E, F}: now the cover is {A,B} + {C,D} + {E,F} = 3 disjoint sets,
+		// backing = 0 dedicated + 3 = 3, one short of the floor. THIS is the
+		// assertion the retired-lane ledger exists for: without it, the
+		// pruned {A,B} batch would be invisible and the cover would be only
+		// {C,D} + {E,F} = 2, dedicated A/B = 2, backing = 4 — accepted, and
+		// the wave would have quietly regained the consolidation budget it
+		// spent on the pruned batch.
+		const rejection = await attemptConsolidatedRetry(
+			[DIM_E, DIM_F],
+			'retry-ef',
+		);
+		expect(rejection).not.toBeNull();
+		expect(rejection?.message).toContain(TIER_L_MESSAGE);
+		expect(rejection?.message).toContain(
+			'this wave would be backed by only 3 distinct lanes',
+		);
+		expect(rejection?.message).toContain(
+			`at least ${PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR} distinct`,
+		);
+	}, 60_000);
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-tier-l-overlap.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-tier-l-overlap.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_BASE_LANE_FLOORS,
+	PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	attemptBaseBatch,
+	failEntireInitialWave,
+	recordInitialWave,
+	setupTierLFixtures,
+	TIER_L_MESSAGE,
+	teardownTierLFixtures,
+} from './dispatch-lanes-pr-review-tier-l.test-fixtures.js';
+
+/**
+ * Issue #1968 review round 2, MUST-FIX A — the cumulative tier-L floor must be
+ * measured as a MINIMUM COVER of the consolidated dimensions, not as a count of
+ * declared consolidated lane instances.
+ *
+ * Declaring a lane is free, so a count of declarations inflates without bound
+ * while `consolidatedDimensions` saturates at six. Two families of declaration
+ * defeat a count-of-declarations floor while satisfying every other clause:
+ *
+ * 1. **Overlapping pairs.** Four pairwise consolidations, each individually
+ *    legal, whose union is all six dimensions — but three of which already cover
+ *    all six. The wave then settles at three producing lanes of two dimensions
+ *    each: exactly `PR_REVIEW_BASE_LANE_FLOORS.M`, i.e. the tier-L depth the
+ *    floor exists to defend has been silently downgraded to a tier-M dispatch.
+ * 2. **Duplicate declarations.** The same consolidated set re-declared across
+ *    several batches, each re-declaration buying a lane of budget it does not
+ *    back, settling at two producing lanes.
+ *
+ * The floor constant is not the defect and must not be raised: any cover of six
+ * dimensions containing at least one multi-element set has at most five sets, so
+ * a floor of six would forbid all consolidation and delete the retry exception.
+ */
+
+const [DIM_A, DIM_B, DIM_C, DIM_D, DIM_E, DIM_F] = PR_REVIEW_BASE_DIMENSION_IDS;
+
+beforeEach(setupTierLFixtures);
+afterEach(teardownTierLFixtures);
+
+/** One consolidated lane owning `owned`, declared as its own base batch. */
+function consolidatedBatch(
+	owned: readonly string[],
+	batchId: string,
+): Promise<Error | null> {
+	return attemptBaseBatch(
+		[
+			{
+				laneId: `${batchId}-lane`,
+				workflowLane: owned[0] as string,
+				ownedWorkflowLanes: [...owned],
+			},
+		],
+		batchId,
+	);
+}
+
+describe('PR_REVIEW tier-L cumulative floor counts a minimum cover', () => {
+	test('overlapping pair consolidations cannot settle at the tier-M lane count', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+
+		// Three pairs are accepted: each leaves a cover strictly larger than the
+		// floor once the dimensions no consolidated lane claims are added back.
+		expect(await consolidatedBatch([DIM_A, DIM_B], 'pair-ab')).toBeNull();
+		expect(await consolidatedBatch([DIM_B, DIM_C], 'pair-bc')).toBeNull();
+		expect(await consolidatedBatch([DIM_D, DIM_E], 'pair-de')).toBeNull();
+
+		// The fourth pair completes a three-set cover of all six dimensions
+		// ({B,C}, {D,E}, {F,A}), so the wave would be backed by three lanes — the
+		// tier-M dispatch shape. Counting declarations instead of a cover admitted
+		// this, because four separate lane objects had been declared.
+		const error = await consolidatedBatch([DIM_F, DIM_A], 'pair-fa');
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			`this wave would be backed by only ${PR_REVIEW_BASE_LANE_FLOORS.M} distinct lanes`,
+		);
+		expect(error?.message).toContain(
+			`at least ${PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR} distinct`,
+		);
+	});
+
+	test('re-declaring the same consolidated set buys no additional budget', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+
+		// The identical three-dimension set, declared three times. Each declaration
+		// used to add one to the backing count while covering nothing new.
+		for (const attempt of ['dup-1', 'dup-2', 'dup-3']) {
+			expect(
+				await consolidatedBatch([DIM_A, DIM_B, DIM_C], attempt),
+			).toBeNull();
+		}
+
+		// Two sets now cover all six dimensions, so the wave would be backed by two
+		// producing lanes — below even the tier-M shape.
+		const error = await consolidatedBatch([DIM_D, DIM_E, DIM_F], 'dup-def');
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'this wave would be backed by only 2 distinct lanes',
+		);
+	});
+});
+
+const { minimumConsolidatedLaneCover, MAX_COVER_UNIVERSE_BITS } = gateInternals;
+
+/** `count` synthetic dimension ids, distinct from the six real ones. */
+function synthetic(count: number): string[] {
+	return Array.from({ length: count }, (_value, index) => `d${index}`);
+}
+
+describe('minimumConsolidatedLaneCover', () => {
+	test('no consolidated lane costs nothing', () => {
+		expect(minimumConsolidatedLaneCover([])).toBe(0);
+	});
+
+	test('identical sets collapse to a single covering lane', () => {
+		expect(
+			minimumConsolidatedLaneCover([
+				[DIM_A, DIM_B, DIM_C],
+				[DIM_C, DIM_B, DIM_A],
+				[DIM_A, DIM_B, DIM_C],
+			]),
+		).toBe(1);
+	});
+
+	test('disjoint sets each cost a lane', () => {
+		expect(
+			minimumConsolidatedLaneCover([
+				[DIM_A, DIM_B],
+				[DIM_C, DIM_D],
+				[DIM_E, DIM_F],
+			]),
+		).toBe(3);
+	});
+
+	test('the cover is exact and order-independent for overlapping sets', () => {
+		// {B,C} + {D,E} + {F,A} covers all six, so {A,B} is redundant. A greedy
+		// subset-elimination walk answers 4 in this order and 3 in the reverse; an
+		// order-dependent count is not a floor, because declaration order belongs
+		// to the controller being gated.
+		const sets = [
+			[DIM_A, DIM_B],
+			[DIM_B, DIM_C],
+			[DIM_D, DIM_E],
+			[DIM_F, DIM_A],
+		];
+		expect(minimumConsolidatedLaneCover(sets)).toBe(3);
+		expect(minimumConsolidatedLaneCover([...sets].reverse())).toBe(3);
+	});
+
+	test('an oversized universe falls back to a fail-closed lower bound', () => {
+		// One wide set plus three pairs. The exact cover is 4; the bound is
+		// ceil(|universe| / largest set). Sized to straddle MAX_COVER_UNIVERSE_BITS
+		// so the two branches are driven by the same shape.
+		const wide = MAX_COVER_UNIVERSE_BITS - 6;
+		const build = (extra: number): string[][] => {
+			const ids = synthetic(wide + extra + 6);
+			return [
+				ids.slice(0, wide + extra),
+				ids.slice(wide + extra, wide + extra + 2),
+				ids.slice(wide + extra + 2, wide + extra + 4),
+				ids.slice(wide + extra + 4, wide + extra + 6),
+			];
+		};
+		// Exactly at the bound: the exact DP runs.
+		expect(minimumConsolidatedLaneCover(build(0))).toBe(4);
+		// One dimension past it: the lower bound runs instead, and it is a genuine
+		// lower bound — never above the exact answer, so it can only reject more.
+		const oversized = build(1);
+		const bound = Math.ceil(
+			(MAX_COVER_UNIVERSE_BITS + 1) / (MAX_COVER_UNIVERSE_BITS - 5),
+		);
+		expect(minimumConsolidatedLaneCover(oversized)).toBe(bound);
+		expect(bound).toBeLessThanOrEqual(4);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-tier-l-retry-split.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-tier-l-retry-split.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	assertPrReviewBaseCoverageSettled,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	attemptBaseBatch,
+	attemptConsolidatedRetry,
+	failEntireInitialWave,
+	persistBaseLane,
+	recordInitialWave,
+	SESSION_ID,
+	setupTierLFixtures,
+	singleton,
+	TIER_L_MESSAGE,
+	teardownTierLFixtures,
+	tierLDirectory,
+} from './dispatch-lanes-pr-review-tier-l.test-fixtures.js';
+
+/**
+ * Issue #1968 MUST-FIX 1 — the tier-L lane floor must be CUMULATIVE over the
+ * base wave, not per batch.
+ *
+ * The per-batch clause ("a batch claiming all six dimensions needs at least six
+ * lanes") is defeated by splitting one consolidation across two batches: claim
+ * five dimensions in a consolidated batch, then the sixth in a *singleton*
+ * batch. The singleton batch never reaches the tier-L predicate at all — the
+ * predicate only runs when a batch contains a consolidated lane — so every
+ * rejection has to happen at the consolidated batch, before the split can
+ * complete. That is what these tests pin.
+ */
+
+const [DIM_A, DIM_B, DIM_C, DIM_D, DIM_E, DIM_F] = PR_REVIEW_BASE_DIMENSION_IDS;
+
+beforeEach(setupTierLFixtures);
+afterEach(teardownTierLFixtures);
+
+describe('PR_REVIEW tier-L cumulative consolidation floor', () => {
+	test('the 5-then-1 split is blocked at the consolidated batch', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+
+		// Batch A claims five of six dimensions across two lanes. Per batch this
+		// is legal (five < six, so the all-six clause never fires) and every
+		// consolidated dimension is terminally failed with no successful source —
+		// the shape that used to be ACCEPTED and left the wave with three
+		// producing lanes once a trivial singleton batch B covered the sixth.
+		const error = await attemptBaseBatch(
+			[
+				{
+					laneId: 'retry-abc',
+					workflowLane: DIM_A,
+					ownedWorkflowLanes: [DIM_A, DIM_B, DIM_C],
+				},
+				{
+					laneId: 'retry-de',
+					workflowLane: DIM_D,
+					ownedWorkflowLanes: [DIM_D, DIM_E],
+				},
+			],
+			'base-retry-five',
+		);
+
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'this wave would be backed by only 3 distinct lanes',
+		);
+		expect(error?.message).toContain(
+			`at least ${PR_REVIEW_TIER_L_CONSOLIDATED_LANE_FLOOR} distinct`,
+		);
+		// The dead end is real: with batch A rejected, the split cannot complete.
+		await expect(
+			assertPrReviewBaseCoverageSettled(tierLDirectory(), SESSION_ID),
+		).rejects.toThrow('base coverage is incomplete');
+	});
+
+	test('splitting the consolidation across separate batches is still blocked', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+
+		// Two dimensions per consolidated batch: the first two are accepted, and
+		// the third — which would drop the wave to three backing lanes — is not.
+		// The floor is measured over DECLARED consolidated lanes, so declaring all
+		// three before any of them lands does not evade it.
+		expect(
+			await attemptConsolidatedRetry([DIM_A, DIM_B], 'retry-ab'),
+		).toBeNull();
+		expect(
+			await attemptBaseBatch(
+				[
+					{
+						laneId: 'retry-cd',
+						workflowLane: DIM_C,
+						ownedWorkflowLanes: [DIM_C, DIM_D],
+					},
+				],
+				'retry-cd-batch',
+			),
+		).toBeNull();
+		const error = await attemptBaseBatch(
+			[
+				{
+					laneId: 'retry-ef',
+					workflowLane: DIM_E,
+					ownedWorkflowLanes: [DIM_E, DIM_F],
+				},
+			],
+			'retry-ef-batch',
+		);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'this wave would be backed by only 3 distinct lanes',
+		);
+	});
+
+	test('singleton re-dispatch is always available after a rejected consolidation', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+		expect(
+			await attemptBaseBatch(
+				[
+					{
+						laneId: 'retry-abc',
+						workflowLane: DIM_A,
+						ownedWorkflowLanes: [DIM_A, DIM_B, DIM_C],
+					},
+					{
+						laneId: 'retry-de',
+						workflowLane: DIM_D,
+						ownedWorkflowLanes: [DIM_D, DIM_E],
+					},
+				],
+				'base-retry-five',
+			),
+		).not.toBeNull();
+
+		// The cumulative floor never blocks a full-depth recovery: a batch with no
+		// consolidated lane does not reach the tier-L predicate, so re-running the
+		// whole wave at one lane per dimension is always allowed and settles.
+		expect(
+			await attemptBaseBatch(
+				PR_REVIEW_BASE_DIMENSION_IDS.map((dimension) =>
+					singleton(dimension, 'redo'),
+				),
+				'base-redo',
+			),
+		).toBeNull();
+		for (const dimension of PR_REVIEW_BASE_DIMENSION_IDS) {
+			await persistBaseLane({
+				batchId: 'base-redo',
+				laneId: `redo-${dimension}`,
+				workflowLane: dimension,
+			});
+		}
+		await expect(
+			assertPrReviewBaseCoverageSettled(tierLDirectory(), SESSION_ID),
+		).resolves.toMatchObject({ sessionID: SESSION_ID });
+	});
+
+	test('a consolidated lane superseded by dedicated lanes stops spending budget', async () => {
+		await recordInitialWave();
+		await failEntireInitialWave();
+		// One consolidated retry is declared and then fails outright.
+		expect(
+			await attemptConsolidatedRetry([DIM_A, DIM_B], 'retry-ab'),
+		).toBeNull();
+		await persistBaseLane({
+			batchId: 'retry-ab',
+			laneId: 'retry-consolidated',
+			workflowLane: DIM_A,
+			ownedWorkflowLanes: [DIM_A, DIM_B],
+			status: 'error',
+		});
+		// Dedicated lanes then cover both of its dimensions successfully.
+		expect(
+			await attemptBaseBatch(
+				[singleton(DIM_A, 'fix'), singleton(DIM_B, 'fix')],
+				'base-fix-ab',
+			),
+		).toBeNull();
+		for (const dimension of [DIM_A, DIM_B]) {
+			await persistBaseLane({
+				batchId: 'base-fix-ab',
+				laneId: `fix-${dimension}`,
+				workflowLane: dimension,
+			});
+		}
+		// The dead consolidated lane no longer counts against the wave, so a fresh
+		// two-dimension consolidation still has budget: four dedicated dimensions
+		// (A, B from singletons plus the two the new lane does not claim) plus one
+		// consolidated lane = five backing lanes.
+		expect(
+			await attemptConsolidatedRetry([DIM_C, DIM_D], 'retry-cd'),
+		).toBeNull();
+
+		// A THIRD consolidation is what actually discriminates the supersession
+		// rule. Counting the superseded {A,B} lane the wave is {A,B} {C,D} {E,F} —
+		// a minimum cover of 3 over all six dimensions, no dedicated dimension
+		// left, so 3 < 4 and this would be rejected. Dropping it leaves {C,D}
+		// {E,F} covering four dimensions plus dedicated A and B = 4, exactly the
+		// floor. Without this step both counts (4 vs 5) clear the floor and the
+		// supersession branch is invisible.
+		expect(
+			await attemptConsolidatedRetry([DIM_E, DIM_F], 'retry-ef'),
+		).toBeNull();
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-tier-l-retry.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-tier-l-retry.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	activatePrWorkflow,
+	assertPrReviewBaseCoverageSettled,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	attemptBaseBatch,
+	attemptConsolidatedRetry,
+	HEAD_SHA,
+	persistBaseLane,
+	recordInitialWave,
+	SESSION_ID,
+	setTierLRevisionDigest,
+	setupTierLFixtures,
+	singleton,
+	TIER_L_MESSAGE,
+	teardownTierLFixtures,
+	tierLDirectory,
+} from './dispatch-lanes-pr-review-tier-l.test-fixtures.js';
+
+/**
+ * Issue #1968 P3: a tier-L base RETRY batch may consolidate dimensions into one
+ * lane only when every consolidated dimension already ran to a terminal,
+ * non-successful end, none of them currently has a successful source, and the
+ * batch keeps the tier-L lane floors.
+ *
+ * `dispatch-lanes-pr-workflow-gate.test.ts` is over the FR-006 500-line cap and
+ * may not grow, so this sibling hosts the accept/reject matrix. The cumulative
+ * (whole-wave) floor added by MUST-FIX 1 lives in
+ * `dispatch-lanes-pr-review-tier-l-retry-split.test.ts`.
+ */
+
+const [DIM_A, DIM_B, DIM_C, DIM_D, DIM_E, DIM_F] = PR_REVIEW_BASE_DIMENSION_IDS;
+
+beforeEach(setupTierLFixtures);
+afterEach(teardownTierLFixtures);
+
+describe('PR_REVIEW tier-L consolidated retry batches', () => {
+	test('(a) an initial wave that never completed still rejects a consolidated retry', async () => {
+		await recordInitialWave();
+		// No delegation records at all: the six lanes were declared and never ran.
+		// "No successful source" is trivially true here, which is precisely why the
+		// predicate requires a recorded TERMINAL failure instead.
+		const error = await attemptConsolidatedRetry([DIM_A, DIM_B]);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'no recorded lane that reached a terminal non-successful state',
+		);
+	});
+
+	test('(a2) lanes still in flight reject a consolidated retry', async () => {
+		await recordInitialWave();
+		// A pending record is a record — but not a terminal one.
+		await recordPendingDelegation(tierLDirectory(), {
+			correlationId: 'in-flight',
+			jobId: null,
+			subagentSessionId: 'in-flight',
+			parentSessionId: SESSION_ID,
+			callID: 'call-in-flight',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'base-initial',
+			laneId: `lane-${DIM_A}`,
+			mode: 'swarm-pr-review:base',
+			workflowLane: DIM_A,
+			workspace: {
+				directory: tierLDirectory(),
+				gitHead: HEAD_SHA,
+				dirtyHash: null,
+				prHeadSha: HEAD_SHA,
+				scope: null,
+			},
+		});
+		const error = await attemptConsolidatedRetry([DIM_A, DIM_B]);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain('still in flight');
+	});
+
+	test('(b) dimensions whose lanes ran and failed accept a consolidated retry', async () => {
+		await recordInitialWave();
+		await persistBaseLane({
+			batchId: 'base-initial',
+			laneId: `lane-${DIM_A}`,
+			workflowLane: DIM_A,
+			status: 'error',
+		});
+		await persistBaseLane({
+			batchId: 'base-initial',
+			laneId: `lane-${DIM_B}`,
+			workflowLane: DIM_B,
+			status: 'error',
+		});
+		const error = await attemptConsolidatedRetry([DIM_A, DIM_B]);
+		expect(error).toBeNull();
+		const state = await enforcePrReviewBaseDimensions(
+			tierLDirectory(),
+			SESSION_ID,
+			[singleton(DIM_C, 'later')],
+			{ batchId: 'base-later', prHeadSha: HEAD_SHA },
+		);
+		expect(state.prReviewBaseDispatches?.map((batch) => batch.batchId)).toEqual(
+			['base-initial', 'base-retry-consolidated', 'base-later'],
+		);
+	});
+
+	test('(b3) a consolidated retry actually settles tier-L base coverage', async () => {
+		// The point of the exception: re-run only the failed dimensions and still
+		// finish, instead of re-dispatching a full six-lane singleton fan-out.
+		await recordInitialWave();
+		for (const dimension of [DIM_A, DIM_B]) {
+			await persistBaseLane({
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				workflowLane: dimension,
+				status: 'error',
+			});
+		}
+		for (const dimension of [DIM_C, DIM_D, DIM_E, DIM_F]) {
+			await persistBaseLane({
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				workflowLane: dimension,
+			});
+		}
+		expect(await attemptConsolidatedRetry([DIM_A, DIM_B])).toBeNull();
+		await persistBaseLane({
+			batchId: 'base-retry-consolidated',
+			laneId: 'retry-consolidated',
+			workflowLane: DIM_A,
+			ownedWorkflowLanes: [DIM_A, DIM_B],
+		});
+		await expect(
+			assertPrReviewBaseCoverageSettled(tierLDirectory(), SESSION_ID),
+		).resolves.toMatchObject({ prHeadSha: HEAD_SHA });
+	});
+
+	test('(b2) a completed-but-degraded lane counts as a terminal failure', async () => {
+		await recordInitialWave();
+		// Status `completed`, but the artifact never reaches the store, so the
+		// record fails the integrity chain. Completion alone is not success.
+		for (const dimension of [DIM_A, DIM_B]) {
+			const correlationId = `degraded-${dimension}`;
+			await recordPendingDelegation(tierLDirectory(), {
+				correlationId,
+				jobId: null,
+				subagentSessionId: correlationId,
+				parentSessionId: SESSION_ID,
+				callID: `call-${correlationId}`,
+				normalizedAgent: 'explorer',
+				swarmPrefixedAgent: 'explorer',
+				planTaskId: null,
+				evidenceTaskId: null,
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				mode: 'swarm-pr-review:base',
+				workflowLane: dimension,
+				workspace: {
+					directory: tierLDirectory(),
+					gitHead: HEAD_SHA,
+					dirtyHash: null,
+					prHeadSha: HEAD_SHA,
+					scope: null,
+				},
+			});
+			await appendDelegationTransition(tierLDirectory(), correlationId, {
+				status: 'completed',
+				result: { text: '', chars: 0, truncated: true, digest: '' },
+			});
+		}
+		expect(await attemptConsolidatedRetry([DIM_A, DIM_B])).toBeNull();
+	});
+
+	test('(c) a dimension with a successful singleton rejects a consolidated retry', async () => {
+		await recordInitialWave();
+		await persistBaseLane({
+			batchId: 'base-initial',
+			laneId: `lane-${DIM_A}`,
+			workflowLane: DIM_A,
+		});
+		await persistBaseLane({
+			batchId: 'base-initial',
+			laneId: `lane-${DIM_B}`,
+			workflowLane: DIM_B,
+			status: 'error',
+		});
+		const error = await attemptConsolidatedRetry([DIM_A, DIM_B]);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain('already have a successful source');
+		expect(error?.message).toContain(DIM_A);
+	});
+
+	test('a worktree edit alone never unlocks consolidation', async () => {
+		await recordInitialWave();
+		for (const dimension of PR_REVIEW_BASE_DIMENSION_IDS) {
+			await persistBaseLane({
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				workflowLane: dimension,
+			});
+		}
+		// Every artifact is now stale against the current revision, so nothing has
+		// a *successful* source any more. Failure is deliberately derived from the
+		// revision-independent record integrity chain, so the six lanes are still
+		// not failed and consolidation stays closed.
+		setTierLRevisionDigest('revision-after-a-whitespace-edit');
+		const error = await attemptConsolidatedRetry([DIM_A, DIM_B]);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'no recorded lane that reached a terminal non-successful state',
+		);
+	});
+
+	test('the tier-L lane floor survives: one lane may never own all six', async () => {
+		await recordInitialWave();
+		for (const dimension of PR_REVIEW_BASE_DIMENSION_IDS) {
+			await persistBaseLane({
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				workflowLane: dimension,
+				status: 'error',
+			});
+		}
+		const error = await attemptConsolidatedRetry([
+			...PR_REVIEW_BASE_DIMENSION_IDS,
+		]);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain('owns all 6 dimensions on its own');
+	});
+
+	test('the tier-L lane floor survives: a full-coverage retry needs six lanes', async () => {
+		await recordInitialWave();
+		for (const dimension of PR_REVIEW_BASE_DIMENSION_IDS) {
+			await persistBaseLane({
+				batchId: 'base-initial',
+				laneId: `lane-${dimension}`,
+				workflowLane: dimension,
+				status: 'error',
+			});
+		}
+		const error = await attemptBaseBatch(
+			[
+				{
+					laneId: 'retry-abc',
+					workflowLane: DIM_A,
+					ownedWorkflowLanes: [DIM_A, DIM_B, DIM_C],
+				},
+				{
+					laneId: 'retry-def',
+					workflowLane: DIM_D,
+					ownedWorkflowLanes: [DIM_D, DIM_E, DIM_F],
+				},
+			],
+			'base-retry-two-lanes',
+		);
+		expect(error?.message).toContain(TIER_L_MESSAGE);
+		expect(error?.message).toContain(
+			'claims all 6 dimensions with only 2 lanes',
+		);
+	});
+
+	test('P3.2: at tier L a successful singleton outranks a consolidated source', async () => {
+		await activatePrWorkflow(tierLDirectory(), SESSION_ID, 'PR_REVIEW');
+		// 1. Both dimensions run and fail, unlocking a consolidated retry.
+		await enforcePrReviewBaseDimensions(
+			tierLDirectory(),
+			SESSION_ID,
+			[singleton(DIM_A, 'fail'), singleton(DIM_B, 'fail')],
+			{ batchId: 'base-failed', prHeadSha: HEAD_SHA },
+		);
+		await persistBaseLane({
+			batchId: 'base-failed',
+			laneId: `fail-${DIM_A}`,
+			workflowLane: DIM_A,
+			status: 'error',
+		});
+		await persistBaseLane({
+			batchId: 'base-failed',
+			laneId: `fail-${DIM_B}`,
+			workflowLane: DIM_B,
+			status: 'error',
+		});
+		// 2. A singleton retry for DIM_A is declared but has not landed yet — the
+		//    only order in which both source classes can coexist, because a
+		//    dimension with a live successful source may not be consolidated over.
+		await enforcePrReviewBaseDimensions(
+			tierLDirectory(),
+			SESSION_ID,
+			[singleton(DIM_A, 'single')],
+			{ batchId: 'base-singleton-a', prHeadSha: HEAD_SHA },
+		);
+		// 3. The consolidated retry is declared and lands first.
+		expect(await attemptConsolidatedRetry([DIM_A, DIM_B])).toBeNull();
+		await persistBaseLane({
+			batchId: 'base-retry-consolidated',
+			laneId: 'retry-consolidated',
+			workflowLane: DIM_A,
+			ownedWorkflowLanes: [DIM_A, DIM_B],
+			candidateIds: ['CONSOLIDATED-A', 'CONSOLIDATED-B'],
+		});
+		// 4. The older singleton's record completes late.
+		await persistBaseLane({
+			batchId: 'base-singleton-a',
+			laneId: `single-${DIM_A}`,
+			workflowLane: DIM_A,
+			candidateIds: ['SINGLETON-A'],
+		});
+
+		const inventory = await gateInternals.derivePrReviewCandidateInventory(
+			tierLDirectory(),
+			SESSION_ID,
+		);
+		// Most-recent-wins alone would have credited the consolidated lane for
+		// DIM_A. Tier L prefers the singleton, which is the lane that actually
+		// satisfied the tier's per-dimension depth contract; the consolidated lane
+		// is still the source for the dimension nothing else covers.
+		expect(inventory).toContain('SINGLETON-A');
+		expect(inventory).toContain('CONSOLIDATED-B');
+		expect(inventory).not.toContain('CONSOLIDATED-A');
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-tier-l.test-fixtures.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-tier-l.test-fixtures.ts
@@ -1,0 +1,239 @@
+import { mkdtempSync, realpathSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store.js';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	activatePrWorkflow,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+} from '../../../src/hooks/pr-workflow-gate.js';
+
+/**
+ * Shared fixtures for the tier-L consolidated-retry suites.
+ *
+ * Bun scopes `beforeEach`/`afterEach` to the test file whose module evaluation
+ * registered them, and a shared module is evaluated once per process, so this
+ * module deliberately exports plain setup/teardown functions instead of
+ * registering hooks itself. Each consuming test file wires them up.
+ */
+
+export const SESSION_ID = 'tier-l-retry';
+export const HEAD_SHA = 'abc123';
+export const REVISION_DIGEST = 'tier-l-revision';
+export const TIER_L_MESSAGE =
+	'depth tier L requires one dedicated lane per dimension';
+const CANDIDATE_HEADER =
+	'[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence';
+
+let directory = '';
+let currentRevisionDigest = REVISION_DIGEST;
+
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveRevisionDigest =
+	gateInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+
+/** The temp worktree the current test is running against. */
+export function tierLDirectory(): string {
+	return directory;
+}
+
+/** The digest the stubbed resolver currently returns. */
+export function tierLRevisionDigest(): string {
+	return currentRevisionDigest;
+}
+
+/** Simulate a worktree edit by moving the resolved revision digest. */
+export function setTierLRevisionDigest(next: string): void {
+	currentRevisionDigest = next;
+}
+
+export function setupTierLFixtures(): void {
+	directory = realpathSync(
+		mkdtempSync(path.join(os.tmpdir(), 'pr-review-tier-l-')),
+	);
+	currentRevisionDigest = REVISION_DIGEST;
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolvePrWorkflowRevisionDigest = () => currentRevisionDigest;
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+}
+
+export async function teardownTierLFixtures(): Promise<void> {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolvePrWorkflowRevisionDigest = originalResolveRevisionDigest;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	await fs.rm(directory, { recursive: true, force: true });
+}
+
+function artifactText(
+	rows: ReadonlyArray<{ candidateId: string; dimension: string }>,
+): string {
+	return [
+		CANDIDATE_HEADER,
+		...rows.map(
+			({ candidateId, dimension }) =>
+				`${candidateId} | ${dimension} | HIGH | correctness | src/${dimension}.ts:1 | claim about ${dimension} | evidence for ${dimension} | impact on ${dimension} | HIGH`,
+		),
+	].join('\n');
+}
+
+/**
+ * Persist one base lane's delegation record and artifact. Written per lane
+ * rather than per batch so a single batch can mix a terminally-failed lane with
+ * a successful one, which is exactly the state the retry predicate discriminates
+ * on.
+ */
+export async function persistBaseLane(options: {
+	batchId: string;
+	laneId: string;
+	workflowLane: string;
+	ownedWorkflowLanes?: string[];
+	candidateIds?: string[];
+	status?: 'completed' | 'error';
+}): Promise<void> {
+	const correlationId = `${options.batchId}--${options.laneId}`;
+	const owned = options.ownedWorkflowLanes?.length
+		? options.ownedWorkflowLanes
+		: [options.workflowLane];
+	const candidateIds =
+		options.candidateIds ?? owned.map((dimension) => `C-${dimension}`);
+	const text = artifactText(
+		owned.map((dimension, index) => ({
+			candidateId: candidateIds[index] ?? `C-${dimension}`,
+			dimension,
+		})),
+	);
+	await recordPendingDelegation(directory, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `call-${correlationId}`,
+		normalizedAgent: 'explorer',
+		swarmPrefixedAgent: 'explorer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: options.batchId,
+		laneId: options.laneId,
+		mode: 'swarm-pr-review:base',
+		workflowLane: options.workflowLane,
+		...(options.ownedWorkflowLanes
+			? { ownedWorkflowLanes: options.ownedWorkflowLanes }
+			: {}),
+		workspace: {
+			directory,
+			gitHead: HEAD_SHA,
+			dirtyHash: null,
+			prHeadSha: HEAD_SHA,
+			scope: null,
+		},
+	});
+	const stored = storeLaneOutput(directory, {
+		batchId: options.batchId,
+		laneId: options.laneId,
+		agent: 'explorer',
+		role: 'explorer',
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: 'swarm-pr-review:base',
+		workflowLane: options.workflowLane,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: REVISION_DIGEST,
+		source: 'collect_lane_results',
+		text,
+	});
+	await appendDelegationTransition(directory, correlationId, {
+		status: options.status ?? 'completed',
+		result: {
+			text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			...(stored.ref ? { outputRef: stored.ref } : {}),
+		},
+	});
+}
+
+export function singleton(workflowLane: string, prefix = 'lane') {
+	return { laneId: `${prefix}-${workflowLane}`, workflowLane };
+}
+
+/** Activate PR_REVIEW and declare the tier-L six-lane singleton initial wave. */
+export async function recordInitialWave(): Promise<void> {
+	await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW');
+	await enforcePrReviewBaseDimensions(
+		directory,
+		SESSION_ID,
+		PR_REVIEW_BASE_DIMENSION_IDS.map((dimension) => singleton(dimension)),
+		{ batchId: 'base-initial', prHeadSha: HEAD_SHA },
+	);
+}
+
+/** Fail every initial-wave lane terminally — a realistic provider outage. */
+export async function failEntireInitialWave(): Promise<void> {
+	for (const dimension of PR_REVIEW_BASE_DIMENSION_IDS) {
+		await persistBaseLane({
+			batchId: 'base-initial',
+			laneId: `lane-${dimension}`,
+			workflowLane: dimension,
+			status: 'error',
+		});
+	}
+}
+
+/** Record a base batch, returning the rejection error or `null` on acceptance. */
+export async function attemptBaseBatch(
+	lanes: ReadonlyArray<{
+		laneId: string;
+		workflowLane: string;
+		ownedWorkflowLanes?: string[];
+	}>,
+	batchId: string,
+): Promise<Error | null> {
+	return enforcePrReviewBaseDimensions(directory, SESSION_ID, lanes, {
+		batchId,
+		prHeadSha: HEAD_SHA,
+		revisionDigest: currentRevisionDigest,
+	}).then(
+		() => null,
+		(reason: unknown) => reason as Error,
+	);
+}
+
+/** The single-consolidated-lane retry shape most cases exercise. */
+export async function attemptConsolidatedRetry(
+	ownedWorkflowLanes: readonly string[],
+	batchId = 'base-retry-consolidated',
+): Promise<Error | null> {
+	return attemptBaseBatch(
+		[
+			{
+				laneId: 'retry-consolidated',
+				workflowLane: ownedWorkflowLanes[0],
+				ownedWorkflowLanes: [...ownedWorkflowLanes],
+			},
+		],
+		batchId,
+	);
+}

--- a/tests/unit/tools/write-pr-review-trigger-eval-validation.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-validation.test.ts
@@ -47,6 +47,8 @@ const originalGateRevisionDigest =
 	gateInternals.resolvePrWorkflowRevisionDigest;
 const originalResolveRevisionDigest =
 	writerInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveRevisionDigestAsync =
+	writerInternals.resolvePrWorkflowRevisionDigestAsync;
 const originalResolveMergeBase = writerInternals.resolveMergeBase;
 
 function tempRoot(): string {
@@ -224,6 +226,8 @@ afterEach(() => {
 	gateInternals.resolvePrWorkflowRevisionDigest = originalGateRevisionDigest;
 	writerInternals.resolvePrWorkflowRevisionDigest =
 		originalResolveRevisionDigest;
+	writerInternals.resolvePrWorkflowRevisionDigestAsync =
+		originalResolveRevisionDigestAsync;
 	writerInternals.resolveMergeBase = originalResolveMergeBase;
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -315,6 +319,35 @@ describe('write_pr_review_trigger_eval - row validation', () => {
 		expect(result.message).toContain('NO-MATCH');
 		expect(result.message).toContain('MATCHED');
 		expect(result.message).toContain('NOT_TRIGGERED');
+	});
+
+	test('binds the revision digest off the blocking synchronous path', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+		// Restore the sync seam to its real implementation so the selection rule
+		// must fall through to the async twin; a regression to the blocking
+		// resolver would shell out to real git here instead.
+		writerInternals.resolvePrWorkflowRevisionDigest =
+			originalResolveRevisionDigest;
+		let asyncCalls = 0;
+		writerInternals.resolvePrWorkflowRevisionDigestAsync = async () => {
+			asyncCalls += 1;
+			return REVISION_DIGEST;
+		};
+		const args = {
+			run_id: 'async-digest',
+			pr_head_sha: HEAD_SHA,
+			base_sha: 'def456',
+			base_ref: 'origin/main',
+			rows: rows(),
+		};
+		const response = JSON.parse(
+			await executeWritePrReviewTriggerEval(args, root, {
+				sessionID: SESSION_ID,
+			}),
+		);
+		expect(response).toMatchObject({ success: true });
+		expect(asyncCalls).toBe(1);
 	});
 
 	test('rejects traversal', async () => {


### PR DESCRIPTION
Closes #1968

## Summary

The PR-workflow gates used the entire inventory on the current revision as the atomic unit of validity, failed closed, and were invariant to change size — so every *local* failure became *global* rework. One failed lane in a six-lane reviewer batch re-ran all six; a tier-L retry re-ran the full singleton fan-out; a one-line PR_FEEDBACK fix re-verified every already-closed item; and three batch limits were permanent dead ends with no recovery path.

This moves the unit of validity from the batch to the review item — in a place where doing it *partially* is a safety regression rather than a partial win (the issue records a first attempt that died in adversarial review).

- **Reviewer/critic settlement is now a single item-keyed composition** shared by settlement and every verdict derivation. Settlement *is* "every required item has a verdict" over the same map the gates read, so it cannot pass while the authoritative verdict map is empty — the failure mode that would otherwise skip the critic gate entirely and ship CONFIRMED CRITICAL/HIGH findings unchallenged (constraint B1).
- **The marker check yields a per-item verdict map instead of a lane boolean**, so one bad item no longer discards its healthy siblings. Without this the atomic unit would still have been the lane and the headline benefit would have been false against the code.
- **Explicit per-item conflict rule** (B2): where several successful lanes cover the same item, the most recent wins — computed once and shared, so settlement and derivation can never disagree. A batch contributes only against the candidate inventory it was validated against (B3), and critic claims bind per item to a digest of the exact reviewer row they challenged, replacing the blanket rule that any new reviewer batch invalidated every critic batch.
- **Tier-L retries** may consolidate only dimensions with a recorded, failed attempt, and a wave may never fall below the tier-M lane count. The floor counts a *minimum cover* of the consolidated dimensions, so neither splitting a consolidation across batches nor overlapping or duplicate declarations evades it (B6).
- **The batch limits are no longer dead ends** (B7). Base, validation and feedback-verification batches are collected when they provably contribute nothing, inside the same append transaction, aborting if any derived inventory or coverage set would change. Where reclaiming would have loosened a fail-closed control — the critic session-reuse ban, the tier-L consolidation floor, cumulative feedback item ownership — the control is carried forward in a bounded ledger and the GC aborts, never the check.
- **PR_FEEDBACK** Stage A re-records retain gate batches when the revision digest is unchanged and the obligation set did not narrow.
- **Revision digests** resolve once per gate entry point and name the exact bound that failed; caps rise with the git output buffer in step, since raising the file cap alone was inert. A double-armed enumeration deadline could report a timeout as a generic Git failure; that race now has one owner.

### Acceptance criteria to evidence

| # | Criterion | Evidence |
|---|---|---|
| 1 | Composed partial batches settle; B2 admitted-gap and conflicting-verdict fail closed | `composePrReviewPhaseVerdicts`; `pr-workflow-gate-review-item-coherence.test.ts` |
| 2 | Composed batches can never silently empty the critic inventory (B1) | `assertSettledPhaseHasAuthoritativeVerdicts` plus `derivePrReviewCriticInventoryForCoverageGate`; `pr-workflow-gate-b1-invariant.test.ts` (11 tests) |
| 3 | Tier-L retry consolidates only failed dimensions; successful singleton never superseded | `tierLConsolidationRejection`, `minimumConsolidatedLaneCover`; the four `dispatch-lanes-pr-review-tier-l-*` suites |
| 4 | `MAX_WORKFLOW_BATCHES` no longer a dead end | `pruneWorkflowBatches` and `prunePrFeedbackVerificationsForCapacity` at all three cap sites; `pr-workflow-gate-batch-gc`, `-feedback-batch-gc`, `-gc-ledger-overflow` |
| 5 | PR_FEEDBACK re-verification | `stageARetainsGateBatches`; `pr-workflow-gate-stage-a-retention.test.ts` (14 tests). Item-scoped invalidation recorded as unsound — see Design decisions |
| 6 | Digest caps usable on large diffs | caps raised together with `GIT_SNAPSHOT_MAX_BUFFER`; discriminated failure reasons; `workspace-snapshot-digest-bounds`, `-digest-failure-reasons`, `pr-workflow-gate-digest-diagnostics` (every arm pinned: the 7 production `RevisionDigestFailureReason` members, plus the gate-local `seam-unavailable` case that only fires when a test injects the legacy `string \| null` seam) |
| 7 | No added synchronous digest resolution (M2) | one resolve per gate entry point; per-record sync fallback removed; `pr-workflow-gate-digest-threading.test.ts` asserts exactly 1 |
| 8 | Skill prose updated; drift clean; release fragment | both swarm-pr skills plus mirrors; `docs/releases/pending/1968-*.md`; stale unreleased narrative corrected |
| 9 | Independent adversarial design review before implementation | two fresh critics on the plan returned NEEDS_REVISION and BLOCKED with 6 blockers, each resolved before any production edit |

### Design decisions

- **Item-scoped PR_FEEDBACK invalidation is deliberately not implemented.** `prFeedbackScopes.files` is caller-asserted and only path-sanitized, never intersected with the real changed set, and is keyed by `taskId` with no persisted binding to feedback item ids — keying invalidation on it lets a controller dodge invalidation by under-declaring, turning fail-closed into fail-open (invariant 9). The four gate phases are also holistic by contract. Acceptance criterion 5 explicitly permits this recorded-rationale branch.
- **The lane-level "every declared obligation settled" check was dropped** in favour of item completeness; it is part of the all-or-nothing accounting this issue removes. An abandoned declared lane is now a named diagnostic. Tested in both directions.
- **The critic row-digest binding does not close the leave-and-return path.** An earlier draft claimed it did; that is retracted in the code comment. A byte-identical row from a different lane re-admits the bound claim — content-equivalent by construction and still pinned to the current revision digest, but not prevented.

## Invariant audit

- 1 (plugin init): not touched — no `src/index.ts`, manifest, or entry-shape change; the gate is not reachable from the init path. Verified anyway: `node scripts/repro-704.mjs` gave T1 240.8ms (deadline 400ms), T2 183.7ms, T3 193.1ms, all OK.
- 2 (runtime portability): not touched — no `bun:` imports and no `Bun.*` outside `bun-compat`. Verified: `bun run build` clean and `node --input-type=module -e "await import('./dist/index.js')"` printed `dist import OK`.
- 3 (subprocesses): touched — `src/background/workspace-snapshot.ts`. All call sites remain array-form with explicit `git -C <dir>` and `cwd`, `stdin: 'ignore'`, bounded stdout/stderr via `readBoundedGitOutput` (SIGKILL on overflow), `killProcessTree: true`, and best-effort `proc.kill('SIGKILL')` plus `clearTimeout` in `finally`. `runGitAsyncDetailed` no longer passes `timeout` to `bunSpawn`: the deadline now has exactly one owner (a `Promise.race` against `setTimeout(timeoutMs)`), because two timers on the same deadline made the reported failure reason depend on their firing order and misreported a timeout as `git-failed`. The call remains bounded, non-interactive and killable. Audit command `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns 5 sites, all conforming. `GIT_SNAPSHOT_MAX_BUFFER` was raised from 512KB to 32MB module-wide: still a hard bound, and the coupling is required because raising the file cap alone was inert.
- 4 (.swarm containment): not touched — state stays in the existing per-session gate file under `.swarm/pr-workflow-gates/`.
- 5 (plan durability): not touched — no ledger, projection, or plan-schema change.
- 6 (test_runner safety): not touched — all validation via `bun run test:unit:ci` and per-file shell loops; no broad `test_runner` scope was used.
- 7 (test writing): touched — `bun:test` only; zero `mock.module` in any touched test file (DI via `_internals` / `_test_exports` with save and restore in `afterEach`); `os.tmpdir()` plus `path.join` throughout. `bash scripts/check-mock-cleanup.sh` passes (14 pre-existing non-blocking violations, none in this change). `bash scripts/check-test-file-cap.sh` reports 0 new-file and 0 ratchet violations.
- 8 (session state): touched — four new optional top-level keys on the intentionally non-strict parent schema (`prReviewBatchCoherence`, `prReviewRetiredReviewerSessionIds`, `prReviewRetiredConsolidatedLanes`, `prFeedbackRetiredItemOwnership`), never fields on a `.strict()` child. Each is session-scoped and schema-bounded by the same constant the GC checks; rollback is asserted by parsing files a new plugin actually wrote against a v1-shaped schema.
- 9 (guardrails/retry): touched — every change preserves fail-closed direction. Where a reclaim would have loosened a control, the GC aborts instead of the check. The guardrail `assertSettledPhaseHasAuthoritativeVerdicts` is proven to bite by mutation, including a counterfactual showing `completePrWorkflow` walking past the critic gate when the guardrail is neutered.
- 10 (chat/system msg): not touched — no hook output or message-shape change.
- 11 (tool registration): not touched — no new tool, agent-map, command, or help entry. `bun run scripts/check-tool-registration.ts` reports 116 tools coherent. `bun run drift:check` reports zero findings naming any file in this change.
- 12 (release/cache): touched — `docs/releases/pending/1968-pr-workflow-composable-gate-accounting.md` added, and the now-false unreleased narrative in `pr-workflow-mechanical-gates.md` corrected. `git diff origin/main..HEAD -- package.json CHANGELOG.md .release-please-manifest.json` is empty.

## Test plan

- [x] `bun run build` exit 0; `node --input-type=module -e "await import('./dist/index.js')"` printed `dist import OK`
- [x] `node scripts/repro-704.mjs` 3/3 OK (240.8ms / 183.7ms / 193.1ms)
- [x] `bun run typecheck` exit 0
- [x] `bun run lint:ci` checked 3013 files, no fixes applied
- [x] `bun run scripts/check-tool-registration.ts` 116 tools coherent
- [x] `check-mock-cleanup.sh`, `check-invariants.sh`, `check-cross-contamination.sh`, `check-test-clock.sh` all exit 0 (pre-existing advisories only, none in changed files)
- [x] `bash scripts/check-test-file-cap.sh` 0 new-file, 0 ratchet violations
- [x] `bash .opencode/skills/issue-tracer/scripts/scan-deferred.sh` clean, no deferred-work markers on added lines
- [x] `bun run test:unit:ci` over the 21 changed test files: 21/21 exit 0 (CI-equivalent gate)
- [x] Per-file sweep of the 76-file PR-workflow / PR-review / PR-feedback / workspace-snapshot regression set: 75 green (AGENTS.md invariant 6 requires per-file runs)
- [x] `bun test tests/security` 163 pass 0 fail; `tests/adversarial` 846 pass 0 fail; `tests/smoke` 10 pass 0 fail
- [x] Mutation testing: every new fail-closed control verified to bite. Five controls that initially shipped wired-but-undiscriminated now have mutation-proven tests

### Pre-existing failures

- `bun test tests/integration ./test` gives 749 pass / 215 fail on this branch, and **identically** on clean `origin/main` (749 pass / 215 fail / 2081 expect() calls / 964 tests / 80 files), verified in a separate worktree at `1adff503` with `bun install --frozen-lockfile`. Not inherited from this change.
- `tests/unit/hooks/pr-workflow-gate-feedback-attachment.test.ts` fails with a Windows `EBUSY` on temp-dir teardown and reproduces identically at `1adff503`. This change touches none of its code paths.
- `bun run drift:check` reports 16-17 pre-existing skill-mirror drift findings on unrelated skills (brainstorm, clarify, council and others); zero name any file in this change, and the check is soft-warn by default.

## Waivers

None.
