### PR TITLE
fix(scripts): make the FR-006 test-file cap gate cross-platform (#2078)

### DIFF
--- a/.agents/skills/test-file-split/SKILL.md
+++ b/.agents/skills/test-file-split/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: test-file-split
 audience: swarm-plugin
-description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.sh as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
+description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.ts as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
 ---
 
 # Test File Split Protocol (FR-006)
 
-`scripts/check-test-file-cap.sh` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
+`scripts/check-test-file-cap.ts` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
 
 Read first: `.opencode/skills/writing-tests/SKILL.md` (or `.claude/skills/writing-tests/SKILL.md`) for bun:test framework rules, mock isolation patterns, and file placement conventions.
 

--- a/.claude/skills/test-file-split/SKILL.md
+++ b/.claude/skills/test-file-split/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: test-file-split
 audience: swarm-plugin
-description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.sh as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
+description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.ts as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
 ---
 
 # Test File Split Protocol (FR-006)
 
-`scripts/check-test-file-cap.sh` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
+`scripts/check-test-file-cap.ts` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
 
 Read first: `.opencode/skills/writing-tests/SKILL.md` (or `.claude/skills/writing-tests/SKILL.md`) for bun:test framework rules, mock isolation patterns, and file placement conventions.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,11 +214,20 @@ jobs:
       # Diff-scoped ratchet (FR-006): fails only on NEW test files over 500
       # lines or existing over-cap files that grew. Pre-existing violators
       # are non-blocking. Escape hatch: TEST_CAP_ENFORCE=0 soft-warns.
-      # (issue #1781 E1)
+      # (issue #1781 E1). Ported to TypeScript in issue #2078 so Windows
+      # contributors can run the identical gate locally with
+      # `bun run check:test-file-cap` — no Bash required.
       - name: Test file line-cap ratchet (FR-006)
         if: needs.detect-release.outputs.is-release != 'true'
-        shell: bash
-        run: chmod +x scripts/check-test-file-cap.sh && bash scripts/check-test-file-cap.sh
+        run: bun run check:test-file-cap
+      # Issue #2078 recurrence guardrail: a NEW Bash-only gate wired into any
+      # workflow is blocked, because Windows contributors cannot run it
+      # locally. Existing Bash gates are baselined in
+      # scripts/gate-portability-baseline.json; porting one must remove its
+      # entry (stale entries also fail).
+      - name: CI gate portability ratchet (issue #2078)
+        if: needs.detect-release.outputs.is-release != 'true'
+        run: bun run check:gate-portability
       # Line-scoped (not file-scoped): fails only on NEW/changed lines that add
       # a raw tmpdir() call not wrapped in realpathSync. Pre-existing raw calls
       # elsewhere in a touched file are not flagged (issue #1737 FR-011 scope

--- a/.opencode/skills/test-file-split/SKILL.md
+++ b/.opencode/skills/test-file-split/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: test-file-split
 audience: swarm-plugin
-description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.sh as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
+description: Protocol for splitting test files that approach or exceed the FR-006 500-line limit (enforced in CI by scripts/check-test-file-cap.ts as a diff-scoped ratchet). Covers describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, and cascading-split detection. Load when a test file approaches or exceeds 500 lines.
 ---
 
 # Test File Split Protocol (FR-006)
 
-`scripts/check-test-file-cap.sh` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
+`scripts/check-test-file-cap.ts` enforces the **500-line cap** per test file (FR-006 / SC-006.1) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. This skill covers the complete splitting protocol.
 
 Read first: `.opencode/skills/writing-tests/SKILL.md` (or `.claude/skills/writing-tests/SKILL.md`) for bun:test framework rules, mock isolation patterns, and file placement conventions.
 

--- a/.opencode/skills/writing-tests/SKILL.md
+++ b/.opencode/skills/writing-tests/SKILL.md
@@ -615,7 +615,21 @@ authority checks:
 
 ## FR-006: Test File Size Limit (500 lines)
 
-`scripts/check-test-file-cap.sh` enforces the **500-line cap** per test file (FR-006) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns (use only for a deliberate growth PR).
+`scripts/check-test-file-cap.ts` enforces the **500-line cap** per test file (FR-006) as a **diff-scoped ratchet**: new test files over 500 lines and existing over-cap files that grew fail the quality gate and block PR merge. Pre-existing over-cap files not touched by the PR are non-blocking. Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns (use only for a deliberate growth PR).
+
+### Local validation (all platforms, including Windows)
+
+Run the **identical** gate CI runs — no Bash required (issue #2078):
+
+```
+bun run check:test-file-cap
+```
+
+- Works in Windows PowerShell, macOS, and Linux; `scripts/check-test-file-cap.sh` is a zero-logic shim that `exec`s the same TypeScript file, so the two entry points cannot report different results.
+- The gate is **diff-scoped**: it compares your branch against the first of `origin/main`, `origin/master`, `main`, `master` that resolves. Run `git fetch origin main` first — a stale or missing base makes the comparison stale, and with **no** base branch resolvable the gate has nothing to compare and reports zero violations (a vacuous pass, not a real one). A branch that is *behind* its base is the other stale-base trap: the diff then contains the base's own commits in reverse, so counts are meaningless until you rebase.
+- Directory-independent: the gate resolves the repository root itself, so running it from a subdirectory gives the same result as running it from the root.
+- Exit `1` means a violation and enforcement is on; exit `0` with printed `ERROR` lines means you set `TEST_CAP_ENFORCE=0` (soft-warn). Verify the summary counters, not just the exit code.
+- The gate reads files **from the working tree** but takes the changed-file list from `<base>..HEAD`, so a new over-cap test file that is not yet committed is invisible to it. Commit before trusting a green run.
 
 For the full splitting protocol (describe-block extraction, shared helper management, pure-function extraction, mock isolation verification, cascading-split detection), read `file:.swarm/bundled-skills/test-file-split/SKILL.md`.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -100,7 +100,7 @@ import { execFileSync } from 'node:child_process';
 ### Test File Size Limits
 
 To prevent monolithic test files that cause mock isolation issues and slow CI:
-- **Maximum 500 lines per test file** (enforced in CI by `scripts/check-test-file-cap.sh` as a diff-scoped ratchet: new over-cap files and existing over-cap files that grew fail the gate; pre-existing over-cap files untouched by the PR are non-blocking; `TEST_CAP_ENFORCE=0` soft-warns)
+- **Maximum 500 lines per test file** (enforced in CI by `scripts/check-test-file-cap.ts` as a diff-scoped ratchet: new over-cap files and existing over-cap files that grew fail the gate; pre-existing over-cap files untouched by the PR are non-blocking; `TEST_CAP_ENFORCE=0` soft-warns). Run the same gate locally on any platform, Windows included, with `bun run check:test-file-cap`.
 - `delegation-gate.test.ts` was split into 45 focused files (FR-006 SC-006.1) — all under 500 lines
 - When a test file exceeds 500 lines, split it by behavior/feature into focused files
 

--- a/contributing.md
+++ b/contributing.md
@@ -266,7 +266,7 @@ All tests use `bun:test`. Do not use Jest, Vitest, or any other framework. See `
 
 ### Test file size limits
 
-- **Maximum 500 lines per test file** (FR-006 SC-006.1), enforced by `scripts/check-test-file-cap.sh` as a diff-scoped ratchet (new over-cap files and grown over-cap files fail CI; pre-existing violators are non-blocking). Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns.
+- **Maximum 500 lines per test file** (FR-006 SC-006.1), enforced by `scripts/check-test-file-cap.ts` as a diff-scoped ratchet (new over-cap files and grown over-cap files fail CI; pre-existing violators are non-blocking). Escape hatch: `TEST_CAP_ENFORCE=0` soft-warns. Verify locally on any platform — Windows PowerShell included — with `bun run check:test-file-cap` (fetch `origin/main` first; the check is diff-scoped and reads committed changes).
 - `delegation-gate.test.ts` was the monolith — 2835 lines split into 45 focused files, each under 500 lines
 - When a test file exceeds 500 lines, split it by behavior/feature into focused files
 - SME tests (FR-008) use parameterization to keep files lean while maximizing coverage

--- a/docs/releases/pending/2078-test-file-cap-cross-platform.md
+++ b/docs/releases/pending/2078-test-file-cap-cross-platform.md
@@ -1,0 +1,24 @@
+# Cross-platform FR-006 test-file cap gate + Bash-only-gate recurrence ratchet (issue #2078)
+
+Issue: #2078
+
+## What
+
+`scripts/check-test-file-cap.sh` enforced the FR-006 500-line test-file cap in CI but was Bash-only. On a Windows host without Bash in PATH it could not run, so Windows contributors had no way to verify the cap locally before pushing and fell back to manual line counting.
+
+The ratchet is now implemented once, in TypeScript:
+
+- **`scripts/check-test-file-cap.ts`** — the single source of truth for the cap value (`MAX_LINES = 500`), the `TEST_CAP_ENFORCE` truth table, `wc -l`-equivalent CRLF-normalized line counting, and the new-file / ratchet / pre-existing decision table. The ratchet decision table, the message strings, and the exit codes are byte-for-byte unchanged (verified by running the pre-change script and the port side by side against the real repo). Git plumbing is injected into a pure `evaluateCap()` so the decision table is directly unit-testable. Two deliberate improvements over the Bash original: changed-file lists are read NUL-separated (`git diff -z`), fixing path-quoting fragility; and the gate resolves the repository root via `git rev-parse --show-toplevel`, so running it from a subdirectory no longer produces a silent vacuous pass (previously every file lookup missed and the gate reported "all checks passed").
+- **`bun run check:test-file-cap`** — the single command a contributor runs on Windows PowerShell, macOS, or Linux.
+- **`scripts/check-test-file-cap.sh`** — retained as a zero-logic shim that `exec`s the TypeScript gate, so every existing reference to the `.sh` path keeps working and the two entry points cannot report different results. A test asserts the shim contains no cap value, no `MAX_LINES`, and no `TEST_CAP_ENFORCE` parsing, which is what prevents the drifting-clone outcome the issue warned against.
+- **`.github/workflows/ci.yml`** — the quality-job step now runs `bun run check:test-file-cap` with no `shell: bash` and no `chmod`. CI behavior is otherwise unchanged: it still hard-fails on a cap violation.
+
+## Recurrence guardrail
+
+Fixing the one script does not close the class — the next gate added as a `.sh` reintroduces it silently. **`scripts/check-gate-portability.ts`** (`bun run check:gate-portability`, wired into the CI quality job) fails when any `scripts/**/*.sh` referenced from a `.github/workflows/` file — or, recursively, from a local composite action under `.github/actions/` — is missing from `scripts/gate-portability-baseline.json`. The eight currently-referenced Bash scripts are baselined with a category (`legacy-bash-gate` or `ci-infrastructure`) and a written justification; stale entries and invalid categories also fail, so porting a legacy gate forces its exemption to be removed rather than rotting.
+
+The check announces the roots it scanned (`Scan roots: .github/workflows, .github/actions`) before its summary. That line is load-bearing, not decoration: `.github/actions/` does not exist in this repo today, so a silently narrowed scan set would otherwise be invisible in both CI output and tests. Mutation testing confirms the guardrail's own coverage — ignoring the roots parameter, threading only the first root, dropping the actions entry from the defaults, narrowing the default binding, hardcoding the announcement, and removing the announcement each turn the suite red.
+
+## Docs
+
+`.opencode/skills/writing-tests/SKILL.md` gains a "Local validation (all platforms, including Windows)" subsection covering the command, the `origin/main` fetch prerequisite, the vacuous-pass case when no base branch resolves, the soft-warn exit-code trap, and the fact that the gate takes its file list from `<base>..HEAD` (so uncommitted work is invisible to it). `contributing.md`, `TESTING.md`, and the `test-file-split` skill mirrors point at the new entry point.

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
 		"repro:704": "node scripts/repro-704.mjs",
 		"repro:1144": "bun scripts/repro-1144.mjs",
 		"repro:1873": "bun build scripts/repro-1873-entry.ts --outdir dist-build-test/repro-1873 --target node --format esm && node scripts/repro-1873.mjs",
-		"check:events": "bun run scripts/check-event-contract.ts"
+		"check:events": "bun run scripts/check-event-contract.ts",
+		"check:test-file-cap": "bun run scripts/check-test-file-cap.ts",
+		"check:gate-portability": "bun run scripts/check-gate-portability.ts"
 	},
 	"dependencies": {
 		"@opencode-ai/plugin": "^1.18.3",

--- a/scripts/check-gate-portability.ts
+++ b/scripts/check-gate-portability.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env bun
+/**
+ * Issue #2078 recurrence guardrail — "Bash-only CI gate" class ratchet.
+ *
+ * Defect class: a contributor-facing CI check implemented as a Bash-only
+ * script and invoked from a workflow as `bash scripts/<name>.sh` cannot be run
+ * on a Windows host without Bash in PATH. Windows contributors then have no
+ * way to reproduce the gate locally, fall back to manual verification, and
+ * routinely skip it — which is exactly the failure issue #2078 reported for
+ * `check-test-file-cap.sh`.
+ *
+ * Fixing the one instance does not close the class: the next gate added as a
+ * `.sh` reintroduces it silently. This script makes the class mechanically
+ * detectable.
+ *
+ * Rule: every `scripts/**\/*.sh` path referenced from any GitHub Actions YAML
+ * under `.github/workflows/` OR `.github/actions/` (local composite actions,
+ * scanned recursively — a gate invoked from an action is the same gate wearing
+ * a different hat) must be listed in
+ * `scripts/gate-portability-baseline.json`. A NEW Bash-only gate therefore
+ * fails CI, and the fix is to implement it in TypeScript (`bun run
+ * scripts/<name>.ts`, wired through a `package.json` script) the way
+ * `check-test-file-cap.ts` now is.
+ *
+ * The baseline is also checked for rot: an entry naming a script no longer
+ * referenced by any workflow fails, so porting a legacy gate forces the
+ * baseline to shrink rather than silently keeping a dead exemption.
+ *
+ * Usage: bun run check:gate-portability
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'..',
+);
+
+export const WORKFLOW_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+/** Local composite actions are scanned too — they can invoke gates as well. */
+export const ACTIONS_DIR = path.join(REPO_ROOT, '.github', 'actions');
+export const BASELINE_PATH = path.join(
+	REPO_ROOT,
+	'scripts',
+	'gate-portability-baseline.json',
+);
+
+/**
+ * Why a Bash-only gate is still permitted.
+ * - `legacy-bash-gate`: predates issue #2078; contributor-facing but not yet
+ *   ported. Porting it is welcome and must remove the baseline entry.
+ * - `ci-infrastructure`: runs only inside the GitHub Actions runner (never a
+ *   pre-push local gate), so a Windows contributor is never expected to run it.
+ */
+export const ALLOWED_CATEGORIES = [
+	'legacy-bash-gate',
+	'ci-infrastructure',
+] as const;
+export type GateCategory = (typeof ALLOWED_CATEGORIES)[number];
+
+export interface BaselineEntry {
+	script: string;
+	category: GateCategory;
+	reason: string;
+}
+
+/** Matches any `scripts/…​.sh` path token appearing in workflow YAML. */
+const SCRIPT_REF_PATTERN = /scripts\/[A-Za-z0-9_./-]*\.sh/g;
+
+/**
+ * Collect every `scripts/*.sh` path referenced by the given workflow sources.
+ * Comment lines (`#` after optional whitespace) are ignored so a prose mention
+ * of a script in an explanatory comment does not require a baseline entry.
+ */
+export function collectScriptRefs(
+	sources: Array<{ file: string; content: string }>,
+): Map<string, string[]> {
+	const refs = new Map<string, string[]>();
+	for (const { file, content } of sources) {
+		for (const rawLine of content.split('\n')) {
+			const line = rawLine.replace(/\r$/, '');
+			if (/^\s*#/.test(line)) {
+				continue;
+			}
+			SCRIPT_REF_PATTERN.lastIndex = 0;
+			let match = SCRIPT_REF_PATTERN.exec(line);
+			while (match !== null) {
+				const script = match[0];
+				const seen = refs.get(script);
+				if (seen) {
+					if (!seen.includes(file)) {
+						seen.push(file);
+					}
+				} else {
+					refs.set(script, [file]);
+				}
+				match = SCRIPT_REF_PATTERN.exec(line);
+			}
+		}
+	}
+	return refs;
+}
+
+export interface PortabilityResult {
+	messages: string[];
+	unbaselined: string[];
+	staleBaseline: string[];
+	invalidCategories: string[];
+	exitCode: number;
+}
+
+export function evaluatePortability(
+	referenced: Map<string, string[]>,
+	baseline: BaselineEntry[],
+): PortabilityResult {
+	const messages: string[] = [];
+	const baselineScripts = new Set(baseline.map((entry) => entry.script));
+
+	const invalidCategories: string[] = [];
+	for (const entry of baseline) {
+		if (!ALLOWED_CATEGORIES.includes(entry.category)) {
+			invalidCategories.push(entry.script);
+			messages.push(
+				`ERROR (bad category): ${entry.script} declares category "${entry.category}"; allowed: ${ALLOWED_CATEGORIES.join(', ')}.`,
+			);
+		}
+		if (!entry.reason || entry.reason.trim().length === 0) {
+			invalidCategories.push(entry.script);
+			messages.push(
+				`ERROR (missing reason): ${entry.script} has no justification in the baseline.`,
+			);
+		}
+	}
+
+	const unbaselined: string[] = [];
+	for (const [script, files] of [...referenced.entries()].sort()) {
+		if (!baselineScripts.has(script)) {
+			unbaselined.push(script);
+			messages.push(
+				`ERROR (new Bash-only gate): ${script} is invoked from ${files.join(', ')} but is not in scripts/gate-portability-baseline.json.`,
+			);
+			messages.push(
+				'  A Bash-only gate cannot be run by Windows contributors (issue #2078).',
+			);
+			messages.push(
+				'  Implement it as scripts/<name>.ts + a package.json script (see check-test-file-cap.ts),',
+			);
+			messages.push(
+				'  or add a baseline entry with a category and a written justification.',
+			);
+		}
+	}
+
+	const staleBaseline: string[] = [];
+	for (const script of [...baselineScripts].sort()) {
+		if (!referenced.has(script)) {
+			staleBaseline.push(script);
+			messages.push(
+				`ERROR (stale baseline): ${script} is baselined but no workflow references it. Remove the entry.`,
+			);
+		}
+	}
+
+	const failures =
+		unbaselined.length + staleBaseline.length + invalidCategories.length;
+
+	messages.push('');
+	messages.push('=== CI gate portability (issue #2078) summary ===');
+	messages.push(`Referenced Bash gates:   ${referenced.size}`);
+	messages.push(`Unbaselined (new):       ${unbaselined.length}`);
+	messages.push(`Stale baseline entries:  ${staleBaseline.length}`);
+	messages.push(`Invalid baseline rows:   ${invalidCategories.length}`);
+
+	if (failures === 0) {
+		messages.push('All CI gate portability checks passed.');
+	}
+
+	return {
+		messages,
+		unbaselined,
+		staleBaseline,
+		invalidCategories,
+		exitCode: failures > 0 ? 1 : 0,
+	};
+}
+
+/**
+ * Recursively collect `*.yml` / `*.yaml` sources under `dir`. Composite
+ * actions (`.github/actions/<name>/action.yml`) are scanned as well as
+ * workflows: a `run: bash scripts/x.sh` inside a local composite action is the
+ * same Bash-only gate wearing a different hat (issue #2078 review finding 4).
+ */
+function collectYamlFiles(
+	dir: string,
+	labelPrefix: string,
+): Array<{ file: string; content: string }> {
+	if (!fs.existsSync(dir)) {
+		return [];
+	}
+	const out: Array<{ file: string; content: string }> = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		const abs = path.join(dir, entry.name);
+		const label = `${labelPrefix}/${entry.name}`;
+		if (entry.isDirectory()) {
+			out.push(...collectYamlFiles(abs, label));
+		} else if (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml')) {
+			out.push({ file: label, content: fs.readFileSync(abs, 'utf-8') });
+		}
+	}
+	return out;
+}
+
+/** Scan roots, as `[absolute dir, label used in error messages]` pairs. */
+export const DEFAULT_SCAN_ROOTS: ReadonlyArray<readonly [string, string]> = [
+	[WORKFLOW_DIR, '.github/workflows'],
+	[ACTIONS_DIR, '.github/actions'],
+];
+
+/**
+ * Read every YAML source that can invoke a gate. Callers (including tests)
+ * may pass their own roots; the default pair is what CI scans. Each root is
+ * walked recursively, because a composite action's `action.yml` sits one level
+ * deeper than a workflow file.
+ */
+export function readWorkflowSources(
+	roots: ReadonlyArray<readonly [string, string]> = DEFAULT_SCAN_ROOTS,
+): Array<{ file: string; content: string }> {
+	const sources: Array<{ file: string; content: string }> = [];
+	for (const [dir, label] of roots) {
+		sources.push(...collectYamlFiles(dir, label));
+	}
+	return sources;
+}
+
+export function readBaseline(file: string = BASELINE_PATH): BaselineEntry[] {
+	const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+		entries?: BaselineEntry[];
+	};
+	return parsed.entries ?? [];
+}
+
+/** Header line naming the roots that were scanned, for the run's own output. */
+export function formatScanRoots(
+	roots: ReadonlyArray<readonly [string, string]>,
+): string {
+	return `Scan roots: ${roots.map(([, label]) => label).join(', ')}`;
+}
+
+export function main(
+	roots: ReadonlyArray<readonly [string, string]> = DEFAULT_SCAN_ROOTS,
+): number {
+	// Printing the roots is not decoration: `.github/actions/` does not exist in
+	// this repo today, so a silently narrowed scan set would otherwise be
+	// invisible in both CI output and tests (issue #2078 final-critic note 1).
+	// This line makes the default binding observable, so shrinking it fails a
+	// test instead of quietly disarming the guardrail.
+	console.log(formatScanRoots(roots));
+	const referenced = collectScriptRefs(readWorkflowSources(roots));
+	const result = evaluatePortability(referenced, readBaseline());
+	for (const line of result.messages) {
+		console.log(line);
+	}
+	return result.exitCode;
+}
+
+const isDirectRun =
+	typeof process.argv[1] === 'string' &&
+	path.resolve(process.argv[1]) ===
+		path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectRun) {
+	process.exit(main());
+}

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -194,7 +194,7 @@ echo "=== Check 4: mock.module allowlist growth ratchet (issue #1666) ==="
 # Diff-scoped ratchet: fails CI when scripts/mock-allowlist.txt grows relative
 # to the PR base, unless each newly added target has a matching standalone
 # marker line  # APPROVED-NEW: <normalized-target>  somewhere in the file.
