### PR TITLE
test(build): stop mock.module pollution leaking out of tests/unit/build

### DIFF
--- a/docs/releases/pending/build-test-mock-module-registry-pollution.md
+++ b/docs/releases/pending/build-test-mock-module-registry-pollution.md
@@ -7,8 +7,9 @@
 `src/lang/detector` and `src/lang/profiles` via `mock.module` with **partial**
 objects — `LANGUAGE_REGISTRY` was mocked with a `get` method and nothing else.
 
-Both mocks now follow the AGENTS.md invariant 7 spread-real-exports pattern, and
-a permanent regression guard was added at
+Both mocks now follow the AGENTS.md invariant 7 spread-real-exports pattern, the
+shared scaffolding moved to `tests/unit/build/discovery-profiles-mocks.ts`, and a
+local-only regression guard was added at
 `tests/unit/build/zz-imports-plugin-entry.test.ts`.
 
 ## Why
@@ -41,13 +42,13 @@ on the prototype. `{ ...realProfiles.LANGUAGE_REGISTRY, get: mockGet }` copies
 only own enumerable properties and would silently drop every method, leaving the
 mock just as partial as before.
 
-The mocks instead derive from the real singleton:
+The mocks instead derive from the real singleton, via
+`deriveMockedRegistry` in `tests/unit/build/discovery-profiles-mocks.ts`
+(schematic — see the helper for the exact generic signature):
 
 ```ts
-const mockedLanguageRegistry = Object.create(
-	realProfiles.LANGUAGE_REGISTRY,
-) as typeof realProfiles.LANGUAGE_REGISTRY;
-mockedLanguageRegistry.get = (...args) => mockLangRegistryGet(...args);
+const derived = Object.create(realRegistry) as R;
+derived.get = ((...args: Parameters<R['get']>) => mockGet(...args)) as R['get'];
 ```
 
 Prototype lookup keeps every real method and the instance's private `Map`s
@@ -56,7 +57,20 @@ reachable, and the own-property `get` override never mutates the real singleton.
 Caveat for future edits: do not call the registry's mutators (`register`,
 `unregister`) through the derived object — `this.profiles` resolves up the
 prototype chain to the **real** singleton's `Map` and would pollute it globally.
-Neither test file does so today.
+Neither test file does so today, and the caveat is repeated as a doc comment on
+`deriveMockedRegistry` itself so it is visible at the point of use.
+
+### Why the `mock.module` calls stayed in the test files
+
+The shared helper holds only the fixture type and the registry derivation. The
+literal `mock.module('../../../src/lang/detector', …)` /
+`('../../../src/lang/profiles', …)` calls deliberately remain in each
+`*.test.ts`, because `scripts/check-mock-cleanup.sh` and
+`scripts/generate-mock-allowlist.sh` both discover mocks with
+`grep -r --include="*.test.ts"`. Hoisting those calls into a non-test helper
+would have hidden both targets (`scripts/mock-allowlist.txt:93-94`) from the
+very gates that police this defect class — trading a real guardrail for tidier
+files.
 
 ## Migration
 
@@ -65,10 +79,14 @@ affected.
 
 ## Known caveats
 
