### PR TITLE
fix(guardrails): resolve write-target aliases and spiral hash collisions

### DIFF
--- a/docs/releases/pending/2059-2060-write-target-and-spiral.md
+++ b/docs/releases/pending/2059-2060-write-target-and-spiral.md
@@ -2,8 +2,10 @@
 
 ## What
 
-Two independent guardrail-hardening fixes that prevent legitimate agent tool
-calls from being blocked by false-positive verifications.
+Three independent guardrail-hardening fixes that prevent legitimate agent tool
+calls from being blocked by false-positive verifications, plus a shared stable
+serialization helper that eliminates a class of nested-key-filtering bugs
+across the codebase.
 
 - **#2059 — `write-target-resolver`:** the patch resolver now recognizes the
   common payload aliases `patchText`, `patch_text`, `patchPayload`, `text`, and
@@ -13,6 +15,11 @@ calls from being blocked by false-positive verifications.
 - **#2060 — `adversarial-detector`:** the debugging-spiral detector now hashes
   the complete tool-call arguments with a fixed-length, key-sorted hash instead
   of truncating the stringified args at 100 characters.
+- **`file-authority.hashArgs` + `redaction.computeMemoryCohortFingerprint`:**
+  migrated off the same `JSON.stringify(value, sortedKeysArray)` property-list
+  replacer anti-pattern that #2060's fix addressed, using a shared
+  `stableCanonicalStringify` helper so all three call sites use one correct
+  implementation.
 
 ## Why
 
@@ -56,12 +63,40 @@ message.
 - `recordToolCall()` now uses a new `hashArgsForSpiral()` helper that produces
   a fixed-length hash via `bunHash()` (the existing cross-runtime shim: xxHash64
   on Bun, djb2 on Node). Object keys are sorted recursively at every depth via