-# Mirrors scripts/check-test-file-cap.sh's diff-scoped shape and the
+# Mirrors scripts/check-test-file-cap.ts's diff-scoped shape and the
 # MOCK_ALLOWLIST_ENFORCE truth table (default-enforce-when-unset, like
 # TEST_CAP_ENFORCE). Closes the remaining open item of issue #1666: the
 # membership check (Check 3) cannot detect growth when the allowlist is
@@ -207,7 +207,7 @@ ratchet_violations=0
 # only (set-difference against the PR base), so defaulting to enforce in CI
 # (where the var is unset) is correct.
 if [ -z "${MOCK_ALLOWLIST_ENFORCE+x}" ]; then
-  ratchet_enforce=1  # unset → enforce (mirror check-test-file-cap.sh:46)
+  ratchet_enforce=1  # unset → enforce (mirror check-test-file-cap.ts resolveEnforce)
 else
   case "$(echo "${MOCK_ALLOWLIST_ENFORCE}" | tr '[:upper:]' '[:lower:]')" in
     0|false|no|off) ratchet_enforce=0;;
@@ -215,7 +215,7 @@ else
   esac
 fi
 
-# --- Resolve base branch (mirror check-test-file-cap.sh:69-76) ---
+# --- Resolve base branch (mirror check-test-file-cap.ts resolveBaseBranch) ---
 ratchet_base_branch=""
 for branch in origin/main origin/master main master; do
   if git rev-parse "$branch" >/dev/null 2>&1; then
