### PR TITLE
test(stability): de-flake merge-queue timeout races and add coverage-gate retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,27 @@ jobs:
             coverage-output.txt
             coverage/lcov.info
           if-no-files-found: warn
+      # Upload the coverage job's flake-annotations file `if: always()` so the
+      # downstream flake-detection workflow_run can pick it up alongside the
+      # unit shards' annotations (issue #1782). run-coverage-gate.sh always
+      # creates flake-annotations-coverage.txt unconditionally (`: >`), even
+      # on a clean run with no retries/failures, so this step normally always
+      # has a file to upload (a 0-byte one on a clean run). if-no-files-found:
+      # ignore is not about the skipped case — a step whose `if:` is false
+      # never evaluates the setting at all. It covers the case where the file
+      # was never created. The two upload steps are the only ones in this job
+      # carrying `always()`, so they still run when an earlier step failed:
+      # if install / build / the gate step itself fails, the script never
+      # executes and never creates the file (the common case), and likewise
+      # if the script aborts under `set -euo pipefail` before creating it.
+      # Neither must fail the job over a missing artifact.
+      - name: Upload coverage flake annotations
+        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flake-annotations-coverage
+          path: flake-annotations-coverage.txt
+          if-no-files-found: ignore
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success
   # to satisfy required checks without doing work. Also skipped for release-please.

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -1,10 +1,15 @@
 # Flake detection (issue #1782, root-cause detection phase §6).
 #
 # Triggers on completion of the `ci.yml` workflow when the triggering event was
-# a merge_group run. Downloads the per-shard flake-annotations artifacts
-# uploaded by ci.yml's unit job, concatenates them, and runs
-# scripts/ci/detect-and-quarantine-flakes.sh to produce quarantine suggestions
-# + a best-effort tracking issue.
+# a merge_group run AND that run's conclusion was `failure` (see the job-level
+# `if:` below). A run that goes green — including one where a flaky test passed
+# on retry — never reaches this workflow, so a self-healed flake is only
+# surfaced when some OTHER job in the same run failed. That is true of the unit
+# shards' annotations as much as the coverage job's.
+# Downloads every flake-annotations artifact uploaded by
+# ci.yml (the per-shard unit annotations AND the coverage job's annotations),
+# concatenates them, and runs scripts/ci/detect-and-quarantine-flakes.sh to
+# produce quarantine suggestions + a best-effort tracking issue.
 #
 # This workflow is ADVISORY ONLY: it never fails a run (the detection script
 # always exits 0). A detected flake already failed in ci.yml; this workflow
@@ -56,7 +61,7 @@ jobs:
           # cannot see the triggering run's artifacts).
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pattern: flake-annotations-unit-shard-*
+          pattern: flake-annotations-*
           merge-multiple: true
           path: annotations
 
@@ -64,7 +69,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p detection-out
-          cat annotations/flake-annotations-unit-shard-*.txt 2>/dev/null > detection-out/flake-annotations.txt || true
+          cat annotations/flake-annotations-*.txt 2>/dev/null > detection-out/flake-annotations.txt || true
           echo "Combined annotation line count: $(wc -l < detection-out/flake-annotations.txt | tr -d ' ')"
           if [ ! -s detection-out/flake-annotations.txt ]; then
             echo "No flake annotations found (ci.yml may have failed for a non-test reason)."

--- a/docs/releases/pending/1782-merge-queue-timeout-flakes-and-coverage-retry.md
+++ b/docs/releases/pending/1782-merge-queue-timeout-flakes-and-coverage-retry.md
@@ -1,0 +1,31 @@
+# `test(stability)`: de-flake merge-queue timeout races and give the coverage gate retry parity
+
+## Summary
+
+- **De-flaked three wall-clock races** that repeatedly evicted PRs from the merge queue. Each raced a real timer against real work and could invert on a fast or loaded runner:
+  - `tests/unit/background/workspace-snapshot-digest-failure-reasons.test.ts` — two cases set `_internals.revisionEnumerationTimeoutMs = 1` and asserted that enumerating a tiny temp git fixture *exceeded* 1ms. On a fast runner enumeration finished first, the digest succeeded, and the assertions failed. This one failed CI on 6+ PRs; on PR #2080 it failed all three attempts, exhausted the retry budget, and was evicted from the queue.
+  - `tests/unit/turbo/lean/runner.timeout-adversarial.test.ts` — raced a 5ms lane-dispatch timeout against a mock rejecting at 20ms (4x margin), then waited a fixed `Bun.sleep(100)` for cleanup.
+  - `tests/unit/review/dispatcher.test.ts` — waited a fixed `Bun.sleep(40)` for a real 15ms timeout to propagate (2.67x margin).
+- **The fix removes the race rather than widening it.** Each competing branch is now structurally unable to win: stubs never settle on their own, so the production deadline is the sole resolver; observations await the real signal (an `'abort'` event, a bounded poll on the observable condition) instead of guessing a window. Deadlines were not simply raised — that narrows a race without removing it.
+- **Gave `scripts/ci/run-coverage-gate.sh` the same bounded retry** the unit and integration jobs already had (`max_retries=2`, three attempts). The coverage job is merge-queue-only, so a single transient flake there evicted a PR with no chance to self-heal, and a requeue costs a full ~30-60 min re-run. The `coverage/` directory is reset before **every** attempt, preserving the per-file lcov isolation invariant from issue #1712.
+- **Wired the new flake annotations end-to-end**, not just emitted them: the script writes `flake-annotations-coverage.txt`, the `coverage` job uploads it, and `flake-detection.yml`'s artifact pattern was broadened from `flake-annotations-unit-shard-*` to `flake-annotations-*` so the advisory quarantine-suggestion pipeline actually consumes it.
+- **Made one timing guard self-policing.** The async enumeration test's per-test budget is now a named constant plus an assertion that the budget still sits below the deadline a mis-wired call would take, so lowering `GIT_SNAPSHOT_TIMEOUT_MS` fails loudly instead of silently rendering the guard inert.
+- **Split `runner.timeout-adversarial.test.ts` under FR-006.** The de-flake grew an already-over-cap file (1032 -> 1097 lines), which trips the cap ratchet. Its `ATTACK VECTOR T6` block moved to `tests/unit/turbo/lean/runner.timeout-adversarial-lane-state.test.ts`; the original now shrinks to 896.
+- **Added 8 structural tests** in `tests/unit/scripts/ci/ci-yml-integration.test.ts` covering the retry loop, the in-loop coverage reset, both annotation appends, the upload step, and the broadened detection pattern — so the new CI behavior is not untested.
+
+## User-facing changes
+
+None. No runtime or `src/` behavior changed — this touches tests, CI scripts, workflow YAML, and docs only.
+
+## Migration notes
+
+None required.
+
+## Known caveats
+
+- `flake-detection.yml` only runs when the triggering `ci` run concluded in `failure`, so a flake that self-heals on retry is logged in its job's step output but is not auto-surfaced as a quarantine suggestion. This is a property of the trigger and applies to the unit shards' annotations exactly as much as the coverage job's; it is now documented in `docs/testing/test-stability.md` rather than left implicit.
+- The bounded-poll helpers in the new lane-state test are bounded by **poll count**, not milliseconds. This is deliberate: Windows quantizes timer waits to its ~15.6ms scheduler tick, so a sub-tick nominal interval costs the same there while costing far less on Linux, and a millisecond-denominated bound overshoots ~3x on Windows and pushes its own error path past the per-test budget.
+
+## Discovery context
+
+The digest-timeout flake was traced from a merge-queue eviction of PR #2080. The remaining races were found by sweeping for the same shape — a real timer raced against real work with a small margin — rather than fixing only the reported instance. Related: #1705 (quarantine ledger), #1712 (per-file coverage isolation), #1782 (test-stability sprint), #1968 (the timeout-vs-git-failed distinction the digest tests guard).

--- a/docs/testing/test-stability.md
+++ b/docs/testing/test-stability.md
@@ -157,9 +157,12 @@ Do NOT un-quarantine without a merge-group validation run confirming the fix.
 ## Auto-detection (the flake-detection workflow)
 
 When a merge-group CI run fails, `.github/workflows/flake-detection.yml`
-(`workflow_run` trigger) downloads the per-shard `flake-annotations-*`
-artifacts that ci.yml's unit job uploads, concatenates them, and runs
-`scripts/ci/detect-and-quarantine-flakes.sh`. The script:
+(`workflow_run` trigger) downloads every `flake-annotations-*` artifact
+ci.yml uploads — the per-shard unit annotations AND the coverage job's
+`flake-annotations-coverage` artifact (both jobs run a bounded retry, two
+retries / three attempts total, before treating a failure as real) —
+concatenates them, and runs `scripts/ci/detect-and-quarantine-flakes.sh`.
+The script:
 
 1. Extracts candidate flaky/hard-failed test files from the annotations.
 2. Drops candidates that are already quarantined, have an infra-signature
@@ -173,6 +176,16 @@ artifacts that ci.yml's unit job uploads, concatenates them, and runs
 suggestion and, if warranted, appends the line to the appropriate quarantine
 file in a follow-up PR. Auto-appending directly to the quarantine file would
 require a PAT + branch-protection bypass and is intentionally out of scope.
+
+**A self-healed flake is not always auto-surfaced.** `flake-detection.yml`
+only runs when the triggering `ci` run's overall conclusion is `failure`. A
+flake that passes on retry makes its job succeed, so if nothing else in that
+merge-group run failed, the run goes green and detection never fires — the
+retry is logged in that job's own step output but is not auto-surfaced as a
+quarantine suggestion. This is a property of the trigger, not of any one job:
+it applies to the **unit shards' annotations exactly as much as the coverage
+job's**. Detection only ever sees annotations from runs that failed for some
+reason; a run that self-heals everywhere is invisible to it.
 
 ## Known limitations
 

