### PR TITLE
fix(context): wire role filter into system injection

### DIFF
--- a/docs/releases/pending/1618-role-filter-system-pipeline.md
+++ b/docs/releases/pending/1618-role-filter-system-pipeline.md
@@ -1,0 +1,25 @@
+# Wire role-scoped context filtering into system injection
+
+## What changed
+
+- The production system-context pipeline now routes leading `[FOR: ...]`
+  fragments through the shared role filter after all injectors run and before
+  system messages are collapsed.
+- Prefixed multi-swarm agent names continue to match their canonical roles.
+- Untagged, malformed, and `[FOR: ALL]` system context remains available, and
+  missing session identity fails open.
+
+## Why
+
+The role filter previously had unit coverage but no production caller. Its
+historical system-prompt exemption also meant that simply invoking it on the
+real `output.system` shape would not filter anything. As a result, targeted
+system fragments could reach agents outside their intended roles.
+
+## Compatibility
+
+Existing direct callers retain their historical system-entry and metrics
+behavior. The new chat hook intentionally omits metrics persistence so it does
+not add synchronous filesystem I/O to the prompt-construction hot path.
+
+Closes: #1618

--- a/src/context/role-filter.ts
+++ b/src/context/role-filter.ts
@@ -18,6 +18,11 @@ export interface ContextEntry {
 	name?: string;
 }
 