@@ -242,7 +242,7 @@ else
   # --- Read head entries from the working-tree allowlist ---
   # `tr -d '\r'` normalizes CRLF→LF so a Windows contributor with
   # core.autocrlf=true does not false-trigger "every entry is new" (issue
-  # #1781 re-critic B6 — same landmine as check-test-file-cap.sh:102).
+  # #1781 re-critic B6 — same landmine as check-test-file-cap.ts).
   head_entries=()
   while IFS= read -r pattern; do
     case "$pattern" in
@@ -311,7 +311,7 @@ else
   # --- For each added entry, require a matching approved marker ---
   # Only increment the script-level `violations` counter when enforce is on.
   # In soft-warn mode we still report each violation but do not fail the build
-  # (mirrors check-test-file-cap.sh:161-169's exit-decision gating).
+  # (mirrors check-test-file-cap.ts evaluateCap's exit-decision gating).
   for added in ${added_entries[@]+"${added_entries[@]}"}; do
     if array_contains "$added" ${approved_markers[@]+"${approved_markers[@]}"}; then
       continue

--- a/scripts/check-test-file-cap.sh
+++ b/scripts/check-test-file-cap.sh
@@ -1,171 +1,18 @@
 #!/usr/bin/env bash
-# Issue #1781 E1 — enforce the FR-006 500-line test-file cap as a diff-scoped
-# ratchet. AGENTS.md invariant 7 and contributing.md/TESTING.md document the
-# rule; this script makes it bite in CI.
+# Issue #2078 — ZERO-LOGIC SHIM.
 #
-# Ratchet semantics (mirrors scripts/check-mock-cleanup.sh FB-001 and
-# scripts/check-test-clock.sh):
-#   - Pre-existing over-cap files NOT in the PR diff → non-blocking (silent).
-#   - NEW test files in the diff over the cap → ERROR (blocking).
-#   - MODIFIED test files in the diff that are over the cap AND grew →
-#     ERROR (ratchet arm).
-#   - MODIFIED over-cap files that shrank or stayed equal → pass.
-#   - Pre-existing violators never fail unrelated PRs.
+# The FR-006 500-line test-file cap ratchet (issue #1781 E1) now lives in
+# scripts/check-test-file-cap.ts so it runs identically on Windows, macOS, and
+# Linux. This shim exists only so the historical `scripts/check-test-file-cap.sh`
+# path keeps working for existing docs, release-note fragments, and muscle
+# memory. It MUST NOT contain any cap value, ratchet rule, or env-var parsing —
+# every such decision belongs to the TypeScript implementation, which is the
+# single source of truth. Adding logic here re-creates the drifting-clone
+# problem issue #2078 was filed to prevent.
 #
-# Escape hatch (issue #1781 re-critic B5): TEST_CAP_ENFORCE. Default is ENFORCE
-# (unset → hard-fail), the opposite of DRIFT_CHECK_ENFORCE's default, because
-# the ratchet is already scoped to new/grown files only. Set
-#   TEST_CAP_ENFORCE=0|false|no|off
-# to soft-warn (print violations, exit 0) — useful for a deliberate growth PR.
-#
-# Line-ending handling (issue #1781 re-critic B6): `tr -d '\r' | wc -l`
-# normalizes CRLF→LF before counting so a pure line-ending normalization does
-# not false-fail "grew by 1".
-#
-# Rename handling (issue #1781 re-critic B6): `git diff --diff-filter=A
-# --find-renames=100%` treats only exact-content renames as renames (R); a
-# renamed+grown file falls below 100% similarity → classified as Added →
-# flagged by the new-file arm.
-#
-# Portability (issue #1729 merge_group macOS): bash 3.2 on macOS — no
-# associative arrays, no `grep -P`. Plain indexed arrays + grep -E only.
+# Preferred cross-platform invocation:
+#   bun run check:test-file-cap
 set -euo pipefail
 
