### PR TITLE
fix(dispatch): retry transient session creation

### DIFF
--- a/docs/releases/pending/1615-bounded-launch-retry.md
+++ b/docs/releases/pending/1615-bounded-launch-retry.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added one bounded retry for transient `session.create` failures in blocking and asynchronous lane dispatch. Retry generations remain visible in immediate and collected results, timed-out late sessions are cleaned up, and duplicate correlation IDs cannot overwrite terminal ledger state. Prompt execution and native `Task` launches remain single-shot because the current OpenCode host API does not expose an idempotent replay primitive after execution may have started.

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -26,6 +26,7 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import { z } from 'zod';
 import { withEvidenceLock } from '../evidence/lock.js';
 import { validateSwarmPath } from '../hooks/utils.js';
@@ -41,6 +42,7 @@ export const MAX_LIVE_BACKGROUND_FALLBACKS = 256;
 export const MAX_LIVE_BACKGROUND_CODER_RESERVATIONS = 256;
 export const MAX_BACKGROUND_OBSERVED_FILES = 5_000;
 export const MAX_BACKGROUND_ADVISORY_CHARS = 4_000;
+const MAX_BACKGROUND_DELEGATION_GENERATION = 1_000_000;
 const MAX_RECOVERY_LEDGER_BYTES = 4 * 1024 * 1024;
 const MAX_RECOVERY_FALLBACK_BYTES = 1024 * 1024;
 
@@ -546,7 +548,12 @@ const RecordSchema = z
 		worktree: WorktreeDescriptorSchema.optional(),
 		coderReservationId: z.string().min(1).max(256).optional(),
 		prompt: PromptSchema.optional(),
-		generation: z.number().optional(),
+		generation: z
+			.number()
+			.int()
+			.positive()
+			.max(MAX_BACKGROUND_DELEGATION_GENERATION)
+			.optional(),
 		terminalResult: TerminalResultSchema.optional(),
 		coderSettlement: CoderSettlementSchema.optional(),
 		advisoryInbox: AdvisoryInboxSchema.optional(),
