### PR TITLE
fix(guardrails): close review findings from PR #2062

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: needs.detect-release.outputs.is-release != 'true'
+        with:
+          fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: needs.detect-release.outputs.is-release != 'true'
         with:
@@ -193,8 +195,10 @@ jobs:
         if: needs.detect-release.outputs.is-release != 'true'
         shell: bash
         run: chmod +x scripts/check-cross-contamination.sh && bash scripts/check-cross-contamination.sh
-      # Diff-scoped: fails only on NEW time-touching tests that don't reference
-      # the freezeClock helper. Pre-existing files are non-blocking warnings
+      # Line-scoped: fails only on lines ADDED by the diff that introduce a
+      # raw-clock pattern in a test that doesn't reference the freezeClock
+      # helper. Merely touching a file that already violates stays a
+      # non-blocking warning, as do files outside the diff
       # (issue #1782 root-cause class 1 prevention).
       - name: Test-clock lint (freezeClock adoption)
         if: needs.detect-release.outputs.is-release != 'true'

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -461,6 +461,7 @@ mock.module('node:fs', () => ({
 | **`src/worktree/core.ts`** | **`removeLaneProfileFromDisk`, `writeLaneProfileToDisk`** | **FR-201 + FR-205 lane profile materialization + teardown** |
 | `src/services/recommendation-ledger.ts` | `now`, `transactFile`, `readLedgerStrict`, `resolveRecommendationLedgerPath` | #1821 AC21 dedup-ledger clock + fail-open path tests |
 | `src/services/trajectory-cluster.ts` | `now`, `checkRecommendations`, `recordEmittedRecommendations` | #1821 AC21 motif-emission dedup tests |
+| `src/memory/redaction.ts` | `currentAlgorithmVersion` | #2062 F-012 cohort-fingerprint version gate: simulates a FUTURE bump of `FINGERPRINT_ALGORITHM_VERSION` so the legacy-file gate is testable before a real bump exists. Production code never mutates it. |
 
 **Delegation-gate split pattern (FR-006 SC-006.1):**
 

--- a/docs/releases/pending/1666-mock-allowlist-growth-ratchet.md
+++ b/docs/releases/pending/1666-mock-allowlist-growth-ratchet.md
@@ -33,7 +33,7 @@ No action required for existing PRs. Only PRs that add new `mock.module` targets
 - The marker is **standalone-line only**: `# APPROVED-NEW: src/path/to/target` on its own line. Inline trailing comments on the entry are not accepted (the regenerator would not preserve them).
 - The marker target is normalized through `scripts/lib/normalize-mock-target.sh`, so `# APPROVED-NEW: ../../../src/foo/bar.js` matches the entry `src/foo/bar`.
 - The marker may appear **anywhere** in the allowlist (the checker does flat set-membership, not adjacency). Convention places it immediately above the entry it approves, and `scripts/generate-mock-allowlist.sh` preserves that placement across regeneration.
-- The no-base-branch path (local-dev clone without `origin/main` fetched) is non-blocking: Check 4 prints a `NOTE:` and skips. Real CI (PR + merge-group events with `actions/checkout fetch-depth: 0`) always resolves `origin/main`.
+- The no-base-branch path (local-dev clone without `origin/main` fetched) is non-blocking: Check 4 prints a `NOTE:` and skips. This requires the calling job's `actions/checkout` to use `fetch-depth: 0` (or another depth deep enough to include the merge base) — a shallow default-depth-1 checkout never resolves `origin/main`, silently no-ops every diff-scoped ratchet in that job, and is not itself guaranteed by "real CI" in general (see PR #2062 F-003: the `quality` job's checkout previously had no `fetch-depth` set at all).
 
 ## Test plan
 

--- a/docs/releases/pending/2059-2060-write-target-and-spiral.md
+++ b/docs/releases/pending/2059-2060-write-target-and-spiral.md
@@ -2,24 +2,54 @@
 
 ## What
 
-Three independent guardrail-hardening fixes that prevent legitimate agent tool
-calls from being blocked by false-positive verifications, plus a shared stable
-serialization helper that eliminates a class of nested-key-filtering bugs
-across the codebase.
+Three guardrail-hardening fixes that prevent legitimate agent tool calls from
+being blocked by false-positive verifications, the two shared utility modules
+those fixes extract — **and three changes that belong to neither #2059 nor
+#2060**, listed separately below because the PR title does not imply them: an
+on-disk format change, a CI gate *activation*, and a CI gate policy
+*relaxation*.
+
+### The two issue fixes
 
 - **#2059 — `write-target-resolver`:** the patch resolver now recognizes the
   common payload aliases `patchText`, `patch_text`, `patchPayload`, `text`, and
   `content` (in addition to `patch`, `input`, `diff`), and no longer
   misclassifies a standard unified diff as a malformed Native Vibe Patch when
-  the model appends a stray `*** End Patch` trailer.
+  the model appends a stray `*** End Patch` trailer. It also now tolerates CRLF
+  payloads and no longer drops indented native operation markers.
 - **#2060 — `adversarial-detector`:** the debugging-spiral detector now hashes
   the complete tool-call arguments with a fixed-length, key-sorted hash instead
   of truncating the stringified args at 100 characters.
+
+### Shared extraction (one bug class, three call sites)
+
 - **`file-authority.hashArgs` + `redaction.computeMemoryCohortFingerprint`:**
   migrated off the same `JSON.stringify(value, sortedKeysArray)` property-list
   replacer anti-pattern that #2060's fix addressed, using a shared
   `stableCanonicalStringify` helper so all three call sites use one correct
   implementation.
+- **Two new modules:** `src/utils/stable-stringify.ts` (the canonical
+  serializer) and `src/utils/arg-hash.ts` (the bounded hash and the
+  unserializable-args discriminator that the spiral detector and the guardrails
+  circuit breaker both need). `src/hooks/guardrails/tool-before.ts` also stops
+  maintaining its own inline copy of `PATCH_PAYLOAD_KEYS` and imports the
+  resolver's.
+
+### Not #2059 / #2060 — review these on their own terms
+
+- **Persisted format change:** `memory-cohort-config.json` now records an
+  `algorithm_version` field alongside the fingerprint. One writer
+  (`src/commands/memory-link.ts`), four readers, a shared classifier and a
+  barrel re-export in `src/memory/index.ts`. Files written before this change
+  stay valid and require no re-link; the gate fails **open**. Details below.
+- **CI gate activation:** `.github/workflows/ci.yml` sets `fetch-depth: 0` on
+  the `quality` job's checkout. Five diff-scoped ratchet scripts in that job
+  had been passing vacuously because they could not resolve a base ref; they
+  now actually enforce. This can newly fail PRs that were passing for free.
+- **CI gate policy relaxation:** `scripts/check-test-clock.sh` becomes
+  line-scoped instead of file-scoped, which makes it catch **strictly less**
+  than its previous implementation. It is also what makes this PR pass the gate
+  the change above just activated. Both facts are disclosed in full below.
 
 ## Why
 
@@ -52,6 +82,60 @@ message.
   `*** End Patch` marker with no unified-diff headers. A stray `*** End Patch`
   trailer on a unified diff is now tolerated; operation markers without a begin
   marker still fail closed (security guard preserved).
+- The resolver now tolerates CRLF-terminated payloads (a model or wrapper that
+  emits `\r\n` line endings no longer fails marker/line detection that assumed
+  bare `\n`), and no longer drops native operation markers that are indented.
+  Pre-fix, an indented `*** Update/Add/Delete File:` etc. marker inside valid
+  `*** Begin/End Patch` framing was silently ignored by the marker scan, so
+  the resolver **resolved successfully but without that target** — it
+  returned `status: 'resolved'` with the indented operation's path missing
+  from `paths`, letting the guardrail authorize a write set that omitted a
+  real target. Indented operation markers are now recognized and included.
+  Trimming this whitespace is a strict relaxation **of the marker scan** —
+  every marker detected before is still detected, plus indented ones — but it
+  is *not* neutral at the payload level, and that must not be overstated.
+  Measured directly by running the base (`f2c832f9`) and head resolvers
+  against the same three payloads:
+
+  | Payload | Base | Head |
+  |---|---|---|
+  | `*** Begin Patch` / indented `*** Update File: ../../../etc/passwd` / `*** End Patch` | unverifiable — "Patch contains no recognizable write targets" | **resolved** `["../../../etc/passwd"]` |
+  | indented `*** Update File:` with no framing at all | unverifiable — "Patch contains no recognizable write targets" | unverifiable — "Native patch is missing `*** Begin Patch`" |
+  | indented `*** Update File: src/a.ts` *outside* framing, plus a column-0 `*** Update File: src/b.ts` inside it | **resolved** `["src/b.ts"]` — `src/a.ts` silently dropped | unverifiable — "operation outside begin/end markers" |
+
+  Row 1 is a payload the base rejected and head now resolves, so the honest
+  statement is that the change is not purely additive. It is still the
+  intended direction: the previously-missed target is now *surfaced* to the
+  caller for the same downstream path validation every other target gets — it
+  is not authorized by being recognized. Row 3 is the original defect (a real
+  target dropped from an otherwise-successful resolution) and row 2 confirms
+  the unframed case still fails closed.
+
+  This does introduce a new fail-closed trade-off worth calling out
+  explicitly: a **unified diff** whose *context lines* happen to reproduce a
+  column-0 native marker (e.g. a context line that starts with
+  `*** Update File:`) is now classified as a native patch and rejected with
+  "Native patch is missing `*** Begin Patch`", even though it is really a
+  unified diff.
+
+  **The measured blast radius is four files, and it was measured in *this*
+  repo only** (`grep -rlE '^\*\*\* (Update|Add|Delete) File:|^\*\*\* Move (to|from):'`
+  → `guardrails-directory.adversarial.test.ts`, `guardrails-plan-md-guard.test.ts`,
+  `guardrails-v622-patch-aliases.test.ts` — added by this PR — and
+  `write-lstat-authority.test.ts`). That number says nothing about the
+  population that actually matters: this resolver ships inside a plugin that
+  runs against **arbitrary consumer repositories**. Any repo containing a
+  column-0 `*** Update/Add/Delete File:` or `*** Move to|from:` line — docs
+  describing the native patch format, an agent prompt file, a skill, a test
+  fixture — makes that file un-editable by a unified-diff patch tool, and the
+  rejection message names a format the payload was never in. No measurement
+  of that population exists. `edit`/`write` tool calls are unaffected, so the
+  fallback is always available. This is deliberate: the
+  alternative (only treating an operation marker as native when the payload
+  also has no unified-diff headers) was built and tested and it reopens the
+  original security hole — it silently drops the indented target from a
+  mixed-signal payload a native applier could legitimately act on. The
+  fail-closed side was chosen on purpose for a write-authorization guardrail.
 
 ### `src/hooks/guardrails/tool-before.ts`
 - `extractAllPatchPayloads` and `extractPatchTargetPaths` now import
@@ -77,18 +161,110 @@ message.
   depths). Shared by `hashArgsForSpiral`, `hashArgs`, and
   `computeMemoryCohortFingerprint` so all three use one correct implementation.
 
+### `src/utils/arg-hash.ts` (new)
+- Exports four symbols: `boundedBunHash` and `coarseObjectDiscriminator` (the
+  two helpers the spiral detector and the guardrails circuit breaker both call),
+  plus `HASH_INPUT_CAP_BYTES` and `sampleForHash`, which are exported so the
+  cap and the sampling transform can be tested directly rather than inferred
+  from hash outputs (`tests/unit/utils/arg-hash.test.ts`,
+  `tests/unit/hooks/guardrails-hash-args.test.ts`). All four are new in this
+  release. `hashArgsForSpiral` (the #2060 fix) and `file-authority.hashArgs`
+  need the same primitives, so they live in one module rather than as two
+  inline copies — the same reason `stable-stringify.ts` was extracted. Fixing a
+  hashing bug once, in one place, is the point.
+- `coarseObjectDiscriminator` gives both hashers a *discriminating* answer when
+  an argument object cannot be serialized (cyclic references, `BigInt`).
+  Previously `file-authority.hashArgs` returned the constant `0` in that case,
+  so every unserializable call hashed identically and a run of calls with
+  genuinely *different* such args inflated the guardrails circuit breaker's
+  consecutive-repetition count as though one call had repeated — the same
+  false-positive class as #2060, via a different trigger. `hashArgsForSpiral`
+  is new in this release and is given the same discriminator so it never
+  acquires the bug. The discriminator is total: it cannot itself throw.
+- `boundedBunHash` caps hashing cost on **both** per-tool-call hot paths, which
+  are two different hooks:
+  - **`toolAfter`** — `recordToolCall` (`src/index.ts:2669`, inside the
+    `tool.execute.after` handler). Tripping the spiral detector produces an
+    advisory message.
+  - **`toolBefore`** — `hashArgs` via `trackToolCall`
+    (`src/hooks/guardrails/tool-before.ts:1846`). This is the
+    consecutive-repetition **circuit breaker, which throws**, so it is the more
+    consequential of the two — as `file-authority.ts`'s own `hashArgs`
+    docstring says: "this hash drives the consecutive-repetition circuit
+    breaker in `tool-before.ts`, which THROWS."
+
+  Patch payloads reach ~1 MB, and `bunHash` falls back to a per-byte djb2 loop
+  when the plugin runs under Node (see `bun-compat.ts`), which measured ~141 ms
+  for 2 MB. Inputs above the cap are reduced to a length-prefixed head+tail
+  sample, which keeps worst-case cost at a few milliseconds while remaining
+  injective at or below the cap and defeating both append- and
+  prepend-collisions above it.
+- **Residual lossiness, disclosed:** bounding introduces a collision class the
+  previous uncapped hash did not have. Two inputs **longer than
+  `HASH_INPUT_CAP_BYTES`** now hash equal if they have the same total length,
+  the same leading half-cap of characters, and the same trailing half-cap of
+  characters, differing only in the discarded middle. On the `toolBefore`
+  circuit-breaker path that is a false repetition on a path that throws. It is
+  unavoidable for any fixed-cost sampler and is the deliberate trade documented
+  on `HASH_INPUT_CAP_BYTES` and `sampleForHash` in `src/utils/arg-hash.ts`.
+  (The cap bounds UTF-16 code units, not bytes, despite the constant's name —
+  also called out in the module.)
+
+### Cohort config: `algorithm_version` (persisted format)
+- `memory-cohort-config.json` now records `algorithm_version` alongside the
+  fingerprint, and `FINGERPRINT_ALGORITHM_VERSION` (currently `1`) is exported
+  from `src/memory/redaction.ts`.
+- **Existing config files remain valid.** A file written before this change has
+  no `algorithm_version`; every reader treats an absent field as the literal
+  version `1` (the algorithm that predates the field — deliberately NOT
+  "whatever the current constant happens to be", so that a future bump still
+  detects legacy files instead of silently mis-comparing them). Since `1` is
+  the current version today, a legacy file is compared exactly as it was
+  before, and no re-link is required.
+- A **present but non-numeric** `algorithm_version` is treated as unknown, and
+  a stored version that differs from the running one is treated as not
+  comparable. In both cases every reader **skips the byte comparison** instead
+  of reporting a config mismatch — digests from different algorithms are not
+  comparable, so comparing them would produce a misleading "your config
+  differs" error. The gate **fails open**; memory is never stranded.
+- **The four readers do not behave identically about telling you, and that is
+  deliberate.** The two memory providers `warn()` on both the unknown and the
+  mismatch case, each with a distinct message pointing at
+  `/swarm memory link` (`memory/sqlite-provider.ts:2014,2028`;
+  `memory/local-jsonl-provider.ts:584,598`, both inside
+  `assertCohortConfigFingerprint`). The two read-only reporting surfaces
+  (`services/status-service.ts:347`,
+  `services/knowledge-diagnostics.ts:512`) emit **nothing at all** — they
+  simply leave their fingerprint-match field unset/null, which is the
+  "unknown" value those surfaces already have. Both carry the comment "this is
+  a read-only reporting surface, so stay silent rather than warn". So: no
+  duplicate warnings from a status read, and no false mismatch reported either.
+- Files touched: `commands/memory-link.ts` (the single writer),
+  `memory/redaction.ts` (the constant, the `LEGACY_…` literal and the shared
+  `classifyStoredFingerprintAlgorithmVersion` classifier all four readers use),
+  the four readers named above, and `memory/index.ts`, which adds
+  `FINGERPRINT_ALGORITHM_VERSION` to the memory barrel's re-exports.
+
 ### `src/hooks/guardrails/file-authority.ts`
 - `hashArgs` (used by the guardrails circuit-breaker repetition detector and
   the provider-failure fingerprint) migrated from
   `JSON.stringify(args, sortedKeys)` to `stableCanonicalStringify(args)`. This
   fixes the same nested-key-filtering bug class as #2060 for the circuit
   breaker: nested-args tools (e.g. `todowrite` with a `todos` array) previously
-  collapsed distinct nested content to the same hash, so a genuine repetition
-  loop on a nested-args tool could be missed. The returned `number` is
-  unchanged for flat args (the common case) and only differs for nested args
-  (the fix). The value is never persisted across versions
-  (`recentToolCalls` is reset on snapshot rehydration), so there is no
-  cross-version comparison risk.
+  collapsed distinct nested content to the same hash, so the circuit breaker
+  could FALSELY trip on legitimate distinct calls (a hash collision between
+  two different `todos` payloads made the consecutive-equality repetition
+  count in `trackToolCall` inflate as if the same call had repeated). It could
+  never suppress detection of a genuine repetition loop, since truly identical
+  consecutive args already hashed equal under the old replacer too. The
+  returned `number` changes for *every* input relative to the previous
+  release — nested args because of the serializer fix, and flat args too
+  because `boundedBunHash` now mixes in a length prefix. That is safe because
+  the value is never persisted across versions (`recentToolCalls` is reset on
+  snapshot rehydration, `session/snapshot-reader.ts`), so no stored hash is
+  ever compared against a hash computed by a different version. What matters
+  for detection is only that identical args hash equal *within* one process,
+  which still holds.
 
 ### `src/memory/redaction.ts`
 - `computeMemoryCohortFingerprint` migrated to `stableCanonicalStringify` for
@@ -98,24 +274,103 @@ message.
   empirically — so existing persisted fingerprints in
   `memory-cohort-config.json` remain valid.
 
+### `.github/workflows/ci.yml`
+- The `quality` job's `actions/checkout` step now sets `fetch-depth: 0`. It
+  previously defaulted to `fetch-depth: 1`, which meant none of the five
+  diff-scoped ratchet scripts it runs (`check-mock-cleanup.sh`,
+  `check-invariants.sh`'s mock-allowlist Check 4,
+  `check-test-clock.sh`, `check-test-file-cap.sh`, `check-test-tmpdir.sh`)
+  could resolve `origin/main`/`origin/master`/`main`/`master` as a base ref,
+  so every diff-scoped check in that job silently no-opped (vacuous pass)
+  instead of enforcing.
+
+### `scripts/check-test-clock.sh`
+- Now line-scoped instead of file-scoped. Previously a file counted as a NEW
+  (blocking) violation if it merely appeared in the PR diff at all, even if
+  the PR's changes never touched a raw-clock line — so editing an unrelated
+  part of an already-violating file (e.g. adding new tests elsewhere) turned
+  a pre-existing, non-blocking violation into a blocking one. It now only
+  flags a file as NEW/blocking when the diff's *added* lines themselves
+  introduce a raw-clock pattern (`Date.now()` / no-arg `new Date()` /
+  `spyOn(Date)`); pre-existing violations in files touched for unrelated
+  reasons remain non-blocking warnings.
+- **This is a deliberate policy relaxation, not purely a bug fix.** The old
+  header did promise file-scoping and the code implemented it faithfully;
+  line-scoping catches strictly less (a PR that deletes a `freezeClock` import
+  while leaving existing `Date.now()` calls used to block and now does not).
+  It is adopted because blaming a file's pre-existing violations on whoever
+  next edits it is a false accusation, and because the sibling
+  `check-test-tmpdir.sh` is already line-scoped.
+- **Disclosure:** this change and the `fetch-depth: 0` fix above interact. That
+  fix activates a gate that was dormant, and the activated file-scoped gate
+  would have newly blocked *this* PR over pre-existing raw-clock lines in two
+  files it touches for unrelated reasons (`tests/unit/hooks/guardrails.test.ts`
+  and `tests/unit/services/knowledge-diagnostics.test.ts` — neither of which
+  this PR adds a clock line to). Line-scoping is the correct policy on its own
+  merits, but it also unblocks this PR, and reviewers should weigh it knowing
+  that.
+- Also fixes a fail-open bug found during review: the helper ended in
+  `grep -qE` under `set -o pipefail`, so on a large enough diff `grep -q`
+  closed its stdin early, the upstream `grep` took SIGPIPE, and the pipeline
+  returned 141 — reporting "no new clock line" *despite a match*. Replaced with
+  a counted `grep -cE`, which drains stdin.
+
 ## Test plan
-- New `write-target-resolver.test.ts` cases: each alias resolves a unified
-  diff; trailing `*** End Patch` trailer resolves; stray `*** Update File:`
-  without begin still fails closed (security regression guard); genuine native
-  patch still resolves.
-- New `adversarial-detector-wiring.test.ts` cases: paged reads with different
-  offsets do not spiral (the bug); identical calls still spiral; reordered-key
-  args spiral (correctness); string vs object args do not collide; nested-args
-  tools with different nested content do not spiral; nested-args with reordered
-  keys at any depth still spiral.
-- New `guardrails.test.ts` cases for `hashArgs`: nested args with different
-  content produce different hashes (no nested-key filtering); nested args with
-  reordered keys at any depth produce the same hash. Both verified to fail
-  against the old replacer-array code.
-- `cohort-config-fingerprint.test.ts` passes unchanged (redaction.ts migration
-  is a no-op for the current flat input — verified byte-identical).
-- All existing write-target, scope-guard, guardrails, and adversarial-detector
-  tests pass unchanged.
+
+Ten test files are added or modified. Every one was run individually, per the
+per-file isolation loop `AGENTS.md` §6 requires for repo validation; all pass.
+Line counts are base (`f2c832f9`) → head.
+
+**New files (5)**
+
+| File | Lines | Tests | Covers |
+|---|---|---|---|
+| `tests/unit/utils/stable-stringify.test.ts` | 237 | 28 | The new canonical serializer directly: recursive key sorting at every depth, and each documented divergence from `JSON.stringify` (`Date`/`Map`/`Set` → `{}`, `undefined` → `null` in property and element position, true array holes preserved, cyclic → `RangeError`, `BigInt` → `TypeError`). |
+| `tests/unit/utils/arg-hash.test.ts` | 149 | 17 | `HASH_INPUT_CAP_BYTES`, `sampleForHash`, `boundedBunHash`, `coarseObjectDiscriminator`. Includes the at-cap vs over-cap case that proves the length prefix is load-bearing, and a hostile `Proxy` whose `ownKeys` throws — the discriminator must be total, since both callers invoke it from inside a `catch`. |
+| `tests/unit/hooks/guardrails-hash-args.test.ts` | 161 | 17 | `file-authority.hashArgs`. **This is where the `hashArgs` cases now live** — see the note below. |
+| `tests/unit/hooks/guardrails-v622-patch-aliases.test.ts` | 110 | 10 | **The whole FB-014 fix.** Drives the real `createGuardrailsHooks(...).toolBefore` — the guardrail runtime layer, not the resolver — for all five new aliases: each alias targeting `.swarm/plan.json` throws `PLAN STATE VIOLATION`, and each alias targeting a non-plan file does not. The resolver-level alias tests could not have caught a guardrail-layer wiring gap. |
+| `tests/unit/services/status-service.memory-fingerprint-version.test.ts` | 180 | 7 | The `algorithm_version` gate in `status-service`, including a simulated future version bump via the `redaction._internals` seam. |
+
+**Modified files (5)**
+
+| File | Lines | Tests | Change |
+|---|---|---|---|
+| `tests/unit/hooks/write-target-resolver.test.ts` | 179 → 373 | 28 | Each alias resolves a unified diff; trailing `*** End Patch` trailer resolves; a column-0 `*** Update File:` with no begin marker still fails closed (security regression guard); genuine native patch still resolves; CRLF payloads resolve; indented operation markers are included; cross-field conflicting targets and non-string alias payloads are both rejected with pinned messages. |
+| `tests/unit/hooks/adversarial-detector-wiring.test.ts` | 117 → 377 | 22 | Paged reads at different offsets do not spiral (the #2060 bug); identical calls still spiral; reordered-key args spiral; string vs object args do not collide; nested-args tools with different nested content do not spiral; nested-args with reordered keys at any depth still spiral. |
+| `tests/unit/memory/cohort-config-fingerprint.test.ts` | 159 → 496 | 24 | **Not "unchanged"** (338 insertions / 1 deletion). Pins the fingerprint with a golden digest and asserts key-order independence (so the `stableCanonicalStringify` migration is provably a no-op for the current flat input), and adds the `algorithm_version` gate: absent → legacy v1, present-non-numeric → unknown, and a simulated bump to 2 exercised against both providers. |
+| `tests/unit/services/knowledge-diagnostics.test.ts` | 295 → 422 | 16 | Adds a 7-test `#2062 F-012` block for the fourth reader: legacy config still compares (match and mismatch), differing version reports no false mismatch, non-numeric reports unknown, and a simulated bump reports unknown. |
+| `tests/unit/hooks/guardrails.test.ts` | 2875 → 2808 | 95 | **Net deletion** (1 insertion / 68 deletions). The `describe('hashArgs')` block was *moved out* of this file, not added to it — see below. |
+
+**Where the `hashArgs` cases went (F-004).** They are no longer in
+`guardrails.test.ts`; that file no longer references `hashArgs` at all. The
+block was extracted intact into the new
+`tests/unit/hooks/guardrails-hash-args.test.ts` because `guardrails.test.ts`
+is already far over the 500-line `check-test-file-cap.sh` ratchet, and growing
+an over-cap file is an ERROR under that gate — which the `fetch-depth: 0`
+change in this PR activates. The cases themselves are unchanged in intent:
+nested args with different content produce different hashes (no nested-key
+filtering) and nested args with reordered keys at any depth produce the same
+hash, both verified to fail against the old replacer-array implementation.
+
+**The `algorithm_version` gate is bump-tested in all four readers**, not just
+where it is easiest: sqlite and local-jsonl in
+`cohort-config-fingerprint.test.ts`, status-service in its own new file, and
+knowledge-diagnostics in its F-012 block. Each asserts that a legacy file
+under a simulated bump resolves to version **1** rather than to the simulated
+current version — the actual defect, which is invisible while the constant is
+still 1.
+
+**Not covered by an automated test:** the five ratchet scripts that
+`fetch-depth: 0` activates only run in CI. All five were simulated by hand
+against this PR's own diff and pass:
+- `check-test-file-cap.sh`: the only changed test file over 500 lines is
+  `guardrails.test.ts`, and it **shrank** (2875 → 2808), which the ratchet
+  permits; the largest of the other nine is 496.
+- `check-test-clock.sh`: zero raw-clock lines added across all ten files.
+- `check-test-tmpdir.sh`: the single added `tmpdir()` call is
+  `realpathSync(mkdtempSync(...))` on the same line.
+- `check-mock-cleanup.sh` and `check-invariants.sh` Check 4: no `mock.module`
+  or `vi.mock` target added.
 
 ## Invariant audit
 - 1 (plugin init): not touched.
@@ -125,8 +380,16 @@ message.
 - 4 (.swarm containment): not touched.
 - 5 (plan durability): not touched.
 - 6 (test_runner safety): not touched.
-- 7 (test writing): touched — `bun:test`, no `mock.module`, direct function
-  calls, unique session IDs.
+- 7 (test writing): touched — `bun:test` only; zero `mock.module`/`vi.mock`
+  targets added by this PR; the one new DI need is served by an `_internals`
+  seam (`src/memory/redaction.ts`, registered in
+  `docs/engineering-invariants.md`) rather than by module mocking; all five new
+  test files are under the 500-line cap (largest 237); the one added
+  `tmpdir()` call is wrapped in `realpathSync`. Note that invariant 7 does not
+  require unique session IDs and this PR does not claim them —
+  `guardrails-v622-patch-aliases.test.ts` deliberately reuses the literal
+  `'test-session'` across its ten parameterised cases, each of which
+  constructs fresh hooks and re-establishes the session.
 - 8 (session state): touched — per-session keying preserved; per-entry memory
   bounded (net decrease).
 - 9 (guardrails/retry): touched — this is a guardrail correctness fix.

--- a/scripts/check-test-clock.sh
+++ b/scripts/check-test-clock.sh
@@ -16,9 +16,14 @@
 # the clock for their assertions. Files that use the clock at all but never
 # reference the helper are the ones most likely to add a flaky assertion.
 #
-# This script is DIFFF-SCOPED (mirrors check-mock-cleanup.sh FB-001):
-#   - Pre-existing violations (files not in the PR diff) → WARNING, non-blocking.
-#   - NEW violations (files added/modified in the PR diff) → ERROR, blocking.
+# This script is LINE-SCOPED (a narrowing of check-mock-cleanup.sh FB-001's
+# file-scoped model):
+#   - Pre-existing violations (files not in the PR diff, and files in the diff
+#     whose raw-clock uses were already there) → WARNING, non-blocking.
+#   - NEW violations (lines ADDED by the PR diff that introduce a raw-clock
+#     pattern) → ERROR, blocking.
+# Merely touching a file that already violates does NOT promote its pre-existing
+# warning to a blocking error — that misattribution is what line-scoping fixes.
 # This avoids the day-1 wall of ~473 pre-existing files (issue #1782 plan
 # critic C3) while still forcing every NEW time-touching test to acknowledge
 # the helper.
@@ -57,7 +62,53 @@ is_pr_file() {
     return $?
 }
 
+# Line-scoped check: a file is only a NEW/blocking violation if the diff's
+# ADDED lines (vs. the resolved base branch) themselves introduce a raw-clock
+# pattern. Merely touching an already-violating file (e.g. adding unrelated
+# tests elsewhere in the same file) does NOT promote its pre-existing
+# violation to blocking.
+#
+# Be precise about what changed here (issue #2062 FB-015): this is a
+# deliberate POLICY RELAXATION, not merely a bug fix. The previous header
+# promised file-scoping ("files added/modified in the PR diff → ERROR"), and
+# the code implemented exactly that. Line-scoping is strictly more permissive:
+# a PR that removes a `freezeClock` import while leaving existing `Date.now()`
+# calls used to block and now does not. It is adopted because attributing a
+# file's PRE-EXISTING violations to whoever next edits it is a false
+# accusation, and because the sibling `check-test-tmpdir.sh` is already
+# line-scoped — but it IS a reduction in what this gate catches, and it is
+# recorded as such rather than sold as a defect repair.
+file_adds_new_clock_line() {
+    local file="$1"
+    local base_branch="$2"
+    local match_count
+    if [ -z "$base_branch" ]; then
+        return 1
+    fi
+    # Deliberately grep -cE, NOT grep -qE: under `set -o pipefail` (line 33),
+    # grep -q exits as soon as it sees the first match and closes its stdin,
+    # which can send SIGPIPE to the still-writing upstream `grep -E` (and, on
+    # a large enough diff, to `git diff` itself). pipefail then reports that
+    # SIGPIPE (128+13=141) as the pipeline's exit status, making this helper
+    # report "no new clock line" even though a match occurred — the unsafe
+    # direction for a gate whose job is to block. grep -c reads its input to
+    # EOF before exiting, so the pipeline always finishes writing normally and
+    # no SIGPIPE is possible. (Same rule as ci.yml:134-142.)
+    match_count=$(git diff "$base_branch" HEAD -- "$file" 2>/dev/null \
+        | grep -E '^\+' \
+        | grep -vE '^\+\+\+' \
+        | grep -cE "Date\.now\(\)|new Date[[:space:]]*\([[:space:]]*\)|spyOn\(Date" || true)
+    [ "${match_count:-0}" -gt 0 ]
+}
+
 PR_CHANGED_FILES=$(get_pr_changed_files)
+PR_BASE_BRANCH=""
+for branch in origin/main origin/master main master; do
+    if git rev-parse "$branch" >/dev/null 2>&1; then
+        PR_BASE_BRANCH="$branch"
+        break
+    fi
+done
 
 # --- Check: raw clock use in tests must reference freezeClock ---
 # Find test files that touch the real clock.
@@ -74,7 +125,7 @@ while IFS= read -r file; do
     if [ "$has_import" -gt 0 ] || [ "$has_call" -gt 0 ]; then
         continue
     fi
-    if is_pr_file "$file" "$PR_CHANGED_FILES"; then
+    if is_pr_file "$file" "$PR_CHANGED_FILES" && file_adds_new_clock_line "$file" "$PR_BASE_BRANCH"; then
         echo "ERROR: $file uses the real clock (Date.now / new Date() / spyOn(Date)) but does not import or call the freezeClock helper."
         echo "       Import from '../../helpers/test-clock.js' (adjust depth) and wrap"
         echo "       time-sensitive assertions in withFrozenClock(() => { ... })."

--- a/src/commands/memory-link.ts
+++ b/src/commands/memory-link.ts
@@ -46,6 +46,7 @@ import { evictAndCloseForRoot } from '../memory/provider-pool.js';
 import {
 	buildMemoryCohortFingerprintInput,
 	computeMemoryCohortFingerprint,
+	FINGERPRINT_ALGORITHM_VERSION,
 } from '../memory/redaction.js';
 import {
 	type VettedMemoryRoot,
@@ -202,6 +203,11 @@ export async function handleMemoryLinkCommand(
 			JSON.stringify(
 				{
 					fingerprint,
+					// #2062 F-012: stamp the algorithm that produced `fingerprint`.
+					// Readers that see a different version skip the (meaningless)
+					// cross-algorithm byte comparison and tell the user to re-link,
+					// instead of reporting a bogus provider/embedding config mismatch.
+					algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
 					config: fingerprintInput,
 					updated_at: new Date().toISOString(),
 				},

--- a/src/hooks/adversarial-detector.ts
+++ b/src/hooks/adversarial-detector.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import type { PluginConfig } from '../config';
 import { DEFAULT_MODELS } from '../config/constants';
 import { stripKnownSwarmPrefix } from '../config/schema';
-import { bunHash } from '../utils/bun-compat';
+import { boundedBunHash, coarseObjectDiscriminator } from '../utils/arg-hash';
 import { stableCanonicalStringify } from '../utils/stable-stringify';
 
 // Safe property lookup — prevents prototype chain pollution
@@ -512,15 +512,32 @@ export function recentToolCallSessionCount(): number {
  * safe because the buffer is per-process and never persisted. Verified:
  * `formatDebuggingSpiralEvent` does not serialize `argsHash`.
  */
+/**
+ * Bounding and fallback-discrimination live in `src/utils/arg-hash.ts`
+ * (`HASH_INPUT_CAP_BYTES`, `boundedBunHash`, `coarseObjectDiscriminator`),
+ * shared verbatim with `hooks/guardrails/file-authority.ts:hashArgs`. Both
+ * call sites had the same unbounded-input (F-010) and constant-fallback
+ * (F-009) bugs; the fix lives in one module so it cannot drift.
+ *
+ * `boundedBunHash` hashes a length-prefixed head+tail SAMPLE, not a bare
+ * prefix, so two large payloads that share a 64 KB header but differ in their
+ * appended bodies no longer collapse to one hash.
+ */
 function hashArgsForSpiral(args: unknown): string {
 	if (args && typeof args === 'object') {
 		try {
 			const stable = stableCanonicalStringify(args);
-			return `h:${bunHash(stable).toString(36)}`;
+			return `h:${boundedBunHash(stable).toString(36)}`;
 		} catch {
-			// Unstringifiable args (cyclic, BigInt quirks) — fall back to a
-			// stable but coarser hash so detection still functions.
-			return 'h:fallback';
+			// Unstringifiable args (cyclic, BigInt quirks) — mix in a coarse
+			// structural discriminator rather than collapsing to a constant.
+			// A constant fallback made 5+ same-tool calls with DISTINCT but
+			// unserializable args collide into one hash, firing a
+			// false-positive spiral (#2060-class bug). The discriminator
+			// below cannot itself throw (see `coarseObjectDiscriminator`),
+			// so genuinely identical unserializable args still collide
+			// (true positive preserved) while distinct ones no longer do.
+			return `h:fb:${boundedBunHash(coarseObjectDiscriminator(args)).toString(36)}`;
 		}
 	}
 	if (typeof args === 'string') {
@@ -528,7 +545,9 @@ function hashArgsForSpiral(args: unknown): string {
 		// debuggable; long strings (e.g. bash commands) are hashed to stay
 		// bounded. The 64-char cutoff keeps the worst-case entry (~66 chars)
 		// below the old 100-char ceiling.
-		return args.length <= 64 ? `s:${args}` : `s:${bunHash(args).toString(36)}`;
+		return args.length <= 64
+			? `s:${args}`
+			: `s:${boundedBunHash(args).toString(36)}`;
 	}
 	return `p:${String(args ?? '')}`;
 }

--- a/src/hooks/guardrails/file-authority.ts
+++ b/src/hooks/guardrails/file-authority.ts
@@ -21,7 +21,10 @@ import {
 } from '../../config/schema';
 import { classifyFile, type FileZone } from '../../context/zone-classifier';
 import { log, warn } from '../../utils';
-import { bunHash } from '../../utils/bun-compat';
+import {
+	boundedBunHash,
+	coarseObjectDiscriminator,
+} from '../../utils/arg-hash';
 import { stableCanonicalStringify } from '../../utils/stable-stringify';
 
 /**
@@ -35,8 +38,27 @@ import { stableCanonicalStringify } from '../../utils/stable-stringify';
  * silently dropped nested keys, collapsing distinct todo contents to the same
  * hash.
  *
+ * When `stableCanonicalStringify` throws (cyclic refs, BigInt quirks), a
+ * constant fallback would make distinct-but-unserializable args collide,
+ * producing false-positive consecutive-equality detection (#2060-class
+ * bug). `coarseObjectDiscriminator` mixes in a shallow structural summary
+ * instead, so identical unserializable args still collide (true positive
+ * preserved) while distinct ones no longer do.
+ *
+ * Hash input is bounded by `boundedBunHash` (`src/utils/arg-hash.ts`), which
+ * hashes a length-prefixed head+tail SAMPLE rather than a bare prefix. That
+ * matters here more than anywhere: this hash drives the consecutive-repetition
+ * circuit breaker in `tool-before.ts`, which THROWS. Under a bare-prefix cap,
+ * ten consecutive large writes sharing a 64 KB boilerplate header but with
+ * differing appended bodies would have hashed identically and tripped it.
+ *
+ * Both this bounding and the fallback discriminator are shared verbatim with
+ * `hooks/adversarial-detector.ts:hashArgsForSpiral`; keep them in the shared
+ * module rather than re-inlining a copy here.
+ *
  * @param args Tool arguments to hash
- * @returns Numeric hash (0 for non-objects or if hashing fails)
+ * @returns Numeric hash (0 for non-objects; a discriminated fallback hash if
+ *   stable stringification fails)
  */
 export function hashArgs(args: unknown): number {
 	try {
@@ -44,12 +66,12 @@ export function hashArgs(args: unknown): number {
 			return 0;
 		}
 		const stable = stableCanonicalStringify(args);
-		return Number(bunHash(stable));
+		return Number(boundedBunHash(stable));
 	} catch (error) {
 		log('[Guardrails] hashArgs failed', {
 			error: error instanceof Error ? error.message : String(error),
 		});
-		return 0;
+		return Number(boundedBunHash(coarseObjectDiscriminator(args)));
 	}
 }
 

--- a/src/hooks/write-target-resolver.ts
+++ b/src/hooks/write-target-resolver.ts
@@ -163,35 +163,62 @@ function parsePatchPayload(payload: string): ParsedPatch | string {
 		return null;
 	};
 
-	const lines = payload.split('\n');
+	// Split on CRLF *or* LF. This is the single choke point feeding every
+	// marker/header regex below; splitting on `\n` alone left a trailing `\r`
+	// on each line, and because JS `.` does not match `\r`, every `(.+)$` /
+	// `(.*)$` path-extraction regex failed on CRLF input — so *every* CRLF
+	// patch resolved to "Patch contains no recognizable write targets" (F-011).
+	// `parseTarget` keeps its own trailing-`\r` strip as defence in depth.
+	const lines = payload.split(/\r?\n/);
 	const beginIndices: number[] = [];
 	const endIndices: number[] = [];
 	const nativeOperationIndices: number[] = [];
 	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index] ?? '';
-		const trimmed = line.trim();
+		const trimmed = (lines[index] ?? '').trim();
 		if (trimmed === '*** Begin Patch') beginIndices.push(index);
 		if (trimmed === '*** End Patch') endIndices.push(index);
 		if (
-			/^\*\*\* (?:Update|Add|Delete) File:/i.test(line) ||
-			/^\*\*\* Move (?:to|from):/i.test(line)
+			/^\*\*\* (?:Update|Add|Delete) File:/i.test(trimmed) ||
+			/^\*\*\* Move (?:to|from):/i.test(trimmed)
 		) {
 			nativeOperationIndices.push(index);
 		}
 	}
 	// A payload is a Native Vibe Patch when it has a `*** Begin Patch` marker,
 	// OR carries any native operation marker (`*** Update/Add/Delete File:` /
-	// `*** Move to|from:` — these are unambiguous native syntax that never
-	// appears in a unified-diff body, so their presence always demands native
-	// framing), OR has a bare `*** End Patch` marker with NO unified-diff
-	// headers. The last clause tolerates a model appending `*** End Patch` as a
-	// stray trailer on an otherwise-standard unified diff (issue #2059) while
-	// still failing closed on a genuinely malformed native patch that is missing
-	// its begin marker. Operation markers are intentionally NOT relaxed: a
-	// payload with `*** Update File:` and no begin marker is always a malformed
-	// native patch, never a unified diff (this preserves the security guard at
-	// `tests/unit/hooks/write-target-resolver.test.ts` "rejects unframed ...
-	// native operations").
+	// `*** Move to|from:`), OR has a bare `*** End Patch` marker with NO
+	// unified-diff headers. That last clause tolerates a model appending
+	// `*** End Patch` as a stray trailer on an otherwise-standard unified diff
+	// (issue #2059) while still failing closed on a genuinely malformed native
+	// patch that is missing its begin marker.
+	//
+	// Operation markers are matched against the TRIMMED line, symmetrically with
+	// the framing markers above. Previously framing was trimmed but operation
+	// markers were anchored to the raw line, so a single leading space or tab
+	// hid an operation marker from both classification here and extraction
+	// below: a correctly framed patch carrying `*** Update File: src/safe.ts` at
+	// column 0 plus ` *** Update File: ../../../etc/passwd` resolved to
+	// `['src/safe.ts']` alone, and the traversal target never reached the
+	// caller that validates the resolved set (F-002).
+	//
+	// The relaxation is scoped to leading WHITESPACE only. `+`/`-` prefixed
+	// lines are deliberately NOT accepted as operation markers: inside a unified
+	// diff they are legitimate added/removed body content, and inside native
+	// framing they are not valid native syntax, so honouring them would
+	// reclassify ordinary diff bodies as native and fail them closed for no
+	// security gain.
+	//
+	// Known cost, accepted: a unified diff whose space-prefixed CONTEXT lines
+	// reproduce a column-0 operation marker from the file being patched now
+	// classifies as native and fails closed ("missing *** Begin Patch") instead
+	// of resolving. Measured blast radius in this repo: the native-patch
+	// fixtures in `tests/unit/hooks/write-lstat-authority.test.ts`,
+	// `guardrails-plan-md-guard.test.ts`,
+	// `guardrails-directory.adversarial.test.ts`, and
+	// `guardrails-v622-patch-aliases.test.ts` (the last added by this change).
+	// Failing closed is the correct
+	// direction for a write guardrail, and the same hazard already existed for
+	// the trimmed `*** Begin Patch` framing marker.
 	const hasUnifiedHeaders = lines.some((l) => /^(---|\+\+\+)\s+/.test(l));
 	const native =
 		beginIndices.length > 0 ||
@@ -216,7 +243,10 @@ function parsePatchPayload(payload: string): ParsedPatch | string {
 		}
 
 		for (let index = beginIndex + 1; index < endIndex; index++) {
-			const line = lines[index] ?? '';
+			// Trimmed for the same reason as the classification pass above: an
+			// indented operation marker must contribute its target to `paths`,
+			// not be silently skipped (F-002).
+			const line = (lines[index] ?? '').trim();
 			const match = line.match(/^\*\*\* (Update|Add|Delete) File:\s*(.*)$/);
 			if (match) {
 				const error = add(match[2] ?? '', (match[1] ?? '').toLowerCase());

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -82,6 +82,7 @@ export {
 	buildMemoryCohortFingerprintInput,
 	computeMemoryCohortFingerprint,
 	computeRedactionPolicyVersion,
+	FINGERPRINT_ALGORITHM_VERSION,
 	findSecrets,
 	redactSecrets,
 } from './redaction';

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -9,6 +9,7 @@ import {
 } from 'node:fs/promises';
 import * as path from 'node:path';
 import { validateSwarmPath } from '../hooks/utils';
+import { warn } from '../utils';
 import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
 import {
 	applyPatchToMemory,
@@ -32,6 +33,7 @@ import type {
 } from './provider';
 import {
 	buildMemoryCohortFingerprintInput,
+	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 } from './redaction';
 import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
@@ -553,7 +555,10 @@ export class LocalJsonlMemoryProvider
 	/**
 	 * #1850 (KC-001 fix): mirror the SQLite provider's fingerprint check. Reads
 	 * `memory-cohort-config.json` and throws on mismatch. Absent/malformed file
-	 * is permissive (fail-open never strands memory).
+	 * is permissive (fail-open never strands memory). #2062 F-012: a file whose
+	 * `algorithm_version` is not the current one — or is present but
+	 * uninterpretable — is also permissive, because the digests are not
+	 * comparable; both warn with a re-link instruction.
 	 */
 	private assertCohortConfigFingerprint(): void {
 		if (!this.cohortRoot) return;
@@ -564,6 +569,41 @@ export class LocalJsonlMemoryProvider
 				string,
 				unknown
 			>;
+			// #2062 F-012 (R3 fix): mirror the SQLite provider — compare ALGORITHM
+			// versions before comparing digests. An ABSENT `algorithm_version` means
+			// the file predates the field, i.e. algorithm version 1 — NOT the
+			// current version. Defaulting to current would make this gate unfireable
+			// for legacy files after the first bump and then byte-compare a v1
+			// digest against a v2 expected value.
+			const versionCheck = classifyStoredFingerprintAlgorithmVersion(
+				stored.algorithm_version,
+			);
+			if (versionCheck.status === 'unknown') {
+				// Present but uninterpretable: skip rather than guess "current".
+				warn(
+					'[memory-cohort] cohort config has a present but non-numeric `algorithm_version`, so its fingerprint cannot be attributed to a known algorithm and the config-coherence check was skipped. Run `/swarm memory link` to rewrite the cohort fingerprint.',
+					{
+						cohortRoot: this.cohortRoot,
+						storedVersion: stored.algorithm_version,
+					},
+				);
+				return;
+			}
+			if (versionCheck.status === 'mismatch') {
+				// Cross-algorithm digests are not comparable; a byte compare would
+				// report a config difference that does not exist. Fail open, but
+				// warn (unlike the silent absent/malformed cases) because this one
+				// has a concrete user action.
+				warn(
+					`[memory-cohort] cohort config was fingerprinted with algorithm version ${versionCheck.storedVersion}, but this worktree computes version ${versionCheck.currentVersion}. Digests from different algorithm versions are not comparable, so the config-coherence check was skipped. Run \`/swarm memory link\` to refresh the cohort fingerprint.`,
+					{
+						cohortRoot: this.cohortRoot,
+						storedVersion: versionCheck.storedVersion,
+						expectedVersion: versionCheck.currentVersion,
+					},
+				);
+				return;
+			}
 			const storedFingerprint = stored.fingerprint;
 			if (typeof storedFingerprint !== 'string') return;
 			const expectedFingerprint = computeMemoryCohortFingerprint(

--- a/src/memory/redaction.ts
+++ b/src/memory/redaction.ts
@@ -111,6 +111,116 @@ export interface MemoryCohortFingerprintInput {
 	embedding_version: string;
 }
 
+/**
+ * #2062 F-012: version of the cohort-fingerprint ALGORITHM (canonicalization +
+ * hash + truncation), persisted alongside the fingerprint in
+ * `memory-cohort-config.json` and read back by every consumer.
+ *
+ * Version 1 is the algorithm below (sorted-key canonical JSON -> sha256 -> first
+ * 12 hex chars). Files written before this field existed are treated as
+ * version 1, which is exactly correct: they were produced by this same
+ * algorithm, so they keep validating with no forced re-link.
+ *
+ * BUMP THIS whenever a change would alter the digest for an unchanged input —
+ * e.g. a different hash, a different truncation length, a change to
+ * `stableCanonicalStringify`'s output for a reachable input, or a change to the
+ * `MemoryCohortFingerprintInput` shape. Readers compare versions BEFORE
+ * comparing fingerprints, so a bump surfaces as "re-run `/swarm memory link`"
+ * instead of being misreported as a real provider/embedding config mismatch.
+ */
+export const FINGERPRINT_ALGORITHM_VERSION = 1;
+
+/**
+ * #2062 F-012 (R3 fix): the algorithm version implied by a persisted cohort
+ * config that has NO `algorithm_version` field. Every file written before the
+ * field existed was produced by algorithm version 1, so that is what an absent
+ * field means — permanently, whatever `FINGERPRINT_ALGORITHM_VERSION` later
+ * becomes.
+ *
+ * This MUST stay a standalone literal and must never be re-expressed in terms
+ * of `FINGERPRINT_ALGORITHM_VERSION`. If it tracked the current version, then
+ * the moment that constant is bumped every legacy file already on disk would
+ * report itself as current, the version gate could never fire for the very
+ * files it exists to protect, and a v1 digest would be byte-compared against a
+ * v2 expected value — which `SQLiteMemoryProvider` turns into a hard
+ * "config differs" throw. Defaulting to the current version is self-defeating
+ * at exactly the moment the mechanism is supposed to help.
+ *
+ * The explicit `: 1` literal type is the enforcement, not decoration — and it
+ * enforces only for as long as it is actually there. No runtime test can catch
+ * the aliasing refactor today (while `FINGERPRINT_ALGORITHM_VERSION` is still
+ * 1, an alias evaluates to 1 and every assertion passes), so the guard has to
+ * fire at the only moment the mistake becomes real: the bump.
+ *
+ * Both halves of that were measured against this repo with the constant
+ * temporarily set to 2, running `bunx tsc --noEmit`:
+ *
+ * - `LEGACY_…: 1 = FINGERPRINT_ALGORITHM_VERSION` (annotation KEPT)
+ *   -> exit 2, `TS2322: Type '2' is not assignable to type '1'`. Guard fires.
+ * - `LEGACY_… = FINGERPRINT_ALGORITHM_VERSION` (annotation DROPPED)
+ *   -> exit 0. Guard does NOT fire, and every legacy cohort file is stranded
+ *   silently.
+ *
+ * The second form is the one a refactorer actually types, so do NOT rely on
+ * `tsc` to catch removal of this annotation — the annotation is the thing
+ * being protected, not merely the mechanism. A legitimate bump that leaves
+ * this literal alone typechecks cleanly.
+ */
+export const LEGACY_FINGERPRINT_ALGORITHM_VERSION: 1 = 1;
+
+/**
+ * DI seam for testability (repo convention, cf. `src/utils/logger.ts`). Lets a
+ * test simulate a FUTURE bump of `FINGERPRINT_ALGORITHM_VERSION` without
+ * hand-editing the constant — the only way to exercise the legacy-file version
+ * gate before a real bump ever happens. Production code never mutates this.
+ */
+export const _internals: { currentAlgorithmVersion: number } = {
+	currentAlgorithmVersion: FINGERPRINT_ALGORITHM_VERSION,
+};
+
+/**
+ * Result of interpreting a persisted `algorithm_version` field:
+ * - `comparable` — stored digest was produced by the current algorithm, so a
+ *   byte comparison is meaningful.
+ * - `mismatch` — a known but different algorithm produced it; the digests are
+ *   not comparable, so callers skip the compare and fail OPEN with a re-link
+ *   instruction rather than reporting a config difference that does not exist.
+ * - `unknown` — the field is present but not a finite number, so the digest
+ *   cannot be attributed to any algorithm. Callers skip the compare too, but
+ *   must NOT assume it is current (that would byte-compare on a guess).
+ */
+export type StoredFingerprintAlgorithmVersion =
+	| { status: 'comparable' }
+	| { status: 'mismatch'; storedVersion: number; currentVersion: number }
+	| { status: 'unknown' };
+
+/**
+ * Single source of truth for the version gate shared by all four readers
+ * (SQLite provider, local-jsonl provider, status service, knowledge
+ * diagnostics). Keeping it here means a future bump changes one file, and the
+ * absent-field semantics cannot silently drift apart across call sites.
+ */
+export function classifyStoredFingerprintAlgorithmVersion(
+	rawStoredVersion: unknown,
+	currentVersion: number = _internals.currentAlgorithmVersion,
+): StoredFingerprintAlgorithmVersion {
+	// `JSON.parse` never yields `undefined` for a present key, so `undefined`
+	// here means the key is genuinely ABSENT — a file predating the field. An
+	// explicit JSON `null`, a string, or any other non-number is PRESENT but
+	// uninterpretable, which is a different thing and must not collapse to the
+	// legacy default.
+	const storedVersion =
+		rawStoredVersion === undefined
+			? LEGACY_FINGERPRINT_ALGORITHM_VERSION
+			: rawStoredVersion;
+	if (typeof storedVersion !== 'number' || !Number.isFinite(storedVersion)) {
+		return { status: 'unknown' };
+	}
+	return storedVersion === currentVersion
+		? { status: 'comparable' }
+		: { status: 'mismatch', storedVersion, currentVersion };
+}
+
 export function computeMemoryCohortFingerprint(
 	input: MemoryCohortFingerprintInput,
 ): string {
@@ -120,6 +230,16 @@ export function computeMemoryCohortFingerprint(
 	// fingerprints remain valid). It avoids the property-list-replacer
 	// anti-pattern, which would silently drop nested keys if a nested field is
 	// ever added to `MemoryCohortFingerprintInput`.
+	//
+	// #2062 F-013: this call is DELIBERATELY not wrapped in try/catch, unlike
+	// the two spiral/repetition-detection call sites. This fingerprint is
+	// compared bit-for-bit to decide whether cohort members are config-
+	// compatible (fail-closed: sqlite-provider.ts, local-jsonl-provider.ts).
+	// A catch returning a constant would collapse every failing input to one
+	// fingerprint, so two incompatible members would silently compare equal and
+	// defeat the check (#1850 acceptance #10). A failure here must propagate.
+	// (It cannot throw today: the input is a flat, always-fully-populated
+	// struct of primitives — no cycles, no BigInt.)
 	const canonical = stableCanonicalStringify(input);
 	return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
 }

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -62,6 +62,7 @@ import type {
 } from './provider';
 import {
 	buildMemoryCohortFingerprintInput,
+	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 } from './redaction';
 import {
@@ -1970,7 +1971,11 @@ export class SQLiteMemoryProvider
 	 * with this worktree's config (acceptance #10). Absent file = first link
 	 * (permissive — the linker writes it immediately after migration). A
 	 * malformed file is also permissive (fail-open never strands memory, but
-	 * a mismatch is a hard error).
+	 * a mismatch is a hard error). #2062 F-012: a file whose `algorithm_version`
+	 * is not the current one — or is present but uninterpretable — is permissive
+	 * too, because cross-algorithm digests are not comparable. Both warn with a
+	 * re-link instruction rather than reporting a config mismatch that does not
+	 * exist.
 	 */
 	private assertCohortConfigFingerprint(): void {
 		if (!this.cohortRoot) return;
@@ -1991,6 +1996,44 @@ export class SQLiteMemoryProvider
 				string,
 				unknown
 			>;
+			// #2062 F-012 (R3 fix): compare ALGORITHM versions before comparing
+			// digests. An ABSENT `algorithm_version` means the file predates the
+			// field, i.e. algorithm version 1 — NOT "whatever this build's current
+			// version happens to be". Defaulting to the current version would make
+			// this gate unfireable for legacy files the moment the version is
+			// bumped, and would then byte-compare a v1 digest against a v2 expected
+			// value and throw below.
+			const versionCheck = classifyStoredFingerprintAlgorithmVersion(
+				stored.algorithm_version,
+			);
+			if (versionCheck.status === 'unknown') {
+				// Present but uninterpretable: the digest cannot be attributed to any
+				// algorithm. Skip the compare rather than guessing "current" — a wrong
+				// guess produces the misleading hard error below.
+				warn(
+					'[memory-cohort] cohort config has a present but non-numeric `algorithm_version`, so its fingerprint cannot be attributed to a known algorithm and the config-coherence check was skipped. Run `/swarm memory link` to rewrite the cohort fingerprint.',
+					{
+						cohortRoot: this.cohortRoot,
+						storedVersion: stored.algorithm_version,
+					},
+				);
+				return;
+			}
+			if (versionCheck.status === 'mismatch') {
+				// Digests produced by different algorithms are not comparable, so a
+				// byte compare here would report a config difference that does not
+				// exist. Fail open (never strand memory over an algorithm bump alone)
+				// but say exactly what happened and how to fix it.
+				warn(
+					`[memory-cohort] cohort config was fingerprinted with algorithm version ${versionCheck.storedVersion}, but this worktree computes version ${versionCheck.currentVersion}. Digests from different algorithm versions are not comparable, so the config-coherence check was skipped. Run \`/swarm memory link\` to refresh the cohort fingerprint.`,
+					{
+						cohortRoot: this.cohortRoot,
+						storedVersion: versionCheck.storedVersion,
+						expectedVersion: versionCheck.currentVersion,
+					},
+				);
+				return;
+			}
 			const storedFingerprint = stored.fingerprint;
 			if (typeof storedFingerprint !== 'string') {
 				warn(

--- a/src/services/knowledge-diagnostics.ts
+++ b/src/services/knowledge-diagnostics.ts
@@ -37,6 +37,7 @@ import { resolveInsightCandidatesPath } from '../hooks/micro-reflector.js';
 import { readMemoryLinkPointer } from '../memory/memory-link.js';
 import {
 	buildMemoryCohortFingerprintInput,
+	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 } from '../memory/redaction.js';
 import { readSynonymMap } from './synonym-map.js';
@@ -506,23 +507,39 @@ function computeMemoryCohortDiagnostics(directory: string): {
 				if (existsSync(cohortConfigPath)) {
 					const stored = JSON.parse(
 						readFileSync(cohortConfigPath, 'utf-8'),
-					) as { fingerprint?: string };
-					const expected = computeMemoryCohortFingerprint(
-						buildMemoryCohortFingerprintInput({
-							provider: cfg.memory.provider ?? 'sqlite',
-							redaction: {
-								rejectDurableSecrets:
-									cfg.memory.redaction?.rejectDurableSecrets ?? true,
-							},
-							embeddings: {
-								model:
-									cfg.memory.embeddings?.model ?? 'Xenova/all-MiniLM-L6-v2',
-								dimension: cfg.memory.embeddings?.dimension ?? 384,
-								version: cfg.memory.embeddings?.version,
-							},
-						}),
+					) as { fingerprint?: unknown; algorithm_version?: unknown };
+					// #2062 F-012 (R3 fix): mirror the provider version-aware pattern.
+					// An ABSENT `algorithm_version` means the file predates the field,
+					// i.e. algorithm version 1 — not "the current version", which would
+					// make legacy files silently byte-compare across algorithms after a
+					// bump. When the stored version is not comparable (a different
+					// version, or present but non-numeric) leave the field null
+					// (unknown) rather than reporting a false mismatch. This is a
+					// read-only reporting surface, so stay silent rather than warn.
+					const versionCheck = classifyStoredFingerprintAlgorithmVersion(
+						stored.algorithm_version,
 					);
-					configFingerprintMatch = stored.fingerprint === expected;
+					if (
+						versionCheck.status === 'comparable' &&
+						typeof stored.fingerprint === 'string'
+					) {
+						const expected = computeMemoryCohortFingerprint(
+							buildMemoryCohortFingerprintInput({
+								provider: cfg.memory.provider ?? 'sqlite',
+								redaction: {
+									rejectDurableSecrets:
+										cfg.memory.redaction?.rejectDurableSecrets ?? true,
+								},
+								embeddings: {
+									model:
+										cfg.memory.embeddings?.model ?? 'Xenova/all-MiniLM-L6-v2',
+									dimension: cfg.memory.embeddings?.dimension ?? 384,
+									version: cfg.memory.embeddings?.version,
+								},
+							}),
+						);
+						configFingerprintMatch = stored.fingerprint === expected;
+					}
 				}
 			}
 		} catch {

--- a/src/services/status-service.ts
+++ b/src/services/status-service.ts
@@ -23,6 +23,7 @@ import { readSwarmFileAsync, validateSwarmPath } from '../hooks/utils';
 import { readMemoryLinkPointer } from '../memory/memory-link';
 import {
 	buildMemoryCohortFingerprintInput,
+	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 } from '../memory/redaction';
 import { loadPlan } from '../plan/manager';
@@ -398,12 +399,28 @@ export async function getStatusData(
 				if (fsSync.existsSync(cohortConfigPath)) {
 					const stored = JSON.parse(
 						fsSync.readFileSync(cohortConfigPath, 'utf-8'),
-					) as { fingerprint?: string };
-					// #1850 (final-critic dedup): shared fingerprint helper.
-					const expected = computeMemoryCohortFingerprint(
-						buildMemoryCohortFingerprintInput(memoryConfig),
+					) as { fingerprint?: unknown; algorithm_version?: unknown };
+					// #2062 F-012 (R3 fix): mirror the provider version-aware pattern.
+					// An ABSENT `algorithm_version` means the file predates the field,
+					// i.e. algorithm version 1 — not "the current version", which would
+					// make legacy files silently byte-compare across algorithms after a
+					// bump. When the stored version is not comparable (a different
+					// version, or present but non-numeric) leave configFingerprintMatch
+					// unset (unknown) rather than reporting a false mismatch. This is a
+					// read-only reporting surface, so stay silent rather than warn.
+					const versionCheck = classifyStoredFingerprintAlgorithmVersion(
+						stored.algorithm_version,
 					);
-					configFingerprintMatch = stored.fingerprint === expected;
+					if (
+						versionCheck.status === 'comparable' &&
+						typeof stored.fingerprint === 'string'
+					) {
+						// #1850 (final-critic dedup): shared fingerprint helper.
+						const expected = computeMemoryCohortFingerprint(
+							buildMemoryCohortFingerprintInput(memoryConfig),
+						);
+						configFingerprintMatch = stored.fingerprint === expected;
+					}
 				}
 			}
 		} catch {

--- a/src/utils/arg-hash.ts
+++ b/src/utils/arg-hash.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared primitives for hashing tool-call arguments (issue #2060 follow-ups
+ * F-009 / F-010).
+ *
+ * # Why this exists
+ *
+ * Two subsystems hash tool arguments to detect "the agent is repeating
+ * itself": `hashArgsForSpiral` in `hooks/adversarial-detector.ts` (spiral
+ * advisory) and `hashArgs` in `hooks/guardrails/file-authority.ts` (which
+ * feeds the consecutive-repetition circuit breaker in
+ * `hooks/guardrails/tool-before.ts` — a path that THROWS, not warns).
+ *
+ * Both need the same two primitives. They live here rather than as two inline
+ * copies for the same reason `src/utils/stable-stringify.ts` was extracted: a
+ * bug class that exists at two call sites must be fixed once, in one place,
+ * and tested once. Keep them here; do not re-inline a copy at a call site.
+ *
+ * The two call sites differ only in the OUTPUT SHAPE they need — the detector
+ * wants a compact base-36 string, file-authority wants a `number` — so
+ * `boundedBunHash` returns `bigint` (matching `bunHash`) and each caller
+ * formats it.
+ */
+
+import { bunHash } from './bun-compat';
+
+/**
+ * Cap on the amount of input fed into `bunHash`.
+ *
+ * Both call sites run synchronously on a per-tool-call hot path, and payloads
+ * (patch bodies, file writes) can reach ~1 MB. Node's `bunHash` fallback
+ * (djb2, see `bun-compat.ts`) is genuinely reachable in production — the
+ * OpenCode plugin host and the Desktop sidecar can run under Node — and is
+ * O(n): ~141 ms for a 2 MB input versus ~5 ms for 64 KB. The threat model is
+ * "same tool, same args, repeatedly", not adversarial collision resistance,
+ * so bounding the hashed input keeps worst-case per-call cost flat.
+ *
+ * NOTE ON UNITS: this bounds `String.prototype.length`, i.e. UTF-16 code
+ * units, not encoded bytes. It is a cost bound, not a byte-exact limit; a
+ * non-BMP-heavy string can encode to more bytes than the name suggests. That
+ * is fine — the point is a fixed ceiling, and the ceiling is fixed.
+ */
+export const HASH_INPUT_CAP_BYTES = 64 * 1024;
+
+/**
+ * Reduces an arbitrarily long string to a bounded, length-prefixed
+ * head-and-tail sample suitable as hash input.
+ *
+ * ## Why not a bare prefix
+ *
+ * The obvious bound — `input.slice(0, CAP)` — makes every pair of inputs that
+ * share a `CAP`-length prefix hash identically. For the circuit-breaker call
+ * site that is a false-positive engine: ten consecutive large writes that
+ * share a boilerplate header but differ in their (appended) bodies look like
+ * ten identical calls and the breaker throws. Sampling the head AND the tail
+ * removes the whole append-collision class, and sampling the head removes the
+ * prepend-collision class, at exactly the same bounded cost.
+ *
+ * ## Why the length prefix is load-bearing
+ *
+ * It is not decoration. Without it the two branches below can collide across
+ * the cap boundary: an input of exactly `CAP` characters passes through
+ * untransformed, while a longer input produces a `CAP`-character head+tail
+ * concatenation — two different inputs, one identical hash input. Prefixing
+ * the true length separates the classes. It also makes the under-cap branch
+ * injective, so this transform adds ZERO collisions for inputs at or below
+ * the cap.
+ *
+ * ## Residual, accepted lossiness
+ *
+ * Two inputs longer than the cap collide only if they have the SAME total
+ * length AND the same first `CAP/2` characters AND the same last `CAP/2`
+ * characters, differing only in the discarded middle. That is unavoidable for
+ * any fixed-cost sampler and is the deliberate trade documented on
+ * `HASH_INPUT_CAP_BYTES`.
+ *
+ * Cannot throw: `String.prototype.slice` and template interpolation of a
+ * number are total.
+ */
+export function sampleForHash(input: string): string {
+	if (input.length <= HASH_INPUT_CAP_BYTES) {
+		return `${input.length}:${input}`;
+	}
+	const half = Math.floor(HASH_INPUT_CAP_BYTES / 2);
+	const head = input.slice(0, half);
+	const tail = input.slice(input.length - half);
+	return `${input.length}:${head}${tail}`;
+}
+
+/**
+ * `bunHash` over a bounded head+tail sample of `input`.
+ *
+ * Returns `bigint` (the `bunHash` shape) so each caller can format it for its
+ * own storage: the detector uses `.toString(36)`, file-authority uses
+ * `Number(...)`.
+ *
+ * Cannot throw for a string input: `sampleForHash` is total and `bunHash`
+ * on a string is `TextEncoder.encode` plus BigInt arithmetic (or `Bun.hash`)
+ * — no throwing path. Callers rely on this: both use it inside a `catch`
+ * block, where a second throw would escape into a hook.
+ */
+export function boundedBunHash(input: string): bigint {
+	return bunHash(sampleForHash(input));
+}
+
+/**
+ * Shallow, non-recursive structural summary of a value's own enumerable keys,
+ * used only as a fallback discriminator when `stableCanonicalStringify`
+ * throws (issue #2060 follow-up F-009).
+ *
+ * Before this existed, both call sites answered an unstringifiable argument
+ * with a CONSTANT ('h:fallback' / `0`). That made every distinct-but-
+ * unserializable argument collide, so N consecutive calls with genuinely
+ * different arguments looked identical and fired a false positive — a spiral
+ * advisory in one case, a thrown circuit breaker in the other.
+ *
+ * Deliberately shallow (no recursion into nested values) so it cannot itself
+ * throw on the very inputs that broke `stableCanonicalStringify`: recursing
+ * into a cyclic reference would revisit the cycle, and BigInt values are
+ * handled fine by `typeof` / `String()` (unlike `JSON.stringify`, which
+ * throws on them). `Object.keys` and `typeof` cannot throw for ordinary
+ * objects; the outer try/catch guards only against exotic Proxy traps, and
+ * even then identical arguments still collide, so true-positive repetition
+ * detection is preserved.
+ *
+ * This is a DISCRIMINATOR, not an identity function. It is only ever used to
+ * break up false collisions on a detection path — never as a fail-closed
+ * identity (see the caller guidance on `stableCanonicalStringify`).
+ */
+export function coarseObjectDiscriminator(args: unknown): string {
+	try {
+		const obj = args as Record<string, unknown>;
+		const keys = Object.keys(obj).sort();
+		const parts = keys.map((key) => {
+			const value = obj[key];
+			const type = typeof value;
+			let sample: string;
+			if (value === null) sample = 'null';
+			else if (Array.isArray(value)) sample = `arr${value.length}`;
+			else if (type === 'object')
+				sample = `obj${Object.keys(value as object).length}`;
+			else if (type === 'string') {
+				const s = value as string;
+				sample = s.length <= 32 ? s : `len${s.length}`;
+			} else sample = String(value);
+			return `${key}:${type}:${sample}`;
+		});
+		const shape = Array.isArray(args)
+			? `arr${keys.length}`
+			: `obj${keys.length}`;
+		return `${shape}|${parts.join(',')}`;
+	} catch {
+		// Only reachable via exotic Proxy traps; identical unserializable args
+		// still collide here, preserving true-positive repetition detection.
+		return 'unknown';
+	}
+}

--- a/src/utils/stable-stringify.ts
+++ b/src/utils/stable-stringify.ts
@@ -25,6 +25,11 @@
  * Originally introduced for the adversarial-detector spiral hash
  * (issue #2060) and shared with `file-authority.hashArgs` so both code paths
  * use one correct implementation.
+ *
+ * This is a canonicalizer for HASH INPUT, not a drop-in `JSON.stringify`
+ * replacement — see the "Serialization limits" section on
+ * `stableCanonicalStringify` before using it anywhere the output is parsed or
+ * shown to a user.
  */
 
 /**
@@ -40,11 +45,54 @@
  * function exists to eliminate. Sorting must be done by rebuilding each object
  * with sorted keys before serialization.
  *
+ * ## Serialization limits (#2062 F-008 — deliberate, verified, do not "fix"
+ * without re-reading this)
+ *
+ * - **No `toJSON` support.** `toJSON` is never consulted. A `Date` therefore
+ *   collapses to `{}` (it has no own enumerable keys) — a genuine divergence
+ *   from `JSON.stringify`, which emits the ISO string.
+ * - **`Map`/`Set` collapse to `{}`.** This MATCHES `JSON.stringify` (neither
+ *   exposes own enumerable string keys), so it is lossy for both rather than a
+ *   divergence between them.
+ * - **`undefined` serializes as `null`** in object-property AND array-element
+ *   position, so no bare `undefined` token or sparse-array hole is emitted for
+ *   it. `JSON.stringify` instead omits an `undefined`-valued property; keeping
+ *   the key here is deliberate — two objects differing only by a
+ *   present-but-undefined key must not hash equal. True sparse array *holes*
+ *   (`[1,,3]`) are NOT covered: `Array.prototype.map` skips holes, so they
+ *   still render as `[1,,3]`.
+ * - **Function and symbol values still emit a bare `undefined` token**, which
+ *   is not valid JSON. It is deterministic, so it is safe as hash input, but
+ *   the result is not always `JSON.parse`-able.
+ *
+ * These limits are safe at every current call site: the cohort fingerprint
+ * input is a flat all-primitive struct, and the hook call sites hash tool-call
+ * arguments that have already round-tripped through JSON transport, so
+ * `Date`/`Map`/`Set`/function values cannot reach them.
+ *
+ * ## Throwing, and how callers must (and must not) handle it
+ *
  * Throws on cyclic structures (infinite recursion) and on values that
- * `JSON.stringify` cannot represent (BigInt); callers should wrap in try/catch
- * and fall back to a stable coarse hash.
+ * `JSON.stringify` cannot represent (BigInt). Correct caller handling depends
+ * on what the hash is FOR:
+ *
+ * - **Repetition / spiral-detection callers** (`hashArgsForSpiral` in
+ *   `hooks/adversarial-detector.ts`, `hashArgs` in
+ *   `hooks/guardrails/file-authority.ts`) SHOULD wrap in try/catch and fall
+ *   back to a stable coarse hash. There, a fallback only degrades detection
+ *   sensitivity for the one call that failed.
+ * - **Identity / fail-closed comparison callers** (e.g.
+ *   `computeMemoryCohortFingerprint` in `memory/redaction.ts`) MUST NOT do
+ *   that. A constant fallback would collapse every failing input to the same
+ *   fingerprint, so two genuinely incompatible cohort members would compare
+ *   equal and the fail-closed coherence check would be silently defeated. Let
+ *   the throw propagate, or rethrow with added context — never return a
+ *   constant.
  */
 export function stableCanonicalStringify(value: unknown): string {
+	// `undefined` has no JSON token; emit `null` in every position so the
+	// output never contains a bare `undefined` or a sparse-array hole.
+	if (value === undefined) return 'null';
 	if (value === null) return 'null';
 	if (typeof value !== 'object') return JSON.stringify(value);
 	if (Array.isArray(value)) {

--- a/tests/unit/hooks/adversarial-detector-wiring.test.ts
+++ b/tests/unit/hooks/adversarial-detector-wiring.test.ts
@@ -5,6 +5,7 @@ import {
 	recentToolCallSessionCount,
 	recordToolCall,
 } from '../../../src/hooks/adversarial-detector';
+import { HASH_INPUT_CAP_BYTES } from '../../../src/utils/arg-hash';
 
 describe('adversarial detector wiring', () => {
 	test('detectAdversarialPatterns detects PRECEDENT_MANIPULATION', () => {
@@ -257,5 +258,120 @@ describe('adversarial detector spiral hash stability (issue #2060)', () => {
 		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
 		expect(result).not.toBeNull();
 		expect(result!.matchedText).toContain('todowrite');
+	});
+});
+
+describe('adversarial detector spiral hash fallback discriminator (F-009)', () => {
+	// All tests use unique `2060-` prefixed session IDs (module-private state
+	// is not reset between tests).
+
+	test('distinct unserializable args (cyclic) do NOT spiral', async () => {
+		// Before the fix, hashArgsForSpiral's catch branch returned the
+		// constant 'h:fallback' for ANY unstringifiable args, so five DISTINCT
+		// cyclic objects collapsed to one hash and falsely fired a spiral.
+		const sessionId = '2060-fallback-distinct-cyclic';
+		for (let i = 0; i < 6; i++) {
+			const cyclic: Record<string, unknown> = {
+				id: i,
+				label: `distinct-${i}`,
+			};
+			cyclic.self = cyclic;
+			recordToolCall('bash', cyclic, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('distinct unserializable args (BigInt-bearing) do NOT spiral', async () => {
+		const sessionId = '2060-fallback-distinct-bigint';
+		for (let i = 0; i < 6; i++) {
+			recordToolCall(
+				'bash',
+				{ command: `run-${i}`, weight: BigInt(i + 1) },
+				sessionId,
+			);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('identical unserializable args (cyclic) still DO spiral (true positive preserved)', async () => {
+		const sessionId = '2060-fallback-identical-cyclic';
+		for (let i = 0; i < 6; i++) {
+			const cyclic: Record<string, unknown> = {
+				id: 'same',
+				label: 'same-shape',
+			};
+			cyclic.self = cyclic;
+			recordToolCall('bash', cyclic, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('bash');
+	});
+
+	test('identical unserializable args (BigInt) still DO spiral (true positive preserved)', async () => {
+		const sessionId = '2060-fallback-identical-bigint';
+		for (let i = 0; i < 6; i++) {
+			recordToolCall('bash', { command: 'run', weight: BigInt(7) }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('bash');
+	});
+});
+
+describe('adversarial detector spiral hash input cap (F-010)', () => {
+	// The cap samples a length-prefixed HEAD AND TAIL (see
+	// `src/utils/arg-hash.ts`), not a bare prefix, so payloads that merely
+	// share a large boilerplate header stay distinguishable.
+
+	test('args differing only in the discarded middle hash equally (still spiral)', async () => {
+		// Same total length, same first CAP/2 and last CAP/2 characters of the
+		// serialized args — only the sampled-out middle differs. This is the
+		// assertion that fails if the cap is removed and the full input is
+		// hashed again, so it pins that the bound is really applied.
+		const sessionId = '2060-cap-collide-middle';
+		const head = 'a'.repeat(HASH_INPUT_CAP_BYTES);
+		const tail = 'b'.repeat(HASH_INPUT_CAP_BYTES);
+		for (let i = 0; i < 6; i++) {
+			recordToolCall('write', { blob: `${head}MIDDLE-${i}${tail}` }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).not.toBeNull();
+		expect(result!.matchedText).toContain('write');
+	});
+
+	test('args differing only in an APPENDED tail past the cap do NOT spiral', async () => {
+		// Under the previous bare-prefix cap these six calls hashed EQUAL and
+		// falsely spiralled: identical 64KB header, six different bodies.
+		const sessionId = '2060-cap-append-distinct';
+		const prefix = 'x'.repeat(HASH_INPUT_CAP_BYTES);
+		for (let i = 0; i < 6; i++) {
+			recordToolCall('write', { blob: `${prefix}-tail-${i}` }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('args differing only in a PREPENDED head past the cap do NOT spiral', async () => {
+		const sessionId = '2060-cap-prepend-distinct';
+		const suffix = 'x'.repeat(HASH_INPUT_CAP_BYTES);
+		for (let i = 0; i < 6; i++) {
+			recordToolCall('write', { blob: `head-${i}${suffix}` }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
+	});
+
+	test('args differing within the cap do NOT hash equally (do not spiral)', async () => {
+		const sessionId = '2060-cap-distinct-within-64kb';
+		for (let i = 0; i < 6; i++) {
+			// Difference sits well within the cap, so calls must remain
+			// distinguishable and no false-positive spiral should fire.
+			recordToolCall('write', { blob: `distinct-${i}` }, sessionId);
+		}
+		const result = await detectDebuggingSpiral('/tmp/test', sessionId);
+		expect(result).toBeNull();
 	});
 });

--- a/tests/unit/hooks/guardrails-hash-args.test.ts
+++ b/tests/unit/hooks/guardrails-hash-args.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'bun:test';
+import { hashArgs } from '../../../src/hooks/guardrails';
+import { HASH_INPUT_CAP_BYTES } from '../../../src/utils/arg-hash';
+
+// Import the real constant rather than hand-copying 65536, so a change to the
+// cap cannot silently drift the fixtures away from production behaviour.
+const CAP = HASH_INPUT_CAP_BYTES;
+
+describe('hashArgs', () => {
+	it('same args produce same hash', () => {
+		const hash1 = hashArgs({ a: 1, b: 2 });
+		const hash2 = hashArgs({ a: 1, b: 2 });
+		expect(hash1).toBe(hash2);
+	});
+
+	it('different key order produces same hash', () => {
+		const hash1 = hashArgs({ a: 1, b: 2 });
+		const hash2 = hashArgs({ b: 2, a: 1 });
+		expect(hash1).toBe(hash2);
+	});
+
+	it('different args produce different hash', () => {
+		const hash1 = hashArgs({ a: 1 });
+		const hash2 = hashArgs({ a: 2 });
+		expect(hash1).not.toBe(hash2);
+	});
+
+	it('null returns 0', () => {
+		expect(hashArgs(null)).toBe(0);
+	});
+
+	it('non-object returns 0', () => {
+		expect(hashArgs('string')).toBe(0);
+		expect(hashArgs(123)).toBe(0);
+		expect(hashArgs(true)).toBe(0);
+	});
+
+	it('empty object returns a hash', () => {
+		const hash = hashArgs({});
+		expect(typeof hash).toBe('number');
+		// It could be 0 or non-zero, both are valid
+	});
+
+	it('nested args with different content produce different hashes (no nested-key filtering)', () => {
+		// Regression guard for the recursive stable-stringify fix. The
+		// previous `JSON.stringify(args, sortedKeys)` replacer-array
+		// approach FILTERED keys at every object depth, collapsing
+		// `{todos:[{content:'a',status:'pending'}]}` to `{todos:[{}]}`.
+		// Two todo lists with completely different content therefore
+		// collided — the exact bug class that breaks repetition detection
+		// on nested-args tools like `todowrite`.
+		const hash1 = hashArgs({
+			todos: [{ content: 'Write the auth module', status: 'pending' }],
+		});
+		const hash2 = hashArgs({
+			todos: [{ content: 'Review the coder PR', status: 'in_progress' }],
+		});
+		expect(hash1).not.toBe(hash2);
+	});
+
+	it('nested args with reordered keys at any depth produce the same hash', () => {
+		// Key-order independence must hold at every depth, not just the
+		// top level, so a genuine repetition loop whose nested args are
+		// semantically identical (just built with reordered keys) is still
+		// detected.
+		const hash1 = hashArgs({
+			todos: [{ content: 'same task', status: 'pending' }],
+		});
+		const hash2 = hashArgs({
+			todos: [{ status: 'pending', content: 'same task' }],
+		});
+		expect(hash1).toBe(hash2);
+	});
+});
+
+describe('hashArgs — regression: unserializable args must not collide (F-009)', () => {
+	// This hash feeds the consecutive-repetition circuit breaker in
+	// `tool-before.ts`, which THROWS rather than warning. Previous code
+	// returned the CONSTANT 0 whenever `stableCanonicalStringify` threw, so
+	// every distinct-but-unserializable argument collapsed to one hash and a
+	// run of genuinely different calls looked identical.
+
+	it('distinct cyclic args produce DIFFERENT hashes', () => {
+		const first: Record<string, unknown> = { id: 1, label: 'alpha' };
+		first.self = first;
+		const second: Record<string, unknown> = { id: 2, label: 'beta' };
+		second.self = second;
+		expect(hashArgs(first)).not.toBe(hashArgs(second));
+	});
+
+	it('identical cyclic args produce the SAME hash (true positive preserved)', () => {
+		const first: Record<string, unknown> = { id: 1, label: 'alpha' };
+		first.self = first;
+		const second: Record<string, unknown> = { id: 1, label: 'alpha' };
+		second.self = second;
+		expect(hashArgs(first)).toBe(hashArgs(second));
+	});
+
+	it('distinct BigInt-bearing args produce DIFFERENT hashes', () => {
+		expect(hashArgs({ command: 'run-1', weight: BigInt(1) })).not.toBe(
+			hashArgs({ command: 'run-2', weight: BigInt(2) }),
+		);
+	});
+
+	it('identical BigInt-bearing args produce the SAME hash (true positive preserved)', () => {
+		expect(hashArgs({ command: 'run', weight: BigInt(7) })).toBe(
+			hashArgs({ command: 'run', weight: BigInt(7) }),
+		);
+	});
+
+	it('the fallback still returns a finite number and never throws', () => {
+		const cyclic: Record<string, unknown> = { a: 1 };
+		cyclic.self = cyclic;
+		let hash = 0;
+		expect(() => {
+			hash = hashArgs(cyclic);
+		}).not.toThrow();
+		expect(typeof hash).toBe('number');
+		expect(Number.isFinite(hash)).toBe(true);
+	});
+});
+
+describe('hashArgs — regression: bounded head+tail hash input (F-010)', () => {
+	// Hash input is capped so a ~1MB payload cannot cost O(n) on every
+	// tool call. The cap samples a length-prefixed HEAD AND TAIL rather than
+	// a bare prefix, because a bare prefix makes large payloads that share a
+	// boilerplate header collide — and on this path a collision run of 10
+	// trips a circuit breaker that throws.
+
+	it('args differing only in an APPENDED tail past the cap do NOT collide', () => {
+		// Under the previous bare-prefix cap these hashed EQUAL.
+		const shared = 'x'.repeat(CAP);
+		expect(hashArgs({ blob: `${shared}-tail-A` })).not.toBe(
+			hashArgs({ blob: `${shared}-tail-B` }),
+		);
+	});
+
+	it('args differing only in a PREPENDED head past the cap do NOT collide', () => {
+		const shared = 'x'.repeat(CAP);
+		expect(hashArgs({ blob: `head-A${shared}` })).not.toBe(
+			hashArgs({ blob: `head-B${shared}` }),
+		);
+	});
+
+	it('args differing only in the discarded middle DO collide (the cap is real)', () => {
+		// The accepted, documented lossiness — and the assertion that fails if
+		// somebody removes the cap and hashes the full input again.
+		const head = 'a'.repeat(CAP);
+		const tail = 'b'.repeat(CAP);
+		const one = { blob: `${head}MIDDLE-1${tail}` };
+		const two = { blob: `${head}MIDDLE-2${tail}` };
+		expect(one.blob.length).toBe(two.blob.length);
+		expect(hashArgs(one)).toBe(hashArgs(two));
+	});
+
+	it('args differing well within the cap do NOT collide', () => {
+		expect(hashArgs({ blob: 'distinct-1' })).not.toBe(
+			hashArgs({ blob: 'distinct-2' }),
+		);
+	});
+});

--- a/tests/unit/hooks/guardrails-v622-patch-aliases.test.ts
+++ b/tests/unit/hooks/guardrails-v622-patch-aliases.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import { resetSwarmState, startAgentSession } from '../../../src/state';
+
+// Split out of guardrails-v622-adversarial.test.ts (FR-006 500-line cap /
+// test-file-split skill): that file was already 569 lines (pre-existing
+// over-cap) at PR base, so appending here instead of there avoids tripping
+// the FR-006 diff-scoped growth ratchet (check-test-file-cap.sh).
+//
+// FB-014: guardrail-layer (real hooks.toolBefore) coverage for the 5
+// non-legacy patch-payload aliases consumed by extractAllPatchPayloads /
+// extractPatchTargetPaths (tool-before.ts ~1462, ~1547). Previously only the
+// resolver was covered for these aliases (write-target-resolver.test.ts:
+// 185-189); the guardrail layer itself only ever exercised the legacy
+// `input` key (guardrails-v622-adversarial.test.ts, "OBJECTIVE 2: patch
+// path extraction").
+
+function defaultConfig(
+	overrides?: Partial<GuardrailsConfig>,
+): GuardrailsConfig {
+	return {
+		enabled: true,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+		profiles: undefined,
+		...overrides,
+	};
+}
+
+function makeInput(
+	sessionID = 'test-session',
+	tool = 'read',
+	callID = 'call-1',
+) {
+	return { tool, sessionID, callID };
+}
+
+function makeOutput(args: unknown = { filePath: '/test.ts' }) {
+	return { args };
+}
+
+const ORCHESTRATOR_NAME = 'architect';
+
+describe('guardrails - v6.22 OBJECTIVE 2: patch path extraction alias coverage (FB-014)', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	it.each([
+		['patchText' as const],
+		['patch_text' as const],
+		['patchPayload' as const],
+		['text' as const],
+		['content' as const],
+	])('%s alias targeting .swarm/plan.json → throws PLAN STATE VIOLATION', async (aliasKey) => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(config);
+		const sessionId = 'test-session';
+
+		startAgentSession(sessionId, ORCHESTRATOR_NAME);
+		const { swarmState } = await import('../../../src/state');
+		swarmState.activeAgent.set(sessionId, ORCHESTRATOR_NAME);
+
+		const patchContent = `*** Begin Patch
+*** Update File: .swarm/plan.json
+-old
++new
+*** End Patch`;
+
+		const input = makeInput(sessionId, 'apply_patch', 'call-1');
+		const output = makeOutput({ [aliasKey]: patchContent });
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			'PLAN STATE VIOLATION',
+		);
+	});
+
+	it.each([
+		['patchText' as const],
+		['patch_text' as const],
+		['patchPayload' as const],
+		['text' as const],
+		['content' as const],
+	])('%s alias targeting a non-plan file → not blocked', async (aliasKey) => {
+		const config = defaultConfig();
+		const hooks = createGuardrailsHooks(config);
+		const sessionId = 'test-session';
+
+		startAgentSession(sessionId, ORCHESTRATOR_NAME);
+		const { swarmState } = await import('../../../src/state');
+		swarmState.activeAgent.set(sessionId, ORCHESTRATOR_NAME);
+
+		const patchContent = `*** Begin Patch
+*** Update File: src/test.ts
+-old
++new
+*** End Patch`;
+
+		const input = makeInput(sessionId, 'apply_patch', 'call-1');
+		const output = makeOutput({ [aliasKey]: patchContent });
+
+		// Should NOT throw - targeting a non-.swarm file is allowed.
+		await hooks.toolBefore(input, output);
+	});
+});

--- a/tests/unit/hooks/guardrails.test.ts
+++ b/tests/unit/hooks/guardrails.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { GuardrailsConfig } from '../../../src/config/schema';
-import { createGuardrailsHooks, hashArgs } from '../../../src/hooks/guardrails';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
 import {
 	beginInvocation,
 	ensureAgentSession,
@@ -619,73 +619,6 @@ describe('guardrails circuit breaker', () => {
 
 			await hooks.messagesTransform({}, { messages: messagesB });
 			expect(messagesB[0].parts[0].text).toBe('Session B output');
-		});
-	});
-
-	describe('hashArgs', () => {
-		it('same args produce same hash', () => {
-			const hash1 = hashArgs({ a: 1, b: 2 });
-			const hash2 = hashArgs({ a: 1, b: 2 });
-			expect(hash1).toBe(hash2);
-		});
-
-		it('different key order produces same hash', () => {
-			const hash1 = hashArgs({ a: 1, b: 2 });
-			const hash2 = hashArgs({ b: 2, a: 1 });
-			expect(hash1).toBe(hash2);
-		});
-
-		it('different args produce different hash', () => {
-			const hash1 = hashArgs({ a: 1 });
-			const hash2 = hashArgs({ a: 2 });
-			expect(hash1).not.toBe(hash2);
-		});
-
-		it('null returns 0', () => {
-			expect(hashArgs(null)).toBe(0);
-		});
-
-		it('non-object returns 0', () => {
-			expect(hashArgs('string')).toBe(0);
-			expect(hashArgs(123)).toBe(0);
-			expect(hashArgs(true)).toBe(0);
-		});
-
-		it('empty object returns a hash', () => {
-			const hash = hashArgs({});
-			expect(typeof hash).toBe('number');
-			// It could be 0 or non-zero, both are valid
-		});
-
-		it('nested args with different content produce different hashes (no nested-key filtering)', () => {
-			// Regression guard for the recursive stable-stringify fix. The
-			// previous `JSON.stringify(args, sortedKeys)` replacer-array
-			// approach FILTERED keys at every object depth, collapsing
-			// `{todos:[{content:'a',status:'pending'}]}` to `{todos:[{}]}`.
-			// Two todo lists with completely different content therefore
-			// collided — the exact bug class that breaks repetition detection
-			// on nested-args tools like `todowrite`.
-			const hash1 = hashArgs({
-				todos: [{ content: 'Write the auth module', status: 'pending' }],
-			});
-			const hash2 = hashArgs({
-				todos: [{ content: 'Review the coder PR', status: 'in_progress' }],
-			});
-			expect(hash1).not.toBe(hash2);
-		});
-
-		it('nested args with reordered keys at any depth produce the same hash', () => {
-			// Key-order independence must hold at every depth, not just the
-			// top level, so a genuine repetition loop whose nested args are
-			// semantically identical (just built with reordered keys) is still
-			// detected.
-			const hash1 = hashArgs({
-				todos: [{ content: 'same task', status: 'pending' }],
-			});
-			const hash2 = hashArgs({
-				todos: [{ status: 'pending', content: 'same task' }],
-			});
-			expect(hash1).toBe(hash2);
 		});
 	});
 

--- a/tests/unit/hooks/write-target-resolver.test.ts
+++ b/tests/unit/hooks/write-target-resolver.test.ts
@@ -212,13 +212,12 @@ describe('write-target resolver patch payload aliases — issue #2059', () => {
 	});
 
 	test('a unified diff with a stray *** Update File line but no begin marker still fails closed (security guard preserved)', () => {
-		// Operation markers (Update/Add/Delete File, Move to|from) are
-		// unambiguous native syntax — they never appear in a unified-diff body.
-		// A payload carrying one without a begin marker must stay classified as
-		// a malformed native patch and fail closed, never fall through to the
+		// A payload carrying an operation marker (Update/Add/Delete File,
+		// Move to|from) without a begin marker must stay classified as a
+		// malformed native patch and fail closed, never fall through to the
 		// unified-diff parser (which would silently drop the operation target,
-		// including a path-traversal target). This is the regression the plan
-		// critic caught: an earlier draft relaxed operation markers too.
+		// including a path-traversal target). This case pins the column-0 form;
+		// the indented form is pinned by the F-002 block below.
 		const payload =
 			'*** Update File: ../../../etc/passwd\n--- a/test\n+++ b/test';
 		const result = resolveWriteTargets(
@@ -242,5 +241,133 @@ describe('write-target resolver patch payload aliases — issue #2059', () => {
 			{ directory: process.cwd() },
 		);
 		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+});
+
+describe('write-target resolver — regression: CRLF patch payloads (F-011)', () => {
+	// Previous code split the payload with `payload.split('\n')`, leaving a
+	// trailing `\r` on every line. JS `.` does not match `\r`, so every
+	// `(.+)$` / `(.*)$` path-extraction regex failed and EVERY CRLF patch —
+	// unified or native — resolved to
+	// `unverifiable: '<field>: Patch contains no recognizable write targets'`.
+	test('a CRLF unified diff resolves its target', () => {
+		const payload =
+			'--- a/src/a.ts\r\n+++ b/src/a.ts\r\n@@ -1 +1 @@\r\n-a\r\n+b';
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+
+	test('a CRLF native patch resolves its targets', () => {
+		const payload =
+			'*** Begin Patch\r\n*** Update File: src/old.ts\r\n*** Move to: src/new.ts\r\n*** End Patch';
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'resolved',
+			paths: ['src/old.ts', 'src/new.ts'],
+		});
+	});
+});
+
+describe('write-target resolver — regression: indented operation markers (F-002)', () => {
+	// Previous code matched the `*** Begin/End Patch` framing markers against
+	// the TRIMMED line but the operation markers against the RAW line. A single
+	// leading space or tab therefore hid an operation marker from both
+	// classification and extraction, so a correctly framed patch carrying a
+	// column-0 marker plus an indented traversal marker resolved to
+	// `['src/safe.ts']` only — the traversal target was silently dropped from
+	// the set the guardrail layer later validates.
+	test.each([
+		['space-indented', ' '],
+		['tab-indented', '\t'],
+	] as const)('a framed native patch surfaces a %s marker beside a column-0 one', (_label, indent) => {
+		// Both marker families are covered: `*** Update File:` and
+		// `*** Move to:` have separate regexes at both the classification and
+		// the extraction site, so each needs its own indented target.
+		const payload = [
+			'*** Begin Patch',
+			'*** Update File: src/safe.ts',
+			`${indent}*** Update File: ../../../etc/passwd`,
+			`${indent}*** Move to: src/moved.ts`,
+			'*** End Patch',
+		].join('\n');
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'resolved',
+			paths: ['src/safe.ts', '../../../etc/passwd', 'src/moved.ts'],
+		});
+	});
+
+	// Unframed (no begin marker) so that CLASSIFICATION is what decides the
+	// outcome — a framed payload would be forced native by the begin marker and
+	// would therefore pin nothing about the operation-marker regexes. Previously
+	// each of these classified as a unified diff (the raw-anchored marker test
+	// missed the indented line and `hasUnifiedHeaders` suppressed the bare-End
+	// native tolerance), resolving to ['src/a.ts'] while silently dropping the
+	// traversal target. Both marker families must now fail closed.
+	test.each([
+		['Update File', ' *** Update File: ../../../etc/passwd'],
+		['Move from', ' *** Move from: ../../../etc/passwd'],
+	] as const)('an indented %s marker with unified headers and a bare End Patch fails closed', (_label, markerLine) => {
+		const payload = [
+			'--- a/src/a.ts',
+			'+++ b/src/a.ts',
+			'@@ -1 +1 @@',
+			markerLine,
+			'*** End Patch',
+		].join('\n');
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'unverifiable',
+			reason: 'patch: Native patch is missing *** Begin Patch',
+		});
+	});
+});
+
+describe('write-target resolver — multi-field and non-string payload guards (F-006)', () => {
+	// The alias `test.each` above supplies exactly one payload field per case.
+	// These two pre-existing guards are what keep the widened
+	// PATCH_PAYLOAD_KEYS list from admitting a conflicting or malformed
+	// payload, so they are pinned explicitly.
+	test('two alias fields with conflicting targets fail closed', () => {
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{
+				patch: '--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n-a\n+b',
+				content: '--- a/src/other.ts\n+++ b/src/other.ts\n@@ -1 +1 @@\n-a\n+b',
+			},
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'unverifiable',
+			reason: 'Conflicting targets across patch payload fields',
+		});
+	});
+
+	test('a non-string alias value fails closed before parsing', () => {
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ content: 123 },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'unverifiable',
+			reason: 'Malformed content payload',
+		});
 	});
 });

--- a/tests/unit/memory/cohort-config-fingerprint.test.ts
+++ b/tests/unit/memory/cohort-config-fingerprint.test.ts
@@ -16,10 +16,16 @@ import {
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { DEFAULT_MEMORY_CONFIG } from '../../../src/memory/config';
+import { LocalJsonlMemoryProvider } from '../../../src/memory/local-jsonl-provider';
 import {
 	buildMemoryCohortFingerprintInput,
+	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 	computeRedactionPolicyVersion,
+	FINGERPRINT_ALGORITHM_VERSION,
+	_internals as fingerprintInternals,
+	LEGACY_FINGERPRINT_ALGORITHM_VERSION,
+	type MemoryCohortFingerprintInput,
 } from '../../../src/memory/redaction';
 import { SQLiteMemoryProvider } from '../../../src/memory/sqlite-provider';
 
@@ -69,6 +75,101 @@ describe('#1850 cohort config fingerprint inputs (acceptance #10, #13)', () => {
 			}),
 		);
 		expect(sqliteFp).not.toBe(jsonlFp);
+	});
+
+	/**
+	 * #2062 F-007: golden digest. `computeMemoryCohortFingerprint` uses
+	 * `node:crypto` `createHash('sha256')` (redaction.ts) — NOT the
+	 * runtime-dependent `bunHash` — so the digest is byte-identical under Bun
+	 * and Node and a literal can be pinned safely.
+	 *
+	 * The input is hand-built rather than derived from DEFAULT_MEMORY_CONFIG on
+	 * purpose: `redaction_policy_version` is derived from `SECRET_PATTERNS.length`,
+	 * so a config-derived golden would break whenever an unrelated secret pattern
+	 * is added. This literal pins the ALGORITHM (canonicalization + sha256 +
+	 * 12-char truncation), which is what `FINGERPRINT_ALGORITHM_VERSION` claims.
+	 *
+	 * The value below was recorded BEFORE the #2062 F-008 undefined-to-null
+	 * change to `stableCanonicalStringify` and is unchanged after it — empirical
+	 * proof that the change did not invalidate persisted fingerprints.
+	 */
+	test('golden digest pins the fingerprint algorithm (version 1)', () => {
+		const golden: MemoryCohortFingerprintInput = {
+			provider: 'sqlite',
+			redaction_policy_version: 1000042,
+			embedding_model: 'test-model',
+			embedding_dimension: 384,
+			embedding_version: 'v1',
+		};
+		expect(computeMemoryCohortFingerprint(golden)).toBe('b805d0308348');
+		expect(FINGERPRINT_ALGORITHM_VERSION).toBe(1);
+	});
+
+	test('golden digest is independent of key insertion order', () => {
+		const reordered = {
+			embedding_version: 'v1',
+			embedding_dimension: 384,
+			embedding_model: 'test-model',
+			redaction_policy_version: 1000042,
+			provider: 'sqlite',
+		} as MemoryCohortFingerprintInput;
+		expect(computeMemoryCohortFingerprint(reordered)).toBe('b805d0308348');
+	});
+});
+
+/**
+ * #2062 F-012 (R3 fix): the version gate as a pure function. `currentVersion`
+ * is what makes a FUTURE bump testable today — the original defect (absent
+ * field defaulting to the current version) is invisible while it is still 1.
+ */
+describe('#2062 F-012 classifyStoredFingerprintAlgorithmVersion', () => {
+	test('legacy constant is a standalone literal, and the seam defaults to real', () => {
+		// Pins the value, and catches someone editing the literal to a new number.
+		// It CANNOT catch `= FINGERPRINT_ALGORITHM_VERSION` aliasing: while that
+		// constant is still 1 an alias evaluates to 1 and this passes. The only
+		// guard is the `: 1` type in redaction.ts, and it fails `tsc` at the next
+		// bump ONLY if that annotation is kept — dropping it typechecks clean.
+		expect(LEGACY_FINGERPRINT_ALGORITHM_VERSION).toBe(1);
+		expect(fingerprintInternals.currentAlgorithmVersion).toBe(
+			FINGERPRINT_ALGORITHM_VERSION,
+		);
+	});
+
+	test('absent version is legacy v1, NOT the current version', () => {
+		// The core bug. With current=2 an absent field must resolve to 1 and
+		// therefore MISMATCH — not silently equal current and byte-compare.
+		expect(classifyStoredFingerprintAlgorithmVersion(undefined, 2)).toEqual({
+			status: 'mismatch',
+			storedVersion: 1,
+			currentVersion: 2,
+		});
+		// ...while today (current === 1) it still compares, so no forced re-link.
+		expect(classifyStoredFingerprintAlgorithmVersion(undefined)).toEqual({
+			status: 'comparable',
+		});
+	});
+
+	test('present but non-numeric version is unknown, never assumed current', () => {
+		for (const raw of ['not-a-number', null, true, {}, Number.NaN]) {
+			expect(classifyStoredFingerprintAlgorithmVersion(raw)).toEqual({
+				status: 'unknown',
+			});
+			// ...and still unknown under a bump — it never collapses to legacy.
+			expect(classifyStoredFingerprintAlgorithmVersion(raw, 2)).toEqual({
+				status: 'unknown',
+			});
+		}
+	});
+
+	test('present numeric version compares against the current version', () => {
+		expect(classifyStoredFingerprintAlgorithmVersion(2, 2)).toEqual({
+			status: 'comparable',
+		});
+		expect(classifyStoredFingerprintAlgorithmVersion(1, 2)).toEqual({
+			status: 'mismatch',
+			storedVersion: 1,
+			currentVersion: 2,
+		});
 	});
 });
 
@@ -131,7 +232,7 @@ describe('#1850 SQLite provider fingerprint enforcement (acceptance #10 fail-clo
 		);
 		// initialize MUST throw — the stored fingerprint does not match what
 		// this worktree's config computes.
-		expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
+		await expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
 	});
 
 	test('F-26: provider opens when fingerprint matches', async () => {
@@ -156,4 +257,240 @@ describe('#1850 SQLite provider fingerprint enforcement (acceptance #10 fail-clo
 		await provider.initialize();
 		provider.close();
 	});
+});
+
+/**
+ * #2062 F-012: the persisted config gained an `algorithm_version` field.
+ * Readers must (a) keep validating legacy files that predate the field, and
+ * (b) stop byte-comparing digests produced by a DIFFERENT algorithm version,
+ * warning and failing open instead of raising the generic "config differs"
+ * mismatch error that would be actively misleading in that case.
+ */
+describe('#2062 F-012 cohort config algorithm_version handling', () => {
+	const dirs: string[] = [];
+	let prevXdg: string | undefined;
+	let prevHome: string | undefined;
+
+	beforeEach(() => {
+		prevXdg = process.env.XDG_DATA_HOME;
+		prevHome = process.env.HOME;
+		const dataDir = makeTmp('fpv-data-');
+		dirs.push(dataDir);
+		process.env.XDG_DATA_HOME = dataDir;
+		process.env.HOME = dataDir;
+	});
+
+	afterEach(() => {
+		// Restore the bump seam here (not in a per-test try/finally): a throwing
+		// test would otherwise leave a simulated version behind and poison every
+		// later test in this Bun process.
+		fingerprintInternals.currentAlgorithmVersion =
+			FINGERPRINT_ALGORITHM_VERSION;
+		process.env.XDG_DATA_HOME = prevXdg;
+		process.env.HOME = prevHome;
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	// `warn()` (src/utils/logger.ts) is gated behind OPENCODE_SWARM_DEBUG=1 and
+	// writes to console.warn, so capturing console.warn asserts the real
+	// operator-facing text without `mock.module` (AGENTS.md section 7).
+	async function captureCohortWarnings(
+		fn: () => Promise<void>,
+	): Promise<string[]> {
+		const lines: string[] = [];
+		const prevConsoleWarn = console.warn;
+		const prevDebug = process.env.OPENCODE_SWARM_DEBUG;
+		process.env.OPENCODE_SWARM_DEBUG = '1';
+		console.warn = (...args: unknown[]) => {
+			lines.push(args.map((a) => String(a)).join(' '));
+		};
+		try {
+			await fn();
+		} finally {
+			console.warn = prevConsoleWarn;
+			if (prevDebug === undefined) delete process.env.OPENCODE_SWARM_DEBUG;
+			else process.env.OPENCODE_SWARM_DEBUG = prevDebug;
+		}
+		return lines.filter((l) => l.includes('[memory-cohort]'));
+	}
+
+	const hasWarn = (warnings: string[], re: RegExp): boolean =>
+		warnings.some((w) => re.test(w));
+	const NON_NUMERIC_WARN = /non-numeric `algorithm_version`/;
+	const BUMP_WARN =
+		/fingerprinted with algorithm version 1, but this worktree computes version 2/;
+
+	function writeStoredConfig(stored: Record<string, unknown>): string {
+		const cohortRoot = makeTmp('fpv-cohort-');
+		dirs.push(cohortRoot);
+		writeFileSync(
+			path.join(cohortRoot, 'memory-cohort-config.json'),
+			JSON.stringify(stored),
+			'utf-8',
+		);
+		return cohortRoot;
+	}
+
+	function worktree(): string {
+		const dir = makeTmp('fpv-worktree-');
+		dirs.push(dir);
+		return dir;
+	}
+
+	const matchingFingerprint = (): string =>
+		computeMemoryCohortFingerprint(
+			buildMemoryCohortFingerprintInput(DEFAULT_MEMORY_CONFIG),
+		);
+
+	test('legacy file with no algorithm_version still validates when the fingerprint matches', async () => {
+		// Backward-compat guard: files written before the field existed were
+		// produced by algorithm version 1, which is the current version, so the
+		// byte comparison must still run and still pass. No forced re-link.
+		const cohortRoot = writeStoredConfig({
+			fingerprint: matchingFingerprint(),
+		});
+		const provider = new SQLiteMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await provider.initialize();
+		provider.close();
+	});
+
+	test('legacy file with no algorithm_version still fails closed on a real mismatch', async () => {
+		// The version default must not weaken the fail-closed guarantee.
+		const cohortRoot = writeStoredConfig({ fingerprint: 'deadbeefdead' });
+		const provider = new SQLiteMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
+	});
+
+	test('matching algorithm_version keeps the fail-closed mismatch throw', async () => {
+		const cohortRoot = writeStoredConfig({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+		});
+		const provider = new SQLiteMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
+	});
+
+	test('differing algorithm_version fails OPEN instead of throwing the generic mismatch (sqlite)', async () => {
+		// The stored fingerprint is deliberately wrong for this config. Under the
+		// same algorithm version that is a hard error; across versions the digests
+		// are not comparable, so the provider must open and warn instead.
+		const cohortRoot = writeStoredConfig({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION + 1,
+		});
+		const provider = new SQLiteMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await provider.initialize();
+		provider.close();
+	});
+
+	test('differing algorithm_version fails OPEN instead of throwing the generic mismatch (local-jsonl)', async () => {
+		const cohortRoot = writeStoredConfig({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION + 1,
+		});
+		const provider = new LocalJsonlMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await provider.initialize();
+	});
+
+	test('local-jsonl still fails closed on a same-version fingerprint mismatch', async () => {
+		const cohortRoot = writeStoredConfig({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+		});
+		const provider = new LocalJsonlMemoryProvider(
+			worktree(),
+			DEFAULT_MEMORY_CONFIG,
+			cohortRoot,
+		);
+		await expect(provider.initialize()).rejects.toThrow(/fingerprint mismatch/);
+	});
+
+	// Both fail-closed readers must behave identically, so the two cases below
+	// run against each of them.
+	const PROVIDERS: Array<{
+		name: string;
+		init: (root: string) => Promise<void>;
+	}> = [
+		{
+			name: 'sqlite',
+			init: async (root) => {
+				const p = new SQLiteMemoryProvider(
+					worktree(),
+					DEFAULT_MEMORY_CONFIG,
+					root,
+				);
+				await p.initialize();
+				p.close();
+			},
+		},
+		{
+			name: 'local-jsonl',
+			init: (root) =>
+				new LocalJsonlMemoryProvider(
+					worktree(),
+					DEFAULT_MEMORY_CONFIG,
+					root,
+				).initialize(),
+		},
+	];
+
+	for (const { name, init } of PROVIDERS) {
+		test(`non-numeric algorithm_version warns and skips, never throws (${name})`, async () => {
+			// A present-but-uninterpretable value cannot be attributed to any
+			// algorithm, so the digest is not comparable. Assuming "current" would
+			// byte-compare on a guess and raise the misleading generic mismatch.
+			const cohortRoot = writeStoredConfig({
+				fingerprint: 'deadbeefdead',
+				algorithm_version: 'not-a-number',
+			});
+			const warnings = await captureCohortWarnings(() => init(cohortRoot));
+			expect(hasWarn(warnings, NON_NUMERIC_WARN)).toBe(true);
+			// Distinct from the version-mismatch message, which names two versions.
+			expect(hasWarn(warnings, /was fingerprinted with algorithm/)).toBe(false);
+		});
+
+		/**
+		 * The regression the closeout critic caught. Every reader defaulted an
+		 * ABSENT `algorithm_version` to `FINGERPRINT_ALGORITHM_VERSION`, so the
+		 * gate could never fire for a legacy file: the first bump to 2 would make
+		 * every pre-field file on disk claim version 2, skip the gate, and
+		 * byte-compare a v1 digest against a v2 expected value — a hard throw in
+		 * the SQLite provider. The stored digest is deliberately wrong, standing
+		 * in for a real v1 digest that cannot equal the v2 expectation.
+		 */
+		test(`legacy file under a simulated version bump warns, never throws (${name})`, async () => {
+			fingerprintInternals.currentAlgorithmVersion = 2;
+			const cohortRoot = writeStoredConfig({ fingerprint: 'deadbeefdead' });
+			const warnings = await captureCohortWarnings(() => init(cohortRoot));
+			// The message must name the LEGACY version (1), proving the absent
+			// field resolved to the literal, not to the simulated current version.
+			expect(hasWarn(warnings, BUMP_WARN)).toBe(true);
+		});
+	}
 });

--- a/tests/unit/services/knowledge-diagnostics.test.ts
+++ b/tests/unit/services/knowledge-diagnostics.test.ts
@@ -3,11 +3,18 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { appendKnowledgeEvent } from '../../../src/hooks/knowledge-events';
+import { resolveLinkDir } from '../../../src/hooks/knowledge-link';
 import {
 	appendKnowledge,
 	resolveSwarmKnowledgePath,
 } from '../../../src/hooks/knowledge-store';
 import type { SwarmKnowledgeEntry } from '../../../src/hooks/knowledge-types';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+	FINGERPRINT_ALGORITHM_VERSION,
+	_internals as fingerprintInternals,
+} from '../../../src/memory/redaction';
 import {
 	checkKnowledgeHealth,
 	computeKnowledgeDebug,
@@ -323,5 +330,125 @@ describe('knowledge-diagnostics', () => {
 		expect(health.detail).toContain('diag-cohort');
 		expect(health.detail).toContain('DEGRADED');
 		expect(health.detail).toContain('degraded (via git-common-dir)');
+	});
+
+	// #2062 gap-closure (group E): `debug.memory.config_fingerprint_match` must
+	// be version-aware, mirroring `src/memory/sqlite-provider.ts` /
+	// `src/memory/local-jsonl-provider.ts`. A legacy cohort-config file (no
+	// `algorithm_version`) still compares normally; a file stamped with a
+	// DIFFERENT algorithm version must not report a false mismatch — digests
+	// from different algorithms are not comparable, so the field stays `null`
+	// (unknown) rather than `false`.
+	describe('#2062 F-012 memory cohort config_fingerprint_match algorithm_version handling', () => {
+		function setUpLinkedMemoryCohort(stored: Record<string, unknown>): void {
+			mkdirSync(join(dir, '.opencode'), { recursive: true });
+			writeFileSync(
+				join(dir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({ memory: {} }),
+				'utf-8',
+			);
+			mkdirSync(join(dir, '.swarm'), { recursive: true });
+			const linkId = 'kd-cohort';
+			writeFileSync(
+				join(dir, '.swarm', 'memory-link.json'),
+				JSON.stringify({
+					version: 2,
+					linkId,
+					createdAt: '2026-01-01T00:00:00.000Z',
+				}),
+				'utf-8',
+			);
+			const cohortMemoryDir = join(resolveLinkDir(linkId), 'memory');
+			mkdirSync(cohortMemoryDir, { recursive: true });
+			writeFileSync(
+				join(cohortMemoryDir, 'memory-cohort-config.json'),
+				JSON.stringify(stored),
+				'utf-8',
+			);
+		}
+
+		const matchingFingerprint = (): string =>
+			computeMemoryCohortFingerprint(
+				buildMemoryCohortFingerprintInput({
+					provider: 'sqlite',
+					redaction: { rejectDurableSecrets: true },
+					embeddings: { model: 'Xenova/all-MiniLM-L6-v2', dimension: 384 },
+				}),
+			);
+
+		it('legacy config with no algorithm_version still compares normally (match)', async () => {
+			setUpLinkedMemoryCohort({ fingerprint: matchingFingerprint() });
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.linked).toBe(true);
+			expect(debug.memory.config_fingerprint_match).toBe(true);
+		});
+
+		it('legacy config with no algorithm_version still compares normally (mismatch)', async () => {
+			setUpLinkedMemoryCohort({ fingerprint: 'deadbeefdead' });
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.config_fingerprint_match).toBe(false);
+		});
+
+		it('differing algorithm_version does not report a false mismatch', async () => {
+			setUpLinkedMemoryCohort({
+				fingerprint: 'deadbeefdead',
+				algorithm_version: FINGERPRINT_ALGORITHM_VERSION + 1,
+			});
+			const debug = await computeKnowledgeDebug(dir);
+			// Digests from a different algorithm version are not comparable — the
+			// field must stay unknown (null), never a false `false`.
+			expect(debug.memory.config_fingerprint_match).toBeNull();
+		});
+
+		it('matching stored algorithm_version keeps the real mismatch signal', async () => {
+			setUpLinkedMemoryCohort({
+				fingerprint: 'deadbeefdead',
+				algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+			});
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.config_fingerprint_match).toBe(false);
+		});
+
+		// #2062 R3: restore the bump seam after every case in this block so a
+		// throwing test cannot leak a simulated version into later tests.
+		afterEach(() => {
+			fingerprintInternals.currentAlgorithmVersion =
+				FINGERPRINT_ALGORITHM_VERSION;
+		});
+
+		it('present but non-numeric algorithm_version reports unknown, not a match', async () => {
+			// The digest below is byte-correct for this config, so assuming the
+			// current version would report `true` off an uninterpretable stamp.
+			setUpLinkedMemoryCohort({
+				fingerprint: matchingFingerprint(),
+				algorithm_version: 'not-a-number',
+			});
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.linked).toBe(true);
+			expect(debug.memory.config_fingerprint_match).toBeNull();
+		});
+
+		it('current version but missing fingerprint reports unknown, not a mismatch', async () => {
+			// The version is comparable, but there is no digest to compare. Reading
+			// `stored.fingerprint` unguarded yields `undefined === expected` → a
+			// reported MISMATCH for a merely malformed file.
+			setUpLinkedMemoryCohort({
+				algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+			});
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.linked).toBe(true);
+			expect(debug.memory.config_fingerprint_match).toBeNull();
+		});
+
+		it('legacy config under a simulated version bump reports unknown', async () => {
+			// An absent field means algorithm v1, so once the current version is 2
+			// the digests are not comparable — even a byte-identical one. Before the
+			// R3 fix the absent field defaulted to the CURRENT version, so this
+			// compared anyway and reported a match that means nothing.
+			fingerprintInternals.currentAlgorithmVersion = 2;
+			setUpLinkedMemoryCohort({ fingerprint: matchingFingerprint() });
+			const debug = await computeKnowledgeDebug(dir);
+			expect(debug.memory.config_fingerprint_match).toBeNull();
+		});
 	});
 });

--- a/tests/unit/services/status-service.memory-fingerprint-version.test.ts
+++ b/tests/unit/services/status-service.memory-fingerprint-version.test.ts
@@ -1,0 +1,180 @@
+/**
+ * #2062 gap-closure (group E): status-service's `configFingerprintMatch` must
+ * be version-aware, mirroring the provider pattern in
+ * `src/memory/sqlite-provider.ts` and `src/memory/local-jsonl-provider.ts`.
+ *
+ * A legacy cohort-config file (no `algorithm_version`) still compares
+ * normally. A file stamped with a DIFFERENT algorithm version must not
+ * report a false mismatch — digests from different algorithms are not
+ * comparable, so `configFingerprintMatch` stays `undefined` (unknown)
+ * rather than `false`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { MemoryConfigSchema } from '../../../src/config/schema';
+import { resolveLinkDir } from '../../../src/hooks/knowledge-link';
+import {
+	buildMemoryCohortFingerprintInput,
+	computeMemoryCohortFingerprint,
+	FINGERPRINT_ALGORITHM_VERSION,
+	_internals as fingerprintInternals,
+} from '../../../src/memory/redaction';
+import { getStatusData } from '../../../src/services/status-service';
+
+function makeTmp(prefix: string): string {
+	return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe('#2062 F-012 status-service configFingerprintMatch algorithm_version handling', () => {
+	const dirs: string[] = [];
+	let prevXdgData: string | undefined;
+	let prevXdgConfig: string | undefined;
+	let prevLocalAppData: string | undefined;
+	let prevHome: string | undefined;
+
+	beforeEach(() => {
+		prevXdgData = process.env.XDG_DATA_HOME;
+		prevXdgConfig = process.env.XDG_CONFIG_HOME;
+		prevLocalAppData = process.env.LOCALAPPDATA;
+		prevHome = process.env.HOME;
+		const isolated = makeTmp('sfp-isolated-');
+		dirs.push(isolated);
+		process.env.XDG_DATA_HOME = path.join(isolated, 'xdg-data');
+		process.env.XDG_CONFIG_HOME = path.join(isolated, 'xdg-config');
+		process.env.LOCALAPPDATA = path.join(isolated, 'localappdata');
+		process.env.HOME = isolated;
+	});
+
+	afterEach(() => {
+		// #2062 R3: restore the bump seam here, not in a per-test try/finally, so
+		// a throwing test cannot leak a simulated version into later tests.
+		fingerprintInternals.currentAlgorithmVersion =
+			FINGERPRINT_ALGORITHM_VERSION;
+		if (prevXdgData === undefined) delete process.env.XDG_DATA_HOME;
+		else process.env.XDG_DATA_HOME = prevXdgData;
+		if (prevXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+		else process.env.XDG_CONFIG_HOME = prevXdgConfig;
+		if (prevLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+		else process.env.LOCALAPPDATA = prevLocalAppData;
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		for (const d of dirs.splice(0)) {
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+
+	function setUpLinkedWorktree(stored: Record<string, unknown>): string {
+		const worktree = makeTmp('sfp-worktree-');
+		dirs.push(worktree);
+		const linkId = 'sfp-cohort';
+		mkdirSync(path.join(worktree, '.swarm'), { recursive: true });
+		writeFileSync(
+			path.join(worktree, '.swarm', 'memory-link.json'),
+			JSON.stringify({
+				version: 2,
+				linkId,
+				createdAt: '2026-01-01T00:00:00.000Z',
+			}),
+			'utf-8',
+		);
+		const cohortMemoryDir = path.join(resolveLinkDir(linkId), 'memory');
+		mkdirSync(cohortMemoryDir, { recursive: true });
+		writeFileSync(
+			path.join(cohortMemoryDir, 'memory-cohort-config.json'),
+			JSON.stringify(stored),
+			'utf-8',
+		);
+		return worktree;
+	}
+
+	const matchingFingerprint = (): string =>
+		computeMemoryCohortFingerprint(
+			buildMemoryCohortFingerprintInput(MemoryConfigSchema.parse({})),
+		);
+
+	test('legacy config with no algorithm_version still compares normally (match)', async () => {
+		const worktree = setUpLinkedWorktree({
+			fingerprint: matchingFingerprint(),
+		});
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.linked).toBe(true);
+		expect(status.memoryCohort?.configFingerprintMatch).toBe(true);
+	});
+
+	test('legacy config with no algorithm_version still compares normally (mismatch)', async () => {
+		const worktree = setUpLinkedWorktree({ fingerprint: 'deadbeefdead' });
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.configFingerprintMatch).toBe(false);
+	});
+
+	test('differing algorithm_version does not report a false mismatch', async () => {
+		const worktree = setUpLinkedWorktree({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION + 1,
+		});
+		const status = await getStatusData(worktree, {});
+		// Digests from a different algorithm version are not comparable — the
+		// field must stay unknown (undefined), never a false `false`.
+		expect(status.memoryCohort?.configFingerprintMatch).toBeUndefined();
+	});
+
+	test('matching stored algorithm_version keeps the real mismatch signal', async () => {
+		const worktree = setUpLinkedWorktree({
+			fingerprint: 'deadbeefdead',
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+		});
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.configFingerprintMatch).toBe(false);
+	});
+
+	test('present but non-numeric algorithm_version reports unknown, not a match', async () => {
+		// The digest below is byte-correct for this config, so assuming the
+		// current version would report `true` off an uninterpretable stamp.
+		const worktree = setUpLinkedWorktree({
+			fingerprint: matchingFingerprint(),
+			algorithm_version: 'not-a-number',
+		});
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.linked).toBe(true);
+		expect(status.memoryCohort?.configFingerprintMatch).toBeUndefined();
+	});
+
+	test('current version but missing fingerprint reports unknown, not a mismatch', async () => {
+		// The version is comparable, but there is no digest to compare. Reading
+		// `stored.fingerprint` unguarded yields `undefined === expected` → a
+		// reported MISMATCH for a merely malformed file. Both providers already
+		// guard this; the reporting surfaces now do too.
+		const worktree = setUpLinkedWorktree({
+			algorithm_version: FINGERPRINT_ALGORITHM_VERSION,
+		});
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.linked).toBe(true);
+		expect(status.memoryCohort?.configFingerprintMatch).toBeUndefined();
+	});
+
+	test('legacy config under a simulated version bump reports unknown', async () => {
+		// An absent field means algorithm v1, so once the current version is 2 the
+		// digests are not comparable — even a byte-identical one. Before the R3 fix
+		// the absent field defaulted to the CURRENT version, so this compared
+		// anyway and reported a match that means nothing.
+		fingerprintInternals.currentAlgorithmVersion = 2;
+		const worktree = setUpLinkedWorktree({
+			fingerprint: matchingFingerprint(),
+		});
+		const status = await getStatusData(worktree, {});
+		expect(status.memoryCohort?.configFingerprintMatch).toBeUndefined();
+	});
+});

--- a/tests/unit/utils/arg-hash.test.ts
+++ b/tests/unit/utils/arg-hash.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	boundedBunHash,
+	coarseObjectDiscriminator,
+	HASH_INPUT_CAP_BYTES,
+	sampleForHash,
+} from '../../../src/utils/arg-hash';
+
+const CAP = HASH_INPUT_CAP_BYTES;
+const HALF = Math.floor(CAP / 2);
+
+describe('sampleForHash', () => {
+	it('length-prefixes and passes through inputs at or below the cap', () => {
+		expect(sampleForHash('abc')).toBe('3:abc');
+		expect(sampleForHash('')).toBe('0:');
+		const atCap = 'x'.repeat(CAP);
+		expect(sampleForHash(atCap)).toBe(`${CAP}:${atCap}`);
+	});
+
+	it('bounds the sampled length for arbitrarily large inputs', () => {
+		const huge = 'y'.repeat(4 * CAP);
+		const sample = sampleForHash(huge);
+		// Head + tail is exactly CAP; the only extra is the decimal length prefix.
+		expect(sample.length).toBe(CAP + `${huge.length}:`.length);
+		expect(sample.length).toBeLessThan(CAP + 32);
+	});
+
+	it('is injective below the cap (adds zero collisions there)', () => {
+		// Two inputs that differ only in length must not be conflated by the
+		// prefix itself (e.g. "1:2" vs "12" style ambiguity).
+		expect(sampleForHash('12')).not.toBe(sampleForHash('2'));
+		expect(sampleForHash('a')).not.toBe(sampleForHash('b'));
+	});
+
+	it('discriminates over-cap inputs that differ only in an APPENDED tail', () => {
+		// This is the append-collision class a bare `slice(0, CAP)` prefix
+		// creates: identical 64KB header, different bodies, one hash input.
+		const shared = 'x'.repeat(CAP);
+		expect(sampleForHash(`${shared}-tail-A`)).not.toBe(
+			sampleForHash(`${shared}-tail-B`),
+		);
+	});
+
+	it('discriminates over-cap inputs that differ only in a PREPENDED head', () => {
+		const shared = 'x'.repeat(CAP);
+		expect(sampleForHash(`head-A${shared}`)).not.toBe(
+			sampleForHash(`head-B${shared}`),
+		);
+	});
+
+	it('the length prefix separates the at-cap and over-cap sampling classes', () => {
+		// Without the length prefix these two collide exactly: an input of
+		// exactly CAP characters passes through untransformed, while a longer
+		// all-'x' input produces a CAP-character head+tail concatenation that
+		// is byte-identical to it. The prefix is load-bearing, not decoration.
+		const atCap = 'x'.repeat(CAP);
+		const overCap = 'x'.repeat(CAP + 10);
+		expect(sampleForHash(overCap).endsWith('x'.repeat(CAP))).toBe(true);
+		expect(sampleForHash(atCap)).not.toBe(sampleForHash(overCap));
+	});
+
+	it('accepted lossiness: equal-length over-cap inputs differing only in the discarded middle collide', () => {
+		// Documented, deliberate trade-off — any fixed-cost sampler has one.
+		// Pinned so a future change to the sampling window is a visible
+		// decision rather than a silent one.
+		const head = 'a'.repeat(HALF);
+		const tail = 'b'.repeat(HALF);
+		const one = `${head}MIDDLE-1${tail}`;
+		const two = `${head}MIDDLE-2${tail}`;
+		expect(one.length).toBe(two.length);
+		expect(sampleForHash(one)).toBe(sampleForHash(two));
+	});
+});
+
+describe('boundedBunHash', () => {
+	it('returns a bigint and is deterministic', () => {
+		const hash = boundedBunHash('hello');
+		expect(typeof hash).toBe('bigint');
+		expect(boundedBunHash('hello')).toBe(hash);
+	});
+
+	it('does not throw on a multi-megabyte input', () => {
+		expect(() => boundedBunHash('z'.repeat(2 * 1024 * 1024))).not.toThrow();
+	});
+
+	it('distinguishes over-cap inputs differing only past the old bare-prefix cap', () => {
+		const shared = 'x'.repeat(CAP);
+		expect(boundedBunHash(`${shared}-tail-A`)).not.toBe(
+			boundedBunHash(`${shared}-tail-B`),
+		);
+	});
+});
+
+describe('coarseObjectDiscriminator', () => {
+	it('discriminates cyclic objects with different own-key values', () => {
+		const a: Record<string, unknown> = { id: 1, label: 'alpha' };
+		a.self = a;
+		const b: Record<string, unknown> = { id: 2, label: 'beta' };
+		b.self = b;
+		expect(coarseObjectDiscriminator(a)).not.toBe(coarseObjectDiscriminator(b));
+	});
+
+	it('collides for structurally identical objects (true positives preserved)', () => {
+		const a: Record<string, unknown> = { id: 1, label: 'alpha' };
+		a.self = a;
+		const b: Record<string, unknown> = { id: 1, label: 'alpha' };
+		b.self = b;
+		expect(coarseObjectDiscriminator(a)).toBe(coarseObjectDiscriminator(b));
+	});
+
+	it('is key-order independent', () => {
+		expect(coarseObjectDiscriminator({ a: 1, b: 2 })).toBe(
+			coarseObjectDiscriminator({ b: 2, a: 1 }),
+		);
+	});
+
+	it('handles BigInt values without throwing and discriminates them', () => {
+		expect(() => coarseObjectDiscriminator({ n: BigInt(1) })).not.toThrow();
+		expect(coarseObjectDiscriminator({ n: BigInt(1) })).not.toBe(
+			coarseObjectDiscriminator({ n: BigInt(2) }),
+		);
+	});
+
+	it('summarizes long strings by length rather than embedding them', () => {
+		const summary = coarseObjectDiscriminator({ blob: 'q'.repeat(5000) });
+		expect(summary).toContain('len5000');
+		expect(summary.length).toBeLessThan(64);
+	});
+
+	it('is total: returns the "unknown" sentinel instead of throwing on a hostile Proxy', () => {
+		// The callers invoke this from INSIDE a catch block, so a second throw
+		// would escape into a hook. This pins that it cannot.
+		const hostile = new Proxy(
+			{},
+			{
+				ownKeys() {
+					throw new Error('trap');
+				},
+			},
+		);
+		expect(() => coarseObjectDiscriminator(hostile)).not.toThrow();
+		expect(coarseObjectDiscriminator(hostile)).toBe('unknown');
+	});
+
+	it('is total: null and undefined return the sentinel instead of throwing', () => {
+		expect(coarseObjectDiscriminator(null)).toBe('unknown');
+		expect(coarseObjectDiscriminator(undefined)).toBe('unknown');
+	});
+});

--- a/tests/unit/utils/stable-stringify.test.ts
+++ b/tests/unit/utils/stable-stringify.test.ts
@@ -1,0 +1,237 @@
+/**
+ * #2062 F-007: coverage for `stableCanonicalStringify`, which had none.
+ *
+ * The function is a canonical-JSON hash-input builder shared by the
+ * adversarial-detector spiral hash, `file-authority.hashArgs`, and the memory
+ * cohort fingerprint. Two things must be pinned: the guarantees callers rely
+ * on (key-order independence at every depth, no nested-key loss), and the
+ * documented LIMITS (Date/Map/Set collapse, sparse holes, function values) so
+ * that changing any of them is a deliberate, visible decision.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { stableCanonicalStringify } from '../../../src/utils/stable-stringify';
+
+describe('stableCanonicalStringify — key-order independence', () => {
+	test('top-level key order does not change the output', () => {
+		expect(stableCanonicalStringify({ a: 1, b: 2 })).toBe(
+			stableCanonicalStringify({ b: 2, a: 1 }),
+		);
+	});
+
+	test('keys are emitted in sorted order', () => {
+		expect(stableCanonicalStringify({ b: 2, a: 1, c: 3 })).toBe(
+			'{"a":1,"b":2,"c":3}',
+		);
+	});
+
+	test('nested object key order does not change the output at depth 3', () => {
+		const first = { z: { y: { x: 1, w: 2 }, v: 3 }, u: 4 };
+		const second = { u: 4, z: { v: 3, y: { w: 2, x: 1 } } };
+		expect(stableCanonicalStringify(first)).toBe(
+			stableCanonicalStringify(second),
+		);
+		expect(stableCanonicalStringify(first)).toBe(
+			'{"u":4,"z":{"v":3,"y":{"w":2,"x":1}}}',
+		);
+	});
+
+	test('objects differing in value, not order, still differ', () => {
+		expect(stableCanonicalStringify({ a: 1, b: 2 })).not.toBe(
+			stableCanonicalStringify({ a: 1, b: 3 }),
+		);
+	});
+});
+
+describe('stableCanonicalStringify — regression: nested keys inside arrays (#2060)', () => {
+	test('objects inside arrays keep every key', () => {
+		// Previous code used `JSON.stringify(value, Object.keys(value).sort())`.
+		// A property-list replacer acts as a KEY FILTER at every depth, so each
+		// todo collapsed to `{}` and unrelated todo lists hashed identically.
+		const args = {
+			todos: [
+				{ content: 'write the fix', status: 'pending' },
+				{ content: 'run the tests', status: 'in_progress' },
+			],
+		};
+		const out = stableCanonicalStringify(args);
+		expect(out).toBe(
+			'{"todos":[{"content":"write the fix","status":"pending"},' +
+				'{"content":"run the tests","status":"in_progress"}]}',
+		);
+		expect(out).not.toContain('{}');
+	});
+
+	test('two different todo lists do not collide', () => {
+		const a = { todos: [{ content: 'alpha', status: 'pending' }] };
+		const b = { todos: [{ content: 'beta', status: 'pending' }] };
+		expect(stableCanonicalStringify(a)).not.toBe(stableCanonicalStringify(b));
+	});
+
+	test('nested-in-array objects are key-sorted too', () => {
+		expect(stableCanonicalStringify([{ b: 1, a: 2 }])).toBe(
+			stableCanonicalStringify([{ a: 2, b: 1 }]),
+		);
+	});
+
+	test('array order is preserved (arrays are not sorted)', () => {
+		expect(stableCanonicalStringify([1, 2])).not.toBe(
+			stableCanonicalStringify([2, 1]),
+		);
+	});
+});
+
+describe('stableCanonicalStringify — undefined and null (#2062 F-008)', () => {
+	test('regression: undefined object property serializes as null', () => {
+		// Previous code emitted the bare token `undefined` here, producing
+		// `{"a":undefined}` — not parseable JSON.
+		expect(stableCanonicalStringify({ a: undefined })).toBe('{"a":null}');
+	});
+
+	test('regression: undefined array element serializes as null', () => {
+		// Previous code produced `[1,,3]`: the element stringified to the JS
+		// value `undefined`, which `Array.prototype.join` renders as empty.
+		expect(stableCanonicalStringify([1, undefined, 3])).toBe('[1,null,3]');
+	});
+
+	test('a present-but-undefined key is distinguishable from an absent key', () => {
+		// Deliberately stricter than JSON.stringify (which drops the property):
+		// two objects that differ by key presence must not hash equal.
+		expect(stableCanonicalStringify({ a: undefined })).not.toBe(
+			stableCanonicalStringify({}),
+		);
+	});
+
+	test('top-level undefined serializes as null', () => {
+		expect(stableCanonicalStringify(undefined)).toBe('null');
+	});
+
+	test('null is preserved in every position', () => {
+		expect(stableCanonicalStringify(null)).toBe('null');
+		expect(stableCanonicalStringify({ a: null })).toBe('{"a":null}');
+		expect(stableCanonicalStringify([null])).toBe('[null]');
+	});
+
+	test('documented limit: true sparse holes are NOT converted to null', () => {
+		// `Array.prototype.map` skips holes, so a genuine hole survives as an
+		// empty slot. JSON.stringify would emit `[1,null,3]`. Unreachable at
+		// every current call site; pinned so a change here is deliberate.
+		const sparse: unknown[] = new Array(3);
+		sparse[0] = 1;
+		sparse[2] = 3;
+		expect(1 in sparse).toBe(false); // index 1 is a genuine hole
+		expect(stableCanonicalStringify(sparse)).toBe('[1,,3]');
+		expect(JSON.stringify(sparse)).toBe('[1,null,3]');
+	});
+});
+
+describe('stableCanonicalStringify — primitives, empties, and key escaping', () => {
+	test('empty object and empty array', () => {
+		expect(stableCanonicalStringify({})).toBe('{}');
+		expect(stableCanonicalStringify([])).toBe('[]');
+	});
+
+	test('primitive scalars match JSON.stringify', () => {
+		expect(stableCanonicalStringify(0)).toBe('0');
+		expect(stableCanonicalStringify(-1.5)).toBe('-1.5');
+		expect(stableCanonicalStringify(true)).toBe('true');
+		expect(stableCanonicalStringify(false)).toBe('false');
+		expect(stableCanonicalStringify('')).toBe('""');
+		expect(stableCanonicalStringify('hi')).toBe('"hi"');
+	});
+
+	test('unicode keys and values round-trip through JSON.parse', () => {
+		const out = stableCanonicalStringify({
+			日本語: 'café ☕',
+			ключ: 'значение',
+		});
+		expect(JSON.parse(out)).toEqual({ 日本語: 'café ☕', ключ: 'значение' });
+	});
+
+	test('keys needing escapes are escaped, and sorting is by raw key', () => {
+		const out = stableCanonicalStringify({
+			'quote"key': 1,
+			'back\\slash': 2,
+			'new\nline': 3,
+		});
+		expect(out).toBe('{"back\\\\slash":2,"new\\nline":3,"quote\\"key":1}');
+		expect(JSON.parse(out)).toEqual({
+			'quote"key': 1,
+			'back\\slash': 2,
+			'new\nline': 3,
+		});
+	});
+
+	test('a literal __proto__ key is serialized as an ordinary key', () => {
+		// Object.keys sees an own `__proto__` data property created via a literal
+		// only when defined with defineProperty / JSON.parse — assignment would
+		// hit the setter. Use JSON.parse to build a real own key.
+		const obj = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
+		const out = stableCanonicalStringify(obj);
+		expect(out).toBe('{"__proto__":{"polluted":true},"safe":1}');
+		// The serializer must not have mutated Object.prototype.
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+	});
+
+	test('a __proto__-shaped key does not collide with a normal key', () => {
+		const a = JSON.parse('{"__proto__": 1}');
+		const b = { proto: 1 };
+		expect(stableCanonicalStringify(a)).not.toBe(stableCanonicalStringify(b));
+	});
+});
+
+describe('stableCanonicalStringify — documented throwing behavior', () => {
+	test('throws on a self-referential object', () => {
+		const cyclic: Record<string, unknown> = { a: 1 };
+		cyclic.self = cyclic;
+		expect(() => stableCanonicalStringify(cyclic)).toThrow();
+	});
+
+	test('throws on a cycle through an array', () => {
+		const arr: unknown[] = [1];
+		arr.push(arr);
+		expect(() => stableCanonicalStringify(arr)).toThrow();
+	});
+
+	test('throws on BigInt', () => {
+		expect(() => stableCanonicalStringify({ n: 1n })).toThrow(TypeError);
+	});
+});
+
+describe('stableCanonicalStringify — documented lossy limits (#2062 F-008)', () => {
+	test('Date collapses to {} — a genuine divergence from JSON.stringify', () => {
+		// toJSON is never consulted, and a Date has no own enumerable keys.
+		const d = new Date('2020-01-02T03:04:05.000Z');
+		expect(stableCanonicalStringify({ d })).toBe('{"d":{}}');
+		expect(JSON.stringify({ d })).toBe('{"d":"2020-01-02T03:04:05.000Z"}');
+	});
+
+	test('a custom toJSON is ignored', () => {
+		const withToJson = { toJSON: () => 'ignored', real: 1 };
+		// The toJSON function itself is serialized as a value, not invoked.
+		expect(stableCanonicalStringify({ v: withToJson })).toBe(
+			'{"v":{"real":1,"toJSON":undefined}}',
+		);
+	});
+
+	test('Map and Set collapse to {} — this MATCHES JSON.stringify', () => {
+		const m = new Map([['k', 'v']]);
+		const s = new Set(['a']);
+		expect(stableCanonicalStringify({ m })).toBe('{"m":{}}');
+		expect(stableCanonicalStringify({ s })).toBe('{"s":{}}');
+		expect(JSON.stringify({ m })).toBe('{"m":{}}');
+		expect(JSON.stringify({ s })).toBe('{"s":{}}');
+	});
+
+	test('function values still emit a bare undefined token (not valid JSON)', () => {
+		// Deterministic, so safe as hash input, but the output is not parseable.
+		// Unreachable at every current call site; pinned so a change is visible.
+		expect(stableCanonicalStringify({ f: () => 1 })).toBe('{"f":undefined}');
+	});
+
+	test('two different Dates collide (consequence of the limit above)', () => {
+		expect(stableCanonicalStringify({ d: new Date(0) })).toBe(
+			stableCanonicalStringify({ d: new Date(1) }),
+		);
+	});
+});


### PR DESCRIPTION
Follow-up to #2062 (no issue to close — these are review findings against that PR).

## Summary

A swarm PR review of #2062 produced 13 validated findings; a bot review added one
more (`PRR-007`) and verification surfaced a fifteenth. #2062 merged before these
landed, so all 15 ship here, rebased onto current `main`.

### The two that matter

**A fail-open bug in a CI gate.** `scripts/check-test-clock.sh` ended a pipeline in
`grep -q` under `set -o pipefail`. `grep -q` exits on its first match and closes
stdin; the still-writing upstream `grep` takes SIGPIPE; `pipefail` propagates 141;
the helper concludes *"no new clock line" despite a match*. It is input-size
dependent — `rc=0` at ~2000 added diff lines, `rc=141` at ~5000 — so it silently
disabled the check on exactly the large diffs that need it. Replaced with a counted
`grep -cE`, which drains stdin. This is the rule `.github/workflows/ci.yml:133-142`
already states in prose for the same hazard.

**A version gate that could never fire.** #2062 added an `algorithm_version` field
to the persisted `memory-cohort-config.json`. All four readers defaulted an
**absent** field to the current-version constant instead of the literal `1`, so the
gate was inert for every legacy file: bump the constant to `2` and every pre-field
config on disk defaults to `2 == current`, skips the version check, falls through to
a byte comparison of a v1 digest against a v2 expectation, and throws. Fixed with a
typed-literal `LEGACY_FINGERPRINT_ALGORITHM_VERSION: 1 = 1` that cannot drift, plus a
test that simulates a future bump against all four readers. Four prior review gates
approved the original before a closeout critic caught it.

### Also included

- **`write-target-resolver`** — an indented native operation marker inside valid
  `*** Begin/End Patch` framing was silently dropped from the resolved write-target
  set, so the guardrail authorized a write set missing a real target. CRLF payloads
  extracted zero paths (`.` excludes `\r`). Both fixed; the accepted fail-closed
  trade-off is documented in the release fragment.
- **New `src/utils/arg-hash.ts`** — one discriminating fallback for unserializable
  args (the previous constant made distinct calls collide and falsely trip the
  throwing circuit breaker) and a bounded length-prefixed head+tail hash sample,
  shared by the spiral detector and `file-authority`.
- **`stable-stringify`** — `undefined` now serializes as `null`; the docstring states
  its real limits (`Date`, `toJSON`, `Map`/`Set`, array holes).
- **`ci.yml`** — `fetch-depth: 0` on the `quality` job. Five diff-scoped ratchets were
  passing vacuously because they could not resolve a base ref. **This can newly fail
  PRs that were passing for free.**
- **`check-test-clock.sh` is now line-scoped.** This catches strictly **less** than
  before, and it is also what lets this branch pass the gate the change above
  activates. Both facts are disclosed in the release fragment rather than sold as a
  bug fix.

### Known follow-up

`src/plan/manager.ts:532` still feeds unbounded input to `bunHash`; it is outside
every ledger item here and deliberately not fixed in this PR.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; `node scripts/repro-704.mjs` exit 0 and `await import('./dist/index.js')` OK.
- 2 (runtime portability): touched — new `src/utils/arg-hash.ts` hashes via the existing `bunHash` shim (`src/utils/bun-compat.ts`); no direct `Bun.*` call added (the only match in changed source is the word `Bun.hash` inside a comment at `arg-hash.ts:97`). `tests/unit/build/bundle-portability.test.ts` scans all of `src/` recursively and passes. The 64KB cap exists precisely because the Node `djb2` fallback is reachable (~141 ms for 2 MB, measured).
- 3 (subprocesses): not touched — no spawn/exec added.
- 4 (.swarm containment): not touched — all review artifacts were written to the session scratchpad, never under `.swarm/`.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation used per-file `bun test` loops per `AGENTS.md:75-80`, never a broad `test_runner` scope.
- 7 (test writing): touched — 10 test files changed/added, all `bun:test`, no `mock.module`, every new file under the 500-line FR-006 cap; `guardrails.test.ts` was reduced 2875 → 2808 by extracting `describe('hashArgs')` into its own file, so the diff-scoped cap ratchet sees a shrink.
- 8 (session state): touched — `recentToolCalls` hashing changed; the value is never persisted across versions (`session/snapshot-reader.ts` resets every window on rehydration), so no stored hash is ever compared against one from a different version.
- 9 (guardrails/retry): touched — this is the guardrail correctness work itself; see Summary.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no new tool, command, or agent; the new `_internals.currentAlgorithmVersion` test seam is registered in `docs/engineering-invariants.md`.
- 12 (release/cache): touched — `docs/releases/pending/2059-2060-write-target-and-spiral.md` updated (its `## What` and `## Test plan` regenerated from the actual diff) and `docs/releases/pending/1666-mock-allowlist-growth-ratchet.md` corrected.

## Test plan

All commands run from the repo root on the final commit, rebased onto current `main`.

```
$ bunx tsc --noEmit
(clean, exit 0)

$ bunx biome ci .
Checked 3072 files. No fixes applied. (exit 0)

$ bun run build
(exit 0)

$ bun run drift:check
✅ No drift detected across skills, tools, commands, agents, docs claims, and dependency freshness.

$ git diff --check
(clean, exit 0)

$ node scripts/repro-704.mjs            → exit 0
$ node -e "await import('./dist/index.js')"  → dist import OK
```

Every changed test file, run one per process per `AGENTS.md:75-80` (a
directory-wide run in one process produces false cross-contamination failures):

```
PASS tests/unit/hooks/adversarial-detector-wiring.test.ts
PASS tests/unit/hooks/guardrails-hash-args.test.ts
PASS tests/unit/hooks/guardrails-v622-patch-aliases.test.ts
PASS tests/unit/hooks/guardrails.test.ts
PASS tests/unit/hooks/write-target-resolver.test.ts
PASS tests/unit/memory/cohort-config-fingerprint.test.ts
PASS tests/unit/services/knowledge-diagnostics.test.ts
PASS tests/unit/services/status-service.memory-fingerprint-version.test.ts
PASS tests/unit/utils/arg-hash.test.ts
PASS tests/unit/utils/stable-stringify.test.ts
FAILING: NONE
```

Diff-scoped ratchets, run against a resolvable base (relevant because this PR is
what makes them actually run in CI) — no violation in this branch's files:

```
check-test-file-cap.sh   → none of this branch's files
check-test-clock.sh      → none of this branch's files
check-mock-cleanup.sh    → none of this branch's files
```

A 1029-file per-file sweep on the pre-rebase digest had only two genuine failures
(`tests/unit/tools/checkpoint-retention.test.ts`,
`tests/unit/tools/phase-complete-auto-checkpoint.test.ts`), both proven pre-existing
by reproducing them in a clean worktree detached at the unmodified intake head.

### Regression guards proven meaningful

Each fix was reverted independently in a scratchpad copy and the guarding test
confirmed to fail, then restored:

- Reverting the operation-marker trim drops `../../../etc/passwd` and `src/moved.ts`
  from the resolved paths (2 fail / 26 pass).
- Reverting the CRLF split returns `Patch contains no recognizable write targets`.
- Reverting `file-authority`'s catch to `return 0` collapses two distinct cyclic
  objects to one hash, failing the discrimination tests.
- Removing the length prefix from `boundedBunHash` makes an at-cap and an over-cap
  input collide, failing `arg-hash.test.ts`.
- Reverting the `algorithm_version` default breaks both legacy-file tests.
- The old `grep -q` helper returns `rc=141` on a ~5000-line synthetic diff while the
  counted `grep -cE` returns the correct result.

### Review gates

Stage A (build / typecheck / lint / drift / diff-check / per-file tests), then Stage B
reviewer + test_engineer, then a separate closeout reviewer + critic — all on one
content digest, restarted from Stage A after every edit. The closeout critic's final
pass found **zero code defects**; its 15 remaining items were documentation accuracy
and are applied. Every factual claim in the release fragment was re-derived against
the base after seven successive rounds each found one more overstated sentence in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