-MAX_LINES=500
-violations=0
-new_file_violations=0
-ratchet_violations=0
-
-# --- TEST_CAP_ENFORCE truth table (re-critic B5) ---
-# unset OR any value other than 0/false/no/off → hard-fail (default enforce).
-# 0/false/no/off → soft-warn (exit 0). This is the OPPOSITE default from
-# DRIFT_CHECK_ENFORCE: the ratchet is already scoped to new/grown files only,
-# so defaulting to enforce in CI (where the var is unset) is correct.
-if [ -z "${TEST_CAP_ENFORCE+x}" ]; then
-    is_enforce_resolved=1  # unset → enforce
-else
-    case "$(echo "${TEST_CAP_ENFORCE}" | tr '[:upper:]' '[:lower:]')" in
-        0|false|no|off) is_enforce_resolved=0;;
-        *) is_enforce_resolved=1;;
-    esac
-fi
-
-# --- helpers (verbatim from check-test-clock.sh:33-56) ---
-get_pr_changed_files() {
-    local pr_files=""
-    local base_branch=""
-    for branch in origin/main origin/master main master; do
-        if git rev-parse "$branch" >/dev/null 2>&1; then
-            base_branch="$branch"
-            break
-        fi
-    done
-    if [ -n "$base_branch" ]; then
-        pr_files=$(git diff --name-only "$base_branch" HEAD 2>/dev/null || echo "")
-    fi
-    echo "$pr_files"
-}
-
-# Resolve base branch once (used for both changed-file list and added-file list).
-base_branch=""
-for branch in origin/main origin/master main master; do
-    if git rev-parse "$branch" >/dev/null 2>&1; then
-        base_branch="$branch"
-        break
-    fi
-done
-
-PR_CHANGED_FILES="$(get_pr_changed_files)"
-
-# Added-file set: `--find-renames=100%` means only exact-content renames are
-# detected as renames (R); a renamed-and-modified file falls below 100%
-# similarity and shows as Added (A). This is the desired semantics — a renamed
-# file whose content changed should be treated as new for cap purposes.
-ADDED_FILES=""
-if [ -n "$base_branch" ]; then
-    ADDED_FILES=$(git diff --diff-filter=A --name-only --find-renames=100% \
-        "$base_branch" HEAD 2>/dev/null || echo "")
-fi
-
-is_added_file() {
-    local file="$1"
-    if [ -z "$ADDED_FILES" ]; then
-        return 1
-    fi
-    echo "$ADDED_FILES" | grep -qFx "$file"
-    return $?
-}
-
-# Normalized line count: strip CR before counting so CRLF/LF normalization
-# cannot false-fail the ratchet comparison.
-normalized_wc() {
-    tr -d '\r' < "$1" | wc -l | tr -d ' '
-}
-
-# Iterate over every test file currently in the tree that is part of the PR
-# diff (pre-existing over-cap files not in the diff are skipped silently).
-# `while IFS= read -r` (not `for file in $(...)`) so paths with spaces are not
-# word-split — matches the sibling pattern in check-test-clock.sh:62.
-while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    [ -f "$file" ] || continue
-
-    now_lines=$(normalized_wc "$file")
-    if [ "$now_lines" -le "$MAX_LINES" ]; then
-        continue
-    fi
-
-    # File is over the cap. Decide NEW vs RATCHET vs pre-existing.
-    if is_added_file "$file"; then
-        echo "ERROR (new file): $file is $now_lines lines (cap $MAX_LINES, FR-006)."
-        echo "  Split it by behavior/feature into focused files under 500 lines."
-        violations=$((violations + 1))
-        new_file_violations=$((new_file_violations + 1))
-        continue
-    fi
-
-    # Modified file over the cap: ratchet arm. Compare against base line count.
-    if [ -n "$base_branch" ]; then
-        base_lines=$(git show "${base_branch}:${file}" 2>/dev/null \
-            | tr -d '\r' | wc -l | tr -d ' ' || true)
-    else
-        base_lines=0
-    fi
-
-    if [ "$base_lines" -eq 0 ]; then
-        # File did not exist at base under this path (rename/delete-readd) →
-        # treat as new.
-        echo "ERROR (new path): $file is $now_lines lines (cap $MAX_LINES, FR-006); not present at base."
-        violations=$((violations + 1))
-        new_file_violations=$((new_file_violations + 1))
-        continue
-    fi
-
-    if [ "$now_lines" -gt "$base_lines" ]; then
-        echo "ERROR (ratchet): $file grew from $base_lines to $now_lines lines (cap $MAX_LINES, FR-006)."
-        echo "  Over-cap files must not grow. Split the new behavior into a separate file."
-        violations=$((violations + 1))
-        ratchet_violations=$((ratchet_violations + 1))
-        continue
-    fi
-
-    # Over cap but shrank or equal → pass (ratchet allows shrinkage).
-    :
-done < <(echo "$PR_CHANGED_FILES" | grep -E '\.test\.ts$' || true)
-
-echo ""
-echo "=== Test file cap (FR-006) summary ==="
-echo "New-file violations: $new_file_violations"
-echo "Ratchet violations:  $ratchet_violations"
-
-if [ "$violations" -gt 0 ]; then
-    if [ "$is_enforce_resolved" -eq 1 ]; then
-        echo "TEST_CAP_ENFORCE is on (default). Failing the build."
-        exit 1
-    else
-        echo "TEST_CAP_ENFORCE is off — soft-warn (non-blocking)."
-        exit 0
-    fi
-fi
-
-echo "All test-file-cap checks passed."
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+exec bun run "${script_dir}/check-test-file-cap.ts" "$@"

--- a/scripts/check-test-file-cap.ts
+++ b/scripts/check-test-file-cap.ts
@@ -1,0 +1,337 @@
+#!/usr/bin/env bun
+/**
+ * Issue #2078 — cross-platform port of the FR-006 500-line test-file cap
+ * ratchet (originally `scripts/check-test-file-cap.sh`, issue #1781 E1).
+ *
+ * The Bash original could not run on a Windows host without Bash in PATH, so
+ * Windows contributors had no way to verify the cap locally before pushing and
+ * fell back to manual line counting (issue #2078). This TypeScript
+ * implementation is the SINGLE source of truth for the cap value and the
+ * ratchet semantics; `scripts/check-test-file-cap.sh` is now a zero-logic shim
+ * that `exec`s this file, so the two entry points cannot drift.
+ *
+ * Run it anywhere (Windows PowerShell, macOS, Linux):
+ *
+ *   bun run check:test-file-cap
+ *
+ * Ratchet semantics (unchanged from the Bash original):
+ *   - Pre-existing over-cap files NOT in the PR diff → non-blocking (silent).
+ *   - NEW test files in the diff over the cap → ERROR (blocking).
+ *   - MODIFIED test files in the diff that are over the cap AND grew →
+ *     ERROR (ratchet arm).
+ *   - MODIFIED over-cap files that shrank or stayed equal → pass.
+ *   - Pre-existing violators never fail unrelated PRs.
+ *
+ * Escape hatch: TEST_CAP_ENFORCE. Default is ENFORCE (unset → hard-fail),
+ * the opposite of DRIFT_CHECK_ENFORCE's default, because the ratchet is
+ * already scoped to new/grown files only. Set
+ *   TEST_CAP_ENFORCE=0|false|no|off
+ * to soft-warn (print violations, exit 0) — useful for a deliberate growth PR.
+ *
+ * Line-ending handling: CR is stripped before counting so a pure CRLF→LF
+ * normalization does not false-fail "grew by 1". Line counts match `wc -l`
+ * semantics exactly (a trailing line without a newline is not counted), so a
+ * file's number is identical to what the Bash original reported.
+ *
+ * Rename handling: `git diff --diff-filter=A --find-renames=100%` treats only
+ * exact-content renames as renames (R); a renamed+grown file falls below 100%
+ * similarity → classified as Added → flagged by the new-file arm.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** The FR-006 cap. This is the ONLY place the value is declared. */
+export const MAX_LINES = 500;
+
+/** Base branches probed, in order, to resolve the PR base. */
+export const BASE_BRANCH_CANDIDATES = [
+	'origin/main',
+	'origin/master',
+	'main',
+	'master',
+] as const;
+
+/** Only `*.test.ts` files participate in the cap. */
+export const TEST_FILE_PATTERN = /\.test\.ts$/;
+
+/**
+ * TEST_CAP_ENFORCE truth table (issue #1781 re-critic B5):
+ * unset OR any value other than 0/false/no/off → hard-fail (default enforce).
+ * 0/false/no/off → soft-warn (exit 0).
+ */
+export function resolveEnforce(raw: string | undefined): boolean {
+	if (raw === undefined) {
+		return true;
+	}
+	// No trimming: the Bash original compared the raw value, so " off " meant
+	// enforce. Trimming here would silently DISABLE the gate for a
+	// whitespace-padded value — a divergence in the permissive direction.
+	switch (raw.toLowerCase()) {
+		case '0':
+		case 'false':
+		case 'no':
+		case 'off':
+			return false;
+		default:
+			return true;
+	}
+}
+
+/**
+ * `wc -l`-equivalent line count with CR stripped first. Counts newline
+ * characters, so a file whose final line lacks a trailing newline reports the
+ * same number the Bash original did.
+ */
+export function normalizedLineCount(content: string): number {
+	let count = 0;
+	for (let i = 0; i < content.length; i++) {
+		if (content.charCodeAt(i) === 10 /* \n */) {
+			count++;
+		}
+	}
+	return count;
+}
+
+export interface CapEvaluationInput {
+	/** Files changed between the base branch and HEAD (repo-relative paths). */
+	changedFiles: string[];
+	/** Subset of `changedFiles` classified as added (or non-exact renames). */
+	addedFiles: string[];
+	/** Current normalized line count, or `null` if the path is not a file. */
+	currentLineCount: (file: string) => number | null;
+	/** Normalized line count at the base branch; 0 when absent at base. */
+	baseLineCount: (file: string) => number;
+	maxLines?: number;
+	enforce: boolean;
+}
+
+export interface CapEvaluationResult {
+	messages: string[];
+	newFileViolations: number;
+	ratchetViolations: number;
+	violations: number;
+	exitCode: number;
+}
+
+/**
+ * Pure ratchet evaluation. All I/O (git, filesystem) is injected so the
+ * decision table is directly unit-testable without a temp git repository.
+ */
+export function evaluateCap(input: CapEvaluationInput): CapEvaluationResult {
+	const maxLines = input.maxLines ?? MAX_LINES;
+	const added = new Set(input.addedFiles);
+	const messages: string[] = [];
+	let newFileViolations = 0;
+	let ratchetViolations = 0;
+
+	for (const file of input.changedFiles) {
+		if (!file || !TEST_FILE_PATTERN.test(file)) {
+			continue;
+		}
+		const nowLines = input.currentLineCount(file);
+		if (nowLines === null) {
+			// Deleted in the diff, or otherwise not a regular file in the tree.
+			continue;
+		}
+		if (nowLines <= maxLines) {
+			continue;
+		}
+
+		if (added.has(file)) {
+			messages.push(
+				`ERROR (new file): ${file} is ${nowLines} lines (cap ${maxLines}, FR-006).`,
+			);
+			messages.push(
+				'  Split it by behavior/feature into focused files under 500 lines.',
+			);
+			newFileViolations++;
+			continue;
+		}
+
+		const baseLines = input.baseLineCount(file);
+		if (baseLines === 0) {
+			// File did not exist at base under this path (rename/delete-readd) →
+			// treat as new.
+			messages.push(
+				`ERROR (new path): ${file} is ${nowLines} lines (cap ${maxLines}, FR-006); not present at base.`,
+			);
+			newFileViolations++;
+			continue;
+		}
+
+		if (nowLines > baseLines) {
+			messages.push(
+				`ERROR (ratchet): ${file} grew from ${baseLines} to ${nowLines} lines (cap ${maxLines}, FR-006).`,
+			);
+			messages.push(
+				'  Over-cap files must not grow. Split the new behavior into a separate file.',
+			);
+			ratchetViolations++;
+			continue;
+		}
+
+		// Over cap but shrank or equal → pass (ratchet allows shrinkage).
+	}
+
+	const violations = newFileViolations + ratchetViolations;
+
+	messages.push('');
+	messages.push('=== Test file cap (FR-006) summary ===');
+	messages.push(`New-file violations: ${newFileViolations}`);
+	messages.push(`Ratchet violations:  ${ratchetViolations}`);
+
+	let exitCode = 0;
+	if (violations > 0) {
+		if (input.enforce) {
+			messages.push('TEST_CAP_ENFORCE is on (default). Failing the build.');
+			exitCode = 1;
+		} else {
+			messages.push('TEST_CAP_ENFORCE is off — soft-warn (non-blocking).');
+		}
+	} else {
+		messages.push('All test-file-cap checks passed.');
+	}
+
+	return {
+		messages,
+		newFileViolations,
+		ratchetViolations,
+		violations,
+		exitCode,
+	};
+}
+
+// --- git plumbing -----------------------------------------------------------
+
+interface GitResult {
+	exitCode: number;
+	stdout: string;
+}
+
+function runGit(args: string[], cwd: string): GitResult {
+	let proc: ReturnType<typeof Bun.spawnSync>;
+	try {
+		proc = Bun.spawnSync({
+			cmd: ['git', ...args],
+			cwd,
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+		});
+	} catch (error) {
+		// `git` missing from PATH would otherwise surface as a raw Bun stack
+		// trace with no hint about what the gate needs.
+		throw new Error(
+			`check-test-file-cap: failed to run \`git ${args.join(' ')}\` — is git on PATH? (${String(error)})`,
+		);
+	}
+	return {
+		exitCode: proc.exitCode ?? 1,
+		stdout: proc.stdout.toString(),
+	};
+}
+
+/**
+ * Resolve the repository root so the gate behaves identically no matter which
+ * directory a contributor runs it from. `git diff --name-only` emits
+ * root-relative paths; resolving them against an arbitrary cwd made every
+ * `statSync` miss, which the gate reported as "all checks passed" — a silent
+ * vacuous pass (issue #2078 review finding 2). Falls back to `cwd` when the
+ * directory is not a git worktree, where there is nothing to compare anyway.
+ */
+export function resolveRepoRoot(cwd: string): string {
+	const top = runGit(['rev-parse', '--show-toplevel'], cwd);
+	if (top.exitCode !== 0) {
+		return cwd;
+	}
+	const trimmed = top.stdout.trim();
+	return trimmed.length > 0 ? path.resolve(trimmed) : cwd;
+}
+
+/** Split a NUL-separated `git -z` path list. */
+export function splitNulList(raw: string): string[] {
+	return raw.split('\0').filter((entry) => entry.length > 0);
+}
+
+export function resolveBaseBranch(cwd: string): string | null {
+	for (const branch of BASE_BRANCH_CANDIDATES) {
+		if (runGit(['rev-parse', branch], cwd).exitCode === 0) {
+			return branch;
+		}
+	}
+	return null;
+}
+
+export function main(startDir: string = process.cwd()): number {
+	const cwd = resolveRepoRoot(startDir);
+	const baseBranch = resolveBaseBranch(cwd);
+
+	let changedFiles: string[] = [];
+	let addedFiles: string[] = [];
+	if (baseBranch) {
+		const changed = runGit(['diff', '--name-only', '-z', baseBranch, 'HEAD'], cwd);
+		if (changed.exitCode === 0) {
+			changedFiles = splitNulList(changed.stdout);
+		}
+		const addedResult = runGit(
+			[
+				'diff',
+				'--diff-filter=A',
+				'--name-only',
+				'-z',
+				'--find-renames=100%',
+				baseBranch,
+				'HEAD',
+			],
+			cwd,
+		);
+		if (addedResult.exitCode === 0) {
+			addedFiles = splitNulList(addedResult.stdout);
+		}
+	}
+
+	const result = evaluateCap({
+		changedFiles,
+		addedFiles,
+		enforce: resolveEnforce(process.env.TEST_CAP_ENFORCE),
+		currentLineCount: (file) => {
+			const abs = path.resolve(cwd, file);
+			let stat: fs.Stats;
+			try {
+				stat = fs.statSync(abs);
+			} catch {
+				return null;
+			}
+			if (!stat.isFile()) {
+				return null;
+			}
+			return normalizedLineCount(fs.readFileSync(abs, 'utf-8').replace(/\r/g, ''));
+		},
+		baseLineCount: (file) => {
+			if (!baseBranch) {
+				return 0;
+			}
+			const show = runGit(['show', `${baseBranch}:${file}`], cwd);
+			if (show.exitCode !== 0) {
+				return 0;
+			}
+			return normalizedLineCount(show.stdout.replace(/\r/g, ''));
+		},
+	});
+
+	for (const line of result.messages) {
+		console.log(line);
+	}
+	return result.exitCode;
+}
+
+const isDirectRun =
+	typeof process.argv[1] === 'string' &&
+	path.resolve(process.argv[1]) ===
+		path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectRun) {
+	process.exit(main());
+}