-  a dedicated `stableCanonicalStringify` helper (not a `JSON.stringify`
+  the shared `stableCanonicalStringify` helper (not a `JSON.stringify`
   property-list replacer, which would silently drop nested keys and
   re-introduce collisions for nested-args tools like `todowrite`). Strings
   above 64 chars are hashed too, keeping per-entry memory bounded (net decrease
   vs. the old 100-char ceiling). `SPIRAL_THRESHOLD` (5) is unchanged — the fix
   is in the hash, not the threshold.
+
+### `src/utils/stable-stringify.ts` (new)
+- Exports `stableCanonicalStringify`, a recursive canonical JSON serializer
+  that sorts object keys at every depth without filtering (unlike a
+  `JSON.stringify` property-list replacer, which filters keys at nested
+  depths). Shared by `hashArgsForSpiral`, `hashArgs`, and
+  `computeMemoryCohortFingerprint` so all three use one correct implementation.
+
+### `src/hooks/guardrails/file-authority.ts`
+- `hashArgs` (used by the guardrails circuit-breaker repetition detector and
+  the provider-failure fingerprint) migrated from
+  `JSON.stringify(args, sortedKeys)` to `stableCanonicalStringify(args)`. This
+  fixes the same nested-key-filtering bug class as #2060 for the circuit
+  breaker: nested-args tools (e.g. `todowrite` with a `todos` array) previously
+  collapsed distinct nested content to the same hash, so a genuine repetition
+  loop on a nested-args tool could be missed. The returned `number` is
+  unchanged for flat args (the common case) and only differs for nested args
+  (the fix). The value is never persisted across versions
+  (`recentToolCalls` is reset on snapshot rehydration), so there is no
+  cross-version comparison risk.
+
+### `src/memory/redaction.ts`
+- `computeMemoryCohortFingerprint` migrated to `stableCanonicalStringify` for
+  consistency and to future-proof against a nested field ever being added to
+  `MemoryCohortFingerprintInput`. For the current flat input shape the output
+  is byte-identical to the prior `JSON.stringify(input, sortedKeys)` — verified
+  empirically — so existing persisted fingerprints in
+  `memory-cohort-config.json` remain valid.
 
 ## Test plan
 - New `write-target-resolver.test.ts` cases: each alias resolves a unified
@@ -73,6 +108,12 @@ message.
   args spiral (correctness); string vs object args do not collide; nested-args
   tools with different nested content do not spiral; nested-args with reordered
   keys at any depth still spiral.
+- New `guardrails.test.ts` cases for `hashArgs`: nested args with different
+  content produce different hashes (no nested-key filtering); nested args with
+  reordered keys at any depth produce the same hash. Both verified to fail
+  against the old replacer-array code.
+- `cohort-config-fingerprint.test.ts` passes unchanged (redaction.ts migration
+  is a no-op for the current flat input — verified byte-identical).
 - All existing write-target, scope-guard, guardrails, and adversarial-detector
   tests pass unchanged.
 

--- a/docs/releases/pending/2059-2060-write-target-and-spiral.md
+++ b/docs/releases/pending/2059-2060-write-target-and-spiral.md
@@ -1,0 +1,94 @@
+# Write-target resolver patch aliases + spiral detector hash fix
+
+## What
+
+Two independent guardrail-hardening fixes that prevent legitimate agent tool
+calls from being blocked by false-positive verifications.
+
+- **#2059 — `write-target-resolver`:** the patch resolver now recognizes the
+  common payload aliases `patchText`, `patch_text`, `patchPayload`, `text`, and
+  `content` (in addition to `patch`, `input`, `diff`), and no longer
+  misclassifies a standard unified diff as a malformed Native Vibe Patch when
+  the model appends a stray `*** End Patch` trailer.
+- **#2060 — `adversarial-detector`:** the debugging-spiral detector now hashes
+  the complete tool-call arguments with a fixed-length, key-sorted hash instead
+  of truncating the stringified args at 100 characters.
+
+## Why
+
+### #2059
+Models and tool wrappers frequently emit patch content under alternative field
+names. The resolver's narrow `PATCH_PAYLOAD_KEYS` list rejected them with
+`WRITE TARGET UNVERIFIABLE: No patch payload was provided`, blocking valid
+patches. Separately, a standard unified diff that happened to end with
+`*** End Patch` (or included a `*** Update File:` line) was misclassified as a
+Native Vibe Patch and rejected with `Native patch is missing *** Begin Patch`,
+because any native marker triggered native classification.
+
+### #2060
+`recordToolCall()` truncated its argument hash at 100 characters via
+`.slice(0, 100)`. For paged `read` calls on a long file path, the differing
+`offset` value sat past character 100 and was sliced off, so five legitimate
+calls on different offsets produced identical hashes and triggered a
+false-positive `debugging_spiral_detected` event with an advisory hard-stop
+message.
+
+## Changes
+
+### `src/hooks/write-target-resolver.ts`
+- `PATCH_PAYLOAD_KEYS` expanded to include the five aliases and **exported** so
+  the guardrail layer reuses one source of truth (the same list had drifted
+  into three copies).
+- Native classification now requires a `*** Begin Patch` marker, OR any native
+  operation marker (`*** Update/Add/Delete File:`, `*** Move to|from:` — these
+  are unambiguous native syntax and always demand framing), OR a bare
+  `*** End Patch` marker with no unified-diff headers. A stray `*** End Patch`
+  trailer on a unified diff is now tolerated; operation markers without a begin
+  marker still fail closed (security guard preserved).
+
+### `src/hooks/guardrails/tool-before.ts`
+- `extractAllPatchPayloads` and `extractPatchTargetPaths` now import
+  `PATCH_PAYLOAD_KEYS` from `write-target-resolver` instead of maintaining
+  inline copies. Historical precedence (`input ?? patch ?? diff ?? cmd[1]`) is
+  preserved.
+
+### `src/hooks/adversarial-detector.ts`
+- `recordToolCall()` now uses a new `hashArgsForSpiral()` helper that produces
+  a fixed-length hash via `bunHash()` (the existing cross-runtime shim: xxHash64
+  on Bun, djb2 on Node). Object keys are sorted recursively at every depth via
+  a dedicated `stableCanonicalStringify` helper (not a `JSON.stringify`
+  property-list replacer, which would silently drop nested keys and
+  re-introduce collisions for nested-args tools like `todowrite`). Strings
+  above 64 chars are hashed too, keeping per-entry memory bounded (net decrease
+  vs. the old 100-char ceiling). `SPIRAL_THRESHOLD` (5) is unchanged — the fix
+  is in the hash, not the threshold.
+
+## Test plan
+- New `write-target-resolver.test.ts` cases: each alias resolves a unified
+  diff; trailing `*** End Patch` trailer resolves; stray `*** Update File:`
+  without begin still fails closed (security regression guard); genuine native
+  patch still resolves.
+- New `adversarial-detector-wiring.test.ts` cases: paged reads with different
+  offsets do not spiral (the bug); identical calls still spiral; reordered-key
+  args spiral (correctness); string vs object args do not collide; nested-args
+  tools with different nested content do not spiral; nested-args with reordered
+  keys at any depth still spiral.
+- All existing write-target, scope-guard, guardrails, and adversarial-detector
+  tests pass unchanged.
+
+## Invariant audit
+- 1 (plugin init): not touched.
+- 2 (runtime portability): touched — `bunHash` is the existing cross-runtime
+  shim; no new direct `Bun.*` calls.
+- 3 (subprocesses): not touched.
+- 4 (.swarm containment): not touched.
+- 5 (plan durability): not touched.
+- 6 (test_runner safety): not touched.
+- 7 (test writing): touched — `bun:test`, no `mock.module`, direct function
+  calls, unique session IDs.
+- 8 (session state): touched — per-session keying preserved; per-entry memory
+  bounded (net decrease).
+- 9 (guardrails/retry): touched — this is a guardrail correctness fix.
+- 10 (chat/system msg): not touched.
+- 11 (tool registration): not touched.
+- 12 (release/cache): touched — this fragment.

--- a/src/hooks/adversarial-detector.ts
+++ b/src/hooks/adversarial-detector.ts
@@ -4,6 +4,7 @@ import type { PluginConfig } from '../config';
 import { DEFAULT_MODELS } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import { bunHash } from '../utils/bun-compat';
+import { stableCanonicalStringify } from '../utils/stable-stringify';
 
 // Safe property lookup — prevents prototype chain pollution
 function safeGet<T>(
@@ -486,34 +487,6 @@ export function recentToolCallSessionCount(): number {
 }
 
 /**
- * Recursively produces a canonical JSON string with object keys sorted at
- * EVERY depth (not just the top level). Arrays are serialized element-wise in
- * index order. This is the correct way to make two semantically-equal values
- * serialize identically regardless of key-insertion order.
- *
- * Why not `JSON.stringify(value, sortedKeysArray)`: a property-list replacer
- * array acts as a KEY FILTER at every object depth, not just the top level, so
- * any key not in the (top-level-derived) list is silently dropped from nested
- * objects. For tool args like `{todos:[{content,status}]}`, that collapses
- * every todo to `{}`, re-introducing the exact false-spiral collision class
- * this function exists to eliminate. Sorting must be done by rebuilding each
- * object with sorted keys before serialization.
- */
-function stableCanonicalStringify(value: unknown): string {
-	if (value === null) return 'null';
-	if (typeof value !== 'object') return JSON.stringify(value);
-	if (Array.isArray(value)) {
-		return `[${value.map((el) => stableCanonicalStringify(el)).join(',')}]`;
-	}
-	const obj = value as Record<string, unknown>;
-	const keys = Object.keys(obj).sort();
-	const entries = keys
-		.map((k) => `${JSON.stringify(k)}:${stableCanonicalStringify(obj[k])}`)
-		.join(',');
-	return `{${entries}}`;
-}
-
-/**
  * Stable, fixed-length hash of tool-call args for spiral detection (issue #2060).
  *
  * Replaces the old `.slice(0, 100)` truncation, which collided for any args
@@ -526,13 +499,14 @@ function stableCanonicalStringify(value: unknown): string {
  * patch payloads can reach 1 MB, and the buffer retains up to
  * `MAX_RECENT_CALLS` (20) calls × `MAX_TRACKED_SESSIONS` (500) sessions.
  *
- * Object keys are sorted at every depth via `stableCanonicalStringify`, so
- * `{a:{b:1,c:2}}` and `{a:{c:2,b:1}}` hash equally — a correctness improvement
- * over the old code, which would have missed a genuine spiral whose args had
- * reordered keys. Crucially, the recursive sort does NOT drop nested keys (a
- * property-list replacer array would, re-introducing collisions for nested
- * args like todo lists). Strings are hashed too (not stored raw) so a multi-KB
- * `bash` command cannot blow up the per-entry size.
+ * Object keys are sorted at every depth via the shared `stableCanonicalStringify`
+ * (`src/utils/stable-stringify.ts`), so `{a:{b:1,c:2}}` and `{a:{c:2,b:1}}` hash
+ * equally — a correctness improvement over the old code, which would have
+ * missed a genuine spiral whose args had reordered keys. Crucially, the
+ * recursive sort does NOT drop nested keys (a property-list replacer array
+ * would, re-introducing collisions for nested args like todo lists). Strings
+ * are hashed too (not stored raw) so a multi-KB `bash` command cannot blow up
+ * the per-entry size.
  *
  * `bunHash` returns different values on Bun (xxHash64) vs Node (djb2); this is
  * safe because the buffer is per-process and never persisted. Verified:

--- a/src/hooks/adversarial-detector.ts
+++ b/src/hooks/adversarial-detector.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { PluginConfig } from '../config';
 import { DEFAULT_MODELS } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
+import { bunHash } from '../utils/bun-compat';
 
 // Safe property lookup — prevents prototype chain pollution
 function safeGet<T>(
@@ -485,6 +486,80 @@ export function recentToolCallSessionCount(): number {
 }
 
 /**
+ * Recursively produces a canonical JSON string with object keys sorted at
+ * EVERY depth (not just the top level). Arrays are serialized element-wise in
+ * index order. This is the correct way to make two semantically-equal values
+ * serialize identically regardless of key-insertion order.
+ *
+ * Why not `JSON.stringify(value, sortedKeysArray)`: a property-list replacer
+ * array acts as a KEY FILTER at every object depth, not just the top level, so
+ * any key not in the (top-level-derived) list is silently dropped from nested
+ * objects. For tool args like `{todos:[{content,status}]}`, that collapses
+ * every todo to `{}`, re-introducing the exact false-spiral collision class
+ * this function exists to eliminate. Sorting must be done by rebuilding each
+ * object with sorted keys before serialization.
+ */
+function stableCanonicalStringify(value: unknown): string {
+	if (value === null) return 'null';
+	if (typeof value !== 'object') return JSON.stringify(value);
+	if (Array.isArray(value)) {
+		return `[${value.map((el) => stableCanonicalStringify(el)).join(',')}]`;
+	}
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	const entries = keys
+		.map((k) => `${JSON.stringify(k)}:${stableCanonicalStringify(obj[k])}`)
+		.join(',');
+	return `{${entries}}`;
+}
+
+/**
+ * Stable, fixed-length hash of tool-call args for spiral detection (issue #2060).
+ *
+ * Replaces the old `.slice(0, 100)` truncation, which collided for any args
+ * whose first 100 JSON characters matched — e.g. paged `read` calls on a long
+ * file path where the differing `offset` value sat past character 100, making
+ * five legitimate calls look identical and triggering a false-positive
+ * `debugging_spiral_detected` event.
+ *
+ * The hash is fixed-length so memory stays bounded regardless of arg size:
+ * patch payloads can reach 1 MB, and the buffer retains up to
+ * `MAX_RECENT_CALLS` (20) calls × `MAX_TRACKED_SESSIONS` (500) sessions.
+ *
+ * Object keys are sorted at every depth via `stableCanonicalStringify`, so
+ * `{a:{b:1,c:2}}` and `{a:{c:2,b:1}}` hash equally — a correctness improvement
+ * over the old code, which would have missed a genuine spiral whose args had
+ * reordered keys. Crucially, the recursive sort does NOT drop nested keys (a
+ * property-list replacer array would, re-introducing collisions for nested
+ * args like todo lists). Strings are hashed too (not stored raw) so a multi-KB
+ * `bash` command cannot blow up the per-entry size.
+ *
+ * `bunHash` returns different values on Bun (xxHash64) vs Node (djb2); this is
+ * safe because the buffer is per-process and never persisted. Verified:
+ * `formatDebuggingSpiralEvent` does not serialize `argsHash`.
+ */
+function hashArgsForSpiral(args: unknown): string {
+	if (args && typeof args === 'object') {
+		try {
+			const stable = stableCanonicalStringify(args);
+			return `h:${bunHash(stable).toString(36)}`;
+		} catch {
+			// Unstringifiable args (cyclic, BigInt quirks) — fall back to a
+			// stable but coarser hash so detection still functions.
+			return 'h:fallback';
+		}
+	}
+	if (typeof args === 'string') {
+		// Short strings are cheap to compare directly and keep the hash
+		// debuggable; long strings (e.g. bash commands) are hashed to stay
+		// bounded. The 64-char cutoff keeps the worst-case entry (~66 chars)
+		// below the old 100-char ceiling.
+		return args.length <= 64 ? `s:${args}` : `s:${bunHash(args).toString(36)}`;
+	}
+	return `p:${String(args ?? '')}`;
+}
+
+/**
  * Record a tool call for debugging spiral detection.
  * Call this from toolAfter to track repetitive patterns.
  */
@@ -493,10 +568,7 @@ export function recordToolCall(
 	args: unknown,
 	sessionId: string,
 ): void {
-	const argsHash =
-		typeof args === 'string'
-			? args.slice(0, 100)
-			: JSON.stringify(args ?? '').slice(0, 100);
+	const argsHash = hashArgsForSpiral(args);
 	let calls = recentToolCallsBySession.get(sessionId);
 	if (!calls) {
 		calls = [];

--- a/src/hooks/guardrails/file-authority.ts
+++ b/src/hooks/guardrails/file-authority.ts
@@ -22,19 +22,29 @@ import {
 import { classifyFile, type FileZone } from '../../context/zone-classifier';
 import { log, warn } from '../../utils';
 import { bunHash } from '../../utils/bun-compat';
+import { stableCanonicalStringify } from '../../utils/stable-stringify';
 
 /**
- * Hashes tool arguments for repetition detection
+ * Hashes tool arguments for repetition detection.
+ *
+ * Uses `stableCanonicalStringify` (recursive key-sorting at every depth, no
+ * nested-key filtering) so that two args with the same values hash equally
+ * regardless of key insertion order — including nested objects. This matters
+ * for repetition detection on nested-args tools (e.g. `todowrite` with a
+ * `todos` array): the previous `JSON.stringify(args, sortedKeys)` replacer
+ * silently dropped nested keys, collapsing distinct todo contents to the same
+ * hash.
+ *
  * @param args Tool arguments to hash
- * @returns Numeric hash (0 if hashing fails)
+ * @returns Numeric hash (0 for non-objects or if hashing fails)
  */
 export function hashArgs(args: unknown): number {
 	try {
 		if (typeof args !== 'object' || args === null) {
 			return 0;
 		}
-		const sortedKeys = Object.keys(args as Record<string, unknown>).sort();
-		return Number(bunHash(JSON.stringify(args, sortedKeys)));
+		const stable = stableCanonicalStringify(args);
+		return Number(bunHash(stable));
 	} catch (error) {
 		log('[Guardrails] hashArgs failed', {
 			error: error instanceof Error ? error.message : String(error),

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -46,7 +46,10 @@ import {
 	resolveWriteTargets,
 	type WriteAnalysis,
 } from '../shell-write-detect';
-import { resolveWriteTargets as resolveFileWriteTargets } from '../write-target-resolver';
+import {
+	PATCH_PAYLOAD_KEYS,
+	resolveWriteTargets as resolveFileWriteTargets,
+} from '../write-target-resolver';
 import { appendGuardrailDecision } from './audit-log';
 import {
 	DC_SAFE_TARGETS,
@@ -1460,7 +1463,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		const toolArgs = args as Record<string, unknown> | undefined;
 		if (!toolArgs) return [];
 		const out: string[] = [];
-		for (const key of ['patch', 'input', 'diff'] as const) {
+		for (const key of PATCH_PAYLOAD_KEYS) {
 			const v = toolArgs[key];
 			if (typeof v === 'string' && v.length > 0) out.push(v);
 		}
@@ -1526,12 +1529,33 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			}
 		}
 
-		const patchText = (toolArgs?.input ??
-			toolArgs?.patch ??
-			toolArgs?.diff ??
-			(Array.isArray(toolArgs?.cmd) ? toolArgs.cmd[1] : undefined)) as
-			| string
-			| undefined;
+		// Resolve the patch payload field, preserving the historical precedence
+		// (`input` > `patch` > `diff`) before the additional aliases added for
+		// issue #2059, and falling back to `cmd[1]` last. `PATCH_PAYLOAD_KEYS`
+		// is the single source of truth for the recognized field set, but its
+		// declared order is not the legacy precedence, so we check the legacy
+		// three explicitly first.
+		let patchText: string | undefined;
+		for (const key of ['input', 'patch', 'diff'] as const) {
+			const v = toolArgs?.[key];
+			if (typeof v === 'string') {
+				patchText = v;
+				break;
+			}
+		}
+		if (patchText === undefined) {
+			for (const key of PATCH_PAYLOAD_KEYS) {
+				if (key === 'patch' || key === 'input' || key === 'diff') continue;
+				const v = toolArgs?.[key];
+				if (typeof v === 'string') {
+					patchText = v;
+					break;
+				}
+			}
+		}
+		if (patchText === undefined && Array.isArray(toolArgs?.cmd)) {
+			patchText = toolArgs.cmd[1] as string | undefined;
+		}
 		if (typeof patchText !== 'string') return Array.from(paths);
 		if (patchText.length > 1_000_000) {
 			throw new Error(

--- a/src/hooks/write-target-resolver.ts
+++ b/src/hooks/write-target-resolver.ts
@@ -23,7 +23,35 @@ type WriteTargetResolver = (
 
 const SCALAR_PATH_KEYS = ['path', 'filePath', 'file', 'target'] as const;
 const ARRAY_PATH_KEYS = ['files', 'paths', 'targetFiles'] as const;
-const PATCH_PAYLOAD_KEYS = ['patch', 'input', 'diff'] as const;
+
+/**
+ * Field names a patch-family tool (`patch` / `apply_patch` /
+ * `swarm_apply_patch`) may use to carry its patch payload. Issue #2059: models
+ * and tool wrappers commonly emit `patchText`, `patch_text`, `patchPayload`,
+ * `text`, or `content`; recognizing only `patch`/`input`/`diff` made the
+ * resolver throw `WRITE TARGET UNVERIFIABLE: No patch payload was provided`
+ * for valid diffs.
+ *
+ * Exported so the guardrail layer (`tool-before.ts`) can reuse the single
+ * source of truth instead of drifting its own inline copies (the drift is what
+ * hid the original bug — three copies of this list existed).
+ *
+ * Collision safety: the patch resolver only runs for tools in
+ * `WRITE_TOOL_NAMES`, and `extract_code_blocks` (which uses `content`) routes
+ * to `extractResolver`, not `patchResolver`. Any future `WRITE_TOOL_NAMES`
+ * addition that uses `text` or `content` for a non-patch purpose must be
+ * audited against this list.
+ */
+export const PATCH_PAYLOAD_KEYS = [
+	'patch',
+	'input',
+	'diff',
+	'patchText',
+	'patch_text',
+	'patchPayload',
+	'text',
+	'content',
+] as const;
 
 function unverifiable(reason: string): WriteTargetResolution {
 	return { status: 'unverifiable', reason };
@@ -151,10 +179,24 @@ function parsePatchPayload(payload: string): ParsedPatch | string {
 			nativeOperationIndices.push(index);
 		}
 	}
+	// A payload is a Native Vibe Patch when it has a `*** Begin Patch` marker,
+	// OR carries any native operation marker (`*** Update/Add/Delete File:` /
+	// `*** Move to|from:` — these are unambiguous native syntax that never
+	// appears in a unified-diff body, so their presence always demands native
+	// framing), OR has a bare `*** End Patch` marker with NO unified-diff
+	// headers. The last clause tolerates a model appending `*** End Patch` as a
+	// stray trailer on an otherwise-standard unified diff (issue #2059) while
+	// still failing closed on a genuinely malformed native patch that is missing
+	// its begin marker. Operation markers are intentionally NOT relaxed: a
+	// payload with `*** Update File:` and no begin marker is always a malformed
+	// native patch, never a unified diff (this preserves the security guard at
+	// `tests/unit/hooks/write-target-resolver.test.ts` "rejects unframed ...
+	// native operations").
+	const hasUnifiedHeaders = lines.some((l) => /^(---|\+\+\+)\s+/.test(l));
 	const native =
 		beginIndices.length > 0 ||
-		endIndices.length > 0 ||
-		nativeOperationIndices.length > 0;
+		nativeOperationIndices.length > 0 ||
+		(!hasUnifiedHeaders && endIndices.length > 0);
 	if (native) {
 		if (beginIndices.length === 0)
 			return 'Native patch is missing *** Begin Patch';

--- a/src/memory/redaction.ts
+++ b/src/memory/redaction.ts
@@ -101,6 +101,7 @@ export function computeRedactionPolicyVersion(
  * are considered config-compatible.
  */
 import { createHash } from 'node:crypto';
+import { stableCanonicalStringify } from '../utils/stable-stringify';
 
 export interface MemoryCohortFingerprintInput {
 	provider: string;
@@ -113,7 +114,13 @@ export interface MemoryCohortFingerprintInput {
 export function computeMemoryCohortFingerprint(
 	input: MemoryCohortFingerprintInput,
 ): string {
-	const canonical = JSON.stringify(input, Object.keys(input).sort());
+	// `stableCanonicalStringify` sorts keys at every depth (the current input
+	// is flat, so output is byte-identical to the prior
+	// `JSON.stringify(input, Object.keys(input).sort())` — existing
+	// fingerprints remain valid). It avoids the property-list-replacer
+	// anti-pattern, which would silently drop nested keys if a nested field is
+	// ever added to `MemoryCohortFingerprintInput`.
+	const canonical = stableCanonicalStringify(input);
 	return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
 }
 

--- a/src/utils/stable-stringify.ts
+++ b/src/utils/stable-stringify.ts
@@ -1,0 +1,59 @@
+/**
+ * Stable JSON serialization helpers.
+ *
+ * # Why this exists
+ *
+ * Several subsystems hash tool-call arguments for repetition / spiral
+ * detection. Two requirements make naive `JSON.stringify(value)` incorrect:
+ *
+ * 1. **Key-order independence.** Two semantically identical objects whose
+ *    keys were inserted in different order (`{a:1,b:2}` vs `{b:2,a:1}`) must
+ *    hash equally, otherwise a genuine repetition loop whose args happen to
+ *    be built with reordered keys is missed.
+ *
+ * 2. **No nested-key loss.** A `JSON.stringify(value, sortedKeysArray)`
+ *    property-list replacer looks like it sorts keys — and it does, but only
+ *    for the top level. At every deeper object it acts as a *filter*,
+ *    dropping any key not present in the (top-level-derived) list. For nested
+ *    args like `{todos:[{content,status}]}` every todo collapses to `{}`,
+ *    re-introducing the exact false-collision class this is meant to prevent.
+ *
+ * `stableCanonicalStringify` rebuilds each object with sorted keys at every
+ * depth (no filtering) and serializes arrays element-wise, producing a stable
+ * canonical string suitable for hashing.
+ *
+ * Originally introduced for the adversarial-detector spiral hash
+ * (issue #2060) and shared with `file-authority.hashArgs` so both code paths
+ * use one correct implementation.
+ */
+
+/**
+ * Recursively produces a canonical JSON string with object keys sorted at
+ * EVERY depth (not just the top level). Arrays are serialized element-wise in
+ * index order.
+ *
+ * Why not `JSON.stringify(value, sortedKeysArray)`: a property-list replacer
+ * array acts as a KEY FILTER at every object depth, not just the top level, so
+ * any key not in the (top-level-derived) list is silently dropped from nested
+ * objects. For tool args like `{todos:[{content,status}]}`, that collapses
+ * every todo to `{}`, re-introducing the exact false-collision class this
+ * function exists to eliminate. Sorting must be done by rebuilding each object
+ * with sorted keys before serialization.
+ *
+ * Throws on cyclic structures (infinite recursion) and on values that
+ * `JSON.stringify` cannot represent (BigInt); callers should wrap in try/catch
+ * and fall back to a stable coarse hash.
+ */
+export function stableCanonicalStringify(value: unknown): string {
+	if (value === null) return 'null';
+	if (typeof value !== 'object') return JSON.stringify(value);
+	if (Array.isArray(value)) {
+		return `[${value.map((el) => stableCanonicalStringify(el)).join(',')}]`;
+	}
+	const obj = value as Record<string, unknown>;
+	const keys = Object.keys(obj).sort();
+	const entries = keys
+		.map((k) => `${JSON.stringify(k)}:${stableCanonicalStringify(obj[k])}`)
+		.join(',');
+	return `{${entries}}`;
+}

--- a/tests/unit/hooks/adversarial-detector-wiring.test.ts
+++ b/tests/unit/hooks/adversarial-detector-wiring.test.ts
@@ -115,3 +115,147 @@ describe('adversarial detector memory cap (invariant-8)', () => {
 		expect(detected).not.toBeNull();
 	});
 });
+
+describe('adversarial detector spiral hash stability (issue #2060)', () => {
+	// All tests in this block use unique `2060-` prefixed session IDs because
+	// `recentToolCallsBySession` / `lastSpiralTimestampBySession` are
+	// module-private and NOT reset between tests.
+
+	test('paged read calls on a long file path with different offsets do NOT spiral', async () => {
+		// The bug from the issue: five legitimate `read` calls on the same long
+		// path with different `offset` values produced identical 100-char
+		// truncated hashes and triggered a false-positive spiral. The fix hashes
+		// the full args, so differing offsets must produce differing hashes.
+		//
+		// The path is deliberately long enough that the differing `offset`
+		// value sits PAST character 100 in the JSON serialization — under the
+		// old `.slice(0, 100)` truncation these six calls collapsed to the same
+		// hash (verified: JSON length is 121 chars, and the old slice dropped
+		// the offset entirely). This makes the test a genuine regression guard:
+		// it would FAIL against the old truncated-hash implementation.
+		const sessionId = '2060-false-positive-long-path';
+		const longPath =
+			'/home/user/very/deeply/nested/project/module/src/state/State_AggEntityMappings.h';
+		for (const offset of [0, 1000, 2000, 3000, 4000, 5000]) {
+			recordToolCall(
+				'read',
+				{ filePath: longPath, offset, limit: 100 },
+				sessionId,
+			);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('truly identical tool calls still spiral (true-positive preserved)', async () => {
+		// Regression guard: the fix must not weaken detection of a genuine loop.
+		const sessionId = '2060-true-positive-preserved';
+		for (let i = 0; i < 6; i++) {
+			recordToolCall('bash', { command: 'npm test' }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('bash');
+	});
+
+	test('semantically identical args with reordered keys spiral (key-order independence)', async () => {
+		// Correctness improvement: `{a,b}` and `{b,a}` describe the same call.
+		// The old truncated hash would have missed a spiral whose args were
+		// semantically identical but key-order-different. The key-sorted hash
+		// treats them as equal so a real loop is still caught.
+		const sessionId = '2060-key-order-independence';
+		for (let i = 0; i < 6; i++) {
+			// Alternate key insertion order each call — same values, same tool.
+			if (i % 2 === 0) {
+				recordToolCall(
+					'read',
+					{ filePath: '/tmp/reorder.ts', offset: 42, limit: 10 },
+					sessionId,
+				);
+			} else {
+				recordToolCall(
+					'read',
+					{ limit: 10, offset: 42, filePath: '/tmp/reorder.ts' },
+					sessionId,
+				);
+			}
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('read');
+	});
+
+	test('a string arg and an object arg sharing a prefix do NOT collide', async () => {
+		// A string-typed arg and an object-typed arg are structurally different;
+		// even if their string forms share a prefix they must hash distinctly so
+		// the detector does not manufacture a false spiral.
+		const sessionId = '2060-string-vs-object-no-collision';
+		const longString =
+			'apply_patch --verbose --- a/src/a.ts +++ b/src/a.ts ' + 'x'.repeat(120);
+		for (let i = 0; i < 6; i++) {
+			if (i % 2 === 0) {
+				recordToolCall('patch', longString, sessionId);
+			} else {
+				recordToolCall('patch', { patch: longString }, sessionId);
+			}
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('nested-args tools (e.g. todowrite) with different nested content do NOT spiral', async () => {
+		// Regression guard for the final-critic finding: a JSON.stringify
+		// property-list replacer array filters keys at EVERY object depth, not
+		// just the top level. A naive `JSON.stringify(args, sortedTopLevelKeys)`
+		// would collapse `{todos:[{content:'a',...}]}` to `{todos:[{}]}`, making
+		// six todowrite calls with completely different todo contents hash
+		// identically — re-introducing the exact false-spiral bug class #2060
+		// exists to fix. The recursive stable stringifier must preserve nested
+		// keys so different todo contents produce different hashes.
+		const sessionId = '2060-nested-args-no-collision';
+		const todos = [
+			'Write the authentication module',
+			'Add unit tests for the auth layer',
+			'Review the PR from the coder',
+			'Fix the lint errors in src/index.ts',
+			'Update the documentation',
+			'Refactor the database connection pool',
+		];
+		for (const content of todos) {
+			recordToolCall(
+				'todowrite',
+				{ todos: [{ content, status: 'pending' }] },
+				sessionId,
+			);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('nested-args with reordered keys at any depth still spiral', async () => {
+		// Correctness guard: key-order independence must hold at every depth,
+		// not just the top level. Six calls whose nested objects have the same
+		// key/value pairs in different insertion orders describe the same
+		// operation and must still be detected as a genuine loop.
+		const sessionId = '2060-nested-key-order-independence';
+		for (let i = 0; i < 6; i++) {
+			// Alternate nested key order each call — same values, same tool.
+			if (i % 2 === 0) {
+				recordToolCall(
+					'todowrite',
+					{ todos: [{ content: 'same task', status: 'pending' }] },
+					sessionId,
+				);
+			} else {
+				recordToolCall(
+					'todowrite',
+					{ todos: [{ status: 'pending', content: 'same task' }] },
+					sessionId,
+				);
+			}
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('todowrite');
+	});
+});

--- a/tests/unit/hooks/guardrails.test.ts
+++ b/tests/unit/hooks/guardrails.test.ts
@@ -656,6 +656,37 @@ describe('guardrails circuit breaker', () => {
 			expect(typeof hash).toBe('number');
 			// It could be 0 or non-zero, both are valid
 		});
+
+		it('nested args with different content produce different hashes (no nested-key filtering)', () => {
+			// Regression guard for the recursive stable-stringify fix. The
+			// previous `JSON.stringify(args, sortedKeys)` replacer-array
+			// approach FILTERED keys at every object depth, collapsing
+			// `{todos:[{content:'a',status:'pending'}]}` to `{todos:[{}]}`.
+			// Two todo lists with completely different content therefore
+			// collided — the exact bug class that breaks repetition detection
+			// on nested-args tools like `todowrite`.
+			const hash1 = hashArgs({
+				todos: [{ content: 'Write the auth module', status: 'pending' }],
+			});
+			const hash2 = hashArgs({
+				todos: [{ content: 'Review the coder PR', status: 'in_progress' }],
+			});
+			expect(hash1).not.toBe(hash2);
+		});
+
+		it('nested args with reordered keys at any depth produce the same hash', () => {
+			// Key-order independence must hold at every depth, not just the
+			// top level, so a genuine repetition loop whose nested args are
+			// semantically identical (just built with reordered keys) is still
+			// detected.
+			const hash1 = hashArgs({
+				todos: [{ content: 'same task', status: 'pending' }],
+			});
+			const hash2 = hashArgs({
+				todos: [{ status: 'pending', content: 'same task' }],
+			});
+			expect(hash1).toBe(hash2);
+		});
 	});
 
 	describe('circular buffer', () => {

--- a/tests/unit/hooks/write-target-resolver.test.ts
+++ b/tests/unit/hooks/write-target-resolver.test.ts
@@ -177,3 +177,70 @@ describe('write-target resolver registry — issue #1875', () => {
 		expect(extra).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
 	});
 });
+
+describe('write-target resolver patch payload aliases — issue #2059', () => {
+	// Models and tool wrappers commonly emit patch content under alternative
+	// field names. The resolver must recognize each of them.
+	test.each([
+		['patchText'],
+		['patch_text'],
+		['patchPayload'],
+		['text'],
+		['content'],
+	] as const)('resolves a unified diff carried under the %s alias', (field) => {
+		const payload = '--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n-a\n+b';
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ [field]: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+
+	test('a unified diff with a trailing *** End Patch trailer (no begin) resolves as a unified diff', () => {
+		// Issue #2059 repro: a model emits a standard unified diff but appends
+		// "*** End Patch" at the bottom. The bare End marker must not classify
+		// the payload as a malformed Native Vibe Patch.
+		const payload =
+			'--- a/src/main.cpp\n+++ b/src/main.cpp\n@@ -1 +1 @@\n-old\n+new\n*** End Patch';
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/main.cpp'] });
+	});
+
+	test('a unified diff with a stray *** Update File line but no begin marker still fails closed (security guard preserved)', () => {
+		// Operation markers (Update/Add/Delete File, Move to|from) are
+		// unambiguous native syntax — they never appear in a unified-diff body.
+		// A payload carrying one without a begin marker must stay classified as
+		// a malformed native patch and fail closed, never fall through to the
+		// unified-diff parser (which would silently drop the operation target,
+		// including a path-traversal target). This is the regression the plan
+		// critic caught: an earlier draft relaxed operation markers too.
+		const payload =
+			'*** Update File: ../../../etc/passwd\n--- a/test\n+++ b/test';
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result.status).toBe('unverifiable');
+		if (result.status === 'unverifiable') {
+			expect(result.reason).toContain('*** Begin Patch');
+		}
+	});
+
+	test('a genuine native patch (begin + operation + end) still resolves', () => {
+		// Regression guard for the native classification change: a real native
+		// patch must continue to resolve after relaxing the bare-End case.
+		const payload = '*** Begin Patch\n*** Update File: src/a.ts\n*** End Patch';
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+});


### PR DESCRIPTION
Closes #2059
Closes #2060

## Summary

Two independent guardrail-hardening fixes that prevent legitimate agent tool
calls from being blocked by false-positive verifications, plus a follow-up that
extends the #2060 hash fix to the two other call sites that shared the same
nested-key-filtering bug class. All work was investigated end-to-end via the
issue-tracer methodology, reviewed by an independent plan critic (Kimi K3), an
independent implementation reviewer (Kimi K2.7), and a final critic (Kimi K3)
— which together caught four real bugs before merge.

### #2059 — `write-target-resolver` rejects common patch aliases + misclassifies unified diffs
The patch resolver recognized only `patch`/`input`/`diff`, so models and tool
wrappers that emit `patchText`, `patch_text`, `patchPayload`, `text`, or
`content` got `WRITE TARGET UNVERIFIABLE: No patch payload was provided` for
valid diffs. Separately, a standard unified diff that happened to end with a
`*** End Patch` trailer was misclassified as a malformed Native Vibe Patch and
rejected with `Native patch is missing *** Begin Patch`, because any native
marker triggered native classification.

**Fix:**
- Expanded `PATCH_PAYLOAD_KEYS` to include the five aliases and **exported it**
  as the single source of truth. The same list had drifted into three copies
  (one in `write-target-resolver.ts`, two inline in `tool-before.ts`); all
  three now reference the one export.
- Tightened native classification: a payload is Native Vibe Patch when it has a
  `*** Begin Patch` marker, OR any native operation marker (`*** Update/Add/
  Delete File:`, `*** Move to|from:` — unambiguous native syntax that always
  demands framing), OR a bare `*** End Patch` marker with no unified-diff
  headers. A stray `*** End Patch` trailer on a unified diff is now tolerated;
  operation markers without a begin marker still fail closed (security guard
  preserved — verified across 7 cases).

### #2060 — `recordToolCall()` truncation caused false-positive spiral hard stops
`recordToolCall()` hashed args via `.slice(0, 100)`. For paged `read` calls on
a long file path, the differing `offset` value sat past character 100 and was
sliced off, so five legitimate calls with different offsets produced identical
hashes and triggered a false-positive `debugging_spiral_detected` advisory
hard-stop.

**Fix:** replaced the truncation with a fixed-length hash using a recursive
`stableCanonicalStringify` helper (sorts keys at every depth without filtering)
plus `bunHash` (the existing cross-runtime shim: xxHash64 on Bun, djb2 on Node).
Strings above 64 chars are hashed too, keeping per-entry memory bounded (net
decrease vs. the old 100-char ceiling). `SPIRAL_THRESHOLD` (5) is unchanged —
the fix is in the hash, not the threshold (the issue's suggested raise-to-15
was a band-aid and marked Optional).

### What the review pipeline caught (three real bugs)
1. **Plan critic (Kimi K3):** the first draft's native classification regressed
   an existing security test (Case 1) — a malformed `*** Update File:` payload
   would have fallen through to the unified-diff parser. Fixed with the
   operation-markers-always-demand-framing rule.
2. **Implementation reviewer (Kimi K2.7):** the "paged read" regression test
   used a path too short (54 chars → 95-char JSON) to trigger the 100-char
   truncation, so it passed against the old code too. Fixed by lengthening the
   path (now 121-char JSON); verified the test now FAILS against old code.
3. **Final critic (Kimi K3):** an intermediate hash approach used
   `JSON.stringify(args, sortedKeys)`, whose property-list replacer array
   **filters keys at every object depth** — collapsing nested args like
   `{todos:[{content,status}]}` to `{todos:[{}]}` and re-introducing the exact
   false-spiral bug class for nested-args tools. Fixed with a recursive
   stringifier; added a regression test verified to FAIL against the buggy
   version.

## Invariant audit
- 1 (plugin init):       not touched — no init-path code changed.
- 2 (runtime portability): touched — `bunHash` is the existing cross-runtime shim (`src/utils/bun-compat.ts`); no new direct `Bun.*` calls. Verified by `tests/unit/build/bundle-portability.test.ts` (10 pass).
- 3 (subprocesses):       not touched.
- 4 (.swarm containment): not touched.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched — tests run via `bun test` per-file.
- 7 (test writing):       touched — all new tests use `bun:test`, no `mock.module`, unique session IDs (`2060-*`) for module-private state isolation, both files <500 lines (247 and 220 lines).
- 8 (session state):      touched — per-session keying preserved; per-entry memory bounded (worst case 660KB < old 1MB ceiling).
- 9 (guardrails/retry):   touched — this is a guardrail correctness fix.
- 10 (chat/system msg):   not touched.
- 11 (tool registration): not touched.
- 12 (release/cache):     touched — `docs/releases/pending/2059-2060-write-target-and-spiral.md` added.

## Test plan
All commands run from the repo root on the final commit.

```
$ bun test tests/unit/hooks/write-target-resolver.test.ts tests/unit/hooks/adversarial-detector-wiring.test.ts tests/unit/hooks/guardrails-write-target-resolution.test.ts tests/unit/hooks/scope-guard-write-targets.test.ts tests/unit/hooks/adversarial-detector-patterns.test.ts tests/unit/hooks/adversarial-detector.test.ts tests/unit/hooks/adversarial-detector-spiral-handler.test.ts tests/unit/hooks/guardrails.test.ts tests/unit/memory/cohort-config-fingerprint.test.ts tests/unit/build/bundle-portability.test.ts
254 pass
0 fail
1072 expect() calls
Ran 254 tests across 10 files. [2.69s]
```

```
$ bunx tsc --noEmit
(clean)
```

```
$ bunx biome check <9 changed source/test/doc files>
Checked 9 files in 53ms. No fixes applied.
```

```
$ bun run drift:check
✅ No drift detected across skills, tools, commands, agents, docs claims, and dependency freshness.
```

### Regression guards proven meaningful
The false-positive guards were verified to FAIL against the code they replace,
confirming they genuinely catch the bug (not just pass trivially):
- The paged-read test FAILS against old `.slice(0,100)` with
  `"Tool 'read' called 5+ times with identical args"`.
- The adversarial nested-args test FAILS against the intermediate replacer-array
  hash with `"Tool 'todowrite' called 5+ times with identical args"`.
- The `hashArgs` nested-content test FAILS against the old `hashArgs`
  replacer-array code (two distinct todo lists collapsed to the same hash).

## Notes
- The same `JSON.stringify(value, sortedKeysArray)` nested-key-filtering bug
  class that affected the spiral detector also existed in
  `src/hooks/guardrails/file-authority.ts:hashArgs` (guardrails circuit-breaker
  repetition detection + provider-failure fingerprint) and
  `src/memory/redaction.ts:computeMemoryCohortFingerprint` (memory cohort
  config fingerprint). Both are fixed here via a shared
  `stableCanonicalStringify` helper in `src/utils/stable-stringify.ts`, so all
  three call sites use one correct implementation. The redaction.ts migration
  is byte-identical for the current flat input shape, so existing persisted
  fingerprints remain valid.
- The issue's suggested `SPIRAL_THRESHOLD = 15` for `read` was not implemented
  — it was marked Optional and is a band-aid that would let real read-loops run
  3× longer. The hash fix addresses the root cause.