--- a/scripts/ci/run-coverage-gate.sh
+++ b/scripts/ci/run-coverage-gate.sh
@@ -15,6 +15,15 @@ rm -rf "$parts_dir" coverage
 mkdir -p "$parts_dir" coverage
 : > coverage-output.txt
 rm -f coverage-value.txt
+# flake-annotations-coverage.txt mirrors the UNIT job's per-run annotation
+# file (ci.yml's `flake_ann=` assignment and the `>> "$flake_ann"` appends in
+# the unit job) so the advisory flake-detection pipeline can see
+# coverage-job retries and hard failures too, not just unit shards. The
+# integration job is deliberately NOT cited here: it retries in-job but emits
+# its markers to the log only — it writes and uploads no annotation file.
+# Written to a workspace-relative path so it survives past this script and is
+# uploaded by the coverage job `if: always()`.
+: > flake-annotations-coverage.txt
 
 if [ -z "${COVERAGE_TEST_LIST:-}" ]; then
 	# Mirror the unit job's expanded glob (issue #1778 H4) so the coverage gate
@@ -45,11 +54,45 @@ while IFS= read -r test_file; do
 	[ -f "$test_file" ] || continue
 	index=$((index + 1))
 	echo "[coverage] ${index}: ${test_file}"
-	rm -rf coverage
-	mkdir -p coverage
 	tmpout="$tmpdir/coverage-out-$$-$index.txt"
 	exit_code=0
+	# Bounded retry (max_retries=2, three attempts total), mirroring the unit
+	# and integration jobs' in-job retry in ci.yml (both of that file's
+	# `max_retries=2` loops — cited by construct, not line number, because
+	# editing ci.yml shifts those numbers and stale citations here have
+	# already had to be corrected twice).
+	#
+	# This job is merge-queue-only, and nothing in the workflow depends on it
+	# (`needs: [detect-release, quality, unit]`, and no job lists `coverage`
+	# in its own `needs`), so it is unordered against its peers rather than
+	# "last" — but with `timeout-minutes: 60` and the whole suite run per-file
+	# under `--isolate --coverage`, it is typically the long pole. Either way
+	# the stake is the same: unlike a PR-branch unit shard, a single transient
+	# flake here evicts the whole PR from the queue with no chance to
+	# self-heal — a requeue costs a full ~30-60 min re-run.
+	# The coverage dir is reset before EVERY attempt (not just once per file)
+	# so a retried attempt's lcov output can never be contaminated by debris
+	# from that same file's own failed prior attempt — the per-file isolation
+	# invariant from issue #1712 (see the per-file isolation note in
+	# docs/testing/test-stability.md)
+	# must hold across retries, not just across files.
+	max_retries=2
+	retry_num=0
+	rm -rf coverage
+	mkdir -p coverage
 	bun test --isolate --coverage --timeout 60000 "$test_file" > "$tmpout" 2>&1 || exit_code=$?
+	while [ "$exit_code" -ne 0 ] && [ "$retry_num" -lt "$max_retries" ]; do
+		retry_num=$((retry_num + 1))
+		echo "::warning file=${test_file}::Attempt ${retry_num} failed, retrying (${retry_num}/${max_retries}): ${test_file}"
+		exit_code=0
+		rm -rf coverage
+		mkdir -p coverage
+		bun test --isolate --coverage --timeout 60000 "$test_file" > "$tmpout" 2>&1 || exit_code=$?
+		if [ "$exit_code" -eq 0 ]; then
+			echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}"
+			echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> flake-annotations-coverage.txt
+		fi
+	done
 	{
 		echo "### ${test_file}"
 		cat "$tmpout"
@@ -60,6 +103,7 @@ while IFS= read -r test_file; do
 		cat "$tmpout"
 		echo "::endgroup::"
 		echo "::error file=${test_file}::Coverage test failed: ${test_file}"
+		echo "::error file=${test_file}::FAILED: ${test_file}" >> flake-annotations-coverage.txt
 		failed=1
 	elif [ -f coverage/lcov.info ]; then
 		cp coverage/lcov.info "$parts_dir/part-$index.info"

--- a/tests/unit/background/workspace-snapshot-digest-failure-reasons.test.ts
+++ b/tests/unit/background/workspace-snapshot-digest-failure-reasons.test.ts
@@ -45,11 +45,21 @@ function git(directory: string, args: string[]): void {
 	}
 }
 
+/**
+ * Per-test budget for the async enumeration-timeout arm. It is the ONLY thing
+ * that catches that arm's deadline being re-pointed at `gitTimeoutMs`, because
+ * the async twin owns its deadline inside a `Promise.race` no stub can observe.
+ * Named rather than inlined so the test body can assert the window it depends
+ * on; see the sizing note at its use site.
+ */
+const ASYNC_DEADLINE_BUDGET_MS = 4000;
+
 const original = {
 	revisionEnumerationTimeoutMs: _internals.revisionEnumerationTimeoutMs,
 	readChangedFileSync: _internals.readChangedFileSync,
 	yieldControl: _internals.yieldControl,
 	bunSpawn: _internals.bunSpawn,
+	spawnSync: _internals.spawnSync,
 };
 
 /** A closed stream carrying `text`, in the shape `readBoundedGitOutput` reads. */
@@ -103,6 +113,75 @@ function spawnWithHelperOwnedTimeout(
 	}) as typeof _internals.bunSpawn;
 }
 
+/**
+ * Stand-in for `_internals.spawnSync` that reproduces the `ETIMEDOUT` contract
+ * `runGitDetailed` maps to `reason: 'timeout'`
+ * (`src/background/workspace-snapshot.ts:229-234`, Node sets `error.code` to
+ * `'ETIMEDOUT'` when the `timeout` option is exceeded), without racing a real
+ * `spawnSync` deadline against a git process that usually enumerates a tiny
+ * temp repo in well under 1ms on fast CI runners. That wall-clock race failed
+ * all three attempts on PR #2080 and exhausted its retry budget, evicting it
+ * from the merge queue.
+ *
+ * Discriminates on the git ARGS (`diff` / `status`), not on
+ * `options.timeout === _internals.revisionEnumerationTimeoutMs` — the latter
+ * breaks if `gitTimeoutMs` is ever set equal to the enumeration deadline. It
+ * is PERSISTENT, not single-shot: the sync test invokes the digest twice
+ * (`resolvePrWorkflowRevisionDigestDetailed`, then
+ * `resolvePrWorkflowRevisionDigest`), and a `mockImplementationOnce`-style
+ * stub would make the second call pass by falling through to the real
+ * `spawnSync` instead of exercising the stubbed timeout. Every non-enumeration
+ * call (`rev-parse --verify`) delegates to the real `spawnSync` captured
+ * before the stub was installed, so head resolution still genuinely succeeds
+ * and the fabricated failure stays pinned to path enumeration.
+ *
+ * Each enumeration call's `timeout` option is recorded into
+ * `observedEnumerationTimeouts` so the caller can still pin which deadline the
+ * enumeration was handed. Without that, replacing the real spawn removes the
+ * only thing that bound these calls to `revisionEnumerationTimeoutMs` rather
+ * than to `gitTimeoutMs`.
+ *
+ * Untested branches: the `ENOBUFS` -> `buffer-truncated` arm
+ * (`src/background/workspace-snapshot.ts:248`) and the real Node `spawnSync`
+ * `ETIMEDOUT` error-object contract itself, which this stub fabricates rather
+ * than observes. Rationale: `buffer-truncated` is driven through a real
+ * `spawnSync` against a real `ENOBUFS` error object in
+ * `tests/unit/background/workspace-snapshot-digest-bounds.test.ts`, which keeps
+ * the `result.error.code` extraction path verified against real runtime
+ * behavior; the `ETIMEDOUT` code itself has no portable way to be provoked on a
+ * bounded deadline without the wall-clock race this stub exists to remove.
+ */
+function spawnSyncWithEnumerationTimeout(
+	realSpawnSync: typeof _internals.spawnSync,
+	observedEnumerationTimeouts: Array<number | undefined>,
+): typeof _internals.spawnSync {
+	return ((command: string, args?: readonly string[], options?: unknown) => {
+		const argv = args ?? [];
+		const isEnumeration = argv.includes('diff') || argv.includes('status');
+		if (!isEnumeration) {
+			return (realSpawnSync as (...callArgs: unknown[]) => unknown)(
+				command,
+				args,
+				options,
+			);
+		}
+		observedEnumerationTimeouts.push(
+			(options as { timeout?: number } | undefined)?.timeout,
+		);
+		const error = new Error('spawnSync ETIMEDOUT') as NodeJS.ErrnoException;
+		error.code = 'ETIMEDOUT';
+		return {
+			pid: 0,
+			output: [null, '', ''],
+			stdout: '',
+			stderr: '',
+			status: null,
+			signal: null,
+			error,
+		};
+	}) as typeof _internals.spawnSync;
+}
+
 describe('revision digest timeout and read-failed reasons (issue #1968)', () => {
 	let directory: string;
 	let head: string;
@@ -128,6 +207,7 @@ describe('revision digest timeout and read-failed reasons (issue #1968)', () => 
 		_internals.readChangedFileSync = original.readChangedFileSync;
 		_internals.yieldControl = original.yieldControl;
 		_internals.bunSpawn = original.bunSpawn;
+		_internals.spawnSync = original.spawnSync;
 		fs.rmSync(directory, { recursive: true, force: true });
 	});
 
@@ -152,37 +232,116 @@ describe('revision digest timeout and read-failed reasons (issue #1968)', () => 
 	});
 
 	test('sync: a path enumeration that exceeds its deadline is reason "timeout"', () => {
-		fs.writeFileSync(path.join(directory, 'changed.txt'), 'changed\n');
-		// Only the ENUMERATION deadline is lowered; `gitTimeoutMs` still governs
-		// the `rev-parse --verify` that runs first, so the base-head resolution
-		// still succeeds and the timeout is pinned to a path-enumeration call.
-		_internals.revisionEnumerationTimeoutMs = 1;
+		// Asserting this by actually racing a 1ms `spawnSync` deadline against a
+		// real git enumeration of this tiny temp repo was flaky: fast CI runners
+		// finish enumeration in under 1ms, the digest succeeds, and the assertion
+		// below never observes a timeout. PR #2080 hit exactly this race on all
+		// three merge-queue attempts and was evicted after exhausting its retry
+		// budget. Instead, the enumeration spawn is stubbed to return Node's
+		// ETIMEDOUT `spawnSync` result directly — the same shape `runGitDetailed`
+		// (src/background/workspace-snapshot.ts:229-234) documents mapping to
+		// `reason: 'timeout'` — while `rev-parse --verify` still runs for real
+		// via the captured original `spawnSync`, so head resolution still
+		// genuinely succeeds and the failure stays pinned to enumeration.
+		//
+		// The value below is a SENTINEL, not a deadline: nothing waits on it now,
+		// so it exists only to be observed. Replacing the real spawn would
+		// otherwise drop the one thing that pinned enumeration to the enumeration
+		// deadline — with the timeout unobserved, swapping both enumeration calls
+		// to `gitTimeoutMs` still passes. A value no other seam holds makes that
+		// swap fail on the assertion below.
+		_internals.revisionEnumerationTimeoutMs = 4242;
+		const observedEnumerationTimeouts: Array<number | undefined> = [];
+		_internals.spawnSync = spawnSyncWithEnumerationTimeout(
+			original.spawnSync,
+			observedEnumerationTimeouts,
+		);
 
 		const detailed = resolvePrWorkflowRevisionDigestDetailed(directory, head);
 		expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
 		expect(detailed.ok === false && detailed.detail).toContain('timed out');
 		// Not misreported as a broken worktree.
 		expect(detailed).not.toMatchObject({ reason: 'git-failed' });
+		// The enumeration call that ran was bounded by the enumeration deadline,
+		// not by the `gitTimeoutMs` that governs `rev-parse --verify`. Only
+		// `diff` runs: it fails first and the digest returns before reaching
+		// `status`, so this observes one call, not both.
+		expect(observedEnumerationTimeouts).not.toHaveLength(0);
+		for (const observed of observedEnumerationTimeouts) {
+			expect(observed).toBe(_internals.revisionEnumerationTimeoutMs);
+		}
+		// The stub is persistent (not single-shot), so this second, independent
+		// call through the thin delegate exercises the same stubbed timeout
+		// rather than falling through to the real, fast-finishing `spawnSync`.
 		expect(resolvePrWorkflowRevisionDigest(directory, head)).toBeNull();
 	});
 