--- a/scripts/gate-portability-baseline.json
+++ b/scripts/gate-portability-baseline.json
@@ -1,0 +1,45 @@
+{
+	"$comment": "Issue #2078 recurrence guardrail. Every scripts/**/*.sh referenced from a .github/workflows file — or, recursively, from a local composite action under .github/actions — must be listed here. New Bash-only gates are BLOCKED — implement them as scripts/<name>.ts wired through a package.json script (see scripts/check-test-file-cap.ts). Porting a legacy gate must REMOVE its entry; a stale entry fails the check. Enforced by scripts/check-gate-portability.ts (bun run check:gate-portability).",
+	"entries": [
+		{
+			"script": "scripts/check-bash-portability.sh",
+			"category": "legacy-bash-gate",
+			"reason": "FR-012 bash3.2-compatibility lint (issue #1737). Predates issue #2078. Self-referentially Bash-flavored — it scans Bash sources — but its scan is pure text and is portable in principle; not yet ported."
+		},
+		{
+			"script": "scripts/check-cross-contamination.sh",
+			"category": "legacy-bash-gate",
+			"reason": "mock.module / vi.mock leak co-run check. Predates issue #2078. Executes live test co-runs and compares pass counts; porting requires reworking the co-run driver, out of scope for issue #2078."
+		},
+		{
+			"script": "scripts/check-invariants.sh",
+			"category": "legacy-bash-gate",
+			"reason": "AGENTS.md invariant + mock-allowlist growth ratchet (issues #1666, #1781). Predates issue #2078."
+		},
+		{
+			"script": "scripts/check-mock-cleanup.sh",
+			"category": "legacy-bash-gate",
+			"reason": "FB-001 mock-cleanup ratchet. Predates issue #2078."
+		},
+		{
+			"script": "scripts/check-test-clock.sh",
+			"category": "legacy-bash-gate",
+			"reason": "freezeClock adoption line-scoped lint (issue #1782). Predates issue #2078."
+		},
+		{
+			"script": "scripts/check-test-tmpdir.sh",
+			"category": "legacy-bash-gate",
+			"reason": "FR-011 tmpdir canonicalization line-scoped lint (issue #1737). Predates issue #2078."
+		},
+		{
+			"script": "scripts/ci/detect-and-quarantine-flakes.sh",
+			"category": "ci-infrastructure",
+			"reason": "Runs only in the scheduled flake-detection workflow and writes quarantine annotations from runner artifacts. Never a pre-push local gate, so a Windows contributor is not expected to run it."
+		},
+		{
+			"script": "scripts/ci/run-coverage-gate.sh",
+			"category": "ci-infrastructure",
+			"reason": "Consumes merged lcov artifacts produced by the CI shard matrix. Never a pre-push local gate, so a Windows contributor is not expected to run it."
+		}
+	]
+}