@@ -791,24 +798,70 @@ function buildPendingRecord(
 /**
  * Record a `pending` background delegation. Runs the stale sweep first (lazy maintenance,
  * no plugin-init cost), then appends the pending snapshot — all under one lock acquisition
- * so concurrent dispatches cannot interleave. Best-effort: returns null on lock timeout or
- * write failure. Async advisory launchers must treat null as a launch failure so they do
- * not create untracked background work.
+ * so concurrent dispatches cannot interleave. The discriminated outcome lets async
+ * launchers distinguish a safe duplicate from a write failure without disrupting
+ * the already-owned session.
  */
-export async function recordPendingDelegation(
+export type RecordPendingDelegationOutcome =
+	| { status: 'recorded'; record: BackgroundDelegationRecord }
+	| { status: 'duplicate'; record: BackgroundDelegationRecord }
+	| { status: 'conflict'; record: BackgroundDelegationRecord }
+	| { status: 'failed'; record: null };
+
+function pendingLaunchIdentity(record: BackgroundDelegationRecord): object {
+	return {
+		correlationId: record.correlationId,
+		jobId: record.jobId,
+		subagentSessionId: record.subagentSessionId,
+		parentSessionId: record.parentSessionId,
+		callID: record.callID,
+		normalizedAgent: record.normalizedAgent,
+		swarmPrefixedAgent: record.swarmPrefixedAgent,
+		planTaskId: record.planTaskId,
+		evidenceTaskId: record.evidenceTaskId,
+		batchId: record.batchId,
+		laneId: record.laneId,
+		mode: record.mode,
+		workflowLane: record.workflowLane,
+		ownedWorkflowLanes: record.ownedWorkflowLanes,
+		promptHash: record.promptHash,
+		workspace: record.workspace,
+		taskChangeContext: record.taskChangeContext,
+		worktree: record.worktree,
+		coderReservationId: record.coderReservationId,
+		prompt: record.prompt,
+		generation: record.generation ?? 1,
+	};
+}
+
+function samePendingLaunchIdentity(
+	left: BackgroundDelegationRecord,
+	right: BackgroundDelegationRecord,
+): boolean {
+	return isDeepStrictEqual(
+		pendingLaunchIdentity(left),
+		pendingLaunchIdentity(right),
+	);
+}
+
+export async function recordPendingDelegationDetailed(
 	directory: string,
 	input: RecordPendingInput,
 	options: { staleTimeoutMs?: number } = {},
-): Promise<BackgroundDelegationRecord | null> {
+): Promise<RecordPendingDelegationOutcome> {
 	const now = Date.now();
 	const record = buildPendingRecord(input, now);
 	const parsedRecord = RecordSchema.safeParse(record);
 	if (!parsedRecord.success) {
 		logger.warn('[background] recordPendingDelegation rejected invalid input');
-		return null;
+		return { status: 'failed', record: null };
 	}
 
 	try {
+		let outcome: RecordPendingDelegationOutcome = {
+			status: 'failed',
+			record: null,
+		};
 		await withEvidenceLock(
 			directory,
 			BACKGROUND_DELEGATIONS_FILE,
@@ -818,16 +871,52 @@ export async function recordPendingDelegation(
 				if (options.staleTimeoutMs && options.staleTimeoutMs > 0) {
 					sweepStaleLocked(directory, options.staleTimeoutMs, now);
 				}
+				// A correlation identifies one durable launch. Check while holding the
+				// ledger lock so concurrent pending writers cannot append a fresh
+				// snapshot over an already-running or terminal delegation.
+				const existing = findByCorrelationId(
+					directory,
+					parsedRecord.data.correlationId,
+				);
+				if (existing) {
+					outcome = {
+						status: samePendingLaunchIdentity(existing, parsedRecord.data)
+							? 'duplicate'
+							: 'conflict',
+						record: existing,
+					};
+					return;
+				}
 				appendRecord(directory, parsedRecord.data);
+				outcome = { status: 'recorded', record: parsedRecord.data };
 			},
 		);
-		return parsedRecord.data;
+		return outcome;
 	} catch (err) {
 		logger.warn(
 			`[background] recordPendingDelegation failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
-		return null;
+		return { status: 'failed', record: null };
 	}
+}
+
+/**
+ * Idempotent compatibility wrapper. A duplicate returns the authoritative
+ * existing record so native Task replay does not create a fallback owner.
+ */
+export async function recordPendingDelegation(
+	directory: string,
+	input: RecordPendingInput,
+	options: { staleTimeoutMs?: number } = {},
+): Promise<BackgroundDelegationRecord | null> {
+	const outcome = await recordPendingDelegationDetailed(
+		directory,
+		input,
+		options,
+	);
+	return outcome.status === 'recorded' || outcome.status === 'duplicate'
+		? outcome.record
+		: null;
 }
 
 export function buildPromptSnapshot(

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -12,6 +12,7 @@ import type {
 	BackgroundCoderReservation,
 	BackgroundDelegationRecord,
 	BackgroundTaskChangeContext,
+	RecordPendingInput,
 } from '../background/pending-delegations.js';
 import {
 	captureWorkspaceSnapshot,
@@ -2131,6 +2132,54 @@ const recordPendingDelegationForBackground: typeof import('../background/pending
 			await import('../background/pending-delegations.js')
 		).recordPendingDelegationDetailed(...args);
 
+function sameReplayPrompt(
+	existing: BackgroundDelegationRecord['prompt'],
+	incoming: RecordPendingInput['prompt'],
+): boolean {
+	if (existing === undefined || incoming === undefined) {
+		return existing === incoming;
+	}
+	return (
+		existing.digest === incoming.digest &&
+		existing.chars === incoming.chars &&
+		existing.truncated === incoming.truncated &&
+		existing.text === incoming.text
+	);
+}
+
+function hasStableBackgroundReplayIdentity(
+	existing: BackgroundDelegationRecord,
+	incoming: RecordPendingInput,
+): boolean {
+	return (
+		existing.correlationId === incoming.correlationId &&
+		existing.subagentSessionId === incoming.subagentSessionId &&
+		existing.parentSessionId === incoming.parentSessionId &&
+		existing.callID === incoming.callID &&
+		existing.jobId === incoming.jobId &&
+		existing.normalizedAgent === incoming.normalizedAgent &&
+		existing.swarmPrefixedAgent === incoming.swarmPrefixedAgent &&
+		existing.planTaskId === incoming.planTaskId &&
+		existing.evidenceTaskId === incoming.evidenceTaskId &&
+		sameReplayPrompt(existing.prompt, incoming.prompt)
+	);
+}
+
+function hydrateBackgroundReplayInput(
+	existing: BackgroundDelegationRecord,
+	incoming: RecordPendingInput,
+): RecordPendingInput {
+	return {
+		...incoming,
+		workspace: existing.workspace,
+		taskChangeContext: existing.taskChangeContext,
+		worktree: existing.worktree,
+		coderReservationId: existing.coderReservationId,
+		prompt: existing.prompt,
+		generation: existing.generation ?? 1,
+	};
+}
+
 const writeDelegationFallbackForBackground: typeof import('../background/pending-delegations.js').writeDelegationFallback =
 	async (...args) =>
 		(
@@ -3494,7 +3543,7 @@ export function createDelegationGateHook(
 						const { extractDispatchIds } = await import(
 							'../background/task-envelope.js'
 						);
-						const { buildPromptSnapshot } = await import(
+						const { buildPromptSnapshot, findByCorrelationId } = await import(
 							'../background/pending-delegations.js'
 						);
 						const { captureWorkspaceSnapshot } = await import(
@@ -3528,7 +3577,7 @@ export function createDelegationGateHook(
 								stripKnownSwarmPrefix(subagentType) === 'coder'
 									? coderTaskChangeContextByCallID.get(input.callID)
 									: undefined;
-							const pendingInput = {
+							const pendingInputDraft: RecordPendingInput = {
 								correlationId: subagentSessionId,
 								jobId,
 								subagentSessionId,
@@ -3567,6 +3616,21 @@ export function createDelegationGateHook(
 										: undefined,
 								generation: 1,
 							};
+							const existingOwner = findByCorrelationId(
+								directory,
+								subagentSessionId,
+							);
+							const pendingInput =
+								existingOwner &&
+								hasStableBackgroundReplayIdentity(
+									existingOwner,
+									pendingInputDraft,
+								)
+									? hydrateBackgroundReplayInput(
+											existingOwner,
+											pendingInputDraft,
+										)
+									: pendingInputDraft;
 							const primaryOutcome =
 								await _internals.recordPendingDelegationForBackground(
 									directory,
@@ -3578,15 +3642,25 @@ export function createDelegationGateHook(
 								primaryOutcome.status === 'duplicate';
 							backgroundCorrelationConflict =
 								primaryOutcome.status === 'conflict';
-							if (backgroundCorrelationConflict) {
+							if (primaryOutcome.status === 'conflict') {
 								const preservation = await protectUntrackedBackgroundWorktree(
 									evidenceTaskId ?? standardDispatch?.planTaskId,
 									'background correlation id conflicts with an existing immutable launch owner',
 								);
+								const worktreeStatus = !standardDispatch
+									? 'No isolated worktree was attached to this conflicting call.'
+									: preservation.durable
+										? `The current worktree was durably preserved with ${preservation.detail}.`
+										: `The current worktree was not durably preserved (${preservation.detail}); automatic reclamation remains blocked pending recovery.`;
+								const reservationStatus = coderReservation
+									? `The current reservation ${coderReservation.reservationId} was retained and was not bound to the conflicting correlation.`
+									: primaryOutcome.record.coderReservationId
+										? `No new reservation was present for this replay; the durable owner's reservation ${primaryOutcome.record.coderReservationId} remains unchanged.`
+										: 'No current or durable-owner coder reservation was present.';
 								backgroundOwnershipDurable = preservation.durable;
 								pushAdvisory(
 									session,
-									`BACKGROUND DELEGATION CORRELATION CONFLICT: ${subagentType} (${subagentSessionId}) collided with a different durable launch owner. No fallback owner was written and no reservation was bound. Recovery protection: ${preservation.detail}. Do not advance task ${evidenceTaskId ?? 'unknown'} until the collision is resolved.`,
+									`BACKGROUND DELEGATION CORRELATION CONFLICT: ${subagentType} (${subagentSessionId}) collided with a different durable launch owner (parent=${primaryOutcome.record.parentSessionId}, call=${primaryOutcome.record.callID}, agent=${primaryOutcome.record.swarmPrefixedAgent}, task=${primaryOutcome.record.planTaskId ?? 'none'}). Inspect that existing owner and reconcile it before continuing. ${worktreeStatus} ${reservationStatus} No fallback owner was written and no reservation was bound. Do not abort, delete, or re-dispatch this correlation until reconciliation is complete. Do not advance task ${evidenceTaskId ?? 'unknown'} until the collision is resolved.`,
 								);
 							} else if (primaryOutcome.status === 'failed') {
 								backgroundRecordDurable =

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -2125,11 +2125,11 @@ async function resolveEvidenceTaskId(
 	return getEvidenceTaskId(session, directory);
 }
 
-const recordPendingDelegationForBackground: typeof import('../background/pending-delegations.js').recordPendingDelegation =
+const recordPendingDelegationForBackground: typeof import('../background/pending-delegations.js').recordPendingDelegationDetailed =
 	async (...args) =>
 		(
 			await import('../background/pending-delegations.js')
-		).recordPendingDelegation(...args);
+		).recordPendingDelegationDetailed(...args);
 
 const writeDelegationFallbackForBackground: typeof import('../background/pending-delegations.js').writeDelegationFallback =
 	async (...args) =>
@@ -3452,6 +3452,7 @@ export function createDelegationGateHook(
 				);
 				let backgroundRecordDurable = !backgroundSubagentsEnabled;
 				let backgroundOwnershipDurable = backgroundRecordDurable;
+				let backgroundCorrelationConflict = false;
 				if (backgroundSubagentsEnabled) {
 					const protectUntrackedBackgroundWorktree = async (
 						taskId: string | null | undefined,
@@ -3566,14 +3567,28 @@ export function createDelegationGateHook(
 										: undefined,
 								generation: 1,
 							};
-							const primary =
+							const primaryOutcome =
 								await _internals.recordPendingDelegationForBackground(
 									directory,
 									pendingInput,
 									{ staleTimeoutMs: backgroundPendingTimeoutMs },
 								);
-							backgroundRecordDurable = primary !== null;
-							if (!primary) {
+							backgroundRecordDurable =
+								primaryOutcome.status === 'recorded' ||
+								primaryOutcome.status === 'duplicate';
+							backgroundCorrelationConflict =
+								primaryOutcome.status === 'conflict';
+							if (backgroundCorrelationConflict) {
+								const preservation = await protectUntrackedBackgroundWorktree(
+									evidenceTaskId ?? standardDispatch?.planTaskId,
+									'background correlation id conflicts with an existing immutable launch owner',
+								);
+								backgroundOwnershipDurable = preservation.durable;
+								pushAdvisory(
+									session,
+									`BACKGROUND DELEGATION CORRELATION CONFLICT: ${subagentType} (${subagentSessionId}) collided with a different durable launch owner. No fallback owner was written and no reservation was bound. Recovery protection: ${preservation.detail}. Do not advance task ${evidenceTaskId ?? 'unknown'} until the collision is resolved.`,
+								);
+							} else if (primaryOutcome.status === 'failed') {
 								backgroundRecordDurable =
 									(await _internals.writeDelegationFallbackForBackground(
 										directory,
@@ -3585,7 +3600,7 @@ export function createDelegationGateHook(
 									);
 								}
 							}
-							if (!backgroundRecordDurable) {
+							if (!backgroundCorrelationConflict && !backgroundRecordDurable) {
 								const preservation = await protectUntrackedBackgroundWorktree(
 									evidenceTaskId ?? standardDispatch?.planTaskId,
 									'both background correlation stores failed',
@@ -3595,7 +3610,7 @@ export function createDelegationGateHook(
 									session,
 									`BACKGROUND DELEGATION UNTRACKED: ${subagentType} (${subagentSessionId}) launched, but both durable correlation stores failed. Recovery protection: ${preservation.detail}. Do not advance task ${evidenceTaskId ?? 'unknown'} until the dispatch is recovered.`,
 								);
-							} else {
+							} else if (!backgroundCorrelationConflict) {
 								backgroundOwnershipDurable = true;
 								if (coderReservation) {
 									const bound =
@@ -3656,7 +3671,9 @@ export function createDelegationGateHook(
 					clearCoderTaskChangeContext(input.callID);
 					if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
 				}
-				backgroundCoderReservationByCallID.delete(input.callID);
+				if (!backgroundCorrelationConflict) {
+					backgroundCoderReservationByCallID.delete(input.callID);
+				}
 				if (!backgroundResultIsRunning)
 					clearPublishedScopeBindings(input.callID);
 				return;

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -1689,10 +1689,38 @@ function isRetryableSessionCreateFailure(error: unknown): boolean {
 			truncated = true;
 			continue;
 		}
-		if (Array.isArray(object)) {
+		let isArray = false;
+		try {
+			isArray = Array.isArray(object);
+		} catch {
+			truncated = true;
+			continue;
+		}
+		if (isArray) {
+			let arrayLength: number;
+			try {
+				const lengthDescriptor = Object.getOwnPropertyDescriptor(
+					object,
+					'length',
+				);
+				if (
+					!lengthDescriptor ||
+					!('value' in lengthDescriptor) ||
+					typeof lengthDescriptor.value !== 'number' ||
+					!Number.isSafeInteger(lengthDescriptor.value) ||
+					lengthDescriptor.value < 0
+				) {
+					truncated = true;
+					continue;
+				}
+				arrayLength = lengthDescriptor.value;
+			} catch {
+				truncated = true;
+				continue;
+			}
 			const remainingNodes = MAX_CREATE_FAILURE_WALK_NODES - visited;
-			const itemCount = Math.min(object.length, remainingNodes);
-			if (itemCount < object.length) truncated = true;
+			const itemCount = Math.min(arrayLength, remainingNodes);
+			if (itemCount < arrayLength) truncated = true;
 			for (let index = 0; index < itemCount; index++) {
 				let descriptor: PropertyDescriptor | undefined;
 				try {

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -15,7 +15,7 @@ import {
 	type BackgroundDelegationRecord,
 	type BackgroundDelegationResult,
 	findByBatchId,
-	recordPendingDelegation,
+	recordPendingDelegationDetailed,
 } from '../background/pending-delegations.js';
 import {
 	PrReviewInlineTriggerRowSchema,
@@ -74,6 +74,55 @@ const MAX_COLLECT_TIMEOUT_MS = 60 * 60_000;
 const COLLECT_POLL_INTERVAL_MS = 500;
 const MAX_COLLECT_POLL_INTERVAL_MS = 10_000;
 const MAX_ZOD_ISSUES_LISTED = 20;
+const MAX_SESSION_CREATE_GENERATIONS = 2;
+const MAX_CREATE_FAILURE_WALK_NODES = 64;
+const MAX_CREATE_FAILURE_WALK_DEPTH = 6;
+const MAX_CREATE_FAILURE_SIGNAL_CHARS = 8_192;
+
+const TRANSIENT_CREATE_STATUS_CODES = new Set([
+	408, 429, 500, 502, 503, 504, 529,
+]);
+const TRANSIENT_CREATE_SIGNAL_PATTERN =
+	/\b(?:408|429|500|502|503|504|529)\b|rate.?limit|timeout|timed.?out|overloaded|temporarily.?unavailable|provider[_\s-]?unavailable|server.?error|network.?connection.?lost|connection.?(?:refused|reset|timeout|lost)|bad.?gateway|gateway.?timeout|internal.?server.?error|service.?unavailable|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|ENOTFOUND|broken.?pipe|dns(?:[\s_-]+(?:resolution)?)?[\s_-]+fail|name.?not.?resolved|EAI_AGAIN/i;
+const PERMANENT_CREATE_SIGNAL_PATTERN =
+	/authentication|unauthori[sz]ed|forbidden|invalid[_\s-]?(?:api[_\s-]?key|token|credential|configuration|config|agent|model)|unknown[_\s-]?(?:agent|model)|unsupported[_\s-]?(?:agent|model)|model.?not.?found|agent.?not.?found|permission.?denied|access.?denied|quota|usage.?limit|insufficient.?(?:quota|credits?)|payment.?required|credit.?balance|out of credits|billing.?(?:hard.?)?limit/i;
+const PERMANENT_CREATE_STATUS_CODES = new Set([
+	400, 401, 402, 403, 404, 405, 409, 410, 413, 422,
+]);
+const CREATE_FAILURE_FIELD_KEYS = [
+	'status',
+	'statusCode',
+	'status_code',
+	'httpStatus',
+	'http_status',
+	'code',
+	'errorCode',
+	'error_code',
+	'message',
+	'detail',
+	'reason',
+	'cause',
+	'error',
+	'response',
+	'data',
+	'body',
+	'details',
+	'errors',
+	'isRetryable',
+	'retryable',
+] as const;
+const CREATE_FAILURE_SCALAR_KEYS = new Set<string>(CREATE_FAILURE_FIELD_KEYS);
+const CREATE_FAILURE_STATUS_KEYS = new Set([
+	'status',
+	'statusCode',
+	'status_code',
+	'httpStatus',
+	'http_status',
+	'code',
+	'errorCode',
+	'error_code',
+	'response',
+]);
 
 const AGENT_NAME_SEPARATORS = ['_', '-', ' '] as const;
 
@@ -529,6 +578,8 @@ export interface DispatchLaneResult {
 	session_id?: string;
 	slot_id?: string;
 	run_id?: string;
+	/** One-based session.create attempt that produced this result. */
+	generation?: number;
 	started_at: string;
 	completed_at: string;
 	output?: string;
@@ -678,6 +729,7 @@ export const _test_exports = {
 	formatError,
 	nextCollectPollInterval,
 	promptHash,
+	isRetryableSessionCreateFailure,
 	DispatchLanesArgsSchema,
 	DispatchLanesAsyncArgsSchema,
 	DEFAULT_TIMEOUT_MS,
@@ -1466,6 +1518,231 @@ export async function executeCollectLaneResults(
 	return result;
 }
 
+type LaneSessionCreateOutcome =
+	| {
+			ok: true;
+			sessionId: string;
+			generation: number;
+			slotId: string;
+			runId: string;
+	  }
+	| {
+			ok: false;
+			error: string;
+			generation: number;
+			slotId?: string;
+			runId?: string;
+	  };
+
+/**
+ * Create a child session before any prompt can execute. Only this pre-execution
+ * operation is safe to retry. A failed attempt releases its dispatcher slot and
+ * synchronously reacquires before the second attempt, preserving the configured
+ * concurrency ceiling without introducing an unbounded waiter.
+ */
+async function createLaneSession(args: {
+	session: SessionOps;
+	dispatcher: ParallelDispatcher;
+	lane: DispatchLaneSpec;
+	directory: string;
+	timeoutMs: number;
+	context: DispatchLanesExecutionContext;
+}): Promise<LaneSessionCreateOutcome> {
+	let generation = 1;
+	let decision = args.dispatcher.dispatch(args.lane.id);
+	while (true) {
+		if (decision.action !== 'dispatch') {
+			return {
+				ok: false,
+				generation,
+				error: `dispatcher ${decision.action}: ${decision.reason}`,
+			};
+		}
+
+		const createTimeoutMessage = `Lane "${args.lane.id}" session.create timed out after ${args.timeoutMs}ms`;
+		let createPromise: ReturnType<SessionOps['create']>;
+		try {
+			createPromise = args.session.create(
+				buildLaneSessionCreateArgs(args.directory, args.lane, args.context),
+			);
+		} catch (error) {
+			createPromise = Promise.reject(error);
+		}
+		let createTimedOut = false;
+		createPromise
+			.then((result) => {
+				if (createTimedOut && result.data?.id) {
+					scheduleSessionCleanup(args.session, result.data.id);
+				}
+			})
+			.catch(() => undefined);
+
+		let failureSignal: unknown;
+		let failureMessage: string;
+		try {
+			const result = await withTimeout(
+				createPromise,
+				args.timeoutMs,
+				createTimeoutMessage,
+			);
+			if (result.data?.id) {
+				return {
+					ok: true,
+					sessionId: result.data.id,
+					generation,
+					slotId: decision.slot.slotId,
+					runId: decision.slot.runId,
+				};
+			}
+			failureSignal = result.error;
+			failureMessage =
+				result.error === undefined || result.error === null
+					? 'session.create failed: malformed response without a session id'
+					: `session.create failed: ${formatError(result.error)}`;
+		} catch (error) {
+			failureSignal = error;
+			failureMessage = formatError(error);
+			if (failureMessage === createTimeoutMessage) createTimedOut = true;
+		}
+
+		const retryable =
+			createTimedOut || isRetryableSessionCreateFailure(failureSignal);
+		if (retryable && generation < MAX_SESSION_CREATE_GENERATIONS) {
+			// No await may be inserted between these calls: the released capacity is
+			// immediately reclaimed for the same lane generation.
+			args.dispatcher.releaseSlot(decision.slot.slotId);
+			generation++;
+			decision = args.dispatcher.dispatch(args.lane.id);
+			continue;
+		}
+
+		return {
+			ok: false,
+			error: failureMessage,
+			generation,
+			slotId: decision.slot.slotId,
+			runId: decision.slot.runId,
+		};
+	}
+}
+
+function isRetryableSessionCreateFailure(error: unknown): boolean {
+	if (error === undefined || error === null) return false;
+	const seen = new WeakSet<object>();
+	const pending: Array<{ value: unknown; depth: number; key?: string }> = [
+		{ value: error, depth: 0 },
+	];
+	let visited = 0;
+	let signalChars = 0;
+	let transient = false;
+	let permanent = false;
+	let truncated = false;
+
+	while (pending.length > 0 && visited < MAX_CREATE_FAILURE_WALK_NODES) {
+		const current = pending.shift()!;
+		visited++;
+		const { value, depth, key } = current;
+		if ((key === 'isRetryable' || key === 'retryable') && value === false) {
+			permanent = true;
+		}
+
+		if (typeof value === 'number' && Number.isInteger(value)) {
+			if (key === undefined || CREATE_FAILURE_STATUS_KEYS.has(key)) {
+				if (TRANSIENT_CREATE_STATUS_CODES.has(value)) transient = true;
+				if (PERMANENT_CREATE_STATUS_CODES.has(value)) permanent = true;
+			}
+			continue;
+		}
+		if (typeof value === 'string') {
+			if (key !== undefined && !CREATE_FAILURE_SCALAR_KEYS.has(key)) continue;
+			if (
+				key !== undefined &&
+				CREATE_FAILURE_STATUS_KEYS.has(key) &&
+				/^\d+$/.test(value)
+			) {
+				const numericStatus = Number(value);
+				if (TRANSIENT_CREATE_STATUS_CODES.has(numericStatus)) transient = true;
+				if (PERMANENT_CREATE_STATUS_CODES.has(numericStatus)) permanent = true;
+			}
+			const remaining = MAX_CREATE_FAILURE_SIGNAL_CHARS - signalChars;
+			if (remaining <= 0) {
+				truncated = true;
+				continue;
+			}
+			const signal = value.slice(0, remaining);
+			if (signal.length < value.length) truncated = true;
+			signalChars += signal.length;
+			if (PERMANENT_CREATE_SIGNAL_PATTERN.test(signal)) permanent = true;
+			if (TRANSIENT_CREATE_SIGNAL_PATTERN.test(signal)) transient = true;
+			continue;
+		}
+		if (
+			(typeof value !== 'object' && typeof value !== 'function') ||
+			value === null
+		) {
+			continue;
+		}
+		const object = value as object;
+		if (seen.has(object)) continue;
+		seen.add(object);
+		if (depth >= MAX_CREATE_FAILURE_WALK_DEPTH) {
+			truncated = true;
+			continue;
+		}
+		if (Array.isArray(object)) {
+			const remainingNodes = MAX_CREATE_FAILURE_WALK_NODES - visited;
+			const itemCount = Math.min(object.length, remainingNodes);
+			if (itemCount < object.length) truncated = true;
+			for (let index = 0; index < itemCount; index++) {
+				let descriptor: PropertyDescriptor | undefined;
+				try {
+					descriptor = Object.getOwnPropertyDescriptor(object, index);
+				} catch {
+					truncated = true;
+					continue;
+				}
+				if (!descriptor) continue;
+				if (!('value' in descriptor)) {
+					truncated = true;
+					continue;
+				}
+				pending.push({
+					value: descriptor.value,
+					depth: depth + 1,
+					key,
+				});
+			}
+			continue;
+		}
+		for (const propertyKey of CREATE_FAILURE_FIELD_KEYS) {
+			if (pending.length + visited >= MAX_CREATE_FAILURE_WALK_NODES) {
+				truncated = true;
+				break;
+			}
+			let descriptor: PropertyDescriptor | undefined;
+			try {
+				descriptor = Object.getOwnPropertyDescriptor(object, propertyKey);
+			} catch {
+				truncated = true;
+				continue;
+			}
+			if (!descriptor) continue;
+			if (!('value' in descriptor)) {
+				truncated = true;
+				continue;
+			}
+			pending.push({
+				value: descriptor.value,
+				depth: depth + 1,
+				key: propertyKey,
+			});
+		}
+	}
+
+	if (pending.length > 0) truncated = true;
+	return transient && !permanent && !truncated;
+}
+
 async function launchAsyncLane(args: {
 	session: SessionOps;
 	dispatcher: ParallelDispatcher;
@@ -1494,89 +1771,87 @@ async function launchAsyncLane(args: {
 			error: validation.error,
 		};
 	}
-	const decision = args.dispatcher.dispatch(args.lane.id);
-	if (decision.action !== 'dispatch') {
-		return {
-			id: args.lane.id,
-			agent: args.lane.agent,
-			role,
-			status: 'failed',
-			started_at: startedAt,
-			completed_at: isoNow(),
-			error: `dispatcher ${decision.action}: ${decision.reason}`,
-		};
-	}
+	const create = await createLaneSession({
+		session: args.session,
+		dispatcher: args.dispatcher,
+		lane: args.lane,
+		directory: args.directory,
+		timeoutMs: args.timeoutMs,
+		context: args.context,
+	});
 	try {
-		const createTimeoutMessage = `Lane "${args.lane.id}" session.create timed out after ${args.timeoutMs}ms`;
-		const createPromise = args.session.create(
-			buildLaneSessionCreateArgs(args.directory, args.lane, args.context),
-		);
-		let createTimedOut = false;
-		createPromise
-			.then((createResult) => {
-				if (createTimedOut && createResult.data?.id) {
-					scheduleSessionCleanup(args.session, createResult.data.id);
-				}
-			})
-			.catch(() => undefined);
-		const createResult = await withTimeout(
-			createPromise,
-			args.timeoutMs,
-			createTimeoutMessage,
-		).catch((error) => {
-			if (formatError(error) === createTimeoutMessage) {
-				createTimedOut = true;
-			}
-			throw error;
-		});
-		const sessionId = createResult.data?.id;
-		if (!sessionId) {
+		if (!create.ok) {
 			return failedLane(
 				args.lane,
 				role,
 				startedAt,
-				`session.create failed: ${formatError(createResult.error)}`,
-				decision.slot.slotId,
-				decision.slot.runId,
+				create.error,
+				create.slotId,
+				create.runId,
+				undefined,
+				create.generation,
 			);
 		}
+		const sessionId = create.sessionId;
 
-		const pendingRecord = await recordPendingDelegation(args.directory, {
-			correlationId: sessionId,
-			jobId: null,
-			subagentSessionId: sessionId,
-			parentSessionId:
-				args.context.sessionID?.trim() ||
-				`dispatch_lanes_async:${args.batchId}`,
-			callID: args.batchId,
-			normalizedAgent: role,
-			swarmPrefixedAgent: args.lane.agent,
-			planTaskId: null,
-			evidenceTaskId: null,
-			batchId: args.batchId,
-			laneId: args.lane.id,
-			mode: args.mode ?? 'advisory',
-			workflowLane: args.lane.workflow_lane,
-			ownedWorkflowLanes: args.lane.owned_workflow_lanes,
-			promptHash: promptHash(args.lane, args.directory, args.batchId),
-			workspace: {
-				directory: args.directory,
-				gitHead: args.gitHead ?? null,
-				dirtyHash: args.dirtyHash ?? null,
-				prHeadSha: args.prHeadSha ?? null,
-				scope: args.scope ?? null,
+		const pendingOutcome = await recordPendingDelegationDetailed(
+			args.directory,
+			{
+				correlationId: sessionId,
+				jobId: null,
+				subagentSessionId: sessionId,
+				parentSessionId:
+					args.context.sessionID?.trim() ||
+					`dispatch_lanes_async:${args.batchId}`,
+				callID: args.batchId,
+				normalizedAgent: role,
+				swarmPrefixedAgent: args.lane.agent,
+				planTaskId: null,
+				evidenceTaskId: null,
+				batchId: args.batchId,
+				laneId: args.lane.id,
+				mode: args.mode ?? 'advisory',
+				workflowLane: args.lane.workflow_lane,
+				ownedWorkflowLanes: args.lane.owned_workflow_lanes,
+				promptHash: promptHash(args.lane, args.directory, args.batchId),
+				workspace: {
+					directory: args.directory,
+					gitHead: args.gitHead ?? null,
+					dirtyHash: args.dirtyHash ?? null,
+					prHeadSha: args.prHeadSha ?? null,
+					scope: args.scope ?? null,
+				},
+				generation: create.generation,
 			},
-			generation: 1,
-		});
-		if (!pendingRecord) {
+		);
+		if (
+			pendingOutcome.status === 'duplicate' ||
+			pendingOutcome.status === 'conflict'
+		) {
+			return failedLane(
+				args.lane,
+				role,
+				startedAt,
+				pendingOutcome.status === 'duplicate'
+					? 'Async lane session.create returned an already-recorded correlation id'
+					: 'Async lane session.create returned a correlation id owned by a different background delegation',
+				create.slotId,
+				create.runId,
+				sessionId,
+				create.generation,
+			);
+		}
+		if (pendingOutcome.status === 'failed') {
 			cleanupAsyncLaunchSession(args.session, sessionId);
 			return failedLane(
 				args.lane,
 				role,
 				startedAt,
 				'Failed to record async lane in background delegation ledger',
-				decision.slot.slotId,
-				decision.slot.runId,
+				create.slotId,
+				create.runId,
+				sessionId,
+				create.generation,
 			);
 		}
 
@@ -1594,8 +1869,9 @@ async function launchAsyncLane(args: {
 			role,
 			status: 'pending',
 			session_id: sessionId,
-			slot_id: decision.slot.slotId,
-			run_id: decision.slot.runId,
+			slot_id: create.slotId,
+			run_id: create.runId,
+			generation: create.generation,
 			started_at: startedAt,
 			completed_at: isoNow(),
 		};
@@ -1605,11 +1881,13 @@ async function launchAsyncLane(args: {
 			role,
 			startedAt,
 			formatError(error),
-			decision.slot.slotId,
-			decision.slot.runId,
+			create.slotId,
+			create.runId,
+			create.ok ? create.sessionId : undefined,
+			create.generation,
 		);
 	} finally {
-		args.dispatcher.releaseSlot(decision.slot.slotId);
+		if (create.slotId) args.dispatcher.releaseSlot(create.slotId);
 	}
 }
 
@@ -1945,55 +2223,30 @@ async function runLane(
 		};
 	}
 
-	const decision = dispatcher.dispatch(lane.id);
-	if (decision.action !== 'dispatch') {
-		return {
-			id: lane.id,
-			agent: lane.agent,
-			role,
-			status: 'failed',
-			started_at: startedAt,
-			completed_at: isoNow(),
-			error: `dispatcher ${decision.action}: ${decision.reason}`,
-		};
-	}
-
 	const promptController = new AbortController();
-	let sessionId: string | undefined;
+	const create = await createLaneSession({
+		session,
+		dispatcher,
+		lane,
+		directory,
+		timeoutMs,
+		context,
+	});
+	let sessionId: string | undefined = create.ok ? create.sessionId : undefined;
 	try {
-		const createTimeoutMessage = `Lane "${lane.id}" session.create timed out after ${timeoutMs}ms`;
-		const createPromise = session.create(
-			buildLaneSessionCreateArgs(directory, lane, context),
-		);
-		let createTimedOut = false;
-		createPromise
-			.then((createResult) => {
-				if (createTimedOut && createResult.data?.id) {
-					scheduleSessionCleanup(session, createResult.data.id);
-				}
-			})
-			.catch(() => undefined);
-		const createResult = await withTimeout(
-			createPromise,
-			timeoutMs,
-			createTimeoutMessage,
-		).catch((error) => {
-			if (formatError(error) === createTimeoutMessage) {
-				createTimedOut = true;
-			}
-			throw error;
-		});
-		if (!createResult.data?.id) {
+		if (!create.ok) {
 			return failedLane(
 				lane,
 				role,
 				startedAt,
-				`session.create failed: ${formatError(createResult.error)}`,
-				decision.slot.slotId,
-				decision.slot.runId,
+				create.error,
+				create.slotId,
+				create.runId,
+				undefined,
+				create.generation,
 			);
 		}
-		sessionId = createResult.data.id;
+		sessionId = create.sessionId;
 
 		const promptResult = await withTimeout(
 			session.prompt({
@@ -2015,9 +2268,10 @@ async function runLane(
 				role,
 				startedAt,
 				`session.prompt failed: ${formatError(promptResult.error)}`,
-				decision.slot.slotId,
-				decision.slot.runId,
+				create.slotId,
+				create.runId,
 				sessionId,
+				create.generation,
 			);
 		}
 
@@ -2038,8 +2292,9 @@ async function runLane(
 			role,
 			status: 'completed',
 			session_id: sessionId,
-			slot_id: decision.slot.slotId,
-			run_id: decision.slot.runId,
+			slot_id: create.slotId,
+			run_id: create.runId,
+			generation: create.generation,
 			started_at: startedAt,
 			completed_at: isoNow(),
 			...laneOutput,
@@ -2050,12 +2305,13 @@ async function runLane(
 			role,
 			startedAt,
 			formatError(error),
-			decision.slot.slotId,
-			decision.slot.runId,
+			create.slotId,
+			create.runId,
 			sessionId,
+			create.generation,
 		);
 	} finally {
-		dispatcher.releaseSlot(decision.slot.slotId);
+		if (create.slotId) dispatcher.releaseSlot(create.slotId);
 		promptController.abort();
 		if (sessionId) {
 			scheduleSessionCleanup(session, sessionId);
@@ -2168,6 +2424,7 @@ function recordToLaneResult(
 		role: record.normalizedAgent,
 		status,
 		session_id: record.subagentSessionId,
+		generation: record.generation ?? 1,
 		started_at: new Date(record.createdAt).toISOString(),
 		completed_at: new Date(
 			record.completedAt ?? record.updatedAt,
@@ -2220,6 +2477,7 @@ function failedLane(
 	slotId?: string,
 	runId?: string,
 	sessionId?: string,
+	generation?: number,
 ): DispatchLaneResult {
 	return {
 		id: lane.id,
@@ -2229,6 +2487,7 @@ function failedLane(
 		session_id: sessionId,
 		slot_id: slotId,
 		run_id: runId,
+		generation,
 		started_at: startedAt,
 		completed_at: isoNow(),
 		error,

--- a/tests/unit/background/pending-delegations-generation.test.ts
+++ b/tests/unit/background/pending-delegations-generation.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import {
+	appendDelegationTransition,
+	findByCorrelationId,
+	type RecordPendingInput,
+	readDelegations,
+	recordPendingDelegation,
+	recordPendingDelegationDetailed,
+} from '../../../src/background/pending-delegations';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const directories: string[] = [];
+
+function project(): string {
+	const directory = canonicalMkdtemp('pending-generation-');
+	directories.push(directory);
+	return directory;
+}
+
+function pending(generation?: number): RecordPendingInput {
+	return {
+		correlationId: 'session-1',
+		jobId: null,
+		subagentSessionId: 'session-1',
+		parentSessionId: 'parent',
+		callID: 'batch',
+		normalizedAgent: 'reviewer',
+		swarmPrefixedAgent: 'reviewer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: 'batch',
+		laneId: 'lane',
+		...(generation === undefined ? {} : { generation }),
+	};
+}
+
+afterEach(() => {
+	for (const directory of directories.splice(0)) {
+		fs.rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe('pending delegation generation integrity', () => {
+	for (const generation of [Number.NaN, 1.5, 0, -1, 1_000_001]) {
+		test(`rejects invalid generation ${String(generation)}`, async () => {
+			expect(
+				await recordPendingDelegation(project(), pending(generation)),
+			).toBeNull();
+		});
+	}
+
+	test('accepts positive bounded integer generations', async () => {
+		const directory = project();
+		expect(
+			(await recordPendingDelegation(directory, pending(2)))?.generation,
+		).toBe(2);
+		expect(
+			(await recordPendingDelegation(project(), pending(1_000_000)))
+				?.generation,
+		).toBe(1_000_000);
+	});
+
+	test('classifies conflicting correlation identity without reopening a terminal row', async () => {
+		const directory = project();
+		expect(await recordPendingDelegation(directory, pending(1))).not.toBeNull();
+		await appendDelegationTransition(directory, 'session-1', {
+			status: 'error',
+			result: {
+				error: 'terminal',
+				chars: 8,
+				truncated: false,
+				digest: 'digest',
+			},
+		});
+
+		const duplicate = await recordPendingDelegationDetailed(directory, {
+			...pending(2),
+			laneId: 'replacement',
+		});
+		expect(duplicate).toMatchObject({
+			status: 'conflict',
+			record: { status: 'error', laneId: 'lane', generation: 1 },
+		});
+		expect(findByCorrelationId(directory, 'session-1')).toMatchObject({
+			status: 'error',
+			laneId: 'lane',
+			generation: 1,
+			result: { error: 'terminal' },
+		});
+	});
+
+	test('returns the authoritative record for an exact immutable-identity duplicate', async () => {
+		const directory = project();
+		const first = await recordPendingDelegation(directory, pending(2));
+		await appendDelegationTransition(directory, 'session-1', {
+			status: 'running',
+		});
+		const duplicate = await recordPendingDelegationDetailed(
+			directory,
+			pending(2),
+		);
+		expect(first).not.toBeNull();
+		expect(duplicate).toMatchObject({
+			status: 'duplicate',
+			record: { status: 'running', generation: 2 },
+		});
+		expect(await recordPendingDelegation(directory, pending(2))).toMatchObject({
+			status: 'running',
+			generation: 2,
+		});
+	});
+
+	test('normalizes a legacy missing generation to explicit generation 1', async () => {
+		const directory = project();
+		await recordPendingDelegation(directory, pending());
+		const duplicate = await recordPendingDelegationDetailed(
+			directory,
+			pending(1),
+		);
+		expect(duplicate).toMatchObject({
+			status: 'duplicate',
+			record: { correlationId: 'session-1' },
+		});
+	});
+
+	test('admits only one of two concurrent writers for the same correlation', async () => {
+		const directory = project();
+		const outcomes = await Promise.all([
+			recordPendingDelegationDetailed(directory, pending(1)),
+			recordPendingDelegationDetailed(directory, {
+				...pending(2),
+				laneId: 'other',
+			}),
+		]);
+		expect(outcomes.map((outcome) => outcome.status).sort()).toEqual([
+			'conflict',
+			'recorded',
+		]);
+		expect(readDelegations(directory)).toHaveLength(1);
+	});
+});

--- a/tests/unit/background/pending-delegations.test.ts
+++ b/tests/unit/background/pending-delegations.test.ts
@@ -96,7 +96,7 @@ describe('pending-delegations store', () => {
 		expect(findByCorrelationId(dir, 'nope')).toBeNull();
 	});
 
-	it('folds to the latest snapshot per correlationId', async () => {
+	it('keeps the first pending snapshot authoritative for a correlationId', async () => {
 		await recordPendingDelegation(
 			dir,
 			input({
@@ -106,7 +106,7 @@ describe('pending-delegations store', () => {
 			}),
 		);
 		// Second snapshot for the same correlationId with a different task id.
-		await recordPendingDelegation(
+		const duplicate = await recordPendingDelegation(
 			dir,
 			input({
 				correlationId: 'ses_a',
@@ -117,9 +117,11 @@ describe('pending-delegations store', () => {
 		await recordPendingDelegation(dir, input({ correlationId: 'ses_b' }));
 
 		const folded = readDelegations(dir);
-		// Two distinct correlationIds; ses_a folded to the LATEST snapshot.
+		// Two distinct correlationIds; a duplicate pending launch cannot replace
+		// the first durable owner.
 		expect(folded).toHaveLength(2);
-		expect(findByCorrelationId(dir, 'ses_a')?.evidenceTaskId).toBe('9.9');
+		expect(duplicate).toBeNull();
+		expect(findByCorrelationId(dir, 'ses_a')?.evidenceTaskId).toBe('1.1');
 	});
 
 	it('sweeps overdue pendings to stale (deterministic via backdated record)', async () => {

--- a/tests/unit/config/session-create-directory-guardrail.test.ts
+++ b/tests/unit/config/session-create-directory-guardrail.test.ts
@@ -137,14 +137,9 @@ const DECLARED_SITES: DeclaredSite[] = [
 		directoryExpr: 'HELPER buildLaneSessionCreateArgs(args.directory)',
 		classification: 'same-instance',
 		note:
-			'dispatch_lanes_async tool ctx.directory. buildLaneSessionCreateArgs ' +
-			'(src/tools/dispatch-lanes.ts:2510) returns query.directory unchanged.',
-	},
-	{
-		file: 'src/tools/dispatch-lanes.ts',
-		directoryExpr: 'HELPER buildLaneSessionCreateArgs(directory)',
-		classification: 'same-instance',
-		note: 'dispatch_lanes tool ctx.directory, passed through buildLaneSessionCreateArgs unchanged.',
+			'Shared dispatch_lanes and dispatch_lanes_async session-create helper. ' +
+			'Both callers pass their tool ctx.directory as args.directory, and ' +
+			'buildLaneSessionCreateArgs returns query.directory unchanged.',
 	},
 	{
 		file: 'src/turbo/lean/integration.ts',

--- a/tests/unit/hooks/delegation-gate-background-double-store-failure.test.ts
+++ b/tests/unit/hooks/delegation-gate-background-double-store-failure.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { BackgroundDelegationRecord } from '../../../src/background/pending-delegations';
 import type { PluginConfig } from '../../../src/config';
 import {
 	_internals,
@@ -19,12 +20,31 @@ import {
 import { runInitOrphanRecovery } from '../../../src/hooks/init-orphan-recovery';
 import { ensureAgentSession, resetSwarmState } from '../../../src/state';
 import type { WorktreeHandle } from '../../../src/worktree';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
 
 const originalRecord = _internals.recordPendingDelegationForBackground;
 const originalFallback = _internals.writeDelegationFallbackForBackground;
 const originalPreserve =
 	_internals.preserveBackgroundWorktreeOwnershipForCallId;
+const originalBind = _internals.bindBackgroundCoderReservationForDispatch;
+
+const existingRecord: BackgroundDelegationRecord = {
+	schemaVersion: 1,
+	correlationId: 'child-session',
+	jobId: 'existing-job',
+	subagentSessionId: 'child-session',
+	parentSessionId: 'different-parent',
+	callID: 'different-call',
+	normalizedAgent: 'coder',
+	swarmPrefixedAgent: 'coder',
+	planTaskId: 'other-task',
+	evidenceTaskId: 'other-task',
+	status: 'pending',
+	createdAt: 1,
+	updatedAt: 1,
+	generation: 1,
+};
 
 function git(directory: string, args: string[]): string {
 	const result = spawnSync('git', ['-C', directory, ...args], {
@@ -45,6 +65,7 @@ describe('background dispatch double-store recovery', () => {
 		_internals.recordPendingDelegationForBackground = originalRecord;
 		_internals.writeDelegationFallbackForBackground = originalFallback;
 		_internals.preserveBackgroundWorktreeOwnershipForCallId = originalPreserve;
+		_internals.bindBackgroundCoderReservationForDispatch = originalBind;
 		resetStandardWorktreeIsolationState();
 		mergeStatusInternals.resetForTest();
 		resetSwarmState();
@@ -71,7 +92,10 @@ describe('background dispatch double-store recovery', () => {
 				mergeStrategy: 'merge',
 				laneIndex: 0,
 			} satisfies StandardWorktreeDispatch);
-			_internals.recordPendingDelegationForBackground = mock(async () => null);
+			_internals.recordPendingDelegationForBackground = mock(async () => ({
+				status: 'failed',
+				record: null,
+			}));
 			_internals.writeDelegationFallbackForBackground = mock(async () => null);
 			const preserve = mock(async () => ({
 				outcome: 'preserved' as const,
@@ -165,7 +189,10 @@ describe('background dispatch double-store recovery', () => {
 				mergeStrategy: 'merge',
 				laneIndex: 0,
 			});
-			_internals.recordPendingDelegationForBackground = mock(async () => null);
+			_internals.recordPendingDelegationForBackground = mock(async () => ({
+				status: 'failed',
+				record: null,
+			}));
 			_internals.writeDelegationFallbackForBackground = mock(async () => null);
 			_internals.preserveBackgroundWorktreeOwnershipForCallId =
 				originalPreserve;
@@ -216,6 +243,137 @@ describe('background dispatch double-store recovery', () => {
 			expect(
 				fs.readFileSync(path.join(worktreePath, 'valuable.txt'), 'utf8'),
 			).toBe('keep\n');
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('correlation conflict fails closed without fallback or reservation binding', async () => {
+		const { dir, cleanup } = createSafeTestDir('swarm-bg-conflict-');
+		try {
+			await writeApprovedPlan(dir, [{ id: '9.1', files: ['src/example.ts'] }]);
+			const session = ensureAgentSession('parent', 'architect', dir);
+			session.currentTaskId = '9.1';
+			_internals.recordPendingDelegationForBackground = mock(async () => ({
+				status: 'conflict',
+				record: existingRecord,
+			}));
+			const fallback = mock(async () => null);
+			const bind = mock(async () => null);
+			_internals.writeDelegationFallbackForBackground = fallback;
+			_internals.bindBackgroundCoderReservationForDispatch = bind;
+			const hook = createDelegationGateHook(
+				{
+					max_iterations: 5,
+					qa_retry_limit: 3,
+					inject_phase_reminders: true,
+					hooks: { delegation_gate: true, background_subagents: true },
+				} as PluginConfig,
+				dir,
+			);
+			const taskArgs = {
+				subagent_type: 'coder',
+				background: true,
+				task_id: '9.1',
+				prompt:
+					'TASK: 9.1\nFILE: src/example.ts\nACCEPTANCE: preserve the conflicting reservation for safe recovery',
+			};
+			await hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'conflicting-call' },
+				{ args: taskArgs },
+			);
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'parent',
+					callID: 'conflicting-call',
+					args: taskArgs,
+				},
+				{
+					state: 'running',
+					output:
+						'<task id="child-session" state="running">Background task started</task>',
+					metadata: { background: true, jobId: 'new-job' },
+				},
+			);
+
+			expect(fallback).not.toHaveBeenCalled();
+			expect(bind).not.toHaveBeenCalled();
+			expect(session.pendingAdvisoryMessages?.at(-1)).toContain(
+				'BACKGROUND DELEGATION CORRELATION CONFLICT',
+			);
+			expect(session.pendingAdvisoryMessages?.at(-1)).toContain(
+				'No fallback owner was written and no reservation was bound',
+			);
+			expect(session.pendingAdvisoryMessages ?? []).not.toContainEqual(
+				expect.stringContaining('BACKGROUND DELEGATION UNTRACKED'),
+			);
+			await expect(
+				hook.toolBefore(
+					{ tool: 'Task', sessionID: 'parent', callID: 'second-call' },
+					{ args: taskArgs },
+				),
+			).rejects.toThrow(
+				/BACKGROUND_CODER_TASK_RESERVED|PARALLEL_SLOTS_EXHAUSTED/,
+			);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('exact duplicate remains durable without writing fallback', async () => {
+		const { dir, cleanup } = createSafeTestDir('swarm-bg-duplicate-');
+		try {
+			const session = ensureAgentSession('parent', 'architect', dir);
+			session.currentTaskId = '9.2';
+			_internals.recordPendingDelegationForBackground = mock(async () => ({
+				status: 'duplicate',
+				record: {
+					...existingRecord,
+					parentSessionId: 'parent',
+					callID: 'duplicate-call',
+					normalizedAgent: 'reviewer',
+					swarmPrefixedAgent: 'reviewer',
+					planTaskId: '9.2',
+					evidenceTaskId: '9.2',
+				},
+			}));
+			const fallback = mock(async () => null);
+			_internals.writeDelegationFallbackForBackground = fallback;
+			const hook = createDelegationGateHook(
+				{
+					max_iterations: 5,
+					qa_retry_limit: 3,
+					inject_phase_reminders: true,
+					hooks: { delegation_gate: true, background_subagents: true },
+				} as PluginConfig,
+				dir,
+			);
+
+			await hook.toolAfter(
+				{
+					tool: 'Task',
+					sessionID: 'parent',
+					callID: 'duplicate-call',
+					args: {
+						subagent_type: 'reviewer',
+						background: true,
+						task_id: '9.2',
+					},
+				},
+				{
+					state: 'running',
+					output:
+						'<task id="child-session" state="running">Background task started</task>',
+					metadata: { background: true, jobId: 'existing-job' },
+				},
+			);
+
+			expect(fallback).not.toHaveBeenCalled();
+			expect(session.pendingAdvisoryMessages ?? []).not.toContainEqual(
+				expect.stringContaining('CORRELATION CONFLICT'),
+			);
 		} finally {
 			cleanup();
 		}

--- a/tests/unit/hooks/delegation-gate-background-replay.test.ts
+++ b/tests/unit/hooks/delegation-gate-background-replay.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+	BACKGROUND_DELEGATIONS_FILE,
+	findByCorrelationId,
+	recordPendingDelegation,
+	scanBackgroundCoderReservationsForAdmission,
+} from '../../../src/background/pending-delegations';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { resetStandardWorktreeIsolationState } from '../../../src/hooks/delegation-gate/worktree-isolation';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: {
+		delegation_gate: true,
+		background_subagents: true,
+		background_pending_timeout_minutes: 30,
+	},
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function initProject(directory: string): void {
+	const result = spawnSync('git', ['init'], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+function ledgerLineCount(directory: string): number {
+	const ledgerPath = path.join(
+		directory,
+		'.swarm',
+		BACKGROUND_DELEGATIONS_FILE,
+	);
+	return fs.readFileSync(ledgerPath, 'utf8').split(/\r?\n/).filter(Boolean)
+		.length;
+}
+
+describe('background coder toolAfter replay ownership', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(async () => {
+		resetSwarmState();
+		resetStandardWorktreeIsolationState();
+		const safe = createSafeTestDir('swarm-bg-replay-');
+		directory = safe.dir;
+		cleanup = safe.cleanup;
+		initProject(directory);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/example.ts'] },
+		]);
+	});
+
+	afterEach(() => {
+		resetStandardWorktreeIsolationState();
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('treats a byte-identical second real toolAfter as the same durable launch', async () => {
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+		const hook = createDelegationGateHook(config, directory);
+		const args = {
+			subagent_type: 'coder',
+			background: true,
+			task_id: '1.1',
+			prompt:
+				'TASK: 1.1\nFILE: src/example.ts\nACCEPTANCE: persist one replay-stable owner',
+		};
+		const input = {
+			tool: 'Task',
+			sessionID: 'parent',
+			callID: 'coder-call',
+			args,
+		};
+		const output = {
+			state: 'running',
+			output:
+				'<task id="coder-session" state="running">Background task started</task>',
+			metadata: { background: true, jobId: 'coder-job' },
+		};
+
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'coder-call' },
+			{ args },
+		);
+		await hook.toolAfter(input, output);
+		const first = findByCorrelationId(directory, 'coder-session');
+		expect(first?.workspace?.directory).toBe(directory);
+		expect(first?.taskChangeContext?.declaredFiles).toEqual(['src/example.ts']);
+		expect(first?.coderReservationId).toBeTruthy();
+		expect(ledgerLineCount(directory)).toBe(1);
+
+		await hook.toolAfter(input, output);
+
+		expect(findByCorrelationId(directory, 'coder-session')).toEqual(first);
+		expect(ledgerLineCount(directory)).toBe(1);
+		expect(session.pendingAdvisoryMessages ?? []).not.toContainEqual(
+			expect.stringContaining('CORRELATION CONFLICT'),
+		);
+	});
+
+	test('keeps the durable owner and reservation on a true replay conflict', async () => {
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+		const hook = createDelegationGateHook(config, directory);
+		const originalArgs = {
+			subagent_type: 'coder',
+			background: true,
+			task_id: '1.1',
+			prompt:
+				'TASK: 1.1\nFILE: src/example.ts\nACCEPTANCE: preserve the original owner',
+		};
+		const output = {
+			state: 'running',
+			output:
+				'<task id="coder-session" state="running">Background task started</task>',
+			metadata: { background: true, jobId: 'coder-job' },
+		};
+
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'coder-call' },
+			{ args: originalArgs },
+		);
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'parent',
+				callID: 'coder-call',
+				args: originalArgs,
+			},
+			output,
+		);
+		const first = findByCorrelationId(directory, 'coder-session');
+		const reservationId = first?.coderReservationId;
+		expect(reservationId).toBeTruthy();
+
+		const conflictingArgs = {
+			...originalArgs,
+			prompt:
+				'TASK: 1.1\nFILE: src/example.ts\nACCEPTANCE: replace the original owner',
+		};
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'parent',
+				callID: 'coder-call',
+				args: conflictingArgs,
+			},
+			output,
+		);
+
+		expect(findByCorrelationId(directory, 'coder-session')).toEqual(first);
+		expect(ledgerLineCount(directory)).toBe(1);
+		expect(
+			scanBackgroundCoderReservationsForAdmission(directory),
+		).toMatchObject({
+			status: 'ok',
+			reservations: [{ reservationId, correlationId: 'coder-session' }],
+		});
+		const advisory = session.pendingAdvisoryMessages?.at(-1) ?? '';
+		expect(advisory).toContain('BACKGROUND DELEGATION CORRELATION CONFLICT');
+		expect(advisory).toContain(
+			'parent=parent, call=coder-call, agent=coder, task=1.1',
+		);
+		expect(advisory).toContain('Inspect that existing owner and reconcile it');
+		expect(advisory).toContain(
+			'No isolated worktree was attached to this conflicting call.',
+		);
+		expect(advisory).toContain(
+			`No new reservation was present for this replay; the durable owner's reservation ${reservationId} remains unchanged.`,
+		);
+		expect(advisory).not.toContain(
+			'The current worktree and reservation were preserved.',
+		);
+		expect(advisory).toContain(
+			'Do not abort, delete, or re-dispatch this correlation',
+		);
+		expect(session.pendingAdvisoryMessages ?? []).not.toContainEqual(
+			expect.stringContaining('BACKGROUND DELEGATION UNTRACKED'),
+		);
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'second-call' },
+				{ args: originalArgs },
+			),
+		).rejects.toThrow(
+			/BACKGROUND_CODER_TASK_RESERVED|PARALLEL_SLOTS_EXHAUSTED/,
+		);
+	});
+
+	test('reports a current reservation as retained without claiming a disabled worktree', async () => {
+		await recordPendingDelegation(directory, {
+			correlationId: 'colliding-session',
+			jobId: 'owner-job',
+			subagentSessionId: 'colliding-session',
+			parentSessionId: 'owner-parent',
+			callID: 'owner-call',
+			normalizedAgent: 'coder',
+			swarmPrefixedAgent: 'coder',
+			planTaskId: '1.1',
+			evidenceTaskId: '1.1',
+			generation: 1,
+		});
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+		const hook = createDelegationGateHook(config, directory);
+		const args = {
+			subagent_type: 'coder',
+			background: true,
+			task_id: '1.1',
+			prompt:
+				'TASK: 1.1\nFILE: src/example.ts\nACCEPTANCE: retain the current reservation on conflict',
+		};
+
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'current-call' },
+			{ args },
+		);
+		const admission = scanBackgroundCoderReservationsForAdmission(directory);
+		const reservation = admission.reservations[0];
+		expect(reservation?.correlationId).toBeNull();
+		await hook.toolAfter(
+			{
+				tool: 'Task',
+				sessionID: 'parent',
+				callID: 'current-call',
+				args,
+			},
+			{
+				state: 'running',
+				output:
+					'<task id="colliding-session" state="running">Background task started</task>',
+				metadata: { background: true, jobId: 'new-job' },
+			},
+		);
+
+		const advisory = session.pendingAdvisoryMessages?.at(-1) ?? '';
+		expect(advisory).toContain(
+			'No isolated worktree was attached to this conflicting call.',
+		);
+		expect(advisory).toContain(
+			`The current reservation ${reservation?.reservationId} was retained and was not bound to the conflicting correlation.`,
+		);
+		expect(
+			scanBackgroundCoderReservationsForAdmission(directory).reservations,
+		).toContainEqual(reservation);
+		expect(findByCorrelationId(directory, 'colliding-session')).toMatchObject({
+			parentSessionId: 'owner-parent',
+			callID: 'owner-call',
+		});
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate.test-fixtures.ts
+++ b/tests/unit/hooks/pr-workflow-gate.test-fixtures.ts
@@ -138,7 +138,10 @@ export async function persistBatch(
 	} = {},
 ): Promise<void> {
 	for (const [index, lane] of lanes.entries()) {
-		const correlationId = `${batchId}-${index}`;
+		// Correlation IDs identify one immutable launch. Derive the fixture ID from
+		// the logical lane so separate persistBatch calls for disjoint slices of the
+		// same batch cannot collide merely because each slice restarts at index 0.
+		const correlationId = `${batchId}--${lane.laneId}`;
 		const subagentSessionId = options.subagentSessionId ?? correlationId;
 		await recordPendingDelegation(tempDir, {
 			correlationId,

--- a/tests/unit/tools/dispatch-lanes-create-retry-concurrency.test.ts
+++ b/tests/unit/tools/dispatch-lanes-create-retry-concurrency.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import fs from 'node:fs';
+import {
+	findByBatchId,
+	findByCorrelationId,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import type { ParallelDispatcher } from '../../../src/parallel/dispatcher/parallel-dispatcher';
+import {
+	_internals,
+	_test_exports,
+	executeDispatchLanes,
+	executeDispatchLanesAsync,
+	type SessionOps,
+} from '../../../src/tools/dispatch-lanes';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const originalInternals = { ..._internals };
+const tempDirs: string[] = [];
+
+function tempProject(): string {
+	const directory = canonicalMkdtemp('dispatch-create-retry-concurrency-');
+	tempDirs.push(directory);
+	return directory;
+}
+
+function asyncOps(create: SessionOps['create']): SessionOps {
+	return {
+		create,
+		prompt: mock(async () => ({ data: { parts: [] } })),
+		promptAsync: mock(async () => ({})),
+		messages: mock(async () => ({ data: [] })),
+		abort: mock(async () => undefined),
+		delete: mock(async () => undefined),
+	};
+}
+
+afterEach(() => {
+	Object.assign(_internals, originalInternals);
+	for (const directory of tempDirs.splice(0)) {
+		fs.rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe('async create retry ownership and concurrency', () => {
+	test('releases and synchronously reacquires capacity between create attempts', async () => {
+		const events: string[] = [];
+		let slot = 0;
+		const dispatcher: ParallelDispatcher = {
+			config: {
+				enabled: true,
+				maxConcurrentTasks: 1,
+				evidenceLockTimeoutMs: 0,
+			},
+			dispatch: () => {
+				events.push('dispatch');
+				const slotId = `slot-${++slot}`;
+				return {
+					action: 'dispatch',
+					reason: 'slot',
+					slot: { slotId, taskId: 'lane', runId: `run-${slot}`, startedAt: 0 },
+				};
+			},
+			handles: () => [],
+			releaseSlot: () => events.push('release'),
+			shutdown: () => events.push('shutdown'),
+		};
+		_internals.createParallelDispatcher = () => dispatcher;
+		let attempt = 0;
+		const ops: SessionOps = {
+			create: mock(async () => {
+				events.push('create');
+				return ++attempt === 1
+					? { error: { status: 503 } }
+					: { data: { id: 'ok' } };
+			}),
+			prompt: mock(async () => {
+				events.push('prompt');
+				return { data: { parts: [] } };
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+
+		await executeDispatchLanes(
+			{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+
+		expect(events.slice(0, 6)).toEqual([
+			'dispatch',
+			'create',
+			'release',
+			'dispatch',
+			'create',
+			'prompt',
+		]);
+	});
+
+	test('fails a conflicting create id without disrupting its durable owner', async () => {
+		const directory = tempProject();
+		await recordPendingDelegation(directory, {
+			correlationId: 'shared-session',
+			jobId: null,
+			subagentSessionId: 'shared-session',
+			parentSessionId: 'original-parent',
+			callID: 'original-call',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'original-batch',
+			laneId: 'original-lane',
+			generation: 1,
+		});
+		const ops = asyncOps(
+			mock(async () => ({ data: { id: 'shared-session' } })),
+		);
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanesAsync(
+			{
+				batch_id: 'conflicting-batch',
+				lanes: [
+					{ id: 'new-lane', agent: 'reviewer', prompt: 'inspect conflict' },
+				],
+			},
+			directory,
+		);
+
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			error:
+				'Async lane session.create returned a correlation id owned by a different background delegation',
+		});
+		expect(ops.promptAsync).not.toHaveBeenCalled();
+		expect(ops.abort).not.toHaveBeenCalled();
+		expect(ops.delete).not.toHaveBeenCalled();
+		expect(findByCorrelationId(directory, 'shared-session')).toMatchObject({
+			parentSessionId: 'original-parent',
+			batchId: 'original-batch',
+			laneId: 'original-lane',
+		});
+		expect(findByBatchId(directory, 'conflicting-batch')).toEqual([]);
+	});
+
+	test('fails an exact duplicate create id without cleaning up the authoritative row', async () => {
+		const directory = tempProject();
+		const batchId = 'duplicate-batch';
+		const lane = {
+			id: 'duplicate-lane',
+			agent: 'reviewer',
+			prompt: 'inspect exact duplicate',
+		};
+		const create = mock(async () => {
+			await recordPendingDelegation(directory, {
+				correlationId: 'duplicate-session',
+				jobId: null,
+				subagentSessionId: 'duplicate-session',
+				parentSessionId: `dispatch_lanes_async:${batchId}`,
+				callID: batchId,
+				normalizedAgent: 'reviewer',
+				swarmPrefixedAgent: 'reviewer',
+				planTaskId: null,
+				evidenceTaskId: null,
+				batchId,
+				laneId: lane.id,
+				mode: 'advisory',
+				promptHash: _test_exports.promptHash(lane, directory, batchId),
+				workspace: {
+					directory,
+					gitHead: null,
+					dirtyHash: null,
+					prHeadSha: null,
+					scope: null,
+				},
+				generation: 1,
+			});
+			return { data: { id: 'duplicate-session' } };
+		});
+		const ops = asyncOps(create);
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanesAsync(
+			{ batch_id: batchId, lanes: [lane] },
+			directory,
+		);
+
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			error:
+				'Async lane session.create returned an already-recorded correlation id',
+		});
+		expect(ops.promptAsync).not.toHaveBeenCalled();
+		expect(ops.abort).not.toHaveBeenCalled();
+		expect(ops.delete).not.toHaveBeenCalled();
+		expect(findByCorrelationId(directory, 'duplicate-session')).toMatchObject({
+			batchId,
+			laneId: lane.id,
+			status: 'pending',
+		});
+	});
+
+	test('conserves two real dispatcher slots across concurrent retry generations', async () => {
+		const directory = tempProject();
+		let dispatcher: ParallelDispatcher | undefined;
+		_internals.createParallelDispatcher = (config) => {
+			dispatcher = originalInternals.createParallelDispatcher(config);
+			return dispatcher;
+		};
+		const attempts = new Map<string, number>();
+		let activeCreates = 0;
+		let maxActiveCreates = 0;
+		let pairWaiters: Array<() => void> = [];
+		const create = mock(async (input: Parameters<SessionOps['create']>[0]) => {
+			const title = input.body.title;
+			const attempt = (attempts.get(title) ?? 0) + 1;
+			attempts.set(title, attempt);
+			activeCreates++;
+			maxActiveCreates = Math.max(maxActiveCreates, activeCreates);
+			await new Promise<void>((resolve) => {
+				pairWaiters.push(resolve);
+				if (pairWaiters.length === 2) {
+					const pair = pairWaiters;
+					pairWaiters = [];
+					for (const release of pair) release();
+				}
+			});
+			activeCreates--;
+			return attempt === 1
+				? { error: { status: 503 } }
+				: { data: { id: `${title}-generation-${attempt}` } };
+		});
+		const ops = asyncOps(create);
+		_internals.getSessionOps = () => ops;
+		const lanes = Array.from({ length: 4 }, (_, index) => ({
+			id: `lane-${index + 1}`,
+			agent: 'reviewer',
+			prompt: `inspect lane ${index + 1}`,
+		}));
+
+		const result = await executeDispatchLanesAsync(
+			{ batch_id: 'conservation-batch', max_concurrent: 2, lanes },
+			directory,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.lane_results).toHaveLength(4);
+		expect(
+			result.lane_results.every((laneResult) => laneResult.generation === 2),
+		).toBe(true);
+		expect(create).toHaveBeenCalledTimes(8);
+		expect(maxActiveCreates).toBe(2);
+		expect(activeCreates).toBe(0);
+		expect(dispatcher?.handles()).toEqual([]);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-create-retry.test.ts
+++ b/tests/unit/tools/dispatch-lanes-create-retry.test.ts
@@ -1,0 +1,488 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import fs from 'node:fs';
+import {
+	findByBatchId,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import type { ParallelDispatcher } from '../../../src/parallel/dispatcher/parallel-dispatcher';
+import {
+	_internals,
+	_test_exports,
+	executeCollectLaneResults,
+	executeDispatchLanes,
+	executeDispatchLanesAsync,
+	type SessionOps,
+} from '../../../src/tools/dispatch-lanes';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const originalInternals = { ..._internals };
+const tempDirs: string[] = [];
+
+function tempProject(): string {
+	const directory = canonicalMkdtemp('dispatch-create-retry-');
+	tempDirs.push(directory);
+	return directory;
+}
+
+function blockingOps(
+	create: SessionOps['create'],
+	prompt: SessionOps['prompt'] = mock(async () => ({
+		data: { parts: [{ type: 'text', text: 'done' }] },
+	})),
+): SessionOps {
+	return {
+		create,
+		prompt,
+		delete: mock(async () => undefined),
+	};
+}
+
+function asyncOps(
+	create: SessionOps['create'],
+	promptAsync: NonNullable<SessionOps['promptAsync']> = mock(async () => ({})),
+): SessionOps {
+	return {
+		create,
+		prompt: mock(async () => ({ data: { parts: [] } })),
+		promptAsync,
+		messages: mock(async () => ({
+			data: [
+				{
+					info: { role: 'assistant' },
+					parts: [{ type: 'text', text: 'done' }],
+				},
+			],
+		})),
+		delete: mock(async () => undefined),
+	};
+}
+
+afterEach(() => {
+	Object.assign(_internals, originalInternals);
+	for (const directory of tempDirs.splice(0)) {
+		fs.rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe('bounded pre-prompt session.create retry', () => {
+	test('blocking dispatch retries a returned transient failure and exposes generation 2', async () => {
+		let attempt = 0;
+		const create = mock(async () =>
+			++attempt === 1
+				? { error: { response: { status: 503 } } }
+				: { data: { id: 'session-2' } },
+		);
+		const ops = blockingOps(create);
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(ops.prompt).toHaveBeenCalledTimes(1);
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'completed',
+			session_id: 'session-2',
+			generation: 2,
+		});
+	});
+
+	test('async dispatch retries a thrown transient failure and preserves generation through collection', async () => {
+		let attempt = 0;
+		const create = mock(async () => {
+			if (++attempt === 1) throw new Error('ECONNRESET');
+			return { data: { id: 'async-session-2' } };
+		});
+		const ops = asyncOps(create);
+		_internals.getSessionOps = () => ops;
+		const directory = tempProject();
+
+		const launched = await executeDispatchLanesAsync(
+			{
+				batch_id: 'retry-batch',
+				lanes: [{ id: 'tests', agent: 'reviewer', prompt: 'inspect' }],
+			},
+			directory,
+		);
+		expect(launched.lane_results[0]).toMatchObject({
+			status: 'pending',
+			generation: 2,
+		});
+		expect(findByBatchId(directory, 'retry-batch')[0]?.generation).toBe(2);
+
+		const collected = await executeCollectLaneResults(
+			{ batch_id: 'retry-batch' },
+			directory,
+		);
+		expect(collected.lane_results[0]?.generation).toBe(2);
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(ops.promptAsync).toHaveBeenCalledTimes(1);
+	});
+
+	test('async dispatch retries a returned transient failure before prompt admission', async () => {
+		let attempt = 0;
+		const create = mock(async () =>
+			++attempt === 1
+				? { error: { cause: { code: 'EAI_AGAIN' } } }
+				: { data: { id: 'async-returned-2' } },
+		);
+		const ops = asyncOps(create);
+		_internals.getSessionOps = () => ops;
+		const launched = await executeDispatchLanesAsync(
+			{
+				batch_id: 'async-returned',
+				lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }],
+			},
+			tempProject(),
+		);
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(launched.lane_results[0]).toMatchObject({
+			status: 'pending',
+			session_id: 'async-returned-2',
+			generation: 2,
+		});
+	});
+
+	test('fails a duplicate async create id without disrupting its authoritative owner', async () => {
+		const directory = tempProject();
+		await recordPendingDelegation(directory, {
+			correlationId: 'shared-session',
+			jobId: null,
+			subagentSessionId: 'shared-session',
+			parentSessionId: 'original-parent',
+			callID: 'original-batch',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'original-batch',
+			laneId: 'original-lane',
+			generation: 1,
+		});
+		const ops = asyncOps(
+			mock(async () => ({ data: { id: 'shared-session' } })),
+		);
+		ops.abort = mock(async () => undefined);
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanesAsync(
+			{
+				batch_id: 'colliding-batch',
+				lanes: [{ id: 'new-lane', agent: 'explorer', prompt: 'inspect' }],
+			},
+			directory,
+		);
+
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			session_id: 'shared-session',
+			generation: 1,
+		});
+		expect(ops.promptAsync).not.toHaveBeenCalled();
+		expect(ops.abort).not.toHaveBeenCalled();
+		expect(ops.delete).not.toHaveBeenCalled();
+		expect(findByBatchId(directory, 'original-batch')[0]).toMatchObject({
+			status: 'pending',
+			laneId: 'original-lane',
+			generation: 1,
+		});
+		expect(findByBatchId(directory, 'colliding-batch')).toEqual([]);
+	});
+
+	test('stops after exactly two transient create failures', async () => {
+		const create = mock(async () => ({ error: { statusCode: 503 } }));
+		const ops = blockingOps(create);
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(ops.prompt).not.toHaveBeenCalled();
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			generation: 2,
+		});
+	});
+
+	test('reports async create exhaustion immediately as generation 2', async () => {
+		const create = mock(async () => ({ error: { status: 503 } }));
+		const ops = asyncOps(create);
+		_internals.getSessionOps = () => ops;
+		const result = await executeDispatchLanesAsync(
+			{
+				batch_id: 'async-exhausted',
+				lanes: [{ id: 'runtime', agent: 'explorer', prompt: 'inspect' }],
+			},
+			tempProject(),
+		);
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(ops.promptAsync).not.toHaveBeenCalled();
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			generation: 2,
+		});
+	});
+
+	const permanentCases: Array<[string, unknown]> = [
+		['authentication', { status: 401, message: 'authentication failed' }],
+		['configuration', { message: 'invalid configuration' }],
+		['invalid agent', { error: { code: 'INVALID_AGENT' } }],
+		['invalid model', { cause: { message: 'model not found' } }],
+		['quota', { status: 429, message: 'insufficient quota' }],
+		['explicit opt-out', { status: 503, isRetryable: false }],
+	];
+	for (const [label, failure] of permanentCases) {
+		test(`does not retry permanent ${label} create failures`, async () => {
+			const create = mock(async () => ({ error: failure }));
+			const ops = blockingOps(create);
+			_internals.getSessionOps = () => ops;
+			const result = await executeDispatchLanes(
+				{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
+				tempProject(),
+			);
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(ops.prompt).not.toHaveBeenCalled();
+			expect(result.lane_results[0]?.generation).toBe(1);
+		});
+	}
+
+	test('treats a malformed create response as permanent', async () => {
+		const create = mock(async () => ({}));
+		const ops = blockingOps(create);
+		_internals.getSessionOps = () => ops;
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+		expect(create).toHaveBeenCalledTimes(1);
+		expect(result.lane_results[0]).toMatchObject({
+			generation: 1,
+			error: 'session.create failed: malformed response without a session id',
+		});
+	});
+
+	test('walks nested cyclic failures within fixed bounds and lets permanent signals win', () => {
+		const transient: Record<string, unknown> = { message: 'outer failure' };
+		transient.cause = { response: { status: 503 }, cause: transient };
+		expect(_test_exports.isRetryableSessionCreateFailure(transient)).toBe(true);
+
+		const mixed: Record<string, unknown> = { status: 503 };
+		mixed.cause = { message: 'invalid model configuration', cause: mixed };
+		expect(_test_exports.isRetryableSessionCreateFailure(mixed)).toBe(false);
+
+		const oversized = Array.from({ length: 80 }, (_, index) =>
+			index === 0 ? { status: 503 } : { detail: index },
+		);
+		expect(_test_exports.isRetryableSessionCreateFailure(oversized)).toBe(
+			false,
+		);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure({ retryAfterMs: 503 }),
+		).toBe(false);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure({
+				requestId: 'job-503',
+				metadata: { message: 'service unavailable' },
+			}),
+		).toBe(false);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure({
+				status: '401',
+				message: 'service unavailable',
+			}),
+		).toBe(false);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure({
+				code: '400',
+				message: 'server error',
+			}),
+		).toBe(false);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure({ status: '503' }),
+		).toBe(true);
+	});
+
+	test('retries a local create timeout and deletes the late first session without prompting it', async () => {
+		let resolveFirst!: (value: { data: { id: string } }) => void;
+		const first = new Promise<{ data: { id: string } }>((resolve) => {
+			resolveFirst = resolve;
+		});
+		let attempt = 0;
+		const create = mock(() =>
+			++attempt === 1
+				? first
+				: Promise.resolve({ data: { id: 'on-time-session' } }),
+		);
+		const ops = blockingOps(create);
+		_internals.getSessionOps = () => ops;
+		const result = await executeDispatchLanes(
+			{
+				timeout_ms: 10,
+				lanes: [{ id: 'timeout', agent: 'explorer', prompt: 'inspect' }],
+			},
+			tempProject(),
+		);
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'completed',
+			generation: 2,
+		});
+		expect(ops.prompt).toHaveBeenCalledTimes(1);
+		expect(ops.prompt.mock.calls[0]?.[0].path.id).toBe('on-time-session');
+
+		resolveFirst({ data: { id: 'late-first-session' } });
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(ops.delete).toHaveBeenCalledWith({
+			path: { id: 'late-first-session' },
+		});
+	});
+
+	test('never retries a blocking prompt after create generation 2 succeeds', async () => {
+		let attempt = 0;
+		const create = mock(async () =>
+			++attempt === 1
+				? { error: { status: 503 } }
+				: { data: { id: 'session-2' } },
+		);
+		const prompt = mock(async () => ({ error: { status: 503 } }));
+		const ops = blockingOps(create, prompt);
+		_internals.getSessionOps = () => ops;
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+		expect(create).toHaveBeenCalledTimes(2);
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(result.lane_results[0]).toMatchObject({
+			status: 'failed',
+			generation: 2,
+		});
+	});
+
+	const asyncPromptFailures: Array<
+		[string, () => Promise<{ error?: unknown }>]
+	> = [
+		[
+			'returned transient-looking error',
+			async () => ({ error: { status: 503 } }),
+		],
+		[
+			'thrown transport error',
+			async () => {
+				throw new Error('ECONNRESET');
+			},
+		],
+		[
+			'acceptance timeout',
+			async () => await new Promise<never>(() => undefined),
+		],
+	];
+	for (const [
+		caseIndex,
+		[label, implementation],
+	] of asyncPromptFailures.entries()) {
+		test(`keeps promptAsync single-shot after a ${label}`, async () => {
+			const directory = tempProject();
+			const create = mock(async () => ({ data: { id: `prompt-${label}` } }));
+			const promptAsync = mock(implementation);
+			const ops = asyncOps(create, promptAsync);
+			_internals.getSessionOps = () => ops;
+			const batchId = `single-shot-${caseIndex}`;
+			const result = await executeDispatchLanesAsync(
+				{
+					batch_id: batchId,
+					launch_timeout_ms: 10,
+					lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }],
+				},
+				directory,
+			);
+			expect(result.lane_results[0]?.generation).toBe(1);
+			for (let attempt = 0; attempt < 50; attempt++) {
+				if (findByBatchId(directory, batchId)[0]?.status === 'error') break;
+				await new Promise((resolve) => setTimeout(resolve, 1));
+			}
+			expect(promptAsync).toHaveBeenCalledTimes(1);
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(findByBatchId(directory, batchId)[0]?.status).toBe('error');
+		});
+	}
+
+	test('releases and synchronously reacquires dispatcher capacity between create attempts', async () => {
+		const events: string[] = [];
+		let slot = 0;
+		const dispatcher: ParallelDispatcher = {
+			config: {
+				enabled: true,
+				maxConcurrentTasks: 1,
+				evidenceLockTimeoutMs: 0,
+			},
+			dispatch: () => {
+				events.push('dispatch');
+				const slotId = `slot-${++slot}`;
+				return {
+					action: 'dispatch',
+					reason: 'slot',
+					slot: { slotId, taskId: 'lane', runId: `run-${slot}`, startedAt: 0 },
+				};
+			},
+			handles: () => [],
+			releaseSlot: () => events.push('release'),
+			shutdown: () => events.push('shutdown'),
+		};
+		_internals.createParallelDispatcher = () => dispatcher;
+		let attempt = 0;
+		const ops = blockingOps(
+			mock(async () => {
+				events.push('create');
+				return ++attempt === 1
+					? { error: { status: 503 } }
+					: { data: { id: 'ok' } };
+			}),
+			mock(async () => {
+				events.push('prompt');
+				return { data: { parts: [] } };
+			}),
+		);
+		_internals.getSessionOps = () => ops;
+		await executeDispatchLanes(
+			{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
+			tempProject(),
+		);
+		expect(events.slice(0, 6)).toEqual([
+			'dispatch',
+			'create',
+			'release',
+			'dispatch',
+			'create',
+			'prompt',
+		]);
+	});
+
+	test('defaults legacy collected rows without generation to 1', async () => {
+		const directory = tempProject();
+		await recordPendingDelegation(directory, {
+			correlationId: 'legacy-session',
+			jobId: null,
+			subagentSessionId: 'legacy-session',
+			parentSessionId: 'parent',
+			callID: 'legacy-batch',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'legacy-batch',
+			laneId: 'legacy',
+		});
+		_internals.getSessionOps = () =>
+			asyncOps(mock(async () => ({ data: { id: 'unused' } })));
+		const result = await executeCollectLaneResults(
+			{ batch_id: 'legacy-batch' },
+			directory,
+		);
+		expect(result.lane_results[0]?.generation).toBe(1);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-create-retry.test.ts
+++ b/tests/unit/tools/dispatch-lanes-create-retry.test.ts
@@ -4,7 +4,6 @@ import {
 	findByBatchId,
 	recordPendingDelegation,
 } from '../../../src/background/pending-delegations';
-import type { ParallelDispatcher } from '../../../src/parallel/dispatcher/parallel-dispatcher';
 import {
 	_internals,
 	_test_exports,
@@ -145,52 +144,6 @@ describe('bounded pre-prompt session.create retry', () => {
 		});
 	});
 
-	test('fails a duplicate async create id without disrupting its authoritative owner', async () => {
-		const directory = tempProject();
-		await recordPendingDelegation(directory, {
-			correlationId: 'shared-session',
-			jobId: null,
-			subagentSessionId: 'shared-session',
-			parentSessionId: 'original-parent',
-			callID: 'original-batch',
-			normalizedAgent: 'reviewer',
-			swarmPrefixedAgent: 'reviewer',
-			planTaskId: null,
-			evidenceTaskId: null,
-			batchId: 'original-batch',
-			laneId: 'original-lane',
-			generation: 1,
-		});
-		const ops = asyncOps(
-			mock(async () => ({ data: { id: 'shared-session' } })),
-		);
-		ops.abort = mock(async () => undefined);
-		_internals.getSessionOps = () => ops;
-
-		const result = await executeDispatchLanesAsync(
-			{
-				batch_id: 'colliding-batch',
-				lanes: [{ id: 'new-lane', agent: 'explorer', prompt: 'inspect' }],
-			},
-			directory,
-		);
-
-		expect(result.lane_results[0]).toMatchObject({
-			status: 'failed',
-			session_id: 'shared-session',
-			generation: 1,
-		});
-		expect(ops.promptAsync).not.toHaveBeenCalled();
-		expect(ops.abort).not.toHaveBeenCalled();
-		expect(ops.delete).not.toHaveBeenCalled();
-		expect(findByBatchId(directory, 'original-batch')[0]).toMatchObject({
-			status: 'pending',
-			laneId: 'original-lane',
-			generation: 1,
-		});
-		expect(findByBatchId(directory, 'colliding-batch')).toEqual([]);
-	});
-
 	test('stops after exactly two transient create failures', async () => {
 		const create = mock(async () => ({ error: { statusCode: 503 } }));
 		const ops = blockingOps(create);
@@ -305,6 +258,32 @@ describe('bounded pre-prompt session.create retry', () => {
 		expect(
 			_test_exports.isRetryableSessionCreateFailure({ status: '503' }),
 		).toBe(true);
+		expect(_test_exports.isRetryableSessionCreateFailure('ECONNRESET')).toBe(
+			true,
+		);
+		expect(
+			_test_exports.isRetryableSessionCreateFailure(
+				'invalid model configuration',
+			),
+		).toBe(false);
+		const lengthTrap = new Proxy([], {
+			get(target, property, receiver) {
+				if (property === 'length') throw new Error('length trap');
+				return Reflect.get(target, property, receiver);
+			},
+		});
+		expect(() =>
+			_test_exports.isRetryableSessionCreateFailure(lengthTrap),
+		).not.toThrow();
+		const revokedArray = Proxy.revocable([], {});
+		revokedArray.revoke();
+		let revokedResult: boolean | undefined;
+		expect(() => {
+			revokedResult = _test_exports.isRetryableSessionCreateFailure(
+				revokedArray.proxy,
+			);
+		}).not.toThrow();
+		expect(revokedResult).toBe(false);
 	});
 
 	test('retries a local create timeout and deletes the late first session without prompting it', async () => {
@@ -319,6 +298,13 @@ describe('bounded pre-prompt session.create retry', () => {
 				: Promise.resolve({ data: { id: 'on-time-session' } }),
 		);
 		const ops = blockingOps(create);
+		let resolveDeleted!: (args: { path: { id: string } }) => void;
+		const deleted = new Promise<{ path: { id: string } }>((resolve) => {
+			resolveDeleted = resolve;
+		});
+		ops.delete = mock(async (args) => {
+			if (args.path.id === 'late-first-session') resolveDeleted(args);
+		});
 		_internals.getSessionOps = () => ops;
 		const result = await executeDispatchLanes(
 			{
@@ -335,8 +321,7 @@ describe('bounded pre-prompt session.create retry', () => {
 		expect(ops.prompt.mock.calls[0]?.[0].path.id).toBe('on-time-session');
 
 		resolveFirst({ data: { id: 'late-first-session' } });
-		await new Promise((resolve) => setTimeout(resolve, 0));
-		expect(ops.delete).toHaveBeenCalledWith({
+		await expect(deleted).resolves.toEqual({
 			path: { id: 'late-first-session' },
 		});
 	});
@@ -390,6 +375,13 @@ describe('bounded pre-prompt session.create retry', () => {
 			const create = mock(async () => ({ data: { id: `prompt-${label}` } }));
 			const promptAsync = mock(implementation);
 			const ops = asyncOps(create, promptAsync);
+			let resolveCleanup!: () => void;
+			const cleanupStarted = new Promise<void>((resolve) => {
+				resolveCleanup = resolve;
+			});
+			ops.abort = mock(async () => {
+				resolveCleanup();
+			});
 			_internals.getSessionOps = () => ops;
 			const batchId = `single-shot-${caseIndex}`;
 			const result = await executeDispatchLanesAsync(
@@ -401,66 +393,12 @@ describe('bounded pre-prompt session.create retry', () => {
 				directory,
 			);
 			expect(result.lane_results[0]?.generation).toBe(1);
-			for (let attempt = 0; attempt < 50; attempt++) {
-				if (findByBatchId(directory, batchId)[0]?.status === 'error') break;
-				await new Promise((resolve) => setTimeout(resolve, 1));
-			}
+			await cleanupStarted;
 			expect(promptAsync).toHaveBeenCalledTimes(1);
 			expect(create).toHaveBeenCalledTimes(1);
 			expect(findByBatchId(directory, batchId)[0]?.status).toBe('error');
 		});
 	}
-
-	test('releases and synchronously reacquires dispatcher capacity between create attempts', async () => {
-		const events: string[] = [];
-		let slot = 0;
-		const dispatcher: ParallelDispatcher = {
-			config: {
-				enabled: true,
-				maxConcurrentTasks: 1,
-				evidenceLockTimeoutMs: 0,
-			},
-			dispatch: () => {
-				events.push('dispatch');
-				const slotId = `slot-${++slot}`;
-				return {
-					action: 'dispatch',
-					reason: 'slot',
-					slot: { slotId, taskId: 'lane', runId: `run-${slot}`, startedAt: 0 },
-				};
-			},
-			handles: () => [],
-			releaseSlot: () => events.push('release'),
-			shutdown: () => events.push('shutdown'),
-		};
-		_internals.createParallelDispatcher = () => dispatcher;
-		let attempt = 0;
-		const ops = blockingOps(
-			mock(async () => {
-				events.push('create');
-				return ++attempt === 1
-					? { error: { status: 503 } }
-					: { data: { id: 'ok' } };
-			}),
-			mock(async () => {
-				events.push('prompt');
-				return { data: { parts: [] } };
-			}),
-		);
-		_internals.getSessionOps = () => ops;
-		await executeDispatchLanes(
-			{ lanes: [{ id: 'lane', agent: 'explorer', prompt: 'inspect' }] },
-			tempProject(),
-		);
-		expect(events.slice(0, 6)).toEqual([
-			'dispatch',
-			'create',
-			'release',
-			'dispatch',
-			'create',
-			'prompt',
-		]);
-	});
 
 	test('defaults legacy collected rows without generation to 1', async () => {
 		const directory = tempProject();


### PR DESCRIPTION
Refs #1615

## Summary
- retry transient `session.create` failures once in blocking and asynchronous lane dispatch, with one-based generation visibility, dispatcher slot conservation, and late-session cleanup
- classify nested SDK failures through bounded, cycle-safe recognized fields while permanent/auth/config/quota signals and hostile proxy traversal fail closed
- distinguish exact duplicate correlation writes from conflicting owners; exact native Task replays hydrate their durable launch identity, while true conflicts preserve existing ownership and emit concrete reconciliation guidance
- keep `prompt`/`promptAsync` and native Task execution single-shot: existing observation and cancellation APIs do not atomically prove a rejected request was never accepted or executed, and no idempotent replay guarantee exists

## Invariant audit
- 1 (plugin init): not touched - no initialization or registration paths changed
- 2 (runtime portability): touched - `bun run build` and Node ESM import passed
- 3 (subprocesses): not touched - no subprocess production code changed
- 4 (.swarm containment): touched - delegation ledger reads/writes remain under the injected project directory; real-ledger replay and collision tests passed
- 5 (plan durability): not touched - no plan ledger or projection code changed
- 6 (test_runner safety): not touched - validation used explicit Bun test files, never broad `test_runner`
- 7 (test writing): touched - new test files are 269 and 257 lines, existing retry coverage is 426 lines, DI seams are restored, and no `mock.module` was added
- 8 (session state): touched - durable replay identity, correlation ownership, generation, late cleanup, and retained fail-closed reservations are covered by isolated suites
- 9 (guardrails/retry): touched - retry cap is exactly two create generations; prompt paths remain single-shot; concurrency, transient/permanent precedence, hostile proxies, and timeout cleanup are tested
- 10 (chat/system msg): not touched - no chat message transformation changed
- 11 (tool registration): not touched - no tools or agent maps changed
- 12 (release/cache): touched - `docs/releases/pending/1615-bounded-launch-retry.md` remains included; version files and generated `dist/` remain uncommitted

## Test plan
- [x] focused final feedback matrix: 130 passed, 0 failed across 9 files
- [x] replay/conflict gate suites: 7 passed, 0 failed
- [x] PR-workflow fixture blast radius: 270 passed, 1 platform-specific skip, 0 failed across 36 files; the skip was the unchanged `PR workflow exact checkout head > rejects a state-lock parent swapped after exclusive open (PRR-009)` case
- [x] `bun run typecheck`
- [x] `bun run lint:ci`
- [x] `bun run build`
- [x] `node --input-type=module -e "await import('./dist/index.js')"`
- [x] `git diff --check`
- [x] test-file-cap, test-clock, temp-root, and mock-cleanup ratchets reported zero new violations
- [x] independent feedback reviewer: all 11 findings APPROVE
- [x] independent test engineer: all 11 findings PASS
- [x] prior GitHub CI at the reviewed head: quality, six unit shards, integration, coverage, security, package-check, and smoke on Ubuntu/macOS/Windows passed

The local Windows Git-Bash ratchet scripts printed passing summaries but also emitted missing-coreutils noise from this workstation's Git-Bash environment. Typecheck, Biome, focused tests, and GitHub CI provide the authoritative validation; no ratchet reported a new violation.