-	test('async: a path enumeration that exceeds its deadline is reason "timeout"', async () => {
-		fs.writeFileSync(path.join(directory, 'changed.txt'), 'changed\n');
-		_internals.revisionEnumerationTimeoutMs = 1;
+	test(
+		'async: a path enumeration that exceeds its deadline is reason "timeout"',
+		async () => {
+			// Same flakiness as the sync case above, on the async twin: a real
+			// enumeration of this tiny temp repo can finish inside a 1ms deadline on
+			// fast CI runners, so racing a real child process against the wall clock
+			// is nondeterministic. `spawnWithHelperOwnedTimeout` (used verbatim from
+			// the first test in this suite) is reused here for the reason documented
+			// there: `runGitAsyncDetailed` deliberately omits `timeout` from its
+			// spawn options, so the stubbed enumeration child never exits on its
+			// own — the `Promise.race` deadline below is the sole resolver, making
+			// `reason: 'timeout'` a deterministic lower bound rather than a race. If
+			// `timeout` is ever re-added to those spawn options, the stub arms its
+			// own kill timer, `exited` resolves 137, and the reason flips to
+			// `git-failed` — so this still fails on the real #1968 defect.
+			//
+			// Distinct from the first test in this suite (which uses the same stub
+			// and deadline): that test only pins the reason discriminator. This test
+			// additionally pins that `detail` contains `'timed out'`, and that the
+			// thin `resolvePrWorkflowRevisionDigestAsync` delegate collapses the
+			// same failure to `null` — neither of which the first test asserts.
+			//
+			// The async twin owns its deadline inside a `Promise.race` the stub
+			// cannot observe, so — unlike the sync twin, which pins the binding
+			// directly by asserting the timeout its stub was handed — the only thing
+			// that can catch these calls being re-pointed at `gitTimeoutMs` is the
+			// per-test budget below. It must be set EXPLICITLY: CI does not run at
+			// bun's 5s default. `scripts/ci/run-test-with-timeout.ts` DEFAULTS the
+			// sharded unit job to `--timeout 120000` (injected only when the caller
+			// passed no `--timeout` of its own), and the coverage gate's
+			// per-file retry loop in `scripts/ci/run-coverage-gate.sh` (its two
+			// `bun test --isolate --coverage --timeout 60000 "$test_file"`
+			// invocations) uses `--timeout 60000` — either of which would swallow
+			// the mutation silently. A per-test argument overrides the CLI value,
+			// so this budget holds everywhere.
+			//
+			// Sizing: the body makes two sequential digest calls, so a re-point to
+			// `gitTimeoutMs` costs 2 x `GIT_SNAPSHOT_TIMEOUT_MS` while the correct
+			// wiring costs 2 x `revisionEnumerationTimeoutMs`. The budget must sit
+			// between those, and the assertion below enforces the upper half of that
+			// window rather than leaving it to this comment: a timing guard whose
+			// window is only documented goes inert silently the moment someone
+			// lowers the constant it depends on.
+			_internals.revisionEnumerationTimeoutMs = 25;
+			_internals.bunSpawn = spawnWithHelperOwnedTimeout(head);
 
-		// Real git, real child process. Tearing down a killed process tree costs
-		// hundreds of milliseconds on Windows, so this gets an explicit budget
-		// rather than racing bun's 5s default.
-		const detailed = await resolvePrWorkflowRevisionDigestDetailedAsync(
-			directory,
-			head,
-		);
-		expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
-		expect(detailed.ok === false && detailed.detail).toContain('timed out');
-		await expect(
-			resolvePrWorkflowRevisionDigestAsync(directory, head),
-		).resolves.toBeNull();
-	}, 60_000);
+			// If `GIT_SNAPSHOT_TIMEOUT_MS` ever drops far enough that a mis-pointed
+			// deadline would finish INSIDE the budget, the budget stops discriminating
+			// and must come down with it. Fail loudly here rather than silently
+			// passing a test that no longer guards anything.
+			expect(2 * _internals.gitTimeoutMs).toBeGreaterThan(
+				ASYNC_DEADLINE_BUDGET_MS,
+			);
+
+			const detailed = await resolvePrWorkflowRevisionDigestDetailedAsync(
+				directory,
+				head,
+			);
+			expect(detailed).toMatchObject({ ok: false, reason: 'timeout' });
+			expect(detailed.ok === false && detailed.detail).toContain('timed out');
+			await expect(
+				resolvePrWorkflowRevisionDigestAsync(directory, head),
+			).resolves.toBeNull();
+		},
+		ASYNC_DEADLINE_BUDGET_MS,
+	);
 
 	test('sync: a changed path whose content cannot be read is reason "read-failed"', () => {
 		fs.writeFileSync(path.join(directory, 'unreadable.txt'), 'content\n');

--- a/tests/unit/review/dispatcher.test.ts
+++ b/tests/unit/review/dispatcher.test.ts
@@ -169,11 +169,51 @@ describe('ephemeral agent dispatcher', () => {
 	});
 
 	test('aborts a stalled prompt and awaits bounded cleanup before returning', async () => {
+		// The old shape (`timeoutMs: 15` then `await Bun.sleep(40)`) had a
+		// single real timer racing a fixed 40ms observation window — 2.67x
+		// margin, not a removed race. The prompt mock below already never
+		// settles on its own (`return new Promise(() => {})`), so the
+		// dispatch race itself was already deterministic: the production
+		// `setTimeout` in `dispatchEphemeralAgent`
+		// (src/evaluation/ephemeral-agent-dispatcher.ts:238-241) is the only
+		// thing that can ever resolve it. The only nondeterminism left was
+		// the fixed 40ms wait used to *observe* that resolution.
+		//
+		// Fix: wait on the actual `'abort'` event the production timeout
+		// handler fires on `controller.signal`, captured here as
+		// `promptSignal` the moment the prompt mock is invoked (that call is
+		// where the signal first becomes observable to the test, before
+		// `awaitWithAbort` gets a chance to consume it). That event is a
+		// necessary and immediate consequence of the real 15ms timer plus
+		// abort propagation — nothing else in this dispatch can fire it — so
+		// awaiting it has zero margin instead of 2.67x. Delivered via a
+		// deferred so the never-settling prompt promise keeps its shape.
+		// Budget for the self-contained race below. `bun test`'s own
+		// `--timeout` (CLI or the per-test third argument) does NOT reliably
+		// preempt a test that is genuinely stuck on an `await` of a promise
+		// that never settles — confirmed empirically against this repo's Bun
+		// 1.3.14: a minimal `test('x', async () => { await new Promise(() =>
+		// {}) }, 3000)` still ran past both a 3000ms per-test budget and a
+		// 5000ms `--timeout` flag. So the FALSIFIABILITY probe for this test
+		// (removing `controller.abort()` from the production timeout handler)
+		// must be bounded by this test's OWN timer, not by the harness's.
+		const ABORT_WAIT_BUDGET_MS = 2000;
 		let promptSignal: AbortSignal | undefined;
 		let releaseDelete: (() => void) | undefined;
+		let resolveAbortSeen: () => void = () => undefined;
+		const abortSeen = new Promise<void>((resolve) => {
+			resolveAbortSeen = resolve;
+		});
 		const fake = fakeClient({
 			prompt: async (request: unknown) => {
 				promptSignal = (request as { signal: AbortSignal }).signal;
+				if (promptSignal.aborted) {
+					resolveAbortSeen();
+				} else {
+					promptSignal.addEventListener('abort', resolveAbortSeen, {
+						once: true,
+					});
+				}
 				return new Promise(() => {});
 			},
 			remove: () =>
@@ -196,7 +236,31 @@ describe('ephemeral agent dispatcher', () => {
 			return value;
 		});
 
-		await Bun.sleep(40);
+		await Promise.race([
+			abortSeen,
+			new Promise<never>((_, reject) => {
+				setTimeout(() => {
+					reject(
+						new Error(
+							`promptSignal never emitted 'abort' within ${ABORT_WAIT_BUDGET_MS}ms — ` +
+								'the production timeout handler in dispatchEphemeralAgent ' +
+								'(src/evaluation/ephemeral-agent-dispatcher.ts:238-241) may no ' +
+								'longer call controller.abort()',
+						),
+					);
+				}, ABORT_WAIT_BUDGET_MS);
+			}),
+		]);
+		// `abortSeen` resolves the instant `controller.abort()` fires — before
+		// `dispatchEphemeralAgent`'s own `awaitWithAbort` rejection has had a
+		// chance to propagate through its microtask chain into the `finally`
+		// block that issues the bounded `session.delete` call. A bounded
+		// microtask poll (no real timer — this loop advances one microtask
+		// tick per iteration, not wall-clock time) closes that ordering gap
+		// without reintroducing a wall-clock margin.
+		for (let i = 0; i < 1000 && fake.deleteRequest() === undefined; i++) {
+			await Promise.resolve();
+		}
 		expect(promptSignal?.aborted).toBe(true);
 		expect(fake.deleteRequest().path).toEqual({ id: 'review-session' });
 		expect(settled).toBe(false);
@@ -204,7 +268,7 @@ describe('ephemeral agent dispatcher', () => {
 
 		const result = await pending;
 		expect(result.status).toBe('timeout');
-	});
+	}, 4000);
 
 	test('caps the response transcript and preserves SDK error envelopes', async () => {
 		const promptCapped = await dispatchEphemeralAgent({

--- a/tests/unit/scripts/ci/ci-yml-integration.test.ts
+++ b/tests/unit/scripts/ci/ci-yml-integration.test.ts
@@ -10,14 +10,34 @@ const COVERAGE_GATE_SCRIPT_PATH = join(
 	import.meta.dir,
 	'../../../../scripts/ci/run-coverage-gate.sh',
 );
+const FLAKE_DETECTION_YML_PATH = join(
+	import.meta.dir,
+	'../../../../.github/workflows/flake-detection.yml',
+);
 
+/*
+ * Every extractor below ends its lazy match on the same four-alternative
+ * lookahead: the next step, a section comment, the next JOB (two-space key),
+ * or end of input spelled `(?![\s\S])`.
+ *
+ * Do NOT "simplify" that last alternative to `$`. These regexes carry the `/m`
+ * flag, under which `$` matches at every line end — the lookahead would
+ * succeed immediately and collapse each slice to its `- name:` line alone
+ * (measured: 3803 chars -> 22). Assertions would still pass, but the negative
+ * one below (`not.toContain('bun --smol test "$f"')`) would pass vacuously,
+ * which is exactly the guard it exists to provide.
+ *
+ * The job-boundary alternative matters too: without it the coverage-upload
+ * slice ran past the end of its own job into the integration job's steps
+ * (measured: 1067 chars -> 547 once bounded).
+ */
 function extractRunUnitTestsStep(yml: string): string {
 	// Normalize CRLF to LF so regex anchors work consistently
 	const normalized = yml.replace(/\r\n/g, '\n');
 	// The "Run unit tests" step starts at 6-space indentation under the jobs.*.steps key.
 	// Its content ends before the next step (also at 6-space indent) or section comment.
 	const match = normalized.match(
-		/- name: Run unit tests[\s\S]*?(?=\n {6}- name:|\n {6}# ---|Z)/m,
+		/- name: Run unit tests[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
 	);
 	return match ? match[0] : '';
 }
@@ -25,7 +45,7 @@ function extractRunUnitTestsStep(yml: string): string {
 function extractCollectAndPartitionStep(yml: string): string {
 	const normalized = yml.replace(/\r\n/g, '\n');
 	const match = normalized.match(
-		/- name: Collect and partition test files[\s\S]*?(?=\n {6}- name:|\n {6}# ---|Z)/m,
+		/- name: Collect and partition test files[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
 	);
 	return match ? match[0] : '';
 }
@@ -33,7 +53,7 @@ function extractCollectAndPartitionStep(yml: string): string {
 function extractCoverageMeasurementStep(yml: string): string {
 	const normalized = yml.replace(/\r\n/g, '\n');
 	const match = normalized.match(
-		/- name: Coverage gate enforcement[\s\S]*?(?=\n {6}- name:|\n {6}# ---|Z)/m,
+		/- name: Coverage gate enforcement[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
 	);
 	return match ? match[0] : '';
 }
@@ -41,7 +61,23 @@ function extractCoverageMeasurementStep(yml: string): string {
 function extractIntegrationTestsStep(yml: string): string {
 	const normalized = yml.replace(/\r\n/g, '\n');
 	const match = normalized.match(
-		/- name: Integration tests[\s\S]*?(?=\n {6}- name:|\n {6}# ---|Z)/m,
+		/- name: Integration tests[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
+	);
+	return match ? match[0] : '';
+}
+
+function extractUnitFlakeAnnotationsUploadStep(yml: string): string {
+	const normalized = yml.replace(/\r\n/g, '\n');
+	const match = normalized.match(
+		/- name: Upload flake annotations[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
+	);
+	return match ? match[0] : '';
+}
+
+function extractCoverageFlakeAnnotationsUploadStep(yml: string): string {
+	const normalized = yml.replace(/\r\n/g, '\n');
+	const match = normalized.match(
+		/- name: Upload coverage flake annotations[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
 	);
 	return match ? match[0] : '';
 }
@@ -119,5 +155,112 @@ describe('ci.yml integration — merge-queue coverage isolation', () => {
 		expect(coverageGateScript).toContain('scripts/ci/merge-lcov.mjs');
 		expect(coverageGateScript).toContain('coverage/lcov.info');
 		expect(coverageGateScript).toContain('Coverage gate passed');
+	});
+});
+
+describe('ci.yml integration — coverage gate bounded retry (issue #1782 parity)', () => {
+	const yml = readFileSync(CI_YML_PATH, 'utf8');
+	// Normalize CRLF to LF so the loop-body slice/index assertions below are
+	// stable regardless of the checkout's line-ending config.
+	const coverageGateScript = readFileSync(
+		COVERAGE_GATE_SCRIPT_PATH,
+		'utf8',
+	).replace(/\r\n/g, '\n');
+	const flakeDetectionYml = readFileSync(FLAKE_DETECTION_YML_PATH, 'utf8');
+
+	test('coverage helper retries up to max_retries=2 (three attempts total)', () => {
+		expect(coverageGateScript).toContain('max_retries=2');
+		expect(coverageGateScript).toContain(
+			'while [ "$exit_code" -ne 0 ] && [ "$retry_num" -lt "$max_retries" ]; do',
+		);
+	});
+
+	test('coverage helper does NOT use `let` for the retry counter (set -euo pipefail would kill the script on a 0 result)', () => {
+		expect(coverageGateScript).not.toMatch(/(^|\n)\t*let\s/);
+		expect(coverageGateScript).toContain('retry_num=$((retry_num + 1))');
+	});
+
+	// Anchored ordering assertion (writing-tests skill "Anchored Content
+	// Assertions"): a bare `toContain('rm -rf coverage')` would still pass if
+	// someone moved the reset back outside the retry loop, because the
+	// pre-loop reset (once per file, before the first attempt) also contains
+	// that literal. Slicing to the retry-loop body specifically, and then
+	// checking index order INSIDE that slice, is what actually fails if the
+	// reset is relocated outside the loop (issue #1712 per-attempt isolation).
+	test('coverage helper resets the coverage dir INSIDE the retry loop, not just once per file', () => {
+		const whileStart = coverageGateScript.indexOf(
+			'while [ "$exit_code" -ne 0 ] && [ "$retry_num" -lt "$max_retries" ]; do',
+		);
+		expect(whileStart).toBeGreaterThan(-1);
+		const doneIdx = coverageGateScript.indexOf('\n\tdone\n', whileStart);
+		expect(doneIdx).toBeGreaterThan(whileStart);
+		const loopBody = coverageGateScript.slice(whileStart, doneIdx);
+
+		const retryIncrementIdx = loopBody.indexOf('retry_num=$((retry_num + 1))');
+		const rmIdx = loopBody.indexOf('rm -rf coverage');
+		const mkdirIdx = loopBody.indexOf('mkdir -p coverage');
+		const bunTestIdx = loopBody.indexOf(
+			'bun test --isolate --coverage --timeout 60000 "$test_file"',
+		);
+
+		// All four markers must be present inside the loop body itself.
+		expect(retryIncrementIdx).toBeGreaterThan(-1);
+		expect(rmIdx).toBeGreaterThan(-1);
+		expect(mkdirIdx).toBeGreaterThan(-1);
+		expect(bunTestIdx).toBeGreaterThan(-1);
+
+		// And in this order: increment retry counter -> reset coverage dir ->
+		// recreate coverage dir -> re-run bun test. If the reset were moved
+		// outside the loop, rmIdx/mkdirIdx would be -1 inside this slice and
+		// the assertions above would already fail; this also guards against a
+		// reset that's present but reordered after the retried bun test run.
+		expect(rmIdx).toBeGreaterThan(retryIncrementIdx);
+		expect(mkdirIdx).toBeGreaterThan(rmIdx);
+		expect(bunTestIdx).toBeGreaterThan(mkdirIdx);
+	});
+
+	test('coverage helper appends the "passed on retry" notice to flake-annotations-coverage.txt', () => {
+		expect(coverageGateScript).toContain(
+			'echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> flake-annotations-coverage.txt',
+		);
+	});
+
+	test('coverage helper appends the hard-failure error to flake-annotations-coverage.txt', () => {
+		expect(coverageGateScript).toContain(
+			'echo "::error file=${test_file}::FAILED: ${test_file}" >> flake-annotations-coverage.txt',
+		);
+	});
+
+	test('ci.yml uploads flake-annotations-coverage.txt from the coverage job', () => {
+		const coverageUploadStep = extractCoverageFlakeAnnotationsUploadStep(yml);
+		const unitUploadStep = extractUnitFlakeAnnotationsUploadStep(yml);
+		expect(coverageUploadStep).toContain('name: flake-annotations-coverage');
+		expect(coverageUploadStep).toContain(
+			'path: flake-annotations-coverage.txt',
+		);
+		expect(coverageUploadStep).toContain('if-no-files-found: ignore');
+
+		// Pinned to the same upload-artifact SHA as the sibling per-shard step,
+		// so both artifacts are produced by an identically-audited action version.
+		const pinnedShaMatch = unitUploadStep.match(
+			/uses: actions\/upload-artifact@([a-f0-9]+) # v[\d.]+/,
+		);
+		expect(pinnedShaMatch).not.toBeNull();
+		expect(coverageUploadStep).toContain(
+			`uses: actions/upload-artifact@${pinnedShaMatch?.[1]}`,
+		);
+	});
+
+	test('flake-detection.yml downloads the broadened flake-annotations-* pattern (covers unit shards AND coverage)', () => {
+		expect(flakeDetectionYml).toContain('pattern: flake-annotations-*');
+		expect(flakeDetectionYml).not.toContain(
+			'pattern: flake-annotations-unit-shard-*',
+		);
+	});
+
+	test('flake-detection.yml concatenates the downloaded coverage/unit annotations end-to-end', () => {
+		expect(flakeDetectionYml).toContain(
+			'cat annotations/flake-annotations-*.txt 2>/dev/null > detection-out/flake-annotations.txt || true',
+		);
 	});
 });

--- a/tests/unit/turbo/lean/runner.timeout-adversarial-lane-state.test.ts
+++ b/tests/unit/turbo/lean/runner.timeout-adversarial-lane-state.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Adversarial security tests for LeanTurboRunner — concurrent timeout race on
+ * `_timedOutLanes` state, split out of `runner.timeout-adversarial.test.ts`
+ * under FR-006 (500-line test-file cap) once that file grew past the cap.
+ *
+ * Attack vector tested:
+ * - Concurrent timeout races on the `_timedOutLanes` Map, including two
+ *   lanes sharing the same `laneId` and rapid concurrent timeouts across
+ *   distinct lanes that must not corrupt shared timeout-tracking state.
+ *
+ * Strategy:
+ * - Uses a real canonicalized temp dir
+ * - Injects mock SessionClient via the `_sessionOps` instance seam
+ * - Builds lanes as literals and calls `dispatchLane` directly: this file does
+ *   not exercise lane planning or lock acquisition (the sibling file's header
+ *   claims both; that claim is inherited boilerplate — it does not hold there
+ *   either — and is deliberately not repeated here)
+ * - No mock.module usage — all mocking via instance seam or _internals
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { LeanTurboLane } from '../../../../src/turbo/lean/planner';
+import { LeanTurboRunner } from '../../../../src/turbo/lean/runner';
+import * as leanState from '../../../../src/turbo/lean/state';
+import { canonicalMkdtemp } from '../../../helpers/tmpdir';
+
+const SESSION_ID = 'sess-timeout-adversarial';
+
+interface MockSessionOps {
+	create: ReturnType<typeof mock>;
+	prompt: ReturnType<typeof mock>;
+	delete: ReturnType<typeof mock>;
+}
+
+let tmpDir: string;
+
+function makeRunner(options?: {
+	opencodeClient?: null;
+	generatedAgentNames?: string[];
+}) {
+	return new LeanTurboRunner({
+		directory: tmpDir,
+		sessionID: SESSION_ID,
+		...options,
+	});
+}
+
+function injectMockSessionOps(runner: LeanTurboRunner, ops: MockSessionOps) {
+	(runner as unknown as { _sessionOps: MockSessionOps })._sessionOps = ops;
+}
+
+/**
+ * Interval between poll checks used by both bounded-poll helpers below.
+ *
+ * Deliberately 15ms rather than something smaller. Windows quantizes timer
+ * waits to its ~15.6ms scheduler tick, so `Bun.sleep(1)` and `Bun.sleep(5)`
+ * BOTH cost ~15.4ms there (measured on a Windows CI-class box) while costing
+ * ~1ms and ~5ms on Linux. A sub-tick interval therefore makes the per-poll
+ * cost differ by up to 15x across the matrix, which is what made an earlier
+ * millisecond-denominated bound overshoot its stated deadline ~3x on Windows
+ * and become unreachable. At 15ms the measured per-poll cost is ~19ms on
+ * Windows and ~15ms on Linux — close enough that one poll budget is honest on
+ * both.
+ */
+const POLL_INTERVAL_MS = 15;
+
+/**
+ * Default poll budget for both helpers. The slowest condition either one waits
+ * on is the `session.delete` driven by a mock that sleeps 500ms — measured at
+ * ~26 polls on Windows (where each poll costs more than its nominal interval,
+ * so fewer are needed to cover the same wall time) and ~33 on Linux; 260
+ * gives the worse of those roughly 8x headroom. Worst-case wall time is
+ * `maxPolls x` the platform's real cost for `Bun.sleep(POLL_INTERVAL_MS)`:
+ * measured ~5.0s on Windows, ~3.9s on Linux. Both must stay INSIDE the
+ * per-test budget or the helpers' `throw` is dead code and a hung test
+ * surfaces as an opaque harness timeout instead of the diagnostic below.
+ */
+const DEFAULT_MAX_POLLS = 260;
+
+/**
+ * Per-test budget for both tests below. Sized ABOVE the helpers' worst-case
+ * poll cost (~5.0s on Windows) so an exhausted poll budget surfaces as the
+ * helper's own diagnostic rather than an opaque "this test timed out" from the
+ * harness. It is not itself a timing assertion — nothing in either test waits
+ * on it — but it must stay explicit, because CI does not run at bun's 5s
+ * default: `scripts/ci/run-test-with-timeout.ts` DEFAULTS the sharded unit job
+ * to `--timeout 120000` (it injects that only when the caller passed no
+ * `--timeout`, so a caller-supplied value wins) and the coverage gate passes
+ * `--timeout 60000`, either of which would let a genuinely hung test sit for a
+ * minute or more.
+ */
+const POLL_TEST_BUDGET_MS = 12_000;
+
+/**
+ * Bounded poll for T6's "does `_timedOutLanes` drain" assertion. No shared
+ * helper for this exists in `tests/helpers/`, and this is the only call site
+ * in this file, so it is kept local rather than promoted.
+ *
+ * Bounded by POLL COUNT, not by elapsed wall-clock time. Two reasons, and the
+ * bound is deliberately expressed in polls rather than milliseconds so the
+ * signature cannot make a timing claim that is false on some platform:
+ *
+ * 1. `scripts/check-test-clock.sh` is a required CI gate (its step in the
+ *    `quality` job of ci.yml — cited by construct, not line, because edits
+ *    to ci.yml shift line numbers and stale citations have already had to be
+ *    corrected twice in this changeset) that
+ *    blocks a test file performing a raw timestamp read or installing a spy
+ *    on the date object, unless the file imports the freeze-clock helper
+ *    module OR calls one of its wrappers. The gate is LINE-SCOPED, not
+ *    file-scoped (`check-test-clock.sh:82-102`): only lines the diff ADDS
+ *    can block, which is why the sibling file this one was split from still
+ *    passes with 4 pre-existing hits. Freezing the clock here would break a
+ *    poll that depends on real time advancing, so the only way to satisfy
+ *    the gate is not to read the clock at all.
+ *    NOTE: that gate greps for its patterns WITHOUT excluding comments, so
+ *    spelling the forbidden call syntax out here — even inside this docstring
+ *    — would itself trip it. Describe the APIs; do not write them.
+ * 2. A millisecond-denominated bound cannot be honest across the matrix — see
+ *    `POLL_INTERVAL_MS` above for the Windows tick-quantization measurements.
+ *
+ * The helper still waits exactly as long as the background cleanup takes
+ * (returning on the first satisfied check) rather than sleeping a fixed guess,
+ * and fails loudly when the budget is exhausted instead of hanging. Do NOT
+ * reintroduce elapsed-time measurement against a raw timestamp read here.
+ */
+async function pollUntilDrained(
+	map: Map<string, string>,
+	maxPolls: number = DEFAULT_MAX_POLLS,
+): Promise<void> {
+	for (let i = 0; i < maxPolls; i++) {
+		if (map.size === 0) return;
+		await Bun.sleep(POLL_INTERVAL_MS);
+	}
+	if (map.size > 0) {
+		throw new Error(
+			`_timedOutLanes did not drain within ${maxPolls} polls of ${POLL_INTERVAL_MS}ms; ${map.size} entries remain: ${JSON.stringify([...map.entries()])}`,
+		);
+	}
+}
+
+/**
+ * Bounded poll for a `mock()` having been called at least once. Same
+ * poll-count rationale as `pollUntilDrained` above — no raw clock read, so it
+ * stays clear of the `check-test-clock.sh` gate without needing to freeze a
+ * clock that this poll depends on actually advancing.
+ */
+async function pollUntilCalled(
+	mockFn: ReturnType<typeof mock>,
+	maxPolls: number = DEFAULT_MAX_POLLS,
+): Promise<void> {
+	for (let i = 0; i < maxPolls; i++) {
+		if (mockFn.mock.calls.length > 0) return;
+		await Bun.sleep(POLL_INTERVAL_MS);
+	}
+	if (mockFn.mock.calls.length === 0) {
+		throw new Error(
+			`mock was not called within ${maxPolls} polls of ${POLL_INTERVAL_MS}ms`,
+		);
+	}
+}
+
+function writeMinimalPlan(phaseNumber = 1) {
+	const plan = {
+		schema_version: '1.0.0',
+		title: 'Test Plan',
+		swarm: 'test-swarm',
+		current_phase: phaseNumber,
+		phases: [
+			{
+				id: phaseNumber,
+				name: `Phase ${phaseNumber}`,
+				status: 'in_progress',
+				tasks: [
+					{
+						id: `${phaseNumber}.1`,
+						description: 'Task 1',
+						status: 'pending',
+						phase: phaseNumber,
+						size: 'small',
+						depends: [],
+						acceptance: 'Done',
+					},
+					{
+						id: `${phaseNumber}.2`,
+						description: 'Task 2',
+						status: 'pending',
+						phase: phaseNumber,
+						size: 'small',
+						depends: [],
+						acceptance: 'Done',
+					},
+				],
+			},
+		],
+		lean: {
+			max_parallel_coders: 4,
+			require_declared_scope: false,
+			conflict_policy: 'serialize',
+			degrade_on_risk: true,
+			phase_reviewer: false,
+			phase_critic: false,
+			integrated_diff_required: false,
+			allow_docs_only_without_reviewer: false,
+			worktree_isolation: false,
+		},
+	};
+
+	fs.writeFileSync(
+		path.join(tmpDir, '.swarm', 'plan.json'),
+		JSON.stringify(plan, null, 2),
+		'utf-8',
+	);
+}
+
+function writeScopeFiles(taskFiles: Record<string, string[]>) {
+	const scopeDir = path.join(tmpDir, '.swarm', 'scopes');
+	fs.mkdirSync(scopeDir, { recursive: true });
+	for (const [taskId, files] of Object.entries(taskFiles)) {
+		fs.writeFileSync(
+			path.join(scopeDir, `scope-${taskId}.json`),
+			JSON.stringify({ files }),
+			'utf-8',
+		);
+	}
+}
+
+beforeEach(() => {
+	// FR-011: the canonical helper is required here, not the two-call
+	// realpath-wrap idiom the sibling file uses. That idiom is tolerated there
+	// only because its lines are pre-existing; the lint is line-scoped, so in
+	// an all-added file every line counts as added and the wrap — which biome
+	// splits across lines — fails the same-line requirement.
+	tmpDir = canonicalMkdtemp('runner-timeout-adversarial-');
+	fs.mkdirSync(path.join(tmpDir, '.swarm'), { recursive: true });
+	leanState.repairStateUnreadable(tmpDir);
+	// Reset timeout to undefined before each test
+	LeanTurboRunner._internals.laneDispatchTimeoutMs = undefined;
+});
+
+afterEach(() => {
+	leanState.repairStateUnreadable(tmpDir);
+	LeanTurboRunner._internals.laneDispatchTimeoutMs = undefined;
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// best-effort
+	}
+});
+
+// ════════════════════════════════════════════════════════════════════════════════
+// ATTACK VECTOR T6: Concurrent timeout race on _timedOutLanes Map
+// ════════════════════════════════════════════════════════════════════════════════
+
+describe('ATTACK VECTOR T6 — concurrent timeout race on _timedOutLanes', () => {
+	test(
+		'two lanes with same laneId do not interfere on _timedOutLanes',
+		async () => {
+			writeMinimalPlan(1);
+			writeScopeFiles({ '1.1': ['src/a.ts'], '1.2': ['src/b.ts'] });
+
+			const sessionId1 = `session-1-${Math.random().toString(36).slice(2)}`;
+			const sessionId2 = `session-2-${Math.random().toString(36).slice(2)}`;
+
+			// Both lanes share the same laneId (adversarial input)
+			const lane1: LeanTurboLane = {
+				laneId: 'same-lane-id', // Same laneId
+				taskIds: ['1.1'],
+				files: ['src/a.ts'],
+				status: 'pending',
+			};
+			const lane2: LeanTurboLane = {
+				laneId: 'same-lane-id', // Same laneId
+				taskIds: ['1.2'],
+				files: ['src/b.ts'],
+				status: 'pending',
+			};
+
+			const createMock = mock((opts: { query: { directory: string } }) => {
+				const id = opts.query.directory === tmpDir ? sessionId1 : sessionId2;
+				return Promise.resolve({ data: { id }, error: null });
+			});
+			const promptMock = mock(() =>
+				Bun.sleep(500).then(() =>
+					Promise.resolve({
+						data: { parts: [{ type: 'text', text: 'Done' }] },
+						error: null,
+					}),
+				),
+			);
+			const deleteMock = mock(() => Promise.resolve());
+
+			const concurrentOps = {
+				create: createMock,
+				prompt: promptMock,
+				delete: deleteMock,
+			};
+
+			const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
+			injectMockSessionOps(runner, concurrentOps);
+
+			LeanTurboRunner._internals.laneDispatchTimeoutMs = 20;
+
+			// Dispatch both lanes with same laneId concurrently
+			const [result1, result2] = await Promise.all([
+				runner.dispatchLane(lane1, 'mega_coder'),
+				runner.dispatchLane(lane2, 'mega_coder'),
+			]);
+
+			// Both should get timeout errors
+			expect(result1.ok).toBe(false);
+			expect(result2.ok).toBe(false);
+			expect(result1.error).toContain('timed out');
+			expect(result2.error).toContain('timed out');
+
+			// The prompt mock settles 500ms after being invoked (the scenario under
+			// test — a session that eventually completes AFTER its dispatch already
+			// timed out). The old shape observed that with a single fixed
+			// `await Bun.sleep(600)`: only 100ms of slack over the mock's own
+			// 500ms delay, a 1.2x margin — the same flake class that evicted PR
+			// #2080 from the merge queue. Poll the actual observable condition
+			// instead (the mock having been called), with no fixed margin to blow
+			// through under load: this waits exactly as long as the background
+			// cleanup takes, up to the per-test budget below, rather than guessing
+			// a window that can be too short.
+			await pollUntilCalled(deleteMock);
+
+			// At least one orphan session was cleaned up. Deliberately NOT
+			// `toHaveBeenCalledTimes(2)`: both lanes share a laneId, so the
+			// first completion handler clears the map entry and the second
+			// finds `tracked === undefined` and takes the branch that only
+			// clears the marker (runner.ts) — the second lane's session is
+			// never deleted. That orphan leak is real but pre-existing and
+			// adversarial-input-only (duplicate laneId); this assertion
+			// records what actually happens rather than asserting a cleanup
+			// the production code does not perform.
+			expect(deleteMock).toHaveBeenCalled();
+		},
+		POLL_TEST_BUDGET_MS,
+	);
+
+	test(
+		'rapid concurrent timeouts on different lanes do not corrupt _timedOutLanes state',
+		async () => {
+			writeMinimalPlan(1);
+			writeScopeFiles({
+				'1.1': ['src/a.ts'],
+				'1.2': ['src/b.ts'],
+			});
+
+			// 2 lanes that timeout quickly
+			const lanes: LeanTurboLane[] = [
+				{
+					laneId: 'lane-1',
+					taskIds: ['1.1'],
+					files: ['src/a.ts'],
+					status: 'pending',
+				},
+				{
+					laneId: 'lane-2',
+					taskIds: ['1.2'],
+					files: ['src/b.ts'],
+					status: 'pending',
+				},
+			];
+
+			// The old shape raced two real timers 4x apart: `laneDispatchTimeoutMs
+			// = 5` against a prompt mock that rejected via `setTimeout(..., 20)`,
+			// fired concurrently across both lanes through `Promise.all`. A
+			// loaded CI runner narrowing that 15ms gap made the dispatch-timeout
+			// race itself nondeterministic — the exact flake class that evicted
+			// PR #2080 from the merge queue.
+			//
+			// Fix: the prompt mock never settles on its own. It captures each
+			// call's `reject` into `promptRejectFns` instead of scheduling one.
+			// With no rival timer, `dispatchLane`'s own `laneDispatchTimeoutMs`
+			// setTimeout (src/turbo/lean/runner.ts:758-766) is the ONLY thing
+			// that can ever settle the `Promise.race` — the `ok:false` / 'timed
+			// out' assertions below are a deterministic lower bound, not a race.
+			//
+			// That determinism only covers the first half of this test. The
+			// second half asserts `_timedOutLanes` DRAINS — and per
+			// runner.ts:777-807, the drain only happens once `dispatchPromise`
+			// (i.e. `_doDispatch`, which is still running `session.prompt` in
+			// the background after the timeout already won) itself settles.
+			// `_doDispatch` catches its own rejections internally
+			// (runner.ts:936-947) and always RESOLVES with `{ ok: false, error }`
+			// rather than rejecting, so the drain runs through the `.then`
+			// handler's `else` branch (runner.ts:800-801), not the outer
+			// `.catch`. A prompt that never settles would make that resolution —
+			// and therefore the drain — unobservable: the `size === 0`
+			// assertion below would then fail on an exhausted poll budget
+			// rather than on the defect it exists to catch, which is a much
+			// worse diagnostic. So every captured reject is explicitly fired,
+			// with the same error, AFTER the timeout assertions, to drive that
+			// cleanup.
+			const promptRejectFns: Array<(err: Error) => void> = [];
+			const rejectPromptOps = {
+				create: mock(() =>
+					Promise.resolve({
+						data: { id: `session-${Math.random().toString(36).slice(2)}` },
+						error: null,
+					}),
+				),
+				prompt: mock(
+					() =>
+						new Promise<never>((_, reject) => {
+							promptRejectFns.push(reject);
+						}),
+				),
+				delete: mock(() => Promise.resolve()),
+			};
+
+			const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
+			injectMockSessionOps(runner, rejectPromptOps);
+
+			LeanTurboRunner._internals.laneDispatchTimeoutMs = 5;
+
+			// Fire all dispatches concurrently
+			const results = await Promise.all(
+				lanes.map((lane) => runner.dispatchLane(lane, 'mega_coder')),
+			);
+
+			// All should timeout — the dispatch-side timer is the sole resolver
+			// now, so this holds regardless of scheduler load.
+			for (const result of results) {
+				expect(result.ok).toBe(false);
+				expect(result.error).toContain('timed out');
+			}
+
+			// Every lane that timed out sets its sentinel synchronously inside the
+			// `catch` block that raced the timeout (runner.ts:775), before
+			// `dispatchLane` returns. Since `results` above has already resolved
+			// for every lane, the sentinels are guaranteed to be populated by this
+			// point — assert that BEFORE the drain below, so a mutation that
+			// deletes the `.set(...'__pending__')` call at runner.ts:775 (and
+			// therefore never populates `_timedOutLanes` at all) cannot leave the
+			// `size === 0` drain assertion vacuously true. Without this, "went
+			// from populated to empty" and "was never populated" are
+			// indistinguishable.
+			const timedOutLanes = (
+				runner as unknown as { _timedOutLanes: Map<string, string> }
+			)._timedOutLanes;
+			expect(timedOutLanes.size).toBe(lanes.length);
+
+			// `session.create` is an already-resolved promise and `session.prompt`
+			// is called on the microtask chain immediately after — both drain
+			// before the 5ms macrotask timer above can fire, so every lane's
+			// reject function is captured by this point without needing a poll.
+			expect(promptRejectFns.length).toBe(lanes.length);
+			for (const reject of promptRejectFns) {
+				reject(new Error('Prompt rejected'));
+			}
+
+			// _timedOutLanes should drain once each `_doDispatch` resolves (with
+			// `{ ok: false, error: 'Prompt rejected' }`, per its internal catch)
+			// and the `.then` handler's cleanup branch runs. That is background
+			// work with no signal this test can `await` directly, so poll for it
+			// instead of guessing a fixed delay: this waits exactly as long as
+			// the machine needs and only fails on genuine breakage, unlike a
+			// fixed sleep that can be too short under load or needlessly long
+			// otherwise.
+			await pollUntilDrained(timedOutLanes);
+
+			expect(timedOutLanes.size).toBe(0);
+		},
+		POLL_TEST_BUDGET_MS,
+	);
+});

--- a/tests/unit/turbo/lean/runner.timeout-adversarial.test.ts
+++ b/tests/unit/turbo/lean/runner.timeout-adversarial.test.ts
@@ -7,7 +7,10 @@
  * - Session orphan creation when timeout fires after session.create but before prompt
  * - Lock leak when dispatchLane has no timeout (infinite hang with locks held)
  * - Empty files array lane dispatch
- * - Concurrent timeout races on _timedOutLanes Map
+ *
+ * Concurrent timeout races on `_timedOutLanes` (formerly attack vector T6
+ * here) moved to `runner.timeout-adversarial-lane-state.test.ts` under
+ * FR-006 (500-line test-file cap) once this file grew past the cap.
  *
  * Strategy:
  * - Uses real tmpDir + real lane planning via _internals
@@ -669,145 +672,6 @@ describe('ATTACK VECTOR T5 — empty files array lane dispatch', () => {
 		} else {
 			expect(result.reason).toBe('NO_LANES');
 		}
-	});
-});
-
-// ════════════════════════════════════════════════════════════════════════════════
-// ATTACK VECTOR T6: Concurrent timeout race on _timedOutLanes Map
-// ════════════════════════════════════════════════════════════════════════════════
-
-describe('ATTACK VECTOR T6 — concurrent timeout race on _timedOutLanes', () => {
-	test('two lanes with same laneId do not interfere on _timedOutLanes', async () => {
-		writeMinimalPlan(1);
-		writeScopeFiles({ '1.1': ['src/a.ts'], '1.2': ['src/b.ts'] });
-
-		const sessionId1 = `session-1-${Math.random().toString(36).slice(2)}`;
-		const sessionId2 = `session-2-${Math.random().toString(36).slice(2)}`;
-
-		// Both lanes share the same laneId (adversarial input)
-		const lane1: LeanTurboLane = {
-			laneId: 'same-lane-id', // Same laneId
-			taskIds: ['1.1'],
-			files: ['src/a.ts'],
-			status: 'pending',
-		};
-		const lane2: LeanTurboLane = {
-			laneId: 'same-lane-id', // Same laneId
-			taskIds: ['1.2'],
-			files: ['src/b.ts'],
-			status: 'pending',
-		};
-
-		const createMock = mock((opts: { query: { directory: string } }) => {
-			const id = opts.query.directory === tmpDir ? sessionId1 : sessionId2;
-			return Promise.resolve({ data: { id }, error: null });
-		});
-		const promptMock = mock(() =>
-			Bun.sleep(500).then(() =>
-				Promise.resolve({
-					data: { parts: [{ type: 'text', text: 'Done' }] },
-					error: null,
-				}),
-			),
-		);
-		const deleteMock = mock(() => Promise.resolve());
-
-		const concurrentOps = {
-			create: createMock,
-			prompt: promptMock,
-			delete: deleteMock,
-		};
-
-		const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
-		injectMockSessionOps(runner, concurrentOps);
-
-		LeanTurboRunner._internals.laneDispatchTimeoutMs = 20;
-
-		// Dispatch both lanes with same laneId concurrently
-		const [result1, result2] = await Promise.all([
-			runner.dispatchLane(lane1, 'mega_coder'),
-			runner.dispatchLane(lane2, 'mega_coder'),
-		]);
-
-		// Wait for background completions
-		await Bun.sleep(600);
-
-		// Both should get timeout errors
-		expect(result1.ok).toBe(false);
-		expect(result2.ok).toBe(false);
-		expect(result1.error).toContain('timed out');
-		expect(result2.error).toContain('timed out');
-
-		// Both sessions should be cleaned up
-		expect(deleteMock).toHaveBeenCalled();
-	});
-
-	test('rapid concurrent timeouts on different lanes do not corrupt _timedOutLanes state', async () => {
-		writeMinimalPlan(1);
-		writeScopeFiles({
-			'1.1': ['src/a.ts'],
-			'1.2': ['src/b.ts'],
-		});
-
-		// 2 lanes that timeout quickly
-		const lanes: LeanTurboLane[] = [
-			{
-				laneId: 'lane-1',
-				taskIds: ['1.1'],
-				files: ['src/a.ts'],
-				status: 'pending',
-			},
-			{
-				laneId: 'lane-2',
-				taskIds: ['1.2'],
-				files: ['src/b.ts'],
-				status: 'pending',
-			},
-		];
-
-		// Fast create (resolves immediately), prompt rejects after delay
-		// This ensures _doDispatch settles when prompt rejects, triggering completion handler
-		const rejectPromptOps = {
-			create: mock(() =>
-				Promise.resolve({
-					data: { id: `session-${Math.random().toString(36).slice(2)}` },
-					error: null,
-				}),
-			),
-			prompt: mock(
-				() =>
-					new Promise((_, reject) =>
-						setTimeout(() => reject(new Error('Prompt rejected')), 20),
-					),
-			),
-			delete: mock(() => Promise.resolve()),
-		};
-
-		const runner = makeRunner({ generatedAgentNames: ['mega_coder'] });
-		injectMockSessionOps(runner, rejectPromptOps);
-
-		LeanTurboRunner._internals.laneDispatchTimeoutMs = 5;
-
-		// Fire all dispatches concurrently
-		const results = await Promise.all(
-			lanes.map((lane) => runner.dispatchLane(lane, 'mega_coder')),
-		);
-
-		// All should timeout (timeout fires at 5ms, prompt rejects at 20ms)
-		for (const result of results) {
-			expect(result.ok).toBe(false);
-			expect(result.error).toContain('timed out');
-		}
-
-		// Wait for background completions to clean up _timedOutLanes
-		// prompt rejects at 20ms, so by 100ms everything should be settled
-		await Bun.sleep(100);
-
-		// _timedOutLanes should be empty after all completions
-		const timedOutLanes = (
-			runner as unknown as { _timedOutLanes: Map<string, string> }
-		)._timedOutLanes;
-		expect(timedOutLanes.size).toBe(0);
 	});
 });
 


### PR DESCRIPTION
Refs #1782 (test-stability sprint). This PR does not close that umbrella issue — it fixes three of its flake instances plus the coverage-gate retry gap.

## Summary

Three tests raced a real wall clock against real work and could invert on a fast or loaded runner. The worst offender failed CI on 6+ PRs and evicted **#2080** from the merge queue after failing all three attempts and exhausting its retry budget.

- **`workspace-snapshot-digest-failure-reasons.test.ts`** — two cases set `_internals.revisionEnumerationTimeoutMs = 1` and asserted that enumerating a tiny temp git fixture *exceeded* 1ms. On a fast runner enumeration won, the digest returned a real sha256, and the assertions failed.
- **`runner.timeout-adversarial.test.ts`** — raced a 5ms lane-dispatch timeout against a mock rejecting at 20ms (4x margin), then slept a fixed `Bun.sleep(100)` waiting for cleanup.
- **`review/dispatcher.test.ts`** — slept a fixed `Bun.sleep(40)` waiting for a real 15ms timeout to propagate (2.67x margin).

**Each race is removed, not widened.** Competing branches are now structurally unable to win: stubs never settle on their own, so the production deadline is the sole resolver, and observations await the real signal (an `'abort'` event; a bounded poll on the observable condition) instead of a guessed window. Raising the deadlines would have narrowed the race without removing it.

The async twin's stub is reused **verbatim** rather than replaced with a generic never-settling one, and that detail is load-bearing: `runGitAsyncDetailed` deliberately omits `timeout` from its spawn options — that omission *is* the #1968 fix — so the existing stub still flips to `git-failed` if anyone re-adds it. A generic stub would have passed either way and silently killed the regression guard.

**Coverage-gate retry parity.** `run-coverage-gate.sh` had no retry while the unit and integration jobs retry twice. The coverage job is merge-queue-only, so a transient flake there evicted a PR with no chance to self-heal and a requeue costs a full ~30-60 min re-run. Added `max_retries=2` with the `coverage/` reset inside the loop (preserving the per-file lcov isolation invariant, #1712), and wired the new annotations **end-to-end** — script writes → coverage job uploads → `flake-detection.yml` pattern broadened to `flake-annotations-*` → detector parses them — rather than emitting a file nothing consumes.

**One guard made self-policing.** The async enumeration budget is now a named constant plus an assertion that it still sits below the deadline a mis-wired call would take, so lowering `GIT_SNAPSHOT_TIMEOUT_MS` fails loudly instead of silently rendering the guard inert.

**The FR-006 split was required, not incidental.** The de-flake grew an already-over-cap file (1032 → 1097), tripping the cap ratchet; `ATTACK VECTOR T6` moved to a new file and the original shrank to 896. Extraction then promoted a previously-tolerated FR-011 `tmpdir` violation to blocking — every line of a new file counts as added — fixed with `canonicalMkdtemp`.

## Invariant audit

- 1 (plugin init): **not touched** — `git diff --name-only origin/main HEAD -- src/` returns 0 files.
- 2 (runtime portability): **not touched** — no `src/` change; `bun run build` exit 0 and `await import('./dist/index.js')` → "dist import OK" run anyway.
- 3 (subprocesses): **not touched** — no `src/` subprocess code changed. The only changed file matching a spawn pattern is `workspace-snapshot-digest-failure-reasons.test.ts`, where `spawnSync` appears in a *test stub* that fabricates Node's `ETIMEDOUT` result. `run-coverage-gate.sh`'s retry re-invokes `bun test` with its existing explicit `--timeout 60000`, adding no unbounded subprocess.
- 4 (.swarm containment): **not touched** — no `.swarm/` runtime paths changed; evidence files are runtime state and uncommitted.
- 5 (plan durability): **not touched** — no ledger/plan code changed.
- 6 (test_runner safety): **touched (respected)** — `test_runner` was NOT used. Validation ran via per-file shell loops and `bun run test:unit:ci <files>` scoped mode.
- 7 (test writing): **touched** — bun:test only; zero `mock.module` added (the only added match is the words "No mock.module usage" in a docstring); DI via the existing `_internals` and `_sessionOps` seams with `afterEach` restores; `_internals.spawnSync` added to the capture/restore set it was missing from; writing-tests skill loaded first; FR-006 split performed; FR-011 satisfied via `canonicalMkdtemp`. Gates: `check-test-clock` 0, `check-test-file-cap` 0, `check-test-tmpdir` 0, `check-mock-cleanup` 0 — all run against the **committed** tree, not the working tree (see Test plan).
- 8 (session state): **not touched** — no session/global state code changed.
- 9 (guardrails/retry): **not touched** — invariant 9 governs agent-runtime retry semantics (`max_transient_retries`), which is unchanged. The retry added here is a CI shell-script loop, bounded at 3 attempts, with per-attempt `::warning`/`::notice` logging so it can never silently absorb a failure.
- 10 (chat/system msg): **not touched** — no hook contract changed.
- 11 (tool registration): **not touched** — `bun run scripts/check-tool-registration.ts` exit 0: "116 tools, coherent across metadata, handlers, the plugin object, TOOL_NAMES, and AGENT_TOOL_MAP."
- 12 (release/cache): **touched** — added `docs/releases/pending/1782-merge-queue-timeout-flakes-and-coverage-retry.md`. `package.json`, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched (verified by `git diff --name-only`). `dist/` not staged.

## Test plan

- [x] **Determinism** — each changed test file run 5x in its own `bun --smol` process at CI's real budget (`--timeout 120000`): all clean. The digest file specifically was run 10x+ across several rounds, 0 failures.
- [x] **Falsifiability** — every de-flaked guard proven to still fail on the defect it exists for, by mutating production source and restoring it (`git diff --stat src/` empty after each):
  - re-adding `timeout: timeoutMs` to `runGitAsyncDetailed` → both async tests flip `timeout` → `git-failed`
  - breaking the `ETIMEDOUT` mapping → sync test red with `git-failed`
  - re-pointing enumeration at `gitTimeoutMs` → sync red (`Expected: 4242, Received: 3000`); async red at its budget
  - lowering `GIT_SNAPSHOT_TIMEOUT_MS` → the new coupling assertion fires (`Expected: > 4000, Received: 3000`)
  - removing `_timedOutLanes.set(...)` → `mock was not called within 260 polls of 15ms` at ~4.8s
  - removing the drain → `_timedOutLanes did not drain within 260 polls of 15ms; 2 entries remain: [...]` at ~4.9s
- [x] **Item B retry proven behaviourally**, not by reading: a stubbed-`bun` harness showed 1 / 2 / 3 invocations for 0 / 1 / 2 induced failures, exit 0 on self-heal and 1 on exhaustion, correct markers, and a sentinel confirming the `coverage/` reset really is inside the loop.
- [x] **All 8 `quality`-job gates** run against the committed tree: test-tmpdir 0, test-clock 0, test-file-cap 0, mock-cleanup 0, bash-portability 0, tool-registration 0, runtime-src-refs 0, events 0. Four of these diff `HEAD`, so they are false-green on a dirty tree — they were first validated via a `git commit-tree` + throwaway-worktree simulation whose harness was itself falsified (reintroducing a violation flipped it to `blocking: 1`), then confirmed for real post-commit.
- [x] `bun run typecheck` exit 0; `bun run lint:ci` clean (3115 files); `bun run build` exit 0 + dist import OK.
- [x] `bun run test:unit:ci` (scoped to the 5 changed test files) exit 0.
- [x] `bun test tests/security` → 163 pass / 4 skip / 0 fail.
- [x] Co-run of all 5 changed test files in one process → 50 pass / 0 fail (no mock-isolation leakage from the split).
- [x] Adjacent directories unchanged vs baseline: `tests/unit/turbo/lean/` 827 pass / 0 fail, `tests/unit/review/` 105 pass / 0 fail.

### Pre-existing failures (reproduced on clean `origin/main`, not inherited silently)

- `scripts/check-invariants.sh` — exit 1, **744 violations**. Reproduced identically on a clean `origin/main` worktree (same exit, same count). None of the implicated files are in this PR; all are `src/**/__tests__` mock-allowlist entries.
- `scripts/check-cross-contamination.sh` — this gate executes live test co-runs against a zero-margin baseline (71 vs 71), so it drops below baseline under CPU load. It exited 1 while several agents ran concurrently and 0 on three consecutive idle runs. Not a regression from this PR; worth its own hardening issue.
- **`tests/unit/tools/declare-scope-session-binding.test.ts`** — failed `unit (windows-latest, 1)` on the first CI run, exhausting its three attempts. **Not from this PR**: this PR touches nothing scope-related, and the file does not appear in that shard's log alongside any changed file. It fails on a clean `origin/main` worktree locally (0 pass / 1 fail) as well as on this branch, and the failing case differs between runs, so it is a genuine pre-existing flake. It is exactly the test auto-filed for quarantine review in #2073 by the flake-detection workflow, and it has not been added to `scripts/ci/quarantined-tests*.txt`. The failed job was re-run per the commit-pr protocol.
- `tests/unit/background/` reports 80 pre-existing failures and `tests/unit/scripts/` 83, both established as pre-existing by substituting the `origin/main` version of the changed file and observing identical counts.