--- a/tests/unit/scripts/check-gate-portability.test.ts
+++ b/tests/unit/scripts/check-gate-portability.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Issue #2078 recurrence guardrail — tests for
+ * scripts/check-gate-portability.ts.
+ *
+ * Direct-import unit tests of the pure functions (collectScriptRefs,
+ * evaluatePortability), plus a "guardrail bites" integration-style test that
+ * proves a newly added Bash-only gate is actually caught, and a real-repo
+ * assertion that the current checked-in state passes.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	ACTIONS_DIR,
+	type BaselineEntry,
+	collectScriptRefs,
+	DEFAULT_SCAN_ROOTS,
+	evaluatePortability,
+	formatScanRoots,
+	type GateCategory,
+	main,
+	readBaseline,
+	readWorkflowSources,
+	WORKFLOW_DIR,
+} from '../../../scripts/check-gate-portability';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('check-gate-portability — collectScriptRefs', () => {
+	test('ignores lines whose first non-whitespace char is #', () => {
+		const refs = collectScriptRefs([
+			{
+				file: '.github/workflows/x.yml',
+				content: '  # mentions scripts/foo.sh in prose\n',
+			},
+		]);
+		expect(refs.size).toBe(0);
+	});
+
+	test('collects from "run: bash scripts/x.sh"', () => {
+		const refs = collectScriptRefs([
+			{
+				file: '.github/workflows/x.yml',
+				content: '      run: bash scripts/x.sh\n',
+			},
+		]);
+		expect([...refs.keys()]).toEqual(['scripts/x.sh']);
+	});
+
+	test('dedupes across multiple lines within the same file', () => {
+		const refs = collectScriptRefs([
+			{
+				file: '.github/workflows/x.yml',
+				content: 'run: bash scripts/x.sh\nrun: bash scripts/x.sh\n',
+			},
+		]);
+		expect(refs.get('scripts/x.sh')).toEqual(['.github/workflows/x.yml']);
+	});
+
+	test('records every referencing file, not just the first', () => {
+		const refs = collectScriptRefs([
+			{ file: '.github/workflows/a.yml', content: 'run: bash scripts/x.sh\n' },
+			{ file: '.github/workflows/b.yml', content: 'run: bash scripts/x.sh\n' },
+		]);
+		expect(refs.get('scripts/x.sh')).toEqual([
+			'.github/workflows/a.yml',
+			'.github/workflows/b.yml',
+		]);
+	});
+
+	test('handles CRLF line endings without truncating the match', () => {
+		const refs = collectScriptRefs([
+			{
+				file: '.github/workflows/x.yml',
+				content: 'run: bash scripts/x.sh\r\n# scripts/y.sh comment\r\n',
+			},
+		]);
+		expect([...refs.keys()]).toEqual(['scripts/x.sh']);
+	});
+
+	test('picks up nested paths like scripts/ci/foo.sh', () => {
+		const refs = collectScriptRefs([
+			{
+				file: '.github/workflows/x.yml',
+				content: 'run: bash scripts/ci/foo.sh\n',
+			},
+		]);
+		expect([...refs.keys()]).toEqual(['scripts/ci/foo.sh']);
+	});
+});
+
+function entry(overrides: Partial<BaselineEntry>): BaselineEntry {
+	return {
+		script: 'scripts/x.sh',
+		category: 'legacy-bash-gate',
+		reason: 'test fixture reason',
+		...overrides,
+	};
+}
+
+describe('check-gate-portability — evaluatePortability', () => {
+	test('fully baselined -> exit 0 and success message', () => {
+		const referenced = new Map([['scripts/x.sh', ['.github/workflows/x.yml']]]);
+		const result = evaluatePortability(referenced, [entry({})]);
+		expect(result.exitCode).toBe(0);
+		expect(result.messages.join('\n')).toInclude(
+			'All CI gate portability checks passed.',
+		);
+	});
+
+	test('unbaselined referenced script -> exit 1, ERROR (new Bash-only gate)', () => {
+		const referenced = new Map([
+			['scripts/new-thing.sh', ['.github/workflows/x.yml']],
+		]);
+		const result = evaluatePortability(referenced, []);
+		expect(result.exitCode).toBe(1);
+		expect(result.unbaselined).toEqual(['scripts/new-thing.sh']);
+		expect(result.messages.join('\n')).toInclude('ERROR (new Bash-only gate)');
+	});
+
+	test('baselined but unreferenced -> exit 1, ERROR (stale baseline)', () => {
+		const result = evaluatePortability(new Map(), [entry({})]);
+		expect(result.exitCode).toBe(1);
+		expect(result.staleBaseline).toEqual(['scripts/x.sh']);
+		expect(result.messages.join('\n')).toInclude('ERROR (stale baseline)');
+	});
+
+	test('bad category -> exit 1, ERROR (bad category)', () => {
+		const referenced = new Map([['scripts/x.sh', ['.github/workflows/x.yml']]]);
+		const result = evaluatePortability(
+			referenced,
+			// Deliberately invalid category to exercise the validation branch.
+			[entry({ category: 'bogus-category' as GateCategory })],
+		);
+		expect(result.exitCode).toBe(1);
+		expect(result.messages.join('\n')).toInclude('ERROR (bad category)');
+	});
+
+	test('empty/whitespace reason -> exit 1, ERROR (missing reason)', () => {
+		const referenced = new Map([['scripts/x.sh', ['.github/workflows/x.yml']]]);
+		const result = evaluatePortability(referenced, [entry({ reason: '   ' })]);
+		expect(result.exitCode).toBe(1);
+		expect(result.messages.join('\n')).toInclude('ERROR (missing reason)');
+	});
+});
+
+describe('check-gate-portability — GUARDRAIL BITES (issue #2078 recurrence)', () => {
+	test('a brand-new Bash-only gate referenced from a workflow is caught', () => {
+		const tmpDir = canonicalMkdtemp('gate-portability-');
+		try {
+			fs.writeFileSync(
+				path.join(tmpDir, 'new-gate.yml'),
+				[
+					'name: new-gate',
+					'on: push',
+					'jobs:',
+					'  check:',
+					'    runs-on: ubuntu-latest',
+					'    steps:',
+					'      - run: bash scripts/check-something-new.sh',
+					'',
+				].join('\n'),
+			);
+
+			const referenced = collectScriptRefs(
+				readWorkflowSources([[tmpDir, '.github/workflows']]),
+			);
+			const result = evaluatePortability(referenced, readBaseline());
+
+			expect(result.exitCode).toBe(1);
+			expect(result.unbaselined).toContain('scripts/check-something-new.sh');
+			expect(result.messages.join('\n')).toInclude(
+				'scripts/check-something-new.sh',
+			);
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test('a gate hidden in a nested composite action is still caught', () => {
+		const tmpDir = canonicalMkdtemp('gate-portability-nested-');
+		try {
+			// Composite actions live at .github/actions/<name>/action.yml — one
+			// level deeper than a workflow file, so a non-recursive scan would
+			// miss them entirely. The actions root is a real scan root, not a
+			// special case bolted onto the workflows root.
+			const workflowsRoot = path.join(tmpDir, 'workflows');
+			const actionsRoot = path.join(tmpDir, 'actions', 'my-action');
+			fs.mkdirSync(workflowsRoot, { recursive: true });
+			fs.mkdirSync(actionsRoot, { recursive: true });
+			fs.writeFileSync(
+				path.join(actionsRoot, 'action.yml'),
+				[
+					'runs:',
+					'  steps:',
+					'    - run: bash scripts/hidden-gate.sh',
+					'',
+				].join('\n'),
+			);
+
+			const sources = readWorkflowSources([
+				[workflowsRoot, '.github/workflows'],
+				[path.join(tmpDir, 'actions'), '.github/actions'],
+			]);
+			// The label must come from the actions root, proving that root was
+			// the one that produced the hit.
+			expect(sources.map((s) => s.file)).toEqual([
+				'.github/actions/my-action/action.yml',
+			]);
+
+			const result = evaluatePortability(
+				collectScriptRefs(sources),
+				readBaseline(),
+			);
+			expect(result.exitCode).toBe(1);
+			expect(result.unbaselined).toContain('scripts/hidden-gate.sh');
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test('main() consults the actions root, not only the workflows root', () => {
+		const tmpDir = canonicalMkdtemp('gate-portability-main-');
+		const logged: string[] = [];
+		const realLog = console.log;
+		console.log = (line: string) => {
+			logged.push(line);
+		};
+		try {
+			const actionsRoot = path.join(tmpDir, 'actions', 'probe');
+			fs.mkdirSync(actionsRoot, { recursive: true });
+			fs.writeFileSync(
+				path.join(actionsRoot, 'action.yml'),
+				['runs:', '  steps:', '    - run: bash scripts/probe-gate.sh', ''].join(
+					'\n',
+				),
+			);
+
+			// Second root only. If main() ever stops threading its roots through
+			// (e.g. someone hardcodes the workflows root again), this returns 0.
+			const exitCode = main([
+				[path.join(tmpDir, 'workflows'), '.github/workflows'],
+				[path.join(tmpDir, 'actions'), '.github/actions'],
+			]);
+			expect(exitCode).toBe(1);
+			expect(logged.join('\n')).toInclude('scripts/probe-gate.sh');
+		} finally {
+			console.log = realLog;
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test('formatScanRoots reports the roots it was given, not a fixed string', () => {
+		// Guards the announcement the test below relies on: if this were
+		// hardcoded, main() could narrow its scan while still claiming both
+		// roots. Arbitrary labels make that impossible to fake.
+		expect(formatScanRoots([])).toBe('Scan roots: ');
+		expect(
+			formatScanRoots([
+				['/tmp/a', 'alpha'],
+				['/tmp/b', 'beta'],
+			]),
+		).toBe('Scan roots: alpha, beta');
+	});
+
+	test('main() with NO arguments scans both default roots', () => {
+		// The default binding is its own mutation site: narrowing it (e.g.
+		// `= DEFAULT_SCAN_ROOTS.slice(0, 1)`) is invisible to every test that
+		// passes roots explicitly, and invisible in production because
+		// `.github/actions/` does not exist in this repo. Driving main() with no
+		// arguments and reading back the roots it announced closes that seam.
+		const logged: string[] = [];
+		const realLog = console.log;
+		console.log = (line: string) => {
+			logged.push(line);
+		};
+		let exitCode: number;
+		try {
+			exitCode = main();
+		} finally {
+			console.log = realLog;
+		}
+		expect(exitCode).toBe(0);
+		expect(logged[0]).toBe('Scan roots: .github/workflows, .github/actions');
+	});
+
+	test('DEFAULT_SCAN_ROOTS covers both .github/workflows and .github/actions', () => {
+		expect(DEFAULT_SCAN_ROOTS.map(([, label]) => label)).toEqual([
+			'.github/workflows',
+			'.github/actions',
+		]);
+		expect(DEFAULT_SCAN_ROOTS.map(([dir]) => dir)).toEqual([
+			WORKFLOW_DIR,
+			ACTIONS_DIR,
+		]);
+	});
+
+	test('the real repo state (checked-in workflows + baseline) passes', () => {
+		const result = evaluatePortability(
+			collectScriptRefs(readWorkflowSources()),
+			readBaseline(),
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.unbaselined).toEqual([]);
+		expect(result.staleBaseline).toEqual([]);
+		expect(result.invalidCategories).toEqual([]);
+	});
+});

--- a/tests/unit/scripts/check-test-file-cap-pure.test.ts
+++ b/tests/unit/scripts/check-test-file-cap-pure.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #2078 — pure-function unit tests for scripts/check-test-file-cap.ts.
+ *
+ * Direct-import tests of the exported pure functions (MAX_LINES,
+ * resolveEnforce, normalizedLineCount, splitNulList, evaluateCap). No
+ * spawning, no git, no filesystem — all I/O for evaluateCap is injected.
+ * The end-to-end (real git repo) behavior is covered by
+ * tests/unit/scripts/check-test-file-cap.test.ts; this file is Tier 0
+ * (`_test_exports`-style direct import) coverage of the decision table.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	type CapEvaluationInput,
+	evaluateCap,
+	MAX_LINES,
+	normalizedLineCount,
+	resolveEnforce,
+	splitNulList,
+} from '../../../scripts/check-test-file-cap';
+
+describe('check-test-file-cap — MAX_LINES', () => {
+	test('is 500 (single source of truth for FR-006)', () => {
+		expect(MAX_LINES).toBe(500);
+	});
+});
+
+describe('check-test-file-cap — resolveEnforce', () => {
+	test('undefined -> true (default enforce)', () => {
+		expect(resolveEnforce(undefined)).toBe(true);
+	});
+
+	test.each([
+		'0',
+		'false',
+		'no',
+		'off',
+		'FALSE',
+		'Off',
+	])('%p -> false (soft-warn)', (raw) => {
+		expect(resolveEnforce(raw)).toBe(false);
+	});
+
+	test.each([
+		'',
+		'1',
+		'true',
+		'yes',
+		'anything',
+		// Bash-parity: the original compared the RAW value, so a padded value
+		// is not one of the soft-warn tokens and must still enforce. Trimming
+		// here would silently disable the gate (issue #2078 review finding 1).
+		' off ',
+		' 0 ',
+	])('%p -> true (enforce)', (raw) => {
+		expect(resolveEnforce(raw)).toBe(true);
+	});
+});
+
+describe('check-test-file-cap — normalizedLineCount (wc -l semantics)', () => {
+	test('empty string -> 0', () => {
+		expect(normalizedLineCount('')).toBe(0);
+	});
+
+	test('"a\\n" -> 1', () => {
+		expect(normalizedLineCount('a\n')).toBe(1);
+	});
+
+	test('"a\\nb" (no trailing newline) -> 1, not 2', () => {
+		expect(normalizedLineCount('a\nb')).toBe(1);
+	});
+
+	test('"a\\nb\\n" -> 2', () => {
+		expect(normalizedLineCount('a\nb\n')).toBe(2);
+	});
+});
+
+describe('check-test-file-cap — splitNulList', () => {
+	test('empty string -> []', () => {
+		expect(splitNulList('')).toEqual([]);
+	});
+
+	test('"a\\0b\\0" -> ["a", "b"]', () => {
+		expect(splitNulList('a\0b\0')).toEqual(['a', 'b']);
+	});
+});
+
+describe('check-test-file-cap — evaluateCap decision table', () => {
+	function makeInput(
+		overrides: Partial<CapEvaluationInput>,
+	): CapEvaluationInput {
+		return {
+			changedFiles: [],
+			addedFiles: [],
+			currentLineCount: () => null,
+			baseLineCount: () => 0,
+			enforce: true,
+			...overrides,
+		};
+	}
+
+	test('non-.test.ts changed file over cap is ignored', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['src/big-thing.ts'],
+				addedFiles: ['src/big-thing.ts'],
+				currentLineCount: () => 900,
+				baseLineCount: () => 0,
+			}),
+		);
+		expect(result.newFileViolations).toBe(0);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(0);
+		expect(result.messages.join('\n')).not.toInclude('src/big-thing.ts');
+	});
+
+	test('added .test.ts over cap -> new-file violation, exit 1', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/foo.test.ts'],
+				addedFiles: ['tests/foo.test.ts'],
+				currentLineCount: () => 600,
+			}),
+		);
+		expect(result.newFileViolations).toBe(1);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(1);
+		expect(result.messages.join('\n')).toInclude('ERROR (new file)');
+	});
+
+	test('added .test.ts at exactly 500 lines passes (boundary)', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/foo.test.ts'],
+				addedFiles: ['tests/foo.test.ts'],
+				currentLineCount: () => 500,
+			}),
+		);
+		expect(result.newFileViolations).toBe(0);
+		expect(result.exitCode).toBe(0);
+	});
+
+	test('added .test.ts at 501 lines fails (one over boundary)', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/foo.test.ts'],
+				addedFiles: ['tests/foo.test.ts'],
+				currentLineCount: () => 501,
+			}),
+		);
+		expect(result.newFileViolations).toBe(1);
+		expect(result.exitCode).toBe(1);
+	});
+
+	test('modified over-cap file that grew -> ratchet violation', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/big.test.ts'],
+				addedFiles: [],
+				currentLineCount: () => 4050,
+				baseLineCount: () => 4000,
+			}),
+		);
+		expect(result.ratchetViolations).toBe(1);
+		expect(result.newFileViolations).toBe(0);
+		expect(result.exitCode).toBe(1);
+		expect(result.messages.join('\n')).toInclude('ERROR (ratchet)');
+	});
+
+	test('modified over-cap file that shrank -> pass', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/big.test.ts'],
+				addedFiles: [],
+				currentLineCount: () => 3990,
+				baseLineCount: () => 4000,
+			}),
+		);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(0);
+	});
+
+	test('modified over-cap file unchanged in size -> pass', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/big.test.ts'],
+				addedFiles: [],
+				currentLineCount: () => 4000,
+				baseLineCount: () => 4000,
+			}),
+		);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(0);
+	});
+
+	test('modified over-cap file with baseLineCount 0 -> "new path" counted as new-file violation', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/renamed.test.ts'],
+				addedFiles: [],
+				currentLineCount: () => 600,
+				baseLineCount: () => 0,
+			}),
+		);
+		expect(result.newFileViolations).toBe(1);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(1);
+		expect(result.messages.join('\n')).toInclude('ERROR (new path)');
+	});
+
+	test('currentLineCount returning null (deleted file still listed) is ignored, no crash', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/deleted.test.ts'],
+				addedFiles: [],
+				currentLineCount: () => null,
+				baseLineCount: () => 4000,
+			}),
+		);
+		expect(result.newFileViolations).toBe(0);
+		expect(result.ratchetViolations).toBe(0);
+		expect(result.exitCode).toBe(0);
+	});
+
+	test('enforce:false with a violation soft-warns: exit 0, message includes soft-warn', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/foo.test.ts'],
+				addedFiles: ['tests/foo.test.ts'],
+				currentLineCount: () => 600,
+				enforce: false,
+			}),
+		);
+		expect(result.violations).toBe(1);
+		expect(result.exitCode).toBe(0);
+		expect(result.messages.join('\n')).toInclude('soft-warn');
+	});
+
+	test('empty changedFiles -> exit 0 and "All test-file-cap checks passed."', () => {
+		const result = evaluateCap(makeInput({ changedFiles: [] }));
+		expect(result.exitCode).toBe(0);
+		expect(result.violations).toBe(0);
+		expect(result.messages.join('\n')).toInclude(
+			'All test-file-cap checks passed.',
+		);
+	});
+
+	test('a changed file listed twice: summary counters match single-violation message count', () => {
+		const result = evaluateCap(
+			makeInput({
+				changedFiles: ['tests/foo.test.ts', 'tests/foo.test.ts'],
+				addedFiles: ['tests/foo.test.ts'],
+				currentLineCount: () => 600,
+			}),
+		);
+		// The loop iterates changedFiles verbatim, so a duplicate entry is
+		// evaluated twice — the counters must reflect exactly that, proving
+		// evaluateCap does not silently dedupe (which would hide a real
+		// double-counting bug in either direction).
+		expect(result.newFileViolations).toBe(2);
+		expect(result.exitCode).toBe(1);
+		const errorLines = result.messages.filter((m) =>
+			m.startsWith('ERROR (new file)'),
+		);
+		expect(errorLines.length).toBe(2);
+	});
+});

