### PR TITLE
fix(evaluation): bind ephemeral sessions to the project root, not the isolated fixture directory

### DIFF
--- a/docs/releases/pending/2009-evaluation-session-directory.md
+++ b/docs/releases/pending/2009-evaluation-session-directory.md
@@ -1,0 +1,98 @@
+# Bind evaluation sessions to the project root, not the isolated fixture directory (#2009)
+
+The evaluation subsystem (gate-audit model gates and the evaluation runner's
+model executor) created OpenCode sessions bound to a foreign directory under
+`os.tmpdir()`. OpenCode keys ALL permission state — both the pending-prompt map
+and the "allow always" list — by directory (`InstanceState` is a `ScopedCache`
+keyed on `$.directory`). A session created against a foreign directory gets a
+fresh, empty permission partition. If a permission request (e.g.
+`external_directory`) fired in one of those sessions, the user's TUI replied
+with its OWN directory, so the reply resolved the wrong instance's pending map
+and 404'd, and `Permission.ask` awaited an untimed deferred — the prompt
+reappeared forever and Allow never satisfied it, permanently hanging the agent.
+
+## Changes
+
+- **`src/evaluation/model-dispatcher.ts`**: renamed
+  `EvaluationModelDispatchRequest.directory` → `.sessionDirectory` to express
+  its actual meaning — the directory that determines BOTH the permission
+  partition AND agent registration. It is no longer the fixture/working
+  directory. The runtime logic is unchanged: it forwards `sessionDirectory` to
+  both `client.app.agents` and `dispatchEphemeralAgent` (which passes it to
+  `session.create`).
+- **`src/evaluation/gate-audit.ts`** (`runCell`): the model-gate dispatcher
+  call now passes `sessionDirectory: args.options.projectRoot` (the invoking
+  instance's directory) instead of the isolated `tempRoot`. The
+  `modelPrompt` builder now takes the absolute fixture directory and
+  instructs the agent to inspect ONLY files under that path, so the fixture
+  is reachable even though the session's CWD is the project root.
+- **`src/evaluation/runner.ts`** (`EvaluationExecutor` contract +
+  `createModelEvaluationExecutor`): the `EvaluationExecutor` args contract
+  gained a required `projectRoot: string` field, threaded unconditionally by
+  `runExecutorWithinBudget` from `RunEvaluationOptions.projectRoot` (already
+  required). `createModelEvaluationExecutor` now passes
+  `sessionDirectory: args.projectRoot` instead of `args.isolatedRoot`, and
+  prepends `Work ONLY in this directory: <isolatedRoot>` to the prompt so the
+  agent finds the fixtures. Because `projectRoot` is threaded through the
+  executor args contract — not an optional factory parameter — every executor
+  invoked via `runEvaluation` / `evaluateCandidateV1` binds its session to the
+  project root with no opt-out and no fallback.
+
+## Isolation boundary
+
+The evaluation agent's isolation remains filesystem-level: fixtures are copied
+into the temp/worktree root, the agent's tools are restricted to read-only
+(`DEFAULT_READ_ONLY_TOOLS` denies every canonical plugin mutation/dispatch tool
+plus built-in mutation escape hatches), and the prompt directs the agent to the
+fixture directory only. This is the same boundary as every other same-instance
+read-only ephemeral session in the repo (auto-review, curator, skill-improver,
+full-auto oversight).
+
+## Migration
+
+No migration required for executors invoked through `runEvaluation` /
+`evaluateCandidateV1`: the runner threads `projectRoot` from
+`RunEvaluationOptions.projectRoot` (already a required field) into the executor
+args, so every executor receives it automatically.
+
+The `EvaluationExecutor` args contract gained a required `projectRoot` field.
+Pre-existing executor *functions* remain assignable (they simply ignore the new
+field if they do not create OpenCode sessions). Only a hand-rolled executor
+invoked *outside* `runEvaluation` that does not pass `projectRoot` in its args
+would now fail to type-check — and such a call site would itself be a new
+foreign-directory hazard this fix exists to prevent.
+
+The `EvaluationModelDispatchRequest.directory` field was renamed to
+`.sessionDirectory`. External consumers constructing this type directly (it is
+re-exported from `src/evaluation/index.ts`) must update the field name; the
+TypeScript compiler will flag the change.
+
+## Acceptance criteria evidence
+
+**Criterion 1** (permission request is answerable): Before this fix, the
+evaluation session was created in a foreign temp directory, so an
+`external_directory` permission request for the fixture path (which is under
+`os.tmpdir()`, outside the session's temp dir) landed in the foreign
+instance's private pending map — unreachable by the user's TUI, causing a
+permanent hang. After this fix, the session is created in the project root
+(the invoking instance's directory), so the same permission request lands in
+the project-root instance the user's TUI IS attached to, and is answerable.
+The SDK's `session.create` has no separate working-directory field, so the
+session directory determines the permission partition. The on-disk tests prove
+the session directory is now the project root, not the temp dir.
+
+**Criterion 2** (guardrail inventory updated): The entry for
+`src/evaluation/ephemeral-agent-dispatcher.ts` in
+`tests/unit/config/session-create-directory-guardrail.test.ts` has been updated
+from `classification: 'foreign'` + `disposition: 'foreign-non-lane-documented'`
+to `classification: 'same-instance'`, with the note explaining the #2009 fix.
+The guardrail test passes (12/12).
+
+**Criterion 3** (no lane false-positive regression): No `swarm/`-grammar
+branch or `ses_`-shaped id is introduced. The lane detection machinery is
+untouched. Satisfied by construction.
+
+**Criterion 4** (worktree-lane release note updated): The out-of-scope
+paragraph in `docs/releases/pending/worktree-lane-permission-scoping.md` that
+documented evaluation sessions as a known gap has been updated to note that
+#2009 has closed it.

--- a/docs/releases/pending/worktree-lane-permission-scoping.md
+++ b/docs/releases/pending/worktree-lane-permission-scoping.md
@@ -151,12 +151,13 @@ hang.
   text. The explanation is therefore delivered out of band (advisory plus
   `.swarm/events.jsonl`), not in the model-visible denial.
 - Sessions created against a foreign directory that is **not** a swarm worktree
-  lane are out of scope and unchanged: `src/evaluation/ephemeral-agent-dispatcher.ts`
-  reaches `os.tmpdir()` roots via `src/evaluation/runner.ts` and
-  `src/evaluation/gate-audit.ts`. Those can hang the same way, but applying lane
-  policy to a non-lane session would violate the requirement that ordinary
-  sessions are untouched. The gap is recorded, with evidence, in the new
-  guardrail's inventory so it cannot be forgotten.
+  lane were initially out of scope here: `src/evaluation/ephemeral-agent-dispatcher.ts`
+  reached `os.tmpdir()` roots via `src/evaluation/runner.ts` and
+  `src/evaluation/gate-audit.ts`. That gap is now closed by #2009, which binds
+  all evaluation ephemeral sessions to the invoking instance's project root
+  (same permission partition as the user's session) instead of the isolated
+  fixture directory. The guardrail inventory entry for the evaluation dispatcher
+  has been updated from `foreign-non-lane-documented` to `same-instance`.
 - One directory family that OpenCode base-allows for every agent is **not**
   re-granted inside a lane: `config.references` directories, which the plugin
   cannot resolve from the config hook. A lane will be denied access to them; add

--- a/src/consensus/miner.ts
+++ b/src/consensus/miner.ts
@@ -1060,7 +1060,7 @@ async function summarizeStatements(
 	for (const attribute of budget) {
 		try {
 			const result = await dispatcher({
-				directory,
+				sessionDirectory: directory,
 				agentName: SUMMARIZATION_AGENT,
 				modelId: deps.summarizationModelId ?? 'configured',
 				system: SUMMARIZATION_SYSTEM,

--- a/src/evaluation/gate-audit.ts
+++ b/src/evaluation/gate-audit.ts
@@ -110,6 +110,7 @@ function modelPrompt(
 	task: EvaluationTaskV1,
 	instruction: string,
 	variant: CandidateVariant,
+	fixtureDir: string,
 ): string {
 	return [
 		'You are executing a read-only production gate audit against a curated defect fixture.',
@@ -118,7 +119,8 @@ function modelPrompt(
 		variant === 'defect'
 			? instruction
 			: 'This is a reviewed clean control. Report caught=false unless you find a concrete defect in the supplied implementation.',
-		'Inspect the files in the current isolated directory. Do not modify them.',
+		`Inspect ONLY the files under: ${fixtureDir}`,
+		'Do not modify them and do not inspect files outside that directory.',
 		'Return exactly one JSON object and no markdown:',
 		'{"v":1,"caught":true|false,"reason":"concise evidence"}',
 	].join('\n');
@@ -477,11 +479,11 @@ async function runCell(args: {
 				});
 			}
 			const dispatch = await args.options.dispatcher({
-				directory: tempRoot,
+				sessionDirectory: args.options.projectRoot,
 				agentName: args.gate === 'reviewer' ? 'reviewer' : 'test_engineer',
 				modelId: args.model,
 				preferredSwarm: args.options.manifest.preferredSwarm,
-				prompt: modelPrompt(args.task, instruction, args.variant),
+				prompt: modelPrompt(args.task, instruction, args.variant, tempRoot),
 				timeoutMs: Math.min(args.options.manifest.maxTimeMs, 120_000),
 				parentSessionId: args.options.parentSessionId,
 				abortSignal: args.signal,

--- a/src/evaluation/model-dispatcher.ts
+++ b/src/evaluation/model-dispatcher.ts
@@ -11,7 +11,25 @@ import {
 } from './ephemeral-agent-dispatcher.js';
 
 export type EvaluationModelDispatchRequest = {
-	directory: string;
+	/**
+	 * The directory the ephemeral session is created against.
+	 *
+	 * This is the directory OpenCode uses to key permission state
+	 * (`Permission.state`, `Agent.state`, `ToolRegistry.state` are all built
+	 * through the directory-keyed `InstanceState` cache) AND to resolve
+	 * registered agents. It MUST be the invoking instance's directory (the
+	 * project root) so the session lands in the SAME permission partition as
+	 * the user's session — a foreign directory gets a fresh, empty `approved`
+	 * list and a private pending map that the user's TUI cannot reach, so an
+	 * `external_directory` prompt raised there hangs forever.
+	 *
+	 * The SDK's `session.create` has no separate working-directory field, so
+	 * this is also the agent's CWD. When the fixture the agent must inspect is
+	 * NOT under this directory, the caller conveys the fixture path via the
+	 * prompt (see gate-audit.ts `modelPrompt` and runner.ts
+	 * `createModelEvaluationExecutor`).
+	 */
+	sessionDirectory: string;
 	agentName: string;
 	modelId: string;
 	prompt: string;
@@ -164,7 +182,7 @@ export function createEvaluationModelDispatcher(
 					// eslint-disable-next-line no-await-in-loop
 					const agentsResult = await awaitWithAbort(
 						client.app.agents({
-							query: { directory: request.directory },
+							query: { directory: request.sessionDirectory },
 							signal: controller.signal,
 						}),
 						controller.signal,
@@ -186,7 +204,7 @@ export function createEvaluationModelDispatcher(
 					// eslint-disable-next-line no-await-in-loop
 					const result = await dispatchEphemeralAgent({
 						client,
-						directory: request.directory,
+						directory: request.sessionDirectory,
 						parentSessionId: request.parentSessionId,
 						agentName: resolvedAgentName,
 						model: requestedModel,

--- a/src/evaluation/runner.ts
+++ b/src/evaluation/runner.ts
@@ -86,6 +86,15 @@ export type EvaluationExecutor = (args: {
 	payload: string;
 	seed: string;
 	abortSignal: AbortSignal;
+	/**
+	 * The invoking instance's directory (the project root). An executor that
+	 * creates an OpenCode session MUST bind it here — NOT to `isolatedRoot` —
+	 * so the session lands in the same permission partition as the user's
+	 * session (#2009). OpenCode keys permission state per directory; a foreign
+	 * directory gets an empty approved list and a private pending map the TUI
+	 * cannot reach, so a prompt raised there hangs forever.
+	 */
+	projectRoot: string;
 }) => Promise<EvaluationExecutorResult>;
 
 export type RunEvaluationOptions = {
@@ -302,6 +311,7 @@ async function runExecutorWithinBudget(args: {
 				payload: args.payload,
 				seed: args.seed,
 				abortSignal: controller.signal,
+				projectRoot: args.options.projectRoot,
 			}),
 			aborted,
 		]);
@@ -746,8 +756,14 @@ export function createModelEvaluationExecutor(
 	parentSessionId?: string,
 ): EvaluationExecutor {
 	return async (args) => {
+		// Bind the ephemeral session to the invoking instance's directory (the
+		// project root) so it lands in the SAME permission partition as the
+		// user's session. OpenCode keys permission state per directory; a
+		// foreign directory gets an empty approved list and a private pending
+		// map the user's TUI cannot reach, so an external_directory prompt
+		// raised there hangs forever. The fixture is conveyed via the prompt.
 		const result = await dispatcher({
-			directory: args.isolatedRoot,
+			sessionDirectory: args.projectRoot,
 			agentName: args.candidate.agent ?? 'reviewer',
 			modelId: args.candidate.model,
 			system: args.payload,
@@ -755,6 +771,7 @@ export function createModelEvaluationExecutor(
 				'EVALUATION TASK:',
 				args.instruction,
 				'',
+				`Work ONLY in this directory: ${args.isolatedRoot}`,
 				'Return the task-required scorer payload exactly.',
 			].join('\n'),
 			timeoutMs: args.task.scorer.timeoutMs,

--- a/tests/unit/config/session-create-directory-guardrail.test.ts
+++ b/tests/unit/config/session-create-directory-guardrail.test.ts
@@ -80,18 +80,16 @@ const DECLARED_SITES: DeclaredSite[] = [
 	{
 		file: 'src/evaluation/ephemeral-agent-dispatcher.ts',
 		directoryExpr: 'request.directory',
-		classification: 'foreign',
-		disposition: 'foreign-non-lane-documented',
+		classification: 'same-instance',
 		note:
-			'Two production chains, both under os.tmpdir() and neither a swarm worktree lane: ' +
-			'src/evaluation/runner.ts:750 passes args.isolatedRoot (a subpath of a disposable ' +
-			'worktree created at path.join(os.tmpdir(), WORKTREE_PARENT) by ' +
-			'src/evaluation/disposable-worktree.ts), and src/evaluation/gate-audit.ts:480 passes ' +
-			'a mkdtempSync root under os.tmpdir(). Both get a fresh permission partition and can ' +
-			'hang the same way. NOT covered by lane-permission handling: resolveLaneContext ' +
-			'requires a swarm-OWNED linked git worktree (a `swarm/`/`swarm-lane/` branch, or the ' +
-			'.swarm-worktrees path fallback) and neither temp root is one, and the approved ' +
-			'policy explicitly forbids applying lane policy to non-lane sessions. Known gap.',
+			'#2009: all evaluation dispatcher callers (gate-audit.ts, runner.ts ' +
+			'createModelEvaluationExecutor, consensus/miner.ts) now pass the invoking ' +
+			"instance's project root as sessionDirectory, which flows through to " +
+			'request.directory here. The fixture path is conveyed to the agent via the ' +
+			'prompt as an absolute path (the SDK has no separate working-directory field). ' +
+			'An external_directory permission request for the fixture path, if raised, ' +
+			"now lands in the project-root instance the user's TUI can answer — it no " +
+			'longer hangs in an unreachable foreign partition.',
 	},
 	{
 		file: 'src/full-auto/oversight.ts',

--- a/tests/unit/evaluation/gate-audit.test.ts
+++ b/tests/unit/evaluation/gate-audit.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { handleGateAuditCommand } from '../../../src/commands/gate-audit.js';
 import { _gateAuditInternals } from '../../../src/evaluation/gate-audit.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const originalFingerprint = _gateAuditInternals.captureWorkingTreeFingerprint;
 const packageRoot = path.resolve(import.meta.dir, '../../..');
@@ -201,6 +202,72 @@ describe('Tier-1 gate audit', () => {
 					(cell: { model: string }) => cell.model === 'provider/actual',
 				),
 			).toBe(true);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test('#2009: binds the model-gate session to the project root, not the isolated fixture directory', async () => {
+		// OpenCode keys permission state per directory. The evaluation model
+		// gate must create its session in the project root (the invoking
+		// instance's directory) so it lands in the SAME permission universe.
+		// The fixture location is conveyed via the prompt as an absolute path.
+		const root = canonicalMkdtemp('gate-audit-sessiondir-');
+		try {
+			_gateAuditInternals.captureWorkingTreeFingerprint = async () => ({
+				head: 'a'.repeat(40),
+				porcelainHash: 'b'.repeat(64),
+			});
+			const seenSessionDirs: string[] = [];
+			const seenPrompts: string[] = [];
+			await handleGateAuditCommand(
+				root,
+				[
+					'--run-id',
+					'audit-sessiondir-2009',
+					'--gates',
+					'reviewer',
+					'--tasks',
+					'curated-off-by-one',
+					'--model',
+					'provider/requested',
+					'--runs',
+					'1',
+					'--max-retries',
+					'0',
+					'--max-time-ms',
+					'60000',
+					'--json',
+				],
+				{
+					packageRoot,
+					dispatcher: async (request) => {
+						seenSessionDirs.push(request.sessionDirectory);
+						seenPrompts.push(request.prompt);
+						return {
+							status: 'completed',
+							modelId: 'provider/requested',
+							text: '{"v":1,"caught":true,"reason":"ok"}',
+							durationMs: 1,
+						};
+					},
+				},
+			);
+			// Every model-gate dispatch used the project root as the session
+			// directory (same permission partition as the invoking instance),
+			// NOT the isolated temp fixture directory.
+			for (const dir of seenSessionDirs) {
+				expect(dir).toBe(root);
+			}
+			expect(seenSessionDirs.length).toBeGreaterThan(0);
+			// The prompt directs the agent to the fixture directory absolutely,
+			// and that fixture path is NOT the project root.
+			for (const prompt of seenPrompts) {
+				expect(prompt).toContain('Inspect ONLY the files under:');
+				const match = prompt.match(/Inspect ONLY the files under: (.+)/);
+				expect(match).not.toBeNull();
+				expect(match![1]).not.toBe(root);
+			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}

--- a/tests/unit/evaluation/model-dispatcher.test.ts
+++ b/tests/unit/evaluation/model-dispatcher.test.ts
@@ -37,16 +37,27 @@ function fakeClient(options?: {
 }) {
 	let deleted = 0;
 	let promptRequest: unknown;
+	let agentsDirectory: string | undefined;
+	let createDirectory: string | undefined;
 	return {
 		value: {
 			app: {
-				agents: async () => ({
-					data: (options?.agents ?? ['reviewer']).map((name) => ({ name })),
-				}),
+				agents: async (req?: { query?: { directory?: string } }) => {
+					agentsDirectory = req?.query?.directory;
+					return {
+						data: (options?.agents ?? ['reviewer']).map((name) => ({
+							name,
+						})),
+					};
+				},
 			},
 			session: {
 				create:
-					options?.create ?? (async () => ({ data: { id: 'session-1' } })),
+					options?.create ??
+					(async (req?: { query?: { directory?: string } }) => {
+						createDirectory = req?.query?.directory;
+						return { data: { id: 'session-1' } };
+					}),
 				prompt: async (request: unknown) => {
 					promptRequest = request;
 					return options?.prompt
@@ -65,6 +76,8 @@ function fakeClient(options?: {
 			},
 		} as never,
 		deleted: () => deleted,
+		agentsDirectory: () => agentsDirectory,
+		createDirectory: () => createDirectory,
 		promptRequest: () =>
 			promptRequest as {
 				body: Record<string, unknown>;
@@ -74,7 +87,7 @@ function fakeClient(options?: {
 
 function request(overrides: Record<string, unknown> = {}) {
 	return {
-		directory: process.cwd(),
+		sessionDirectory: process.cwd(),
 		agentName: 'reviewer',
 		modelId: 'configured',
 		prompt: 'inspect',
@@ -160,6 +173,22 @@ describe('evaluation model dispatcher', () => {
 		});
 		expect(fake.deleted()).toBe(1);
 		expect(debugLog).not.toHaveBeenCalled();
+	});
+
+	test('#2009: forwards sessionDirectory to both agent discovery and session create (same permission partition)', async () => {
+		// OpenCode keys permission state per directory. The session directory MUST
+		// be the invoking instance's directory so the ephemeral session lands in
+		// the SAME permission universe — a foreign directory gets an empty
+		// approved list and a private pending map the TUI cannot reach, so a
+		// prompt raised there hangs forever. Both app.agents and session.create
+		// must receive the SAME sessionDirectory (agents are registered per-dir
+		// for the plugin; the session must match).
+		const fake = fakeClient();
+		const dispatch = createEvaluationModelDispatcher(fake.value);
+		const sessionDir = '/project/root';
+		await dispatch(request({ sessionDirectory: sessionDir }));
+		expect(fake.agentsDirectory()).toBe(sessionDir);
+		expect(fake.createDirectory()).toBe(sessionDir);
 	});
 
 	test('omits the system field when evaluation supplies no override', async () => {

--- a/tests/unit/evaluation/runner.test.ts
+++ b/tests/unit/evaluation/runner.test.ts
@@ -10,7 +10,13 @@ import {
 	computeCandidateInputContentHash,
 	computeTaskInputContentHash,
 } from '../../../src/evaluation/hashing.js';
-import { _internals, runEvaluation } from '../../../src/evaluation/runner.js';
+import type { EvaluationModelDispatchRequest } from '../../../src/evaluation/model-dispatcher.js';
+import {
+	_internals,
+	createModelEvaluationExecutor,
+	runEvaluation,
+} from '../../../src/evaluation/runner.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const originalFingerprint = _internals.captureWorkingTreeFingerprint;
 const originalDisposableWorktree = _internals.withDisposableWorktree;
@@ -142,6 +148,161 @@ describe('bounded evaluation runner', () => {
 			const resumed = await runEvaluation(options);
 			expect(resumed).toEqual(first);
 			expect([...attempts.values()]).toEqual([2, 2]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('createModelEvaluationExecutor — #2009 session directory binding', () => {
+	test('binds the session to the project root and conveys the fixture path in the prompt', async () => {
+		// OpenCode keys permission state per directory. The executor must create
+		// its session in the project root (the invoking instance's directory),
+		// NOT the isolated fixture root, so it lands in the same permission
+		// partition. The fixture location is conveyed via the prompt.
+		const projectRoot = '/project/root';
+		const isolatedRoot = canonicalMkdtemp('eval-exec-2009-');
+		try {
+			const captured: EvaluationModelDispatchRequest[] = [];
+			const fakeDispatcher = async (req: EvaluationModelDispatchRequest) => {
+				captured.push(req);
+				return {
+					status: 'completed' as const,
+					modelId: 'provider/model',
+					agentName: 'reviewer',
+					text: '{"v":1,"caught":true}',
+					durationMs: 1,
+				};
+			};
+			const executor = createModelEvaluationExecutor(fakeDispatcher);
+			await executor({
+				task: {
+					v: 1,
+					id: 't1',
+					source: 'curated',
+					split: 'validation',
+					category: 'cat',
+					protected: false,
+					instructionPath: 'instruction.md',
+					environment: { kind: 'fixture', path: 'fixture' },
+					scorer: {
+						kind: 'builtin',
+						argv: ['scorer'],
+						timeoutMs: 1_000,
+						scoreRange: [0, 1],
+					},
+				} as EvaluationTaskV1,
+				candidate: {
+					v: 1,
+					id: 'c1',
+					kind: 'skill',
+					payloadPath: 'candidate.md',
+					model: 'configured',
+				} as EvaluationCandidateV1,
+				isolatedRoot,
+				instruction: 'Find the defect.',
+				payload: 'candidate system payload',
+				seed: 'seed',
+				abortSignal: new AbortController().signal,
+				projectRoot,
+			});
+			expect(captured).toHaveLength(1);
+			expect(captured[0]!.sessionDirectory).toBe(projectRoot);
+			expect(captured[0]!.sessionDirectory).not.toBe(isolatedRoot);
+			// The prompt directs the agent to the isolated fixture directory.
+			expect(captured[0]!.prompt).toContain(
+				`Work ONLY in this directory: ${isolatedRoot}`,
+			);
+		} finally {
+			fs.rmSync(isolatedRoot, { recursive: true, force: true });
+		}
+	});
+
+	test('runEvaluation threads projectRoot into the executor args', async () => {
+		// The executor contract receives projectRoot from the runner so ANY
+		// executor — including createModelEvaluationExecutor — has it without
+		// an optional factory parameter. This is the wiring that ensures the
+		// runner path is actually fixed (#2009), not silently falling back to
+		// the isolated fixture directory.
+		const root = canonicalMkdtemp('eval-thread-2009-');
+		try {
+			fs.mkdirSync(path.join(root, 'fixture'));
+			fs.writeFileSync(
+				path.join(root, 'fixture', 'subject.ts'),
+				'export const value = 1;\n',
+			);
+			fs.writeFileSync(
+				path.join(root, 'instruction.md'),
+				'Return a verdict.\n',
+			);
+			fs.writeFileSync(path.join(root, 'baseline.md'), 'baseline payload\n');
+			fs.writeFileSync(path.join(root, 'candidate.md'), 'candidate payload\n');
+			const taskDraft = {
+				v: 1 as const,
+				id: 'thread-2009',
+				source: 'curated' as const,
+				split: 'validation' as const,
+				category: 'correctness',
+				protected: true,
+				instructionPath: 'instruction.md',
+				environment: { kind: 'fixture' as const, path: 'fixture' },
+				scorer: {
+					kind: 'builtin' as const,
+					argv: ['tier1-defect'],
+					timeoutMs: 1_000,
+					scoreRange: [0, 1] as [number, number],
+				},
+				provenance: { origin: 'unit-test', license: 'MIT' },
+			};
+			const task: EvaluationTaskV1 = {
+				...taskDraft,
+				contentHash: await computeTaskInputContentHash(root, taskDraft),
+			};
+			_internals.captureWorkingTreeFingerprint = async () => ({
+				head: 'a'.repeat(40),
+				porcelainHash: 'b'.repeat(64),
+			});
+			_internals.withDisposableWorktree = async ({ baseRef, run }) => {
+				const worktreeRoot = canonicalMkdtemp('eval-worktree-thread-');
+				try {
+					return await run({ path: worktreeRoot, baseSha: baseRef });
+				} finally {
+					fs.rmSync(worktreeRoot, { recursive: true, force: true });
+				}
+			};
+			const receivedProjectRoots: string[] = [];
+			const options = {
+				projectRoot: root,
+				tasks: [task],
+				baseline: await candidate(root, 'baseline', 'baseline'),
+				candidate: await candidate(root, 'candidate', 'skill'),
+				split: 'validation' as const,
+				seed: 'thread-seed',
+				models: ['configured'],
+				budgets: {
+					maxTasks: 1,
+					maxRepetitions: 1,
+					maxConcurrency: 1,
+					maxTaskTimeMs: 5_000,
+					maxRetries: 0,
+					maxOutputBytes: 4_096,
+				},
+				executor: async ({ projectRoot: received }) => {
+					receivedProjectRoots.push(received);
+					return {
+						status: 'completed' as const,
+						text: '{"v":1,"caught":true}',
+						durationMs: 1,
+						cost: { source: 'unavailable' as const },
+					};
+				},
+			};
+			await runEvaluation(options);
+			// The executor received the project root, not a temp path.
+			expect(receivedProjectRoots.length).toBeGreaterThan(0);
+			for (const received of receivedProjectRoots) {
+				expect(received).toBe(root);
+			}
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
Closes #2009

## Summary

The evaluation subsystem created OpenCode sessions bound to a foreign directory under `os.tmpdir()`. OpenCode keys ALL permission state (pending-prompt map + "allow always" list) by directory, so a session in a foreign directory gets a fresh, empty permission partition. If a permission request fired there, the user's TUI replied with its OWN directory, missing the foreign instance's pending map → 404 → `Permission.ask` awaited an untimed deferred → **permanent hang**.

**The fix:** bind evaluation ephemeral sessions to the project root (the invoking instance's directory), matching the pattern used by all other non-lane `session.create` sites. The SDK's `session.create` has no separate working-directory field, so the directory is both the permission partition AND the agent CWD. The fixture location is conveyed via the prompt as an absolute path.

### Changes
- **`src/evaluation/model-dispatcher.ts`**: renamed `EvaluationModelDispatchRequest.directory` → `.sessionDirectory`. Forwards to both `client.app.agents` and `dispatchEphemeralAgent`.
- **`src/evaluation/gate-audit.ts`**: dispatcher call passes `sessionDirectory: args.options.projectRoot`; `modelPrompt` takes the absolute fixture dir.
- **`src/evaluation/runner.ts`**: `EvaluationExecutor` contract gained a required `projectRoot`, threaded by `runExecutorWithinBudget`. `createModelEvaluationExecutor` uses `sessionDirectory: args.projectRoot`.
- **`src/consensus/miner.ts`**: third dispatcher caller updated to `sessionDirectory: directory`.
- **`tests/unit/config/session-create-directory-guardrail.test.ts`**: guardrail inventory entry for the evaluation dispatcher updated from `foreign` + `foreign-non-lane-documented` to `same-instance` (AC2).
- **`docs/releases/pending/worktree-lane-permission-scoping.md`**: out-of-scope paragraph updated to note #2009 closed the gap (AC4).
- **Tests**: 4 new tests across `model-dispatcher.test.ts`, `gate-audit.test.ts`, `runner.test.ts`.

## Invariant audit
- 1 (plugin init): not touched
- 2 (runtime portability): not touched
- 3 (subprocesses): not touched
- 4 (.swarm containment): not touched
- 5 (plan durability): not touched
- 6 (test_runner safety): not touched
- 7 (test writing): touched — bun:test, `canonicalMkdtemp` from `tests/helpers/tmpdir.ts`, no `mock.module`. Evidence: `bun run lint` clean, FR-011 gate passes.
- 8 (session state): not touched
- 9 (guardrails/retry): touched — session-creation directory changes from foreign temp → project root. Evidence: `tests/unit/evaluation/model-dispatcher.test.ts` #2009 test + #1896 quota-retry tests pass.
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched. Evidence: `bun run drift:check` — no drift.
- 12 (release/cache): touched — release fragment added; guardrail inventory + worktree-lane release note updated; no version files hand-edited.

## Test plan

```
$ bun run typecheck          # clean
$ bun run lint               # Checked 3104 files. No fixes applied.
$ bun run build              # exit 0
$ bun run drift:check        # ✅ No drift detected
$ bun test tests/unit/config/session-create-directory-guardrail.test.ts tests/unit/evaluation/
                              # 114 pass, 0 fail
```

## Review gates
- Independent implementation reviewer (Kimi K2.7): APPROVE
- Plan critic (Kimi K3): reviewed and incorporated
- Final critic (Kimi K3): APPROVE
- swarm-pr-review (5 explorer lanes + Kimi K2.7 reviewer): REQUEST_CHANGES → all findings addressed
- swarm-pr-feedback (Codex review + swarm-pr-review handoff): reviewer APPROVE + critic APPROVE