-`tests/unit/build/zz-imports-plugin-entry.test.ts` relies on filename sort order
-so that it imports `src/index.ts` *after* the sibling mocks install. The `zz-`
-prefix is load-bearing; a guard that sorts before `discovery-*` would be inert.
-This is documented in the file's own docstring.
+`tests/unit/build/zz-imports-plugin-entry.test.ts` is a **local-only** guard, and
+the label matters: CI (`scripts/ci/run-unit-tests-local.ts`) runs every test file
+in its own process, so the sibling mocks are never installed alongside it and it
+passes trivially there. It bites only on a shared-process run such as
+`bun test tests/unit/build/` — which is exactly how the defect was found. It is
+also inert under `bun test --randomize`, which can schedule it before the
+`discovery-*` mocks install. Both limits are documented in the file's docstring;
+neither is a defect, but a green CI run is not evidence the guard fired.
 
 `scripts/check-mock-cleanup.sh` still reports 14 pre-existing non-spreading
 `mock.module` violations elsewhere in the repository (currently warning-only,

--- a/docs/releases/pending/build-test-mock-module-registry-pollution.md
+++ b/docs/releases/pending/build-test-mock-module-registry-pollution.md
@@ -1,0 +1,75 @@
+# Fix cross-file `mock.module` pollution in `tests/unit/build/`
+
+## What
+
+`tests/unit/build/discovery-profiles.test.ts` and
+`tests/unit/build/discovery-profiles-adversarial.test.ts` replaced
+`src/lang/detector` and `src/lang/profiles` via `mock.module` with **partial**
+objects — `LANGUAGE_REGISTRY` was mocked with a `get` method and nothing else.
+
+Both mocks now follow the AGENTS.md invariant 7 spread-real-exports pattern, and
+a permanent regression guard was added at
+`tests/unit/build/zz-imports-plugin-entry.test.ts`.
+
+## Why
+
+`mock.module` leaks process-wide in Bun's shared test-runner. Because these two
+mocks did not spread the real module's exports, **any** test file placed in
+`tests/unit/build/` that transitively imported `src/index.ts` crashed at
+module-evaluation time:
+
+```
+TypeError: LANGUAGE_REGISTRY.getAll is not a function
+    at src/tools/repo-graph/builder.ts  (module scope)
+```
+
+`src/tools/repo-graph/builder.ts` computes `SUPPORTED_EXTENSIONS` from
+`LANGUAGE_REGISTRY.getAll()` at module scope, so the partial mock turned a
+sibling file's import into a hard failure. The affected file passed in isolation
+and failed only when the directory was run as a whole, which makes the trap easy
+to misdiagnose as a bug in the new test.
+
+This was hit while implementing #2029 and worked around at the time by
+relocating the new test out of `tests/unit/build/` entirely. The underlying trap
+remained for the next author; this change removes it.
+
+## Notable detail — a plain spread would not have fixed it
+
+`LANGUAGE_REGISTRY` is an instance of the `LanguageRegistry` class
+(`src/lang/profiles.ts`), so `get`, `getAll`, `getByExtension`, and the rest live
+on the prototype. `{ ...realProfiles.LANGUAGE_REGISTRY, get: mockGet }` copies
+only own enumerable properties and would silently drop every method, leaving the
+mock just as partial as before.
+
+The mocks instead derive from the real singleton:
+
+```ts
+const mockedLanguageRegistry = Object.create(
+	realProfiles.LANGUAGE_REGISTRY,
+) as typeof realProfiles.LANGUAGE_REGISTRY;
+mockedLanguageRegistry.get = (...args) => mockLangRegistryGet(...args);
+```
+
+Prototype lookup keeps every real method and the instance's private `Map`s
+reachable, and the own-property `get` override never mutates the real singleton.
+
+Caveat for future edits: do not call the registry's mutators (`register`,
+`unregister`) through the derived object — `this.profiles` resolves up the
+prototype chain to the **real** singleton's `Map` and would pollute it globally.
+Neither test file does so today.
+
+## Migration
+
+No migration required. Test-only change; no runtime or public API surface is
+affected.
+
+## Known caveats
+
+`tests/unit/build/zz-imports-plugin-entry.test.ts` relies on filename sort order
+so that it imports `src/index.ts` *after* the sibling mocks install. The `zz-`
+prefix is load-bearing; a guard that sorts before `discovery-*` would be inert.
+This is documented in the file's own docstring.
+
+`scripts/check-mock-cleanup.sh` still reports 14 pre-existing non-spreading
+`mock.module` violations elsewhere in the repository (currently warning-only,
+outside the scope of this change).

--- a/tests/unit/build/discovery-profiles-adversarial.test.ts
+++ b/tests/unit/build/discovery-profiles-adversarial.test.ts
@@ -13,6 +13,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as realDetector from '../../../src/lang/detector';
 import * as realProfiles from '../../../src/lang/profiles';