--- a/tests/unit/scripts/check-test-file-cap.test.ts
+++ b/tests/unit/scripts/check-test-file-cap.test.ts
@@ -1,9 +1,13 @@
 /**
  * Issue #1781 E1 — diff-scoped ratchet for the FR-006 500-line test-file cap.
+ * Issue #2078 — the gate is now `scripts/check-test-file-cap.ts`, invoked
+ * through `bun` so it runs on Windows hosts with no Bash in PATH.
  *
- * Each test spawns the real `scripts/check-test-file-cap.sh` in a temp git
- * repository so the diff-scoped logic (new-file vs ratchet vs pre-existing)
- * is exercised against real `git diff` output.
+ * Each test spawns the real TypeScript gate in a temp git repository so the
+ * diff-scoped logic (new-file vs ratchet vs pre-existing) is exercised against
+ * real `git diff` output — no Bash involved. The final case additionally
+ * asserts that the retained `check-test-file-cap.sh` shim produces byte-equal
+ * output, which is what makes the two entry points incapable of drifting.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -12,7 +16,16 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { bashCommand } from '../../helpers/bash';
 
-const SCRIPT = path.resolve(process.cwd(), 'scripts', 'check-test-file-cap.sh');
+const TS_GATE = path.resolve(
+	process.cwd(),
+	'scripts',
+	'check-test-file-cap.ts',
+);
+const SH_SHIM = path.resolve(
+	process.cwd(),
+	'scripts',
+	'check-test-file-cap.sh',
+);
 
 interface SpawnResult {
 	exitCode: number;
@@ -20,9 +33,13 @@ interface SpawnResult {
 	stderr: string;
 }
 
-function runScript(repoDir: string, env?: Record<string, string>): SpawnResult {
+function spawn(
+	cmd: string[],
+	repoDir: string,
+	env?: Record<string, string>,
+): SpawnResult {
 	const proc = Bun.spawnSync({
-		cmd: bashCommand(SCRIPT),
+		cmd,
 		cwd: repoDir,
 		env: { ...process.env, ...env },
 		stdin: 'ignore',
@@ -35,6 +52,16 @@ function runScript(repoDir: string, env?: Record<string, string>): SpawnResult {
 		stdout: proc.stdout.toString(),
 		stderr: proc.stderr.toString(),
 	};
+}
+
+/** Run the real gate the way CI and contributors do — via bun, no shell. */
+function runScript(repoDir: string, env?: Record<string, string>): SpawnResult {
+	return spawn([process.execPath, 'run', TS_GATE], repoDir, env);
+}
+
+/** Run the retained Bash shim, which must delegate to the same TS gate. */
+function runShim(repoDir: string, env?: Record<string, string>): SpawnResult {
+	return spawn(bashCommand(SH_SHIM), repoDir, env);
 }
 
 function git(repoDir: string, ...args: string[]): void {
@@ -104,7 +131,7 @@ function track(repoDir: string): string {
 	return repoDir;
 }
 
-describe('check-test-file-cap.sh — diff-scoped ratchet (issue #1781 E1)', () => {
+describe('check-test-file-cap — diff-scoped ratchet (issues #1781 E1, #2078)', () => {
 	test('A. new 600-line test file in the diff FAILS (default enforce)', async () => {
 		const repo = track(makeRepo());
 		writeFile(repo, 'tests/foo.test.ts', 600);
@@ -206,10 +233,50 @@ describe('check-test-file-cap.sh — diff-scoped ratchet (issue #1781 E1)', () =
 
 		// Explicitly unset to simulate CI.
 		const result = await runScript(repo, { TEST_CAP_ENFORCE: '' });
-		// Note: passing '' sets the var to empty string, which the script
-		// treats as "set but empty" → enforce. To truly unset, we'd need to
-		// delete from env; the script's `${TEST_CAP_ENFORCE+x}` test handles
-		// both unset and set-empty as enforce.
+		// Note: passing '' sets the var to empty string, which the gate
+		// treats as "set but empty" → enforce, matching the original Bash
+		// `${TEST_CAP_ENFORCE+x}` semantics.
 		expect(result.exitCode).toBe(1);
+	});
+
+	test('J. issue #2078 — the .sh shim and the .ts gate agree exactly', () => {
+		const repo = track(makeRepo());
+		writeFile(repo, 'tests/foo.test.ts', 600);
+		git(repo, 'add', '-A');
+		git(repo, 'commit', '-q', '-m', 'add big test');
+
+		const direct = runScript(repo);
+		const shim = runShim(repo);
+		expect(shim.exitCode).toBe(direct.exitCode);
+		expect(shim.stdout).toBe(direct.stdout);
+		expect(direct.exitCode).toBe(1);
+	});
+
+	test('L. issue #2078 — running from a subdirectory gives the same verdict', () => {
+		const repo = track(makeRepo());
+		writeFile(repo, 'tests/foo.test.ts', 600);
+		writeFile(repo, 'src/nested/keep.ts', 1);
+		git(repo, 'add', '-A');
+		git(repo, 'commit', '-q', '-m', 'add big test');
+
+		const fromRoot = runScript(repo);
+		const fromSubdir = runScript(path.join(repo, 'src', 'nested'));
+		// Without repo-root resolution the subdirectory run silently reported
+		// "All test-file-cap checks passed" — a vacuous pass.
+		expect(fromSubdir.exitCode).toBe(1);
+		expect(fromSubdir.stdout).toBe(fromRoot.stdout);
+	});
+
+	test('K. issue #2078 — the shim carries no cap value or ratchet logic', () => {
+		const shimSource = fs.readFileSync(SH_SHIM, 'utf-8');
+		const body = shimSource
+			.split('\n')
+			.filter((line) => !line.trimStart().startsWith('#'))
+			.join('\n');
+		// A second cap constant is exactly the drift issue #2078 forbids.
+		expect(body).not.toInclude('500');
+		expect(body).not.toInclude('MAX_LINES');
+		expect(body).not.toInclude('TEST_CAP_ENFORCE');
+		expect(body).toInclude('check-test-file-cap.ts');
 	});
 });


### PR DESCRIPTION
Closes #2078

## Summary

`scripts/check-test-file-cap.sh` enforced the FR-006 500-line test-file cap in CI but was Bash-only, so a Windows contributor on PowerShell with no Bash in PATH could not run it at all — the documented pre-push check had no executable form on that platform, and manual line counting was the fallback.

The ratchet is now implemented **once**, in TypeScript:

- **`scripts/check-test-file-cap.ts`** — the only place `MAX_LINES = 500`, the `TEST_CAP_ENFORCE` truth table, `wc -l`-equivalent CRLF-normalized counting, and the new-file / ratchet / pre-existing decision table live. Git plumbing is injected into a pure `evaluateCap()` so the decision table is unit-testable directly.
- **`bun run check:test-file-cap`** — the single cross-platform command (AC1).
- **`scripts/check-test-file-cap.sh`** — retained as a **zero-logic shim** that `exec`s the TS gate. Keeping the path means every existing reference (`contributing.md`, `TESTING.md`, release-note fragments, `check-invariants.sh` comments) stays truthful instead of going stale or being rewritten. A test asserts the shim contains no `500`, no `MAX_LINES`, and no `TEST_CAP_ENFORCE` parsing, which is what makes the drifting-clone outcome the issue warned about structurally impossible.
- **CI** now runs `bun run check:test-file-cap` with no `shell: bash` and no `chmod`. Hard-fail behavior is unchanged (AC2).

Two deliberate improvements over the Bash original: changed-file lists are read NUL-separated (`git diff -z`), and the gate resolves the repo root via `git rev-parse --show-toplevel` so running it from a subdirectory no longer produces a **silent vacuous pass** (the Bash version reported "all checks passed" from any subdirectory).

**Recurrence guardrail (defect class, not just the instance).** Fixing one script does not stop the next gate from being added as a `.sh`. `scripts/check-gate-portability.ts` (`bun run check:gate-portability`, wired into the CI quality job) fails when any `scripts/**/*.sh` referenced from `.github/workflows/` — or, recursively, from a local composite action under `.github/actions/` — is absent from `scripts/gate-portability-baseline.json`. The 8 currently-referenced Bash scripts are baselined with a category and a written justification; stale entries, missing reasons, and invalid categories also fail, so porting a legacy gate forces its exemption to be removed rather than rot.

**Scope note:** six legacy Bash gates (`check-invariants`, `check-mock-cleanup`, `check-test-clock`, `check-test-tmpdir`, `check-cross-contamination`, `check-bash-portability`) remain Bash-only. The issue's "Out of scope" section fences porting them; they are baselined *with the guardrail landing in this same change*, so no new instance can appear while they queue. Full sweep and dispositions: `08a-recurrence-sweep.md` in the trace, summarized below.

## Invariant audit

`AGENTS.md` / `docs/engineering-invariants.md` reviewed. Touched invariants:

- **Invariant 7 (test writing / FR-006)** — **touched.** This PR changes the enforcement mechanism, not the policy: cap value, ratchet semantics, message strings, exit codes, and the `TEST_CAP_ENFORCE` truth table are byte-for-byte preserved (verified by running the pre-change `.sh` and the new `.ts` side by side against the real repo and diffing stdout). New tests use `canonicalMkdtemp` (FR-011), `bun:test`, no `mock.module`, and all three touched test files are under the 500-line cap.
- **Skill mirroring (`src/config/skill-mirrors.ts`)** — **touched.** `test-file-split` is classified `identical` with `extraIdenticalPaths`; all three copies (`.opencode`, `.claude`, `.agents`) were updated byte-identically. `writing-tests` is classified `divergent` — `.claude` and `.agents` are thin adapters that delegate to `.opencode`, so only `.opencode` carries the new content. `bun run drift:check` reports no drift.
- **Runtime portability** — **touched, and this is the point of the change.** No new Bash dependency is introduced; one is removed.
- Not touched: plugin initialization, subprocess/tool registration, plan durability, `.swarm` storage, session/global state, guardrails/retry, chat/system message hooks, release/cache.

## Test plan

All commands run on this branch at the shipped HEAD.

| Command | Result |
|---|---|
| `bun run typecheck` | exit 0 |
| `bun run lint:ci` | `Checked 3123 files` — 0 errors, **0 warnings** |
| `bun test tests/unit/scripts/check-test-file-cap.test.ts tests/unit/scripts/check-test-file-cap-pure.test.ts tests/unit/scripts/check-gate-portability.test.ts` | **59 pass / 0 fail**, 115 expect() calls |
| `bun run check:test-file-cap` | exit 0 — `New-file 0 / Ratchet 0 / All test-file-cap checks passed` |
| `bun run check:test-file-cap` **in Windows PowerShell** | exit 0 — AC1 verified on the actual target platform |
| `bun run check:gate-portability` | exit 0 — `Referenced Bash gates: 8 / Unbaselined 0 / Stale 0 / Invalid 0` |
| `bash scripts/check-test-tmpdir.sh` | exit 0 — `New violations (blocking): 0` |
| `bash scripts/check-test-clock.sh` | exit 0 |
| `bash scripts/check-mock-cleanup.sh` | exit 0 |
| `bash scripts/check-bash-portability.sh` | exit 0 |
| `bun run drift:check` | ✅ no drift |
| `bun run check:events` | pass (39 event kinds) |
| `bun run check:runtime-src-refs` | pass (47 refs, 47-entry baseline) |
| `bash .opencode/skills/issue-tracer/scripts/scan-deferred.sh` | clean — no deferred-work markers on added lines |

**Guardrail proof (Phase 4.2 step 5).** Appending `run: bash scripts/check-something-new.sh` to `ci.yml` makes `bun run check:gate-portability` exit 1 with `ERROR (new Bash-only gate): scripts/check-something-new.sh …`; restoring `ci.yml` returns exit 0. Both directions are locked in as automated tests, including a composite-action variant and a `main()`-level test that fails if the actions root is ever dropped.

**Known-noisy / pre-existing, proven on clean `origin/main`:**

- `bun test tests/unit/scripts/` reports 83 failures on this branch. A clean `origin/main` worktree reports the **identical 83 with an identical per-suite breakdown** (all `uv_spawn '/bash.exe'` PATH-pollution artifacts in the `trace-init` / `scan-deferred` / `drift-check` suites on this Windows host). Every one of those files passes in isolation. This branch adds 47 passing tests and zero new failures.
- `bash scripts/check-invariants.sh` exits 1 with 743 violations on this branch and **identically 743 / exit 1 on clean `origin/main`** — pre-existing host artifact, not a regression.

## Acceptance Criteria → Evidence

| Criterion | Evidence |
|---|---|
| Windows contributor can run a single command | `bun run check:test-file-cap` executed in a real PowerShell process, exit 0 |
| CI behavior unchanged, still hard-fails | Pre-change `.sh` and new `.ts` produce byte-identical stdout and exit codes across new-file / ratchet / soft-warn scenarios; `ci.yml` step calls `bun run check:test-file-cap` in the same quality job after `setup-bun` + `bun install` |
| `writing-tests/SKILL.md` documents the Windows path | New "Local validation (all platforms, including Windows)" subsection |
| Cap value sourced from one place | `MAX_LINES` exists only in `scripts/check-test-file-cap.ts`; repo-wide grep finds no second constant; a test asserts the shim contains no cap value |

## Waivers

None.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