+export interface FilterByRoleOptions {
+	/** Allow valid leading [FOR: ...] tags to route otherwise-protected system entries. */
+	filterTaggedSystem?: boolean;
+}
+
 /**
  * Regex pattern for extracting [FOR: ...] tags from content
  * Matches patterns like: [FOR: ALL], [FOR: reviewer, test_engineer]
@@ -178,13 +183,15 @@ function logFilteringMetrics(
  *
  * @param entries - Array of context entries to filter
  * @param targetRole - The target agent role to filter for
- * @param directory - Optional project directory for metrics logging (defaults to cwd)
+ * @param directory - Optional project directory for metrics logging
+ * @param options - Optional routing behavior; defaults preserve historical semantics
  * @returns Filtered array of context entries
  */
 export function filterByRole(
 	entries: ContextEntry[],
 	targetRole: string,
 	directory?: string,
+	options: FilterByRoleOptions = {},
 ): ContextEntry[] {
 	// If no entries, return empty array
 	if (!entries || entries.length === 0) {
@@ -195,14 +202,22 @@ export function filterByRole(
 	const filtered: ContextEntry[] = [];
 
 	for (const entry of entries) {
+		// Parse before the exemption check so the production system-hook adapter
+		// can opt valid tagged system fragments into routing. Empty/malformed tags
+		// remain protected system context, and all default callers keep the
+		// historical unconditional system exemption.
+		const allowedAgents = parseForTag(entry.content);
+		const canFilterTaggedSystem =
+			entry.role === 'system' &&
+			options.filterTaggedSystem === true &&
+			allowedAgents !== null &&
+			allowedAgents.length > 0;
+
 		// Check if entry should never be filtered
-		if (shouldNeverFilter(entry)) {
+		if (shouldNeverFilter(entry) && !canFilterTaggedSystem) {
 			filtered.push(entry);
 			continue;
 		}
-
-		// Parse [FOR: ...] tag from content
-		const allowedAgents = parseForTag(entry.content);
 
 		// If no tag present, include for all (backward compatibility)
 		if (allowedAgents === null) {
@@ -222,4 +237,38 @@ export function filterByRole(
 	}
 
 	return filtered;
+}
+
+/**
+ * Create the production adapter for role-scoped system fragments.
+ *
+ * The adapter intentionally has no directory parameter: chat-system filtering
+ * must stay free of synchronous metrics I/O. Missing session or agent identity
+ * fails open so critical system context is never dropped speculatively.
+ */
+export function createRoleFilterSystemHook(
+	getActiveAgentName: (sessionID: string) => string | undefined,
+): {
+	'experimental.chat.system.transform': (
+		input: { sessionID?: string },
+		output: { system?: string[] },
+	) => Promise<void>;
+} {
+	return {
+		'experimental.chat.system.transform': async (input, output) => {
+			if (!input.sessionID || !Array.isArray(output.system)) return;
+
+			const targetRole = getActiveAgentName(input.sessionID);
+			if (!targetRole) return;
+
+			const entries: ContextEntry[] = output.system.map((content) => ({
+				role: 'system',
+				content,
+			}));
+			const filtered = filterByRole(entries, targetRole, undefined, {
+				filterTaggedSystem: true,
+			});
+			output.system = filtered.map(({ content }) => content);
+		},
+	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import {
 	stripKnownSwarmPrefix,
 	WatchdogConfigSchema,
 } from './config/schema';
+import { createRoleFilterSystemHook } from './context/role-filter.js';
 import { updateContextMapAfterAgent } from './context-map/post-agent-update.js';
 import { createEvaluationModelDispatcher } from './evaluation/model-dispatcher.js';
 import { tickAndMaybeDispatchCadence } from './full-auto/cadence.js';
@@ -984,6 +985,9 @@ async function initializeOpenCodeSwarm(
 	const getActiveReviewAgentName = (sessionID: string): string | undefined =>
 		swarmState.activeAgent.get(sessionID) ??
 		swarmState.agentSessions.get(sessionID)?.agentName;
+	const roleFilterSystemHook = createRoleFilterSystemHook(
+		getActiveReviewAgentName,
+	);
 	const commandHandler = createSwarmCommandHandler(
 		ctx.directory,
 		agentDefinitionMap,
@@ -2649,6 +2653,7 @@ async function initializeOpenCodeSwarm(
 							)
 						: undefined,
 				swarmCommandSystemRuleHook,
+				roleFilterSystemHook['experimental.chat.system.transform'],
 				(_input: unknown, output: { system?: string[] }): Promise<void> => {
 					if (Array.isArray(output.system) && output.system.length > 1) {
 						output.system = [output.system.join('\n\n')];

--- a/tests/unit/context/role-filter-wiring.test.ts
+++ b/tests/unit/context/role-filter-wiring.test.ts
@@ -1,0 +1,184 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+import { getSafeDefaultConfigLoadResult } from '../../../src/config';
+import {
+	createRoleFilterSystemHook,
+	filterByRole,
+} from '../../../src/context/role-filter';
+import OpenCodeSwarm, {
+	overrideIndexInternalsForTest,
+} from '../../../src/index';
+import { swarmState } from '../../../src/state';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const SESSION_ID = 'role-filter-wiring-session';
+
+describe('role-filter production wiring', () => {
+	let tempDir: string;
+	let restoreIndexInternals = () => {};
+	let transform: (
+		input: { sessionID?: string },
+		output: { system?: string[] },
+	) => Promise<void>;
+
+	beforeAll(async () => {
+		tempDir = canonicalMkdtemp('swarm-role-filter-wiring-');
+		restoreIndexInternals = overrideIndexInternalsForTest({
+			loadPluginConfigWithMetaAsync: async () =>
+				getSafeDefaultConfigLoadResult(),
+			loadSnapshot: async () => undefined,
+			ensureSwarmGitExcluded: async () => undefined,
+			schedulePostResolutionTasks: () => {},
+		});
+		const plugin = await OpenCodeSwarm.server({
+			client: {} as never,
+			project: {} as never,
+			directory: tempDir,
+			worktree: tempDir,
+			serverUrl: new URL('http://localhost:3000'),
+			$: {} as never,
+		});
+		transform = plugin[
+			'experimental.chat.system.transform'
+		] as typeof transform;
+	});
+
+	afterEach(() => {
+		swarmState.activeAgent.delete(SESSION_ID);
+		swarmState.agentSessions.delete(SESSION_ID);
+	});
+
+	afterAll(async () => {
+		restoreIndexInternals();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('filters tagged system fragments for the active prefixed role before collapse', async () => {
+		swarmState.activeAgent.set(SESSION_ID, 'local_coder');
+		const output = {
+			system: [
+				'base system prompt',
+				'[FOR: architect] architect only',
+				'[FOR: coder, reviewer] implementation context',
+				'[FOR: ALL] shared context',
+				'[FOR: ] malformed tag remains ordinary system context',
+				'[FOR: typo] unknown role context',
+			],
+		};
+
+		await transform({ sessionID: SESSION_ID }, output);
+
+		expect(output.system).toHaveLength(1);
+		const rendered = output.system[0] ?? '';
+		expect(rendered).toContain('base system prompt');
+		expect(rendered).not.toContain('architect only');
+		expect(rendered).toContain('implementation context');
+		expect(rendered).toContain('shared context');
+		expect(rendered).toContain('malformed tag remains ordinary system context');
+		expect(rendered).not.toContain('unknown role context');
+		expect(rendered.indexOf('base system prompt')).toBeLessThan(
+			rendered.indexOf('implementation context'),
+		);
+		const eventsPath = path.join(tempDir, '.swarm', 'events.jsonl');
+		const events = existsSync(eventsPath)
+			? readFileSync(eventsPath, 'utf8')
+			: '';
+		expect(events).not.toContain('"event":"context_filtered"');
+	});
+
+	test('preserves matching tagged system context for a prefixed architect', async () => {
+		swarmState.activeAgent.set(SESSION_ID, 'mega_architect');
+		const output = { system: ['base', '[FOR: architect] design context'] };
+
+		await transform({ sessionID: SESSION_ID }, output);
+
+		expect(output.system).toHaveLength(1);
+		expect(output.system[0]).toContain('design context');
+	});
+
+	test('fails open when the active agent cannot be resolved', async () => {
+		const output = { system: ['base', '[FOR: architect] critical context'] };
+
+		await transform({ sessionID: SESSION_ID }, output);
+
+		expect(output.system).toHaveLength(1);
+		expect(output.system[0]).toContain('critical context');
+	});
+
+	test('retains direct-call zero-exclusion metrics behavior', () => {
+		const metricsDir = path.join(tempDir, 'direct-metrics');
+		filterByRole(
+			[{ role: 'assistant', content: 'shared' }],
+			'coder',
+			metricsDir,
+		);
+
+		const events = readFileSync(
+			path.join(metricsDir, '.swarm', 'events.jsonl'),
+			'utf8',
+		)
+			.trim()
+			.split('\n');
+		const event = JSON.parse(events.at(-1) ?? '{}');
+		expect(event.filteredEntries).toBe(0);
+		expect(event.includedEntries).toBe(1);
+	});
+});
+
+describe('role-filter system hook adapter', () => {
+	test('filters only valid tagged system entries when opted in', async () => {
+		const hook = createRoleFilterSystemHook(() => 'local_coder');
+		const transform = hook['experimental.chat.system.transform'];
+		const output = {
+			system: [
+				'  untagged bytes  ',
+				'[FOR: architect] hidden',
+				'[FOR: coder] visible',
+				'[FOR: ] malformed',
+			],
+		};
+
+		await transform({ sessionID: 'session' }, output);
+
+		expect(output.system).toEqual([
+			'  untagged bytes  ',
+			'[FOR: coder] visible',
+			'[FOR: ] malformed',
+		]);
+	});
+
+	test('fails open for a missing session ID or unresolved agent', async () => {
+		const hook = createRoleFilterSystemHook(() => undefined);
+		const transform = hook['experimental.chat.system.transform'];
+		const withoutSession = { system: ['[FOR: architect] one'] };
+		const withoutAgent = { system: ['[FOR: architect] two'] };
+
+		await transform({}, withoutSession);
+		await transform({ sessionID: 'unknown' }, withoutAgent);
+
+		expect(withoutSession.system).toEqual(['[FOR: architect] one']);
+		expect(withoutAgent.system).toEqual(['[FOR: architect] two']);
+	});
+
+	test('leaves missing and empty system arrays unchanged', async () => {
+		const hook = createRoleFilterSystemHook(() => 'coder');
+		const transform = hook['experimental.chat.system.transform'];
+		const missing: { system?: string[] } = {};
+		const empty = { system: [] as string[] };
+
+		await transform({ sessionID: 'session' }, missing);
+		await transform({ sessionID: 'session' }, empty);
+
+		expect(missing).toEqual({});
+		expect(empty.system).toEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #1618

## Summary
- wire `filterByRole` into the real system-context transform after all fragment producers and before final collapse
- preserve untagged, malformed, matching, multi-role, and `[FOR: ALL]` context while excluding nonmatching tagged fragments for prefixed swarm roles
- preserve existing direct-call metrics semantics and keep the production chat hot path free of synchronous event-file I/O
- add a real-plugin red-to-green regression and a pending release-note fragment

## Invariant audit
- 1 (plugin init): touched - the new hook factory is pure/synchronous; `tests/unit/index.test.ts` passed 13/13 and `node scripts/repro-704.mjs` resolved the 500-file case in 294.2 ms under the 400 ms deadline
- 2 (runtime portability): touched - `bun run build`, bundle node-load/plugin-shape/portability tests, and Node ESM import of `dist/index.js` passed
- 3 (subprocesses): not touched - the changed context module and registration add no spawn or external command
- 4 (.swarm containment): not touched - production filtering receives no directory and writes no runtime state; tests use `canonicalMkdtemp`
- 5 (plan durability): not touched - no plan schema, ledger, projection, or checkpoint path changed
- 6 (test_runner safety): not touched - validation used shell-driven per-file/scoped Bun commands, never broad `test_runner`
- 7 (test writing): touched - the writing-tests protocol was loaded; the new 184-line `bun:test` file has no module mocks and passed mock, clock, line-cap, and tempdir ratchets
- 8 (session state): not touched - the hook reads the existing bounded active-agent/session maps and adds no module state
- 9 (guardrails/retry): not touched - no guardrail, circuit-breaker, retry, or authorization behavior changed
- 10 (chat/system msg): touched - the real-plugin regression passed 7/7 and the two system-message consolidation suites passed 26/26, proving filtering precedes single-message collapse
- 11 (tool registration): not touched - no tool or agent-map surface changed; the 116-tool coherence check passed
- 12 (release/cache): touched - added `docs/releases/pending/1618-role-filter-system-pipeline.md`; package smoke produced a valid 1,043-file tarball and no version/cache code changed

## Test plan
- [x] red-to-green real-plugin role-filter wiring regression (7 tests, 20 assertions)
- [x] existing role-filter compatibility suite (37 tests, 52 assertions)
- [x] scoped CI-equivalent unit gate across 8 affected/runtime-portability files
- [x] TypeScript typecheck and repository-wide Biome CI
- [x] build, Node bundle import, plugin-shape/portability, and repro-704 init deadline
- [x] security suite and adversarial suite (846 adversarial tests)
- [x] smoke suite and npm package smoke
- [x] drift, tool-registration, runtime-reference, event-contract, mock, clock, line-cap, tempdir, and Bash portability checks
- [x] independent implementation review and distinct final critic approval on `ad2402e2`

## Pre-existing local baseline failures
- `scripts/check-invariants.sh` reports the same 743 stale mock-allowlist targets on a clean `origin/main` worktree at `ba88fc6c`; this diff adds no mock
- the knowledge real-host test's uniquely seeded lesson is displaced by unrelated local fixture lessons on both this branch and clean `origin/main`; the changed system-transform path is not involved
- the monolithic local integration invocation showed shared-process contamination (724 pass / 246 fail); issue-specific real-plugin, consolidation, index, security, adversarial, smoke, and package gates are green


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