+import {
+	deriveMockedRegistry,
+	type MockLanguageProfile,
+} from './discovery-profiles-mocks';
 
 // Test directory
 const TEST_DIR = path.join(
@@ -27,20 +31,9 @@ const mockDetectProjectLanguages = mock();
 const mockLangRegistryGet = mock();
 const mockIsCommandAvailable = mock();
 
-// AGENTS.md invariant 7: `mock.module` leaks across test files in Bun's shared
-// test-runner process, so every mock must spread the real module's exports and
-// override only what it needs. A partial mock here previously broke *any* other
-// file in tests/unit/build/ that transitively imported `src/index.ts`
-// (`LANGUAGE_REGISTRY.getAll is not a function` at repo-graph/builder.ts module
-// scope). `LANGUAGE_REGISTRY` is a class instance, so its methods live on the
-// prototype and a plain `{...}` spread would drop them — `Object.create` keeps
-// the whole real object (methods and private Maps) reachable behind the override.
-const mockedLanguageRegistry = Object.create(
-	realProfiles.LANGUAGE_REGISTRY,
-) as typeof realProfiles.LANGUAGE_REGISTRY;
-mockedLanguageRegistry.get = (
-	...args: Parameters<typeof realProfiles.LANGUAGE_REGISTRY.get>
-) => mockLangRegistryGet(...args);
+// Both factories spread the real module per AGENTS.md invariant 7 — a partial
+// mock here leaks process-wide and breaks sibling files. See
+// ./discovery-profiles-mocks.ts for why the registry needs Object.create.
 
 // Mock the detector module
 mock.module('../../../src/lang/detector', () => ({
@@ -52,39 +45,14 @@ mock.module('../../../src/lang/detector', () => ({
 // Mock the profiles module
 mock.module('../../../src/lang/profiles', () => ({
 	...realProfiles,
-	LANGUAGE_REGISTRY: mockedLanguageRegistry,
+	LANGUAGE_REGISTRY: deriveMockedRegistry(
+		realProfiles.LANGUAGE_REGISTRY,
+		(...args) => mockLangRegistryGet(...args),
+	),
 }));
 
 // Mock the isCommandAvailable function by importing from the real module and replacing it
 // We'll need to clear the toolchain cache to ensure clean state
-
-// ============ Helper Types ============
-
-interface MockLanguageProfile {
-	id: string;
-	displayName: string;
-	tier: number;
-	extensions: string[];
-	treeSitter: { grammarId: string; wasmFile: string };
-	build: {
-		detectFiles: string[];
-		commands: Array<{
-			name: string;
-			cmd: string;
-			detectFile?: string;
-			priority: number;
-		}>;
-	};
-	test: { detectFiles: string[]; frameworks: unknown[] };
-	lint: { detectFiles: string[]; linters: unknown[] };
-	audit: {
-		detectFiles: string[];
-		command: string | null;
-		outputFormat: 'json' | 'text';
-	};
-	sast: { nativeRuleSet: string | null; semgrepSupport: string };
-	prompts: { coderConstraints: string[]; reviewerChecklist: string[] };
-}
 
 // ============ Test Setup ============
 

--- a/tests/unit/build/discovery-profiles-adversarial.test.ts
+++ b/tests/unit/build/discovery-profiles-adversarial.test.ts
@@ -11,6 +11,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as realDetector from '../../../src/lang/detector';
+import * as realProfiles from '../../../src/lang/profiles';
 
 // Test directory
 const TEST_DIR = path.join(
@@ -25,17 +27,32 @@ const mockDetectProjectLanguages = mock();
 const mockLangRegistryGet = mock();
 const mockIsCommandAvailable = mock();
 
+// AGENTS.md invariant 7: `mock.module` leaks across test files in Bun's shared
+// test-runner process, so every mock must spread the real module's exports and
+// override only what it needs. A partial mock here previously broke *any* other
+// file in tests/unit/build/ that transitively imported `src/index.ts`
+// (`LANGUAGE_REGISTRY.getAll is not a function` at repo-graph/builder.ts module
+// scope). `LANGUAGE_REGISTRY` is a class instance, so its methods live on the
+// prototype and a plain `{...}` spread would drop them — `Object.create` keeps
+// the whole real object (methods and private Maps) reachable behind the override.
+const mockedLanguageRegistry = Object.create(
+	realProfiles.LANGUAGE_REGISTRY,
+) as typeof realProfiles.LANGUAGE_REGISTRY;
+mockedLanguageRegistry.get = (
+	...args: Parameters<typeof realProfiles.LANGUAGE_REGISTRY.get>
+) => mockLangRegistryGet(...args);
+
 // Mock the detector module
 mock.module('../../../src/lang/detector', () => ({
+	...realDetector,
 	detectProjectLanguages: (...args: unknown[]) =>
 		mockDetectProjectLanguages(...args),
 }));
 
 // Mock the profiles module
 mock.module('../../../src/lang/profiles', () => ({
-	LANGUAGE_REGISTRY: {
-		get: (...args: unknown[]) => mockLangRegistryGet(...args),
-	},
+	...realProfiles,
+	LANGUAGE_REGISTRY: mockedLanguageRegistry,
 }));
 
 // Mock the isCommandAvailable function by importing from the real module and replacing it

--- a/tests/unit/build/discovery-profiles-mocks.ts
+++ b/tests/unit/build/discovery-profiles-mocks.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared mock scaffolding for the `discovery-profiles*` build tests.
+ *
+ * NOTE ON WHAT DELIBERATELY STAYS IN THE TEST FILES: the `mock.module(...)`
+ * calls themselves are NOT hoisted here. `scripts/check-mock-cleanup.sh` and
+ * `scripts/generate-mock-allowlist.sh` both discover mocks with
+ * `grep -r --include="*.test.ts"`, so moving the literal `mock.module` targets
+ * into this helper would hide `src/lang/detector` and `src/lang/profiles`
+ * (`scripts/mock-allowlist.txt:93-94`) from those gates. Only the inert pieces
+ * — the fixture type and the registry derivation — live here.
+ */
+
+/** Shape of the fixture profiles these tests feed through the registry mock. */
+export interface MockLanguageProfile {
+	id: string;
+	displayName: string;
+	tier: number;
+	extensions: string[];
+	treeSitter: { grammarId: string; wasmFile: string };
+	build: {
+		detectFiles: string[];
+		commands: Array<{
+			name: string;
+			cmd: string;
+			detectFile?: string;
+			priority: number;
+		}>;
+	};
+	test: { detectFiles: string[]; frameworks: unknown[] };
+	lint: { detectFiles: string[]; linters: unknown[] };
+	audit: {
+		detectFiles: string[];
+		command: string | null;
+		outputFormat: 'json' | 'text';
+	};
+	sast: { nativeRuleSet: string | null; semgrepSupport: string };
+	prompts: { coderConstraints: string[]; reviewerChecklist: string[] };
+}
+
+/**
+ * Derive a `LANGUAGE_REGISTRY` stand-in that overrides only `get`.
+ *
+ * AGENTS.md invariant 7: `mock.module` leaks across test files in Bun's shared
+ * test-runner process, so a mock must preserve the real module's surface and
+ * override only what it needs. A partial registry mock previously broke *any*
+ * other file in `tests/unit/build/` that transitively imported `src/index.ts`
+ * (`LANGUAGE_REGISTRY.getAll is not a function`, thrown at module scope in
+ * `src/tools/repo-graph/builder.ts`).
+ *
+ * `LANGUAGE_REGISTRY` is a class instance, so its methods live on
+ * `LanguageRegistry.prototype` and a plain `{ ...real }` spread would silently
+ * drop every one of them. `Object.create` keeps the whole real object — methods
+ * and private Maps alike — reachable behind the override, and the own-property
+ * `get` never mutates the real singleton.
+ *
+ * CAVEAT for future tests: do not call the registry's mutators (`register`,
+ * `unregister`) through the returned object. They are inherited from the real
+ * singleton, and `this.profiles` resolves up the prototype chain to the REAL
+ * singleton's Map — mutating it would reintroduce exactly the cross-file
+ * pollution this helper exists to prevent.
+ */
+export function deriveMockedRegistry<
+	R extends { get: (id: string) => unknown },
+>(realRegistry: R, mockGet: (...args: Parameters<R['get']>) => unknown): R {
+	const derived = Object.create(realRegistry) as R;
+	derived.get = ((...args: Parameters<R['get']>) =>
+		mockGet(...args)) as R['get'];
+	return derived;
+}

--- a/tests/unit/build/discovery-profiles.test.ts
+++ b/tests/unit/build/discovery-profiles.test.ts
@@ -13,6 +13,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as realDetector from '../../../src/lang/detector';
+import * as realProfiles from '../../../src/lang/profiles';
 
 // Test directory
 const TEST_DIR = path.join(process.cwd(), 'test-tmp-discovery-profiles');
@@ -23,17 +25,32 @@ const TEST_DIR = path.join(process.cwd(), 'test-tmp-discovery-profiles');
 const mockDetectProjectLanguages = mock();
 const mockLangRegistryGet = mock();
 
+// AGENTS.md invariant 7: `mock.module` leaks across test files in Bun's shared
+// test-runner process, so every mock must spread the real module's exports and
+// override only what it needs. A partial mock here previously broke *any* other
+// file in tests/unit/build/ that transitively imported `src/index.ts`
+// (`LANGUAGE_REGISTRY.getAll is not a function` at repo-graph/builder.ts module
+// scope). `LANGUAGE_REGISTRY` is a class instance, so its methods live on the
+// prototype and a plain `{...}` spread would drop them — `Object.create` keeps
+// the whole real object (methods and private Maps) reachable behind the override.
+const mockedLanguageRegistry = Object.create(
+	realProfiles.LANGUAGE_REGISTRY,
+) as typeof realProfiles.LANGUAGE_REGISTRY;
+mockedLanguageRegistry.get = (
+	...args: Parameters<typeof realProfiles.LANGUAGE_REGISTRY.get>
+) => mockLangRegistryGet(...args);
+
 // Mock the detector module
 mock.module('../../../src/lang/detector', () => ({
+	...realDetector,
 	detectProjectLanguages: (...args: unknown[]) =>
 		mockDetectProjectLanguages(...args),
 }));
 
 // Mock the profiles module
 mock.module('../../../src/lang/profiles', () => ({
-	LANGUAGE_REGISTRY: {
-		get: (...args: unknown[]) => mockLangRegistryGet(...args),
-	},
+	...realProfiles,
+	LANGUAGE_REGISTRY: mockedLanguageRegistry,
 }));
 
 // ============ Helper Types ============

--- a/tests/unit/build/discovery-profiles.test.ts
+++ b/tests/unit/build/discovery-profiles.test.ts
@@ -15,30 +15,22 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as realDetector from '../../../src/lang/detector';
 import * as realProfiles from '../../../src/lang/profiles';
+import {
+	deriveMockedRegistry,
+	type MockLanguageProfile,
+} from './discovery-profiles-mocks';
 
 // Test directory
 const TEST_DIR = path.join(process.cwd(), 'test-tmp-discovery-profiles');
 
 // ============ Mock Pattern Setup ============
 // Always use local mock variables, not vi.mocked()
+// Both factories spread the real module per AGENTS.md invariant 7 — a partial
+// mock here leaks process-wide and breaks sibling files. See
+// ./discovery-profiles-mocks.ts for why the registry needs Object.create.
 
 const mockDetectProjectLanguages = mock();
 const mockLangRegistryGet = mock();
-
-// AGENTS.md invariant 7: `mock.module` leaks across test files in Bun's shared
-// test-runner process, so every mock must spread the real module's exports and
-// override only what it needs. A partial mock here previously broke *any* other
-// file in tests/unit/build/ that transitively imported `src/index.ts`
-// (`LANGUAGE_REGISTRY.getAll is not a function` at repo-graph/builder.ts module
-// scope). `LANGUAGE_REGISTRY` is a class instance, so its methods live on the
-// prototype and a plain `{...}` spread would drop them — `Object.create` keeps
-// the whole real object (methods and private Maps) reachable behind the override.
-const mockedLanguageRegistry = Object.create(
-	realProfiles.LANGUAGE_REGISTRY,
-) as typeof realProfiles.LANGUAGE_REGISTRY;
-mockedLanguageRegistry.get = (
-	...args: Parameters<typeof realProfiles.LANGUAGE_REGISTRY.get>
-) => mockLangRegistryGet(...args);
 
 // Mock the detector module
 mock.module('../../../src/lang/detector', () => ({
@@ -50,36 +42,11 @@ mock.module('../../../src/lang/detector', () => ({
 // Mock the profiles module
 mock.module('../../../src/lang/profiles', () => ({
 	...realProfiles,
-	LANGUAGE_REGISTRY: mockedLanguageRegistry,
+	LANGUAGE_REGISTRY: deriveMockedRegistry(
+		realProfiles.LANGUAGE_REGISTRY,
+		(...args) => mockLangRegistryGet(...args),
+	),
 }));
-
-// ============ Helper Types ============
-
-interface MockLanguageProfile {
-	id: string;
-	displayName: string;
-	tier: number;
-	extensions: string[];
-	treeSitter: { grammarId: string; wasmFile: string };
-	build: {
-		detectFiles: string[];
-		commands: Array<{
-			name: string;
-			cmd: string;
-			detectFile?: string;
-			priority: number;
-		}>;
-	};
-	test: { detectFiles: string[]; frameworks: unknown[] };
-	lint: { detectFiles: string[]; linters: unknown[] };
-	audit: {
-		detectFiles: string[];
-		command: string | null;
-		outputFormat: 'json' | 'text';
-	};
-	sast: { nativeRuleSet: string | null; semgrepSupport: string };
-	prompts: { coderConstraints: string[]; reviewerChecklist: string[] };
-}
 
 // ============ Test Setup ============
 

--- a/tests/unit/build/zz-imports-plugin-entry.test.ts
+++ b/tests/unit/build/zz-imports-plugin-entry.test.ts
@@ -12,6 +12,15 @@
  * The filename intentionally sorts last so the import happens *after* those
  * mocks are installed. If this file starts failing to import, a sibling has
  * reintroduced a non-spreading `mock.module`.
+ *
+ * SCOPE — this is a LOCAL-ONLY guard, deliberately, on two counts:
+ *   1. CI (`scripts/ci/run-unit-tests-local.ts`) runs every test file in its
+ *      own process, so the sibling mocks are never installed alongside this
+ *      file and it passes trivially there. It bites only on a shared-process
+ *      run such as `bun test tests/unit/build/`.
+ *   2. `bun test --randomize` reorders files, which can schedule this one
+ *      before the `discovery-*` mocks install and render it inert for that run.
+ * Neither is a defect to fix here; both are limits on what a green run proves.
  */
 
 import { describe, expect, it } from 'bun:test';

--- a/tests/unit/build/zz-imports-plugin-entry.test.ts
+++ b/tests/unit/build/zz-imports-plugin-entry.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression guard for cross-file `mock.module` pollution in tests/unit/build/.
+ *
+ * `discovery-profiles.test.ts` and `discovery-profiles-adversarial.test.ts`
+ * replace `src/lang/profiles` via `mock.module`, which leaks into every later
+ * file in Bun's shared test-runner process (AGENTS.md invariant 7). When those
+ * mocks were partial (providing `LANGUAGE_REGISTRY.get` but not `getAll`), any
+ * file in this directory that transitively imported `src/index.ts` crashed at
+ * module-evaluation time with `LANGUAGE_REGISTRY.getAll is not a function`
+ * (`src/tools/repo-graph/builder.ts`, module scope).
+ *
+ * The filename intentionally sorts last so the import happens *after* those
+ * mocks are installed. If this file starts failing to import, a sibling has
+ * reintroduced a non-spreading `mock.module`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import OpenCodeSwarm from '../../../src/index.js';
+
+describe('plugin entry imports cleanly after sibling mock.module calls', () => {
+	it('evaluates src/index.ts without a polluted language registry', () => {
+		expect(typeof OpenCodeSwarm).toBe('object');
+		expect(typeof OpenCodeSwarm.server).toBe('function');
+	});
+});


### PR DESCRIPTION
## Summary

`tests/unit/build/discovery-profiles.test.ts` and
`tests/unit/build/discovery-profiles-adversarial.test.ts` replaced `src/lang/detector`
and `src/lang/profiles` via `mock.module` with **partial** objects — `LANGUAGE_REGISTRY`
was mocked with a `get` method and nothing else.

Because `mock.module` leaks process-wide in Bun's shared test-runner (AGENTS.md
invariant 7), any test file placed in `tests/unit/build/` that transitively imported
`src/index.ts` crashed at module-evaluation time:

```
TypeError: LANGUAGE_REGISTRY.getAll is not a function
    at src/tools/repo-graph/builder.ts:126  (module scope)
```

`src/tools/repo-graph/builder.ts:125` computes `SUPPORTED_EXTENSIONS` from
`LANGUAGE_REGISTRY.getAll()` at module scope, so the partial mock turned a sibling
file's *import* into a hard failure. The affected file passed in isolation and failed
only when the directory was run as a whole — easy to misdiagnose as a bug in the new
test. This was hit while implementing #2029 and worked around at the time by relocating
the new test out of `tests/unit/build/` entirely; the trap itself stayed behind.

- Applied the documented spread-real-exports pattern to both mocks.
- Moved the shared scaffolding (the byte-identical `MockLanguageProfile` fixture type and the registry derivation) to `tests/unit/build/discovery-profiles-mocks.ts`.
- Added a **local-only** regression guard: `tests/unit/build/zz-imports-plugin-entry.test.ts`.

**A plain spread would not have fixed this.** `LANGUAGE_REGISTRY` is an instance of the
`LanguageRegistry` class (`src/lang/profiles.ts:86`), so `get`/`getAll`/`getByExtension`
live on the prototype — `{ ...realProfiles.LANGUAGE_REGISTRY, get: mockGet }` copies only
own enumerable properties and silently drops every method, leaving the mock just as
partial. The mocks instead derive from the real singleton via
`Object.create(realProfiles.LANGUAGE_REGISTRY)` with an own-property `get` override, so
prototype lookup keeps every real method and the instance's private `Map`s reachable
while never mutating the real singleton.

### Caveats stated plainly

1. **The guard is local-only, and labelled as such.** `scripts/ci/run-unit-tests-local.ts`
   (and the CI unit job) execute each test file in its own process, so the cross-file leak
   cannot occur there and `zz-imports-plugin-entry.test.ts` passes trivially. It earns
   its place against the local directory-scoped workflow (`bun test tests/unit/build/`),
   which is exactly how this was found. I am not claiming CI enforcement it does not have.
2. **The `zz-` filename prefix is load-bearing** — the guard must sort *after*
   `discovery-*` so its import happens once the mocks are installed.
3. **It is also inert under `bun test --randomize`**, which can schedule it before the
   mocks install. All three limits are in the file's docstring.

### Why the `mock.module` calls did not move into the shared helper

Only inert scaffolding was extracted. The literal `mock.module('…/src/lang/detector', …)`
and `('…/src/lang/profiles', …)` calls stay in each `*.test.ts` on purpose:
`scripts/check-mock-cleanup.sh:69,137` and `scripts/generate-mock-allowlist.sh:33` both
discover mocks with `grep -r --include="*.test.ts"`, so hoisting those calls into a
non-test helper would have hidden both targets (`scripts/mock-allowlist.txt:93-94`) from
the very gates that police this defect class — a tidier diff bought with a real guardrail.
`check-invariants.sh` Check 4 confirms the targets are still tracked: `Base 111 | Head 111 |
Added in this PR: 0`.

No tracking issue exists for this; #2029 is context, not a dependency, so there is no
`Closes` line.

Out of scope but worth flagging: `scripts/check-mock-cleanup.sh` reports **14
pre-existing** non-spreading `mock.module` violations elsewhere (`node:fs`,
`node:child_process`, `node:fs/promises` under `tests/unit/commands/`, `tests/unit/plan/`,
`src/commands/`) plus 3 files using `mock.module` with no `afterEach(mock.restore())`.
Same defect class, currently warning-only, untouched here.

## Invariant audit

- **1 (plugin init):** not touched — no `src/` file changed; `git show --stat HEAD` lists only 2 modified tests, 1 new test, 1 release fragment.
- **2 (runtime portability):** not touched — no runtime code changed. `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`.
- **3 (subprocesses):** not touched — `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` → no matches.
- **4 (.swarm containment):** not touched — no `.swarm` path logic changed; evidence files under `.swarm/evidence/` are runtime state and are not committed.
- **5 (plan durability):** not touched — no plan/manager code changed.
- **6 (test_runner safety):** not touched — `test_runner` was not used for repo validation; all validation ran via shell commands.
- **7 (test writing — mock isolation, DI over `mock.module`):** **TOUCHED — this is the whole change.** Both mocks now spread the real module (`...realDetector`, `...realProfiles`) per the invariant's documented pattern. No new `mock.module` target was introduced: `check-invariants.sh` Check 4 reports `Base entries: 111 | Head entries: 111 | Added in this PR: 0 | Unapproved: 0`. `check-mock-cleanup.sh` lists neither changed file among its 14 pre-existing violations. Both files retain `afterEach(mock.restore())`. Registry mutators are not called through the derived object (`grep -nE "(un)?register\("` on both files → no matches), so the real singleton's private `Map`s cannot be polluted through the prototype chain.
- **8 (session state):** not touched — no session-keyed or module-global state changed.
- **9 (guardrails/retry):** not touched.
- **10 (chat/system msg):** not touched.
- **11 (tool registration):** not touched — `bun run scripts/check-tool-registration.ts` → `116 tools, coherent across metadata, handlers, the plugin object, TOOL_NAMES, and AGENT_TOOL_MAP`.
- **12 (release/cache):** not touched — no version file edited; pending fragment added at `docs/releases/pending/build-test-mock-module-registry-pollution.md`.

## Test plan

- [x] **Reproduced the defect first.** Added the guard, ran `bun test tests/unit/build/` on the unfixed tree → `TypeError: LANGUAGE_REGISTRY.getAll is not a function` at `src/tools/repo-graph/builder.ts:126`. Directory result: 80 pass / 17 fail.
- [x] **Proved the guard is not inert.** Discriminating test: with the fix in place, reverted *only* `discovery-profiles.test.ts` to its partial mock and re-ran — the guard failed again with the identical TypeError. This rules out `afterEach(mock.restore())` being what carries the suite, so the fix is demonstrably what makes it pass.
- [x] `bun test tests/unit/build/` post-fix: 82 pass / 15 fail, where all 15 were pre-existing `dist/` bundle tests failing on `Cannot find module .../dist/index.js` (the worktree had never been built). After `bun install` + `bun run build`, **all 11 files pass**.
- [x] `bun run test:unit:ci` (scoped, CI-equivalent per-file runner) over all 11 `tests/unit/build/` files → 11/11 exitCode 0, 0 quarantined.
- [x] `bun run test:unit:ci` over the blast radius beyond the diff — `tests/unit/lang/{detector,profiles,profile-registry-parity,profiles-tier1}`, `tests/unit/scripts/{check-mock-cleanup,check-mock-allowlist-ratchet,check-invariants,generate-mock-allowlist,release-notes-fragments}`, `tests/unit/skills/{commit-pr-generic,commit-pr-validation-parity}` → 11/11 exitCode 0.
- [x] `bun test tests/integration/lang` → 69 pass / 0 fail.
- [x] `bun test tests/smoke` → 10 pass / 0 fail.
- [x] `bun run typecheck` → clean. `bun run lint:ci` (pinned Biome) → 2997 files, no fixes applied.
- [x] `bash scripts/check-invariants.sh`, `bash scripts/check-mock-cleanup.sh`, `bash scripts/check-cross-contamination.sh`, `bash scripts/check-test-clock.sh` → 0 new/blocking violations.
- [x] `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`. `dist/` not staged (#1047).
- [x] Release-fragment references ground-truth-verified; one hallucinated path (`src/index.observability-init-resilience.test.ts`, which does not exist on this branch) was caught and corrected before commit.
- [x] **Not run locally, closed by CI:** full `bun run test:unit:ci`, `tests/integration` (beyond `lang`), `tests/security`, `tests/adversarial`. Justification for deferring: the diff contains zero `src/` changes and only *narrows* what two `mock.module` calls replace, so it can remove cross-file pollution but cannot introduce it. The one residual risk — another file silently depending on the partial mock — is confined to files sharing a process with these two. **CI has since run all of it green on this exact head (`e4909915`):** `unit` shards 1–6, `integration`, `security`, `coverage`, `package-check`, `php-validation`, `quality`, `drift`, `rust-sandbox-runner`, and `smoke` on ubuntu/macOS/Windows — all SUCCESS. That empirically closes the residual risk rather than leaving it argued.

## Review response (swarm-pr-review, `REQUEST_CHANGES` on `e4909915`)

All five findings addressed in `8bb3152a`.

- **PRR-001 (MEDIUM, the blocker) — fixed, and I reproduced it first.** `TEST_CAP_ENFORCE=1 bash scripts/check-test-file-cap.sh` with the base fetched confirmed both files tripped the FR-006 ratchet (492→509 crossing the cap; 573→590 growing while over it). Extracting the shared scaffolding shrinks both **below** base: **492→476** and **573→558**. The ratchet no longer names either file. **I did not take the review's preferred remediation** — see the section above; hoisting the `mock.module` calls would have hidden both targets from `check-mock-cleanup.sh` and `generate-mock-allowlist.sh`, trading a line-count violation for a guardrail blind spot.
- **PRR-002 — fixed.** `--randomize` caveat added to the guard's docstring.
- **PRR-003 — fixed.** "Permanent regression guard" relabelled "local-only" in the docstring, the release fragment, and this body.
- **PRR-004 — fixed.** The mutator caveat is now a doc comment on `deriveMockedRegistry` itself, visible at the point of use rather than only in the fragment.
- **PRR-005 — fixed.** The fragment's snippet now matches the real signature and is marked schematic.
- **Out of scope, not fixed here:** the `quality` job's shallow checkout (`ci.yml:153-154`) that disarms every diff-scoped ratchet. Real and independently confirmed, but fixing it turns a test-only PR into a CI-infrastructure change. Flagged for a separate issue.

**Re-verified after the restructure:** the discriminating test still bites *through* the new helper indirection — reverting one factory to a partial mock reproduces the identical TypeError (97 pass → 96 pass + error), and restoring returns it to 97/0.

## Pre-existing failures

None carried into this PR. The 15 `dist/` failures observed mid-work were an unbuilt
worktree, not a code defect — they resolve after `bun run build`, and
`bun test tests/unit/build/` is now **97 pass / 0 fail**.

Note for anyone re-running the ratchets locally: this branch is ~44 commits behind
`origin/main`, and `check-test-file-cap.sh` / `check-test-clock.sh` use a **two-dot**
`git diff origin/main HEAD`, so they attribute `main`'s own churn to this PR. The 4
remaining cap violations (`context-budget`, `guardrails`, `message-priority`, +1) and 2
test-clock violations (`guardrails`, `knowledge-diagnostics`) are **not** in this diff —
`git diff --name-only origin/main...HEAD` (three-dot) lists exactly the 5 files above.
