### PR TITLE
fix(pr-review): accept framed candidate transcripts

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -932,6 +932,17 @@ artifact and extracts these records. The canonical record shape is:
 [CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence
 ```
 
+Profile A stores the full assistant transcript, so earlier unmarked progress
+turns may precede the machine-readable section. The parser locates that section
+at the first pipe-delimited line whose first field is exactly `[CANDIDATE]` and
+ignores unmarked preamble, including incidental pipe-delimited text. That first
+marker is authoritative and must be the exact canonical base or micro header;
+a malformed marker or marker-prefixed data row without a header fails closed.
+The Profile A controller coverage gate also refuses a missing marker. The pure
+parser retains markerless positional fallback only for legacy callers outside
+that controller trust boundary. Explorers should continue to make the canonical
+header the first line of their final machine-readable response.
+
 The confidence data value must be exactly LOW, MEDIUM, or HIGH.
 
 Under Profile A the parser normalizes this into a structured `candidates[]`

--- a/docs/releases/pending/pr-review-candidate-transcript-framing.md
+++ b/docs/releases/pending/pr-review-candidate-transcript-framing.md
@@ -1,0 +1,27 @@
+# Accept PR-review candidates after transcript progress text
+
+## What
+
+PR-review candidate parsing now locates the first explicit `[CANDIDATE]`
+protocol marker in a stored async-lane transcript instead of treating an
+earlier pipe-delimited progress message as the candidate header. The parser and
+controller coverage gate share the same framing rule for base and micro-lane
+candidate rows and CLEAN attestations.
+
+## Why
+
+Async lane artifacts preserve all assistant text turns. A harmless progress
+turn containing a pipe could therefore precede a valid canonical candidate
+section and cause both trust boundaries to reject otherwise valid discovery
+evidence, leading to unnecessary retries and blocked PR-review completion.
+
+## Migration
+
+No migration is required. Explorer output should still use one exact canonical
+`[CANDIDATE]` header followed by candidate or CLEAN rows.
+
+## Caveats
+
+The first marker-bearing candidate line remains authoritative. Malformed
+headers and marker-prefixed data rows without a canonical header still fail
+closed, even if a later valid header appears.

--- a/src/background/candidate-contract.ts
+++ b/src/background/candidate-contract.ts
@@ -65,6 +65,39 @@ export function candidateHeaderFamily(
 	return null;
 }
 
+export interface CandidateHeaderSelection {
+	lineIndex: number;
+	fields: string[];
+	family: RowFormatFamily | null;
+	markerBearing: boolean;
+}
+
+/**
+ * Locate the candidate protocol frame in a stored assistant transcript.
+ * Unmarked tabular text remains a compatibility fallback only when the
+ * transcript contains no marker-bearing candidate line. The first marker is
+ * authoritative even when malformed so a later valid header cannot rescue it.
+ */
+export function selectCandidateHeader(
+	lines: readonly string[],
+): CandidateHeaderSelection | null {
+	let markerlessFallback: CandidateHeaderSelection | null = null;
+	for (const [lineIndex, line] of lines.entries()) {
+		const fields = splitPipeFields(line.trim()).map((field) => field.trim());
+		if (fields.length < 2 || !fields.some(Boolean)) continue;
+		const markerBearing = fields[0] === '[CANDIDATE]';
+		const selection: CandidateHeaderSelection = {
+			lineIndex,
+			fields,
+			family: candidateHeaderFamily(fields),
+			markerBearing,
+		};
+		if (markerBearing) return selection;
+		markerlessFallback ??= selection;
+	}
+	return markerlessFallback;
+}
+
 /** Remove fenced markdown blocks before any candidate-contract inspection. */
 export function removeCandidateCodeFences(text: string): string {
 	const lines: string[] = [];

--- a/src/background/candidate-parser.ts
+++ b/src/background/candidate-parser.ts
@@ -8,11 +8,11 @@ import {
 	type CandidateConfidence,
 	type CandidateSeverity,
 	candidateDiagnosticPreview,
-	candidateHeaderFamily,
 	isCandidateLookingShortRow,
 	type RowFormatFamily,
 	removeCandidateCodeFences,
 	type CleanAttestationRecord as SharedCleanAttestationRecord,
+	selectCandidateHeader,
 	splitPipeFields,
 } from './candidate-contract';
 import { appendToSidecar } from './candidate-sidecar-store';
@@ -515,32 +515,20 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 	const cleanedText = removeCandidateCodeFences(input.text);
 	const lines = cleanedText.split('\n');
 
-	// Locate the header row: first non-empty line that looks tabular.
-	let headerIndex = -1;
-	let headerFields: string[] = [];
-
-	for (let i = 0; i < lines.length; i++) {
-		const trimmed = lines[i].trim();
-		if (trimmed === '') continue;
-		const fields = splitPipeFields(trimmed);
-		if (fields.length >= 2 && fields.some((f) => f.trim() !== '')) {
-			headerIndex = i;
-			headerFields = fields.map((f) => f.trim());
-			break;
-		}
-	}
-
-	if (headerIndex === -1) {
+	// Locate the explicit candidate frame, with markerless positional fallback.
+	const header = selectCandidateHeader(lines);
+	if (header === null) {
 		// No header found — nothing to parse.
 		return emptyTextResult(input, flags);
 	}
+	const headerIndex = header.lineIndex;
 
 	// Marker-bearing candidate output has one exact shared header contract. A
 	// markerless unknown header keeps the historical positional fallback, but a
 	// malformed marker header (including a lone marker-prefixed data row) fails
 	// closed instead of being skipped as if it were trustworthy metadata.
-	const headerFamily = candidateHeaderFamily(headerFields) ?? undefined;
-	if (headerFields[0] === '[CANDIDATE]' && headerFamily === undefined) {
+	const headerFamily = header.family ?? undefined;
+	if (header.markerBearing && headerFamily === undefined) {
 		return refusalResult(
 			'invalid-candidate-header',
 			'Candidate output must begin with one exact canonical base or micro [CANDIDATE] header',

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -8,6 +8,7 @@ import {
 	candidateHeaderFamily,
 	type RowFormatFamily,
 	removeCandidateCodeFences,
+	selectCandidateHeader,
 	splitPipeFields,
 } from '../background/candidate-contract.js';
 import { parseCandidates } from '../background/candidate-parser.js';
@@ -5472,17 +5473,12 @@ function analyzePrReviewDiscoveryArtifact(
 		: 'micro_lane';
 	const issues: string[] = [];
 	const canonicalText = removeCandidateCodeFences(text);
-	const firstTabularFields = canonicalText
-		.split(/\r?\n/)
-		.map((line) => splitPipeFields(line).map((field) => field.trim()))
-		.find(
-			(fields) =>
-				fields.length >= 2 && fields.some((field) => field.length > 0),
-		);
-	const headerFamily = firstTabularFields
-		? candidateHeaderFamily(firstTabularFields)
-		: null;
-	if (headerFamily !== fallbackFamily) {
+	const header = selectCandidateHeader(canonicalText.split(/\r?\n/));
+	if (
+		header === null ||
+		!header.markerBearing ||
+		header.family !== fallbackFamily
+	) {
 		appendBoundedCandidateIssue(
 			issues,
 			`field header: expected one exact canonical ${fallbackFamily} [CANDIDATE] header before discovery rows`,

--- a/tests/unit/background/candidate-contract.test.ts
+++ b/tests/unit/background/candidate-contract.test.ts
@@ -210,6 +210,101 @@ describe('shared candidate and CLEAN semantics', () => {
 		);
 	});
 
+	test.each([
+		[
+			'base candidate',
+			'base_explorer',
+			BASE_HEADER,
+			'correctness-state',
+			'C-1 | correctness-state | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH',
+			false,
+		] as const,
+		[
+			'base CLEAN',
+			'base_explorer',
+			BASE_HEADER,
+			'correctness-state',
+			`[CLEAN] | correctness-state | ${CLEAN_SCOPE} | ${CLEAN_EVIDENCE}`,
+			true,
+		] as const,
+		[
+			'micro candidate',
+			'micro_lane',
+			MICRO_HEADER,
+			'concurrency-state',
+			'M-1 | concurrency-state | HIGH | concurrency | src/a.ts:1 | claim | invariant | evidence | HIGH',
+			false,
+		] as const,
+		[
+			'micro CLEAN',
+			'micro_lane',
+			MICRO_HEADER,
+			'concurrency-state',
+			`[CLEAN] | concurrency-state | ${CLEAN_SCOPE} | ${CLEAN_EVIDENCE}`,
+			true,
+		] as const,
+	])('ignores pipe-delimited transcript preamble before a canonical %s section', (_label, family, header, lane, row, expectClean) => {
+		// Regression: the first incidental pipe line used to become the header,
+		// so valid async-lane output failed at both parser trust boundaries.
+		const text = `Review progress | inspected changed files\nContinuing analysis before the final machine-readable section.\n${header}\n${row}`;
+		const parsed = parseCandidates(artifact(text), {
+			accept_partial: false,
+			accept_degraded: false,
+			degraded: false,
+			row_format_version: 1,
+			expected_family: family,
+			...(family === 'base_explorer'
+				? { expected_lane: lane }
+				: { expected_micro_lane: lane }),
+		});
+
+		expect(parsed.error_code).toBeUndefined();
+		expect(parsed.diagnostics.parse_errors).toBe(0);
+		expect(parsed.candidates).toHaveLength(expectClean ? 0 : 1);
+		expect(parsed.clean_attestation !== undefined).toBe(expectClean);
+		expect(prReviewDiscoveryArtifactCoversLane(text, lane)).toBe(true);
+	});
+
+	test('rejects a malformed first candidate marker even before a later canonical header', () => {
+		const row =
+			'C-1 | correctness-state | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH';
+		const text = `[CANDIDATE] | not | a | canonical | header\n${BASE_HEADER}\n${row}`;
+		const parsed = parseCandidates(artifact(text), {
+			accept_partial: false,
+			accept_degraded: false,
+			degraded: false,
+			row_format_version: 1,
+			expected_family: 'base_explorer',
+			expected_lane: 'correctness-state',
+		});
+
+		expect(parsed.error_code).toBe('invalid-candidate-header');
+		expect(parsed.candidates).toEqual([]);
+		expect(prReviewDiscoveryArtifactCoversLane(text, 'correctness-state')).toBe(
+			false,
+		);
+	});
+
+	test('retains parser-only positional fallback when no candidate marker exists', () => {
+		const text =
+			'legacy | positional header\nC-1 | correctness-state | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH';
+		const parsed = parseCandidates(artifact(text), {
+			accept_partial: false,
+			accept_degraded: false,
+			degraded: false,
+			row_format_version: 1,
+			expected_family: 'base_explorer',
+			expected_lane: 'correctness-state',
+		});
+
+		expect(parsed.candidates).toHaveLength(1);
+		expect(parsed.diagnostics.parse_errors).toBe(0);
+		// The controller gate still requires one canonical marker-bearing header.
+		expect(prReviewDiscoveryArtifactCoversLane(text, 'correctness-state')).toBe(
+			false,
+		);
+	});
+
 	test('does not let malformed or duplicate rows authenticate a CLEAN artifact', () => {
 		const lane = 'correctness-state';
 		const clean = `[CLEAN] | ${lane} | ${CLEAN_SCOPE} | ${CLEAN_EVIDENCE}`;

--- a/tests/unit/background/candidate-contract.test.ts
+++ b/tests/unit/background/candidate-contract.test.ts
@@ -5,6 +5,8 @@ import {
 	CANDIDATE_DIAGNOSTIC_PREVIEW_CHARS,
 	candidateHeaderFamily,
 	type RowFormatFamily,
+	selectCandidateHeader,
+	splitPipeFields,
 } from '../../../src/background/candidate-contract';
 import {
 	type ArtifactInput,
@@ -190,6 +192,50 @@ describe('shared candidate and CLEAN semantics', () => {
 		expect(
 			candidateHeaderFamily(`${BASE_HEADER} | extra`.split('|')),
 		).toBeNull();
+	});
+
+	test('selects the first marker-bearing header over a pipe-delimited transcript preamble', () => {
+		expect(
+			selectCandidateHeader([
+				'Review progress | inspected changed files',
+				BASE_HEADER,
+			]),
+		).toEqual({
+			lineIndex: 1,
+			fields: BASE_HEADER.split('|').map((field) => field.trim()),
+			family: 'base_explorer',
+			markerBearing: true,
+		});
+	});
+
+	test('keeps the first malformed candidate marker authoritative', () => {
+		expect(
+			selectCandidateHeader([
+				'[CANDIDATE] | not | a | canonical | header',
+				BASE_HEADER,
+			]),
+		).toMatchObject({
+			lineIndex: 0,
+			family: null,
+			markerBearing: true,
+		});
+	});
+
+	test('retains the first tabular line only when no candidate marker exists', () => {
+		expect(selectCandidateHeader(['legacy | positional header'])).toEqual({
+			lineIndex: 0,
+			fields: ['legacy', 'positional header'],
+			family: null,
+			markerBearing: false,
+		});
+	});
+
+	test('splits escaped pipes without dropping boundary fields', () => {
+		expect(splitPipeFields('left\\|escaped | right |')).toEqual([
+			'left|escaped ',
+			' right ',
+			'',
+		]);
 	});
 
 	test('strips fenced table noise before shared exact-header discovery', () => {


### PR DESCRIPTION
## Summary

- Fix PR-review candidate discovery when a full async assistant transcript has an earlier pipe-delimited progress line before its canonical `[CANDIDATE]` section.
- Centralize marker-aware header selection for the parser and controller coverage gate, preserving parser-only markerless compatibility while keeping the Profile A gate fail-closed.
- Add base/micro candidate and CLEAN regressions, clarify the PR-review skill contract, and add a pending release note.

## Invariant audit

- 1 (plugin init): not touched - no initialization path changed.
- 2 (runtime portability): not touched - no entrypoint, Bun API, package export, or runtime-resolution change; `bun run build` and Node import pass.
- 3 (subprocesses): not touched - no subprocess code changed.
- 4 (.swarm containment): not touched - no runtime state path changed.
- 5 (plan durability): not touched - no ledger, projection, or checkpoint code changed.
- 6 (test_runner safety): not touched - repository validation used shell-run isolated Bun tests, never broad `test_runner`.
- 7 (test writing): touched - regression-first `bun:test` coverage, no mock seam, 367-line test file, scoped CI-equivalent unit gate passes.
- 8 (session state): not touched - selector is pure and stateless.
- 9 (guardrails/retry): not touched - retry behavior was verified but not modified.
- 10 (chat/system msg): not touched - no chat hook or message-shape change.
- 11 (tool registration): not touched - no tool or agent-map change; tool-registration and drift checks pass.
- 12 (release/cache): touched - pending release fragment added; release-owned version files untouched.

## Test plan

- [x] `bun run build` and `node --input-type=module -e "await import('./dist/index.js')"`
- [x] `bun run typecheck`, `bun run lint:ci`, tool-registration, mock-cleanup, invariant, cross-contamination, and test-clock checks
- [x] `bun run test:unit:ci` scoped to 14 parser/gate/tool/skill test files
- [x] `bun test tests/security --timeout 120000` - 163 pass, 4 expected skips
- [x] `bun test tests/adversarial --timeout 120000` - 846 pass
- [x] `bun test tests/smoke --timeout 120000` - 10 pass
- [x] `bun run drift:check`, deferred-work scan, and `git diff --check`
- [!] `bun test tests/integration ./test --timeout 120000` - 749 pass / 215 fail; reproduced exactly on clean `origin/main` at `1adff503`, so documented as pre-existing.

## Pre-existing failures

The full integration command fails identically on this branch and clean `origin/main` (`1adff503`): 749 passing and 215 failing tests. Failures are concentrated in unrelated skill-feedback, macro-reflector, plan-persistence, summarization, and harden-unactionable-entry coverage. No candidate parser, workflow-gate candidate semantics, or async lane delivery test failed.

## Risk and rollback

Risk is low: the controller continues to require one exact marker-bearing candidate header. Revert the shared selector, its two call sites, regression tests, skill clarification, and release fragment together to roll back.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

