### PR TITLE
feat(reflection): surface knowledge/skill/issue signals + action menu

### DIFF
--- a/docs/releases/pending/2077-session-reflection-signals.md
+++ b/docs/releases/pending/2077-session-reflection-signals.md
@@ -1,0 +1,67 @@
+# Session reflection surfaces knowledge/skill/issue signals + optional action menu
+
+## Summary
+
+`/swarm finalize`'s session-reflection stage now surfaces the session signals it
+was already computing but discarding, and presents a numbered action menu after
+the destructive finalize stages complete. This is wiring + surfacing work — no
+new mutation operations, no new store fields, no rebuild of the existing
+memory/learning/skill-usage machinery.
+
+## What changed
+
+### Reflection report (Phase A — advisory compute, zero new writes)
+
+The reflection report now includes a **Session Signals** block rendered
+unconditionally (so it appears even in a clean / NOOP session), covering six
+signal classes:
+
+- **Knowledge Delta** — entries created this session, close-time curation counts
+  (stored/reinforced/skipped/rejected/quarantined), realtime admission counts
+  (admitted/reinforced/rejected recovered read-only from durable markers), and
+  the FR-015 dedup drop count (previously dropped invisibly). Reports
+  `0 lessons captured; 0 deduped as already-known.` in the clean case.
+- **Skill Compliance Signals** — top skills by violation this session, read-only
+  from `.swarm/skill-usage.jsonl`, scope-labeled and tail-bounded.
+- **Contradiction Candidates** — sub-dedup-threshold negation-divergent
+  knowledge pairs, detected (not acted on) using the existing Jaccard bigram
+  primitives. Supersession is surfaced only as a menu item the user opts into.
+- **Issue Candidates** — drafted GitHub issue bodies for problems backed by
+  reproduction evidence (gate-fail verdicts or high tool failure rates).
+- **Negatives** — explicit "0 captured" reporting (the previously-absent NOOP
+  outcome).
+- **Prompt fix** — `REFLECTION_SYSTEM_PROMPT`'s Skill Recommendations section now
+  includes the "capturing nothing is a valid outcome" license (it previously
+  existed only for Problems), reducing over-produced skill recommendations.
+
+### Action menu (Phase B — post-lock, advisory)
+
+After `finalize.lock` is released, the finalize output ends with a numbered
+action menu assembled from the reflection proposals, each routing to an existing
+tool (`/swarm curate`, `gh issue create`, `skill_improve`). Application happens
+in a later user turn — no new mutation pipeline, no writes inside finalize. Under
+full-auto the menu is reported-only (no "reply with numbers" prompt).
+
+## Safety
+
+- No new mutation ops, no new store fields.
+- Contradiction detection is read-only; supersession is never automatic.
+- The action menu runs after `finalize.lock` release; under full-auto it is
+  reported-only.
+- Realtime admission counts are recovered from durable markers (the in-memory
+  `DrainSummary` is discarded at `src/index.ts` — tracked in #1821); realtime
+  rejections (screened-out candidates) remain unobservable and are flagged in the
+  report.
+
+## Tests
+
+- New `src/services/session-reflection.signals.test.ts` covers the gather
+  functions, signals block, action menu, and the both-paths `signalsReport`
+  invariant.
+- New `tests/unit/commands/close-reflection-menu.test.ts` covers the command-level
+  menu rendering (AC-3) and full-auto prompt suppression (AC-4).
+- Existing `session-reflection.test.ts` unchanged (453 lines); existing
+  `close.test.ts` assertion updated to distinguish the skill-compilation hint
+  from the new signals-block delta line.
+
+Closes #2077

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -11,6 +11,7 @@ import {
 } from '../config/schema';
 import { closeProjectDb } from '../db/project-db';
 import { archiveEvidence } from '../evidence/manager';
+import { isFullAutoRunActive } from '../full-auto/state.js';
 import {
 	getGitRepositoryStatus,
 	resetToMainAfterMerge,
@@ -32,6 +33,7 @@ import { tryAcquireLock } from '../parallel/file-locks.js';
 import { closePlanTerminalState } from '../plan/manager';
 import { clearAllScopes } from '../scope/scope-persistence';
 import {
+	buildActionMenu,
 	runSessionReflection,
 	type SessionReflectionResult,
 	writeSessionReflection,
@@ -44,6 +46,7 @@ import {
 import { readEarliestSessionStart } from '../session/session-start-store.js';
 import {
 	endAgentSession,
+	hasActiveFullAuto,
 	resetSwarmStatePreservingSingletons,
 	swarmState,
 } from '../state';
@@ -75,6 +78,8 @@ interface CloseCommandOptions {
 
 interface CurationCounts {
 	stored: number;
+	/** Issue #2077: surfaced for the reflection knowledge-delta report. */
+	reinforced: number;
 	skipped: number;
 	rejected: number;
 	quarantined: number;
@@ -146,6 +151,14 @@ export interface CloseStageContext {
 	hivePromoted: number;
 	sessionKnowledgeCreated: number;
 	fallbackKnowledgeCreated: number;
+	/** Issue #2077: FR-015 dedup drop count (retro lessons dropped as already-known). */
+	dedupDropped: number;
+	/** Issue #2077: false when the dedup knowledge read failed (fail-open). */
+	dedupAvailable: boolean;
+	/** Issue #2077: total retro lessons before dedup. */
+	retroLessonTotal: number;
+	/** Issue #2077: full-auto state computed once, reused at reflection + menu render. */
+	fullAuto: boolean;
 	originalStatuses: Map<string, string>;
 	guaranteeResult: { closedPhaseIds: number[]; closedTaskIds: string[] };
 	archiveResult: string;
@@ -779,6 +792,8 @@ export async function runFinalizeStage(ctx: CloseStageContext): Promise<void> {
 
 	// FR-015: exclude retro lessons already committed in the knowledge store
 	let dedupedRetroLessons = ctx.retroLessons;
+	ctx.retroLessonTotal = ctx.retroLessons.length;
+	ctx.dedupAvailable = true;
 	try {
 		const existingEntries = await readKnowledge<SwarmKnowledgeEntry>(
 			resolveSwarmKnowledgePath(ctx.directory),
@@ -795,7 +810,11 @@ export async function runFinalizeStage(ctx: CloseStageContext): Promise<void> {
 		}
 	} catch {
 		dedupedRetroLessons = ctx.retroLessons; // fail-open
+		ctx.dedupAvailable = false; // issue #2077: distinguish "0 deduped" from "dedup did not run"
 	}
+	// Issue #2077: capture the dedup drop count so the reflection report can
+	// surface "N deduped as already-known" instead of dropping it invisibly.
+	ctx.dedupDropped = ctx.retroLessons.length - dedupedRetroLessons.length;
 
 	ctx.allLessons = [
 		...new Set([...ctx.explicitLessons, ...dedupedRetroLessons]),
@@ -939,6 +958,33 @@ export async function runFinalizeStage(ctx: CloseStageContext): Promise<void> {
 				toolAggregates: swarmState.toolAggregates,
 				agentSessions: swarmState.agentSessions,
 				sessionId: ctx.options.sessionID,
+				sessionStart: ctx.sessionStart,
+				// Issue #2077: thread the configured dedup threshold so a
+				// user-tuned threshold (e.g. 0.8) does not cause contradiction-
+				// candidate false negatives for pairs in [0.6, 0.8) that can
+				// coexist in the active store (the write paths dedup at the
+				// configured value, not the 0.6 default).
+				dedupThreshold: ctx.config.dedup_threshold,
+				// Issue #2077: pass the knowledge delta (close-time curation
+				// counts + FR-015 dedup state) into the reflection service.
+				// Realtime admission counts are recovered read-only inside the
+				// service from durable markers (the in-memory DrainSummary is
+				// discarded at index.ts; tracked in #1821).
+				knowledgeDelta: {
+					sessionKnowledgeCreated: ctx.sessionKnowledgeCreated,
+					dedupDropped: ctx.dedupDropped,
+					dedupAvailable: ctx.dedupAvailable,
+					retroLessonTotal: ctx.retroLessonTotal,
+					curation: ctx.curationResult
+						? {
+								stored: ctx.curationResult.stored,
+								reinforced: ctx.curationResult.reinforced ?? 0,
+								skipped: ctx.curationResult.skipped ?? 0,
+								rejected: ctx.curationResult.rejected ?? 0,
+								quarantined: ctx.curationResult.quarantined ?? 0,
+							}
+						: undefined,
+				},
 			},
 			CLOSE_REFLECTION_TIMEOUT_MS,
 		);
@@ -2081,6 +2127,10 @@ export async function handleCloseCommand(
 			hivePromoted: 0,
 			sessionKnowledgeCreated: 0,
 			fallbackKnowledgeCreated: 0,
+			dedupDropped: 0,
+			dedupAvailable: true,
+			retroLessonTotal: 0,
+			fullAuto: false,
 			originalStatuses: new Map(),
 			guaranteeResult: { closedPhaseIds: [], closedTaskIds: [] },
 			archiveResult: '',
@@ -2095,6 +2145,16 @@ export async function handleCloseCommand(
 			archiveSuffix: '',
 			args,
 		};
+
+		// Issue #2077: compute full-auto state ONCE (guarded by sessionID to
+		// avoid the cross-session leak documented at skill-improver.ts —
+		// hasActiveFullAuto(undefined) scans ALL sessions) and reuse it at both
+		// the reflection call and the menu render so the two cannot disagree.
+		// Combines the in-memory flag (hasActiveFullAuto) with the durable run
+		// state (isFullAutoRunActive) for robustness across process restarts.
+		ctx.fullAuto = options.sessionID
+			? _internals.detectFullAuto(directory, options.sessionID)
+			: false;
 
 		await runFinalizeStage(ctx);
 
@@ -2326,10 +2386,32 @@ export async function handleCloseCommand(
 			}
 		}
 
-		if (ctx.planAlreadyDone) {
-			return `✅ Session finalized. Plan was already in a terminal state — cleanup and archive applied.\n\n**Archive:** ${ctx.archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${reflectionOutput}${warningMsg}`;
+		// Issue #2077: the signals block renders UNCONDITIONALLY (not gated by
+		// the narrative-report hasSignals check above) so the "0 captured; N
+		// deduped" / NOOP line appears even in a clean session — the issue's
+		// "single genuinely-absent capability".
+		let signalsOutput = '';
+		if (ctx.sessionReflection?.signalsReport) {
+			signalsOutput = `\n\n---\n\n${ctx.sessionReflection.signalsReport}`;
 		}
-		return `✅ Swarm finalized. ${ctx.closedPhases.length} phase(s) closed, ${ctx.closedTasks.length} incomplete task(s) marked closed.\n\n**Archive:** ${ctx.archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${reflectionOutput}${warningMsg}`;
+
+		// Issue #2077 Phase B: numbered action menu (advisory; application is a
+		// later user turn via existing tools). Under full-auto the prompt suffix
+		// is suppressed (reported-only) so the run is not blocked.
+		let actionMenuOutput = '';
+		if (
+			ctx.sessionReflection &&
+			ctx.sessionReflection.actionProposals.length > 0
+		) {
+			actionMenuOutput =
+				'\n\n' +
+				buildActionMenu(ctx.sessionReflection.actionProposals, ctx.fullAuto);
+		}
+
+		if (ctx.planAlreadyDone) {
+			return `✅ Session finalized. Plan was already in a terminal state — cleanup and archive applied.\n\n**Archive:** ${ctx.archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${reflectionOutput}${signalsOutput}${actionMenuOutput}${warningMsg}`;
+		}
+		return `✅ Swarm finalized. ${ctx.closedPhases.length} phase(s) closed, ${ctx.closedTasks.length} incomplete task(s) marked closed.\n\n**Archive:** ${ctx.archiveResult}\n**Git:** ${gitAlignResult}${lessonSummary}${knowledgeHintSummary}${skillReviewOutput}${postMortemOutput}${reflectionOutput}${signalsOutput}${actionMenuOutput}${warningMsg}`;
 	} finally {
 		if (finalizeLock.release) {
 			try {
@@ -2360,11 +2442,32 @@ async function acquireFinalizeLock(
 	return { acquired: false };
 }
 
+/**
+ * Issue #2077: detect full-auto state for the action-menu prompt suppression.
+ * Combines the in-memory session flag (hasActiveFullAuto) with the durable
+ * run state (isFullAutoRunActive reads .swarm/full-auto-state.json) so a
+ * process restart mid-run does not silently re-enable the interactive menu
+ * prompt. The durable check is sync and takes a state lock; if it throws,
+ * fall back to the in-memory flag alone. Caller MUST guard with a defined
+ * sessionID to avoid the cross-session leak (hasActiveFullAuto(undefined)
+ * scans all sessions).
+ */
+function detectFullAuto(directory: string, sessionID: string): boolean {
+	if (hasActiveFullAuto(sessionID)) return true;
+	try {
+		return isFullAutoRunActive(directory, sessionID);
+	} catch {
+		// Durable state read failed — fall back to in-memory flag only.
+		return false;
+	}
+}
+
 export const _internals = {
 	ACTIVE_STATE_DIRS_TO_CLEAN,
 	countSessionKnowledgeEntries,
 	CLOSE_SKILL_REVIEW_TIMEOUT_MS,
 	CLOSE_REFLECTION_TIMEOUT_MS,
+	detectFullAuto, // issue #2077: full-auto detection (testable via _internals)
 	guaranteeAllPlansComplete,
 	getGitRepositoryStatus,
 	resetToMainAfterMerge,

--- a/src/services/session-reflection.signals-report.test.ts
+++ b/src/services/session-reflection.signals-report.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Issue #2077 — session-reflection signal REPORT tests (builders + integration).
+ *
+ * Split from session-reflection.signals.test.ts (FR-006: test files < 500
+ * lines). This file covers the pure signal-block/menu builders and the
+ * runSessionReflection integration (both-paths signalsReport, realtime
+ * admission merge + render, deterministic no-embed regression pin).
+ *
+ * Uses _internals DI seam. No mock.module.
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from 'bun:test';
+import * as fs from 'node:fs';
+import { canonicalMkdtemp } from '../../tests/helpers/tmpdir';
+import {
+	_internals,
+	buildActionMenu,
+	buildActionProposals,
+	buildSignalsBlock,
+	type ContradictionCandidate,
+	type KnowledgeDelta,
+	type ReflectionActionProposal,
+	runSessionReflection,
+	type SessionReflectionData,
+} from './session-reflection';
+
+setDefaultTimeout(30_000);
+
+const realInternals = { ..._internals };
+
+afterEach(() => {
+	for (const key of Object.keys(
+		realInternals,
+	) as (keyof typeof realInternals)[]) {
+		(_internals as any)[key] = (realInternals as any)[key];
+	}
+});
+
+function makeData(
+	overrides: Partial<SessionReflectionData> = {},
+): SessionReflectionData {
+	return {
+		timestamp: '2026-08-09T00:00:00.000Z',
+		totalToolCalls: 0,
+		totalToolFailures: 0,
+		toolProblems: [],
+		agentDispatches: [],
+		gateFailures: [],
+		lessonsFromRetros: [],
+		errorTaxonomy: {},
+		skillViolations: [],
+		contradictionCandidates: [],
+		...overrides,
+	};
+}
+
+// ─── buildSignalsBlock ───────────────────────────────────────────────
+
+describe('session-reflection #2077 — buildSignalsBlock', () => {
+	test('emits Knowledge Delta with the NOOP/negative line when nothing captured', () => {
+		const kd: KnowledgeDelta = {
+			sessionKnowledgeCreated: 0,
+			dedupDropped: 0,
+			dedupAvailable: true,
+			retroLessonTotal: 0,
+		};
+		const block = buildSignalsBlock(makeData({ knowledgeDelta: kd }));
+		expect(block).toContain('## Session Signals');
+		expect(block).toContain('0 lessons captured; 0 deduped as already-known.');
+	});
+
+	test('emits dedup-unavailable note when dedupAvailable is false', () => {
+		const kd: KnowledgeDelta = {
+			sessionKnowledgeCreated: 0,
+			dedupDropped: 0,
+			dedupAvailable: false,
+			retroLessonTotal: 0,
+		};
+		const block = buildSignalsBlock(makeData({ knowledgeDelta: kd }));
+		expect(block).toContain('dedup unavailable');
+	});
+
+	test('emits dedup count when lessons were deduped', () => {
+		const kd: KnowledgeDelta = {
+			sessionKnowledgeCreated: 2,
+			dedupDropped: 3,
+			dedupAvailable: true,
+			retroLessonTotal: 5,
+		};
+		const block = buildSignalsBlock(makeData({ knowledgeDelta: kd }));
+		expect(block).toContain('3 retro lesson(s) deduped as already-known.');
+	});
+
+	test('emits skill violations with session scope label', () => {
+		const block = buildSignalsBlock(
+			makeData({
+				skillViolations: [
+					{
+						skillPath: '.opencode/skills/x',
+						violations: 2,
+						total: 5,
+						tailBounded: true,
+						scope: 'session',
+					},
+				],
+			}),
+		);
+		expect(block).toContain('Skill Compliance Signals');
+		expect(block).toContain('[this session]');
+		expect(block).toContain('.opencode/skills/x: 2 violation(s)');
+	});
+
+	test('emits contradiction candidates as advisory', () => {
+		const cc: ContradictionCandidate = {
+			newLesson: 'always x',
+			newEntryId: 'n1',
+			conflictsWithId: 'o1',
+			conflictsWithLesson: 'never x',
+			similarity: 0.5,
+		};
+		const block = buildSignalsBlock(
+			makeData({ contradictionCandidates: [cc] }),
+		);
+		expect(block).toContain('Contradiction Candidates');
+		expect(block).toContain('candidate supersede');
+	});
+
+	test('emits issue candidates only when repro evidence exists', () => {
+		const block = buildSignalsBlock(
+			makeData({
+				gateFailures: [{ gate: 'reviewer', taskId: '1.1', count: 2 }],
+				toolProblems: [
+					{
+						tool: 'bash',
+						failureCount: 5,
+						totalCalls: 10,
+						failureRate: 0.5,
+						avgDurationMs: 100,
+					},
+				],
+			}),
+		);
+		expect(block).toContain('Issue Candidates');
+		expect(block).toContain('Gate reviewer rejected');
+		expect(block).toContain('Tool bash failing');
+	});
+});
+
+// ─── buildActionMenu + buildActionProposals ─────────────────────────
+
+describe('session-reflection #2077 — buildActionMenu', () => {
+	test('returns empty string when no proposals', () => {
+		expect(buildActionMenu([], false)).toBe('');
+	});
+
+	test('numbered menu with reply prompt when not full-auto', () => {
+		const proposals: ReflectionActionProposal[] = [
+			{
+				kind: 'supersede',
+				label: 'SUPERSEDE o1',
+				detail: 'd',
+				routing: '/swarm curate',
+			},
+		];
+		const menu = buildActionMenu(proposals, false);
+		expect(menu).toContain('reply with numbers');
+		expect(menu).toContain('[1] SUPERSEDE o1 → /swarm curate');
+		expect(menu).not.toContain('reported-only');
+	});
+
+	test('reported-only suffix when full-auto (no prompt)', () => {
+		const proposals: ReflectionActionProposal[] = [
+			{
+				kind: 'file_issue',
+				label: 'FILE issue',
+				detail: 'd',
+				routing: 'gh issue create',
+			},
+		];
+		const menu = buildActionMenu(proposals, true);
+		expect(menu.toLowerCase()).toContain('reported-only');
+		expect(menu).not.toContain('reply with numbers');
+	});
+});
+
+describe('session-reflection #2077 — buildActionProposals', () => {
+	test('never produces a capture proposal (critic item 7)', () => {
+		const proposals = buildActionProposals(
+			makeData({
+				knowledgeDelta: {
+					sessionKnowledgeCreated: 0,
+					dedupDropped: 0,
+					dedupAvailable: true,
+					retroLessonTotal: 0,
+				},
+			}),
+		);
+		expect(proposals.every((p) => p.kind !== 'capture')).toBe(true);
+	});
+
+	test('produces supersede from contradiction candidates', () => {
+		const proposals = buildActionProposals(
+			makeData({
+				contradictionCandidates: [
+					{
+						newLesson: 'always x',
+						newEntryId: 'n1',
+						conflictsWithId: 'o1',
+						conflictsWithLesson: 'never x',
+						similarity: 0.5,
+					},
+				],
+			}),
+		);
+		expect(proposals.some((p) => p.kind === 'supersede')).toBe(true);
+	});
+});
+
+// ─── runSessionReflection — critic item 1 regression ────────────────
+
+describe('session-reflection #2077 — signalsReport on both paths', () => {
+	let tempDir: string;
+	beforeEach(() => {
+		tempDir = canonicalMkdtemp('session-reflect-2077-');
+	});
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('signalsReport is present on the LLM path (not just deterministic)', async () => {
+		const mockDelegate = async () => 'LLM analysis: all clear.';
+		_internals.gatherSkillViolations = (() => []) as any;
+		_internals.gatherContradictionCandidates = (async () => []) as any;
+		_internals.gatherRealtimeAdmissionCounts = (async () => undefined) as any;
+
+		const result = await runSessionReflection({
+			directory: tempDir,
+			toolAggregates: new Map(),
+			agentSessions: new Map(),
+			delegate: mockDelegate,
+			knowledgeDelta: {
+				sessionKnowledgeCreated: 0,
+				dedupDropped: 0,
+				dedupAvailable: true,
+				retroLessonTotal: 0,
+			},
+		});
+		expect(result.source).toBe('llm');
+		expect(result.signalsReport).toContain('## Session Signals');
+		expect(result.signalsReport).toContain(
+			'0 lessons captured; 0 deduped as already-known.',
+		);
+		expect(Array.isArray(result.actionProposals)).toBe(true);
+	});
+
+	test('signalsReport is present on the deterministic path too', async () => {
+		_internals.gatherSkillViolations = (() => []) as any;
+		_internals.gatherContradictionCandidates = (async () => []) as any;
+		_internals.gatherRealtimeAdmissionCounts = (async () => undefined) as any;
+
+		const result = await runSessionReflection({
+			directory: tempDir,
+			toolAggregates: new Map(),
+			agentSessions: new Map(),
+			knowledgeDelta: {
+				sessionKnowledgeCreated: 1,
+				dedupDropped: 2,
+				dedupAvailable: true,
+				retroLessonTotal: 3,
+			},
+		});
+		expect(result.source).toBe('deterministic');
+		expect(result.signalsReport).toContain('## Session Signals');
+		expect(result.signalsReport).toContain(
+			'2 retro lesson(s) deduped as already-known.',
+		);
+	});
+
+	test('realtime admission counts merge into knowledgeDelta and render (final-critic item 2)', async () => {
+		_internals.gatherSkillViolations = (() => []) as any;
+		_internals.gatherContradictionCandidates = (async () => []) as any;
+		_internals.gatherRealtimeAdmissionCounts = (async () => ({
+			admitted: 2,
+			reinforced: 1,
+			rejected: 3,
+		})) as any;
+
+		const result = await runSessionReflection({
+			directory: tempDir,
+			toolAggregates: new Map(),
+			agentSessions: new Map(),
+			knowledgeDelta: {
+				sessionKnowledgeCreated: 1,
+				dedupDropped: 0,
+				dedupAvailable: true,
+				retroLessonTotal: 1,
+			},
+		});
+		expect(result.data.knowledgeDelta?.admitted).toBe(2);
+		expect(result.data.knowledgeDelta?.reinforcedRealtime).toBe(1);
+		expect(result.data.knowledgeDelta?.rejectedCurator).toBe(3);
+		expect(result.signalsReport).toContain(
+			'Realtime admission: 2 admitted, 1 reinforced, 3 curator-rejected',
+		);
+		expect(result.signalsReport).toContain('#1821');
+	});
+
+	test('deterministic architectReport does NOT embed the signals block (final-critic item 4)', async () => {
+		_internals.gatherSkillViolations = (() => []) as any;
+		_internals.gatherContradictionCandidates = (async () => []) as any;
+		_internals.gatherRealtimeAdmissionCounts = (async () => undefined) as any;
+
+		const result = await runSessionReflection({
+			directory: tempDir,
+			toolAggregates: new Map(),
+			agentSessions: new Map(),
+			knowledgeDelta: {
+				sessionKnowledgeCreated: 1,
+				dedupDropped: 0,
+				dedupAvailable: true,
+				retroLessonTotal: 1,
+			},
+		});
+		expect(result.source).toBe('deterministic');
+		expect(result.architectReport).not.toContain('## Session Signals');
+		expect(result.signalsReport).toContain('## Session Signals');
+	});
+});

--- a/src/services/session-reflection.signals.test.ts
+++ b/src/services/session-reflection.signals.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Issue #2077 — session-reflection advisory signal tests.
+ *
+ * Covers the six signal classes (knowledge delta, skill violations,
+ * contradiction candidates, negatives/NOOP, drafted issues) and the
+ * post-finalize action menu. Separate from session-reflection.test.ts so
+ * neither file approaches the 500-line FR-006 cap.
+ *
+ * Testing approach: the gather functions call their read-only dependencies
+ * through the `_internals` seam, so tests inject fakes by reassigning
+ * `_internals.readKnowledge` / `_internals.readSkillUsageEntriesTail` /
+ * `_internals.readRejectedLessons` (restored in afterEach) — no mock.module.
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { canonicalMkdtemp } from '../../tests/helpers/tmpdir';
+import type { SwarmKnowledgeEntry } from '../hooks/knowledge-types';
+import type { SkillUsageEntry } from '../hooks/skill-usage-log';
+import {
+	_internals,
+	buildActionMenu,
+	buildActionProposals,
+	buildSignalsBlock,
+	type ContradictionCandidate,
+	gatherContradictionCandidates,
+	gatherRealtimeAdmissionCounts,
+	gatherSkillViolations,
+	type KnowledgeDelta,
+	type ReflectionActionProposal,
+	runSessionReflection,
+	type SessionReflectionData,
+} from './session-reflection';
+
+setDefaultTimeout(30_000);
+
+// Snapshot the seam so afterEach can restore it exactly.
+const realInternals = { ..._internals };
+
+afterEach(() => {
+	for (const key of Object.keys(
+		realInternals,
+	) as (keyof typeof realInternals)[]) {
+		(_internals as any)[key] = (realInternals as any)[key];
+	}
+});
+
+function makeData(
+	overrides: Partial<SessionReflectionData> = {},
+): SessionReflectionData {
+	return {
+		timestamp: '2026-08-09T00:00:00.000Z',
+		totalToolCalls: 0,
+		totalToolFailures: 0,
+		toolProblems: [],
+		agentDispatches: [],
+		gateFailures: [],
+		lessonsFromRetros: [],
+		errorTaxonomy: {},
+		skillViolations: [],
+		contradictionCandidates: [],
+		...overrides,
+	};
+}
+
+// ─── gatherSkillViolations ───────────────────────────────────────────
+
+describe('session-reflection #2077 — gatherSkillViolations', () => {
+	test('returns [] when sessionId is undefined (cannot claim "this session")', () => {
+		const result = gatherSkillViolations('/tmp/whatever');
+		expect(result).toEqual([]);
+	});
+
+	test('ranks skills by violation count, ignoring non-violated verdicts', () => {
+		const entries: SkillUsageEntry[] = [
+			{
+				id: '1',
+				skillPath: '.opencode/skills/a',
+				agentName: 'coder',
+				taskID: 't1',
+				timestamp: '',
+				complianceVerdict: 'violated',
+				sessionID: 's1',
+			},
+			{
+				id: '2',
+				skillPath: '.opencode/skills/a',
+				agentName: 'coder',
+				taskID: 't2',
+				timestamp: '',
+				complianceVerdict: 'compliant',
+				sessionID: 's1',
+			},
+			{
+				id: '3',
+				skillPath: '.opencode/skills/a',
+				agentName: 'coder',
+				taskID: 't3',
+				timestamp: '',
+				complianceVerdict: 'violated',
+				sessionID: 's1',
+			},
+			{
+				id: '4',
+				skillPath: '.opencode/skills/b',
+				agentName: 'coder',
+				taskID: 't4',
+				timestamp: '',
+				complianceVerdict: 'violated',
+				sessionID: 's1',
+			},
+			{
+				id: '5',
+				skillPath: '.opencode/skills/c',
+				agentName: 'coder',
+				taskID: 't5',
+				timestamp: '',
+				complianceVerdict: 'compliant',
+				sessionID: 's1',
+			},
+		];
+		_internals.readSkillUsageEntriesTail = (() => entries) as any;
+		const result = gatherSkillViolations('/tmp/x', 's1');
+		// skill c has 0 violations -> excluded; skill a (2) ranks above b (1).
+		expect(result.map((r) => r.skillPath)).toEqual([
+			'.opencode/skills/a',
+			'.opencode/skills/b',
+		]);
+		expect(result[0].violations).toBe(2);
+		expect(result[0].total).toBe(3);
+		expect(result[0].scope).toBe('session');
+		expect(result[0].tailBounded).toBe(true);
+	});
+
+	test('fail-open returns [] on read error', () => {
+		_internals.readSkillUsageEntriesTail = (() => {
+			throw new Error('read failed');
+		}) as any;
+		expect(gatherSkillViolations('/tmp/x', 's1')).toEqual([]);
+	});
+});
+
+// ─── gatherContradictionCandidates ───────────────────────────────────
+
+describe('session-reflection #2077 — gatherContradictionCandidates', () => {
+	test('returns [] when sessionStart is undefined', async () => {
+		expect(await gatherContradictionCandidates('/tmp/x')).toEqual([]);
+	});
+
+	test('detects a sub-dedup-threshold negation-divergent pair (the only production-real shape)', async () => {
+		// Two lessons engineered so their Jaccard bigram similarity lands in
+		// the [0.45, 0.6) band (5 shared bigrams / 9 union = 0.556) AND they
+		// diverge in negation polarity ("always" vs "never"). This is the only
+		// shape that can coexist in the active store (the write paths dedup at
+		// 0.6), so it is the only shape the band+polarity detector can catch
+		// in production (issue #2077 critic item 3).
+		const entries: SwarmKnowledgeEntry[] = [
+			{
+				id: 'new1',
+				tier: 'swarm',
+				lesson: 'always lock the file before writing data to it',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-09T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+			{
+				id: 'old1',
+				tier: 'swarm',
+				lesson: 'never lock the file before writing data',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-08T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+		];
+		_internals.readKnowledge = (async () => entries) as any;
+		const result = await gatherContradictionCandidates(
+			'/tmp/x',
+			'2026-08-09T00:00:00.000Z',
+		);
+		expect(result.length).toBe(1);
+		expect(result[0].newEntryId).toBe('new1');
+		expect(result[0].conflictsWithId).toBe('old1');
+		expect(result[0].similarity).toBeGreaterThanOrEqual(0.45);
+		expect(result[0].similarity).toBeLessThan(0.6);
+	});
+
+	test('does NOT flag a high-similarity non-negation pair (that is a duplicate, not a contradiction)', async () => {
+		// Identical lessons -> similarity 1.0 (above the band, and a duplicate),
+		// with no negation divergence. Not a contradiction candidate.
+		const entries: SwarmKnowledgeEntry[] = [
+			{
+				id: 'new1',
+				tier: 'swarm',
+				lesson: 'always run tests after changes',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-09T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+			{
+				id: 'old1',
+				tier: 'swarm',
+				lesson: 'always run tests after changes',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-08T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+		];
+		_internals.readKnowledge = (async () => entries) as any;
+		const result = await gatherContradictionCandidates(
+			'/tmp/x',
+			'2026-08-09T00:00:00.000Z',
+		);
+		expect(result).toEqual([]);
+	});
+
+	test('excludes self and dedups symmetric pairs', async () => {
+		// Two session-created negation-divergent entries in the band -> should
+		// emit ONE pair (not two symmetric, not a self-match).
+		const entries: SwarmKnowledgeEntry[] = [
+			{
+				id: 'new1',
+				tier: 'swarm',
+				lesson: 'always lock the file before writing data to it',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-09T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+			{
+				id: 'new2',
+				tier: 'swarm',
+				lesson: 'never lock the file before writing data',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-09T02:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+		];
+		_internals.readKnowledge = (async () => entries) as any;
+		const result = await gatherContradictionCandidates(
+			'/tmp/x',
+			'2026-08-09T00:00:00.000Z',
+		);
+		expect(result.length).toBe(1);
+	});
+
+	test('fail-open returns [] on read error', async () => {
+		_internals.readKnowledge = (async () => {
+			throw new Error('read failed');
+		}) as any;
+		expect(
+			await gatherContradictionCandidates('/tmp/x', '2026-08-09T00:00:00.000Z'),
+		).toEqual([]);
+	});
+});
+
+// ─── gatherRealtimeAdmissionCounts ───────────────────────────────────
+
+describe('session-reflection #2077 — gatherRealtimeAdmissionCounts', () => {
+	test('returns undefined when sessionStart is undefined', async () => {
+		expect(await gatherRealtimeAdmissionCounts('/tmp/x')).toBeUndefined();
+	});
+
+	test('counts admitted (insight marker + session created), reinforced (pre-existing confirmed this session), rejected', async () => {
+		const entries: SwarmKnowledgeEntry[] = [
+			{
+				// admitted: created this session with insight marker
+				id: 'a1',
+				tier: 'swarm',
+				lesson: 'lesson one',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-09T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+				source_knowledge_ids: ['insight:abc'],
+			},
+			{
+				// reinforced: pre-existing, confirmed this session
+				id: 'r1',
+				tier: 'swarm',
+				lesson: 'lesson two',
+				category: 'process',
+				tags: [],
+				scope: 'global',
+				confidence: 0.5,
+				status: 'established',
+				confirmed_by: [
+					{
+						phase_number: 1,
+						confirmed_at: '2026-08-09T02:00:00.000Z',
+						project_name: 'p',
+					},
+				],
+				retrieval_outcomes: {} as any,
+				schema_version: 3,
+				created_at: '2026-08-08T01:00:00.000Z',
+				updated_at: '',
+				project_name: 'p',
+			},
+		];
+		_internals.readKnowledge = (async () => entries) as any;
+		_internals.readRejectedLessons = (async () => [
+			{
+				id: 'x',
+				lesson: 'bad',
+				rejection_reason: 'nope',
+				rejected_at: '2026-08-09T03:00:00.000Z',
+				rejection_layer: 1 as 1,
+			},
+		]) as any;
+		const result = await gatherRealtimeAdmissionCounts(
+			'/tmp/x',
+			'2026-08-09T00:00:00.000Z',
+		);
+		expect(result).toEqual({ admitted: 1, reinforced: 1, rejected: 1 });
+	});
+});

--- a/src/services/session-reflection.ts
+++ b/src/services/session-reflection.ts
@@ -18,9 +18,24 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import {
+	jaccardBigram,
+	readKnowledge,
+	readRejectedLessons,
+	resolveSwarmKnowledgePath,
+	wordBigrams,
+} from '../hooks/knowledge-store';
+import type {
+	RejectedLesson,
+	SwarmKnowledgeEntry,
+} from '../hooks/knowledge-types';
+import {
 	createSkillImproverLLMDelegate,
 	type SkillImproverLLMDelegate,
 } from '../hooks/skill-improver-llm-factory';
+import {
+	normalizeComplianceVerdict,
+	readSkillUsageEntriesTail,
+} from '../hooks/skill-usage-log';
 import { validateSwarmPath } from '../hooks/utils';
 import type { ToolAggregate } from '../state';
 
@@ -46,6 +61,73 @@ export interface GateFailureSummary {
 	count: number;
 }
 
+/**
+ * Knowledge-delta surface for the reflection report (issue #2077).
+ *
+ * `admitted` / `reinforcedRealtime` / `rejectedCurator` are recovered
+ * READ-ONLY from durable markers stamped by the realtime admission path
+ * (`src/learning/admission.ts`) and the curator rejected-lessons file —
+ * the in-memory `DrainSummary` is discarded at `src/index.ts` (issue
+ * #1821), but the outcomes it summarized persist on the entries
+ * themselves, so the counts are reconstructable here without any new
+ * writes. Realtime *rejections* (screened-out candidates that never
+ * reached the store) remain unobservable and are flagged in the report.
+ */
+export interface KnowledgeDelta {
+	/** Entries created this session (count, from countSessionKnowledgeEntries). */
+	sessionKnowledgeCreated: number;
+	/** FR-015 dedup: retro lessons dropped as already-known. */
+	dedupDropped: number;
+	/** False when the dedup read failed (fail-open) — distinguishes "0 deduped" from "dedup did not run". */
+	dedupAvailable: boolean;
+	/** Retro lessons that survived dedup and were curated. */
+	retroLessonTotal: number;
+	/** Close-time curation counts (finalize retro-lesson batch). */
+	curation?: {
+		stored: number;
+		reinforced: number;
+		skipped: number;
+		rejected: number;
+		quarantined: number;
+	};
+	/** Entries admitted this session (created_at >= sessionStart AND carry an `insight:` provenance marker). */
+	admitted?: number;
+	/** Pre-existing entries reinforced this session (some confirmed_by[].confirmed_at >= sessionStart). */
+	reinforcedRealtime?: number;
+	/** Curator-path rejections this session (rejected_at >= sessionStart, from .swarm/knowledge-rejected.jsonl). */
+	rejectedCurator?: number;
+}
+
+export interface SkillViolationSignal {
+	skillPath: string;
+	violations: number;
+	total: number;
+	/** Always true — the 64 KB tail may truncate the denominator. */
+	tailBounded: boolean;
+	/** 'session' when filtered by sessionID; 'all_sessions' when no sessionID was available. */
+	scope: 'session' | 'all_sessions';
+}
+
+export interface ContradictionCandidate {
+	newLesson: string;
+	newEntryId: string;
+	conflictsWithId: string;
+	conflictsWithLesson: string;
+	similarity: number;
+}
+
+export type ReflectionActionKind = 'supersede' | 'file_issue' | 'draft_skill';
+
+export interface ReflectionActionProposal {
+	kind: ReflectionActionKind;
+	/** Short human-readable label for the menu line. */
+	label: string;
+	/** Longer body (issue body, lesson text, etc.). */
+	detail: string;
+	/** Existing tool/command to route to, e.g. '/swarm curate'. */
+	routing: string;
+}
+
 export interface SessionReflectionData {
 	timestamp: string;
 	totalToolCalls: number;
@@ -55,12 +137,23 @@ export interface SessionReflectionData {
 	gateFailures: GateFailureSummary[];
 	lessonsFromRetros: string[];
 	errorTaxonomy: Record<string, number>;
+	knowledgeDelta?: KnowledgeDelta;
+	skillViolations: SkillViolationSignal[];
+	contradictionCandidates: ContradictionCandidate[];
 }
 
 export interface SessionReflectionResult {
 	data: SessionReflectionData;
 	architectReport: string;
+	/**
+	 * Always-rendered signals block (issue #2077). Surfaced UNCONDITIONALLY
+	 * by close.ts (not gated by the narrative-report `hasSignals` check) so
+	 * the "0 captured; N deduped" / NOOP line appears even in a clean
+	 * session. Present on BOTH the llm and deterministic paths.
+	 */
+	signalsReport: string;
 	source: 'llm' | 'deterministic';
+	actionProposals: ReflectionActionProposal[];
 }
 
 // ─── Phase 1: Deterministic gathering ────────────────────────────────
@@ -217,10 +310,234 @@ async function gatherGateFailures(
 	return [...failures.values()].sort((a, b) => b.count - a.count);
 }
 
+// ─── Issue #2077 signal gatherers (advisory, read-only) ──────────────
+//
+// Every function below is READ-ONLY: it reads durable artifacts
+// (.swarm/skill-usage.jsonl, the swarm knowledge file, the rejected
+// lessons file) and never mutates a store. Each fails open to an empty
+// result so reflection never blocks finalize. They are exposed via the
+// `_internals` seam AND invoked through it from `runSessionReflection`,
+// so tests inject fakes without `mock.module`.
+
+/** Lower band for the contradiction-candidate similarity window. */
+const CONTRADICTION_LOWER = 0.45;
+/** Cap on session-created entries scanned for contradiction pairs. */
+const CONTRADICTION_SESSION_CAP = 50;
+/** Cap on emitted contradiction pairs. */
+const CONTRADICTION_PAIR_CAP = 10;
+/** Cap on skill-violation rows. */
+const SKILL_VIOLATION_CAP = 5;
+/** Default realtime admission dedup threshold, mirrored from config schema. */
+const DEFAULT_DEDUP_THRESHOLD = 0.6;
+
+/** Negation-polarity heuristic. A contradiction candidate diverges in polarity. */
+const NEGATION_RE =
+	/\b(never|not|don't|avoid|must\s+not|no\s+longer|forbid|prohibit)\b/i;
+
+function isNegationDivergent(a: string, b: string): boolean {
+	const aNeg = NEGATION_RE.test(a ?? '');
+	const bNeg = NEGATION_RE.test(b ?? '');
+	// Divergence = exactly one side carries negation polarity.
+	return aNeg !== bNeg;
+}
+
+/**
+ * Top skills by violation this session (issue #2077).
+ *
+ * Reads the bounded tail of `.swarm/skill-usage.jsonl`, groups by
+ * `skillPath`, and counts entries where the normalized compliance
+ * verdict is `'violated'`. Returns `[]` when `sessionId` is undefined:
+ * without a session filter the tail is cumulative cross-session data
+ * and MUST NOT be labeled "this session" (issue #2077 critic item 8).
+ * `tailBounded` is always true — the 64 KB tail may truncate the
+ * denominator.
+ */
+export function gatherSkillViolations(
+	directory: string,
+	sessionId?: string,
+): SkillViolationSignal[] {
+	if (!sessionId) return [];
+	try {
+		const entries = _internals.readSkillUsageEntriesTail(directory, {
+			sessionID: sessionId,
+		});
+		const bySkill = new Map<string, { violations: number; total: number }>();
+		for (const entry of entries) {
+			const skill = entry.skillPath;
+			if (!skill) continue;
+			const agg = bySkill.get(skill) ?? { violations: 0, total: 0 };
+			agg.total++;
+			if (normalizeComplianceVerdict(entry.complianceVerdict) === 'violated') {
+				agg.violations++;
+			}
+			bySkill.set(skill, agg);
+		}
+		return [...bySkill.entries()]
+			.map(([skillPath, agg]) => ({
+				skillPath,
+				violations: agg.violations,
+				total: agg.total,
+				tailBounded: true,
+				scope: 'session' as const,
+			}))
+			.filter((s) => s.violations > 0)
+			.sort((a, b) => b.violations - a.violations)
+			.slice(0, SKILL_VIOLATION_CAP);
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Contradiction candidates among session-created knowledge (issue #2077).
+ *
+ * IMPORTANT (issue #2077 critic item 3): the realtime admission and
+ * curator write paths dedup at `dedup_threshold` (default 0.6) BEFORE an
+ * entry becomes active, so two active entries with Jaccard similarity
+ * ≥ that threshold cannot coexist. A detector run at the dedup threshold
+ * would therefore return `[]` in every real session. Instead this looks
+ * in a sub-threshold band `[CONTRADICTION_LOWER, dedupThreshold)` AND
+ * requires negation-polarity divergence — the only shape that can occur
+ * in production. Uses the exported `wordBigrams`/`jaccardBigram`
+ * primitives directly so the score is available (the
+ * `findActiveSwarmNearDuplicate` helper returns only the entry, with no
+ * score and no self-exclusion). Detect-only: never writes, never
+ * auto-supersedes. Supersession is operationally deletion
+ * (`superseded_by IS NULL` read filter) and is surfaced only as a menu
+ * item the user opts into.
+ */
+export async function gatherContradictionCandidates(
+	directory: string,
+	sessionStart?: string,
+	dedupThreshold: number = DEFAULT_DEDUP_THRESHOLD,
+): Promise<ContradictionCandidate[]> {
+	if (!sessionStart) return [];
+	const sessionStartMs = Date.parse(sessionStart);
+	if (!Number.isFinite(sessionStartMs)) return [];
+	try {
+		const all = await _internals.readKnowledge<SwarmKnowledgeEntry>(
+			resolveSwarmKnowledgePath(directory),
+		);
+		const sessionCreated = all
+			.filter((e) => {
+				if (typeof e.created_at !== 'string') return false;
+				const ms = Date.parse(e.created_at);
+				return Number.isFinite(ms) && ms >= sessionStartMs;
+			})
+			.slice(0, CONTRADICTION_SESSION_CAP);
+		if (sessionCreated.length === 0) return [];
+		const seen = new Set<string>();
+		const pairs: ContradictionCandidate[] = [];
+		for (const entry of sessionCreated) {
+			if (pairs.length >= CONTRADICTION_PAIR_CAP) break;
+			const entryBigrams = wordBigrams(entry.lesson);
+			for (const other of all) {
+				if (other.id === entry.id) continue; // self-exclusion
+				const sim = jaccardBigram(entryBigrams, wordBigrams(other.lesson));
+				if (
+					sim >= CONTRADICTION_LOWER &&
+					sim < dedupThreshold &&
+					isNegationDivergent(entry.lesson, other.lesson)
+				) {
+					const key = [entry.id, other.id].sort().join('|');
+					if (seen.has(key)) continue; // dedup symmetric (A,B)/(B,A)
+					seen.add(key);
+					pairs.push({
+						newLesson: entry.lesson,
+						newEntryId: entry.id,
+						conflictsWithId: other.id,
+						conflictsWithLesson: other.lesson,
+						similarity: Math.round(sim * 100) / 100,
+					});
+					if (pairs.length >= CONTRADICTION_PAIR_CAP) break;
+				}
+			}
+		}
+		return pairs;
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Realtime admission counts recovered READ-ONLY from durable markers
+ * (issue #2077 critic item 4). The in-memory `DrainSummary` is
+ * discarded at `src/index.ts`, but the outcomes persist:
+ *   - admitted:   entries created this session with an `insight:` provenance marker
+ *     (stamped by `admitCandidate` via `unionSourceKnowledgeIds`).
+ *   - reinforced: pre-existing entries with a `confirmed_by` record
+ *     stamped this session (the realtime reinforce path).
+ *   - rejected:   curator-path rejections this session, from
+ *     `.swarm/knowledge-rejected.jsonl`.
+ * Returns `undefined` when `sessionStart` is undefined (counts are
+ * session-scoped). Realtime *rejections* (screened-out candidates that
+ * never reached the store) are NOT recoverable and are flagged in the
+ * report as tracked by #1821.
+ */
+export async function gatherRealtimeAdmissionCounts(
+	directory: string,
+	sessionStart?: string,
+): Promise<
+	| {
+			admitted: number;
+			reinforced: number;
+			rejected: number;
+	  }
+	| undefined
+> {
+	if (!sessionStart) return undefined;
+	const sessionStartMs = Date.parse(sessionStart);
+	if (!Number.isFinite(sessionStartMs)) return undefined;
+	try {
+		const entries = await _internals.readKnowledge<SwarmKnowledgeEntry>(
+			resolveSwarmKnowledgePath(directory),
+		);
+		let admitted = 0;
+		let reinforced = 0;
+		for (const e of entries) {
+			const createdMs =
+				typeof e.created_at === 'string'
+					? Date.parse(e.created_at)
+					: Number.NaN;
+			const createdThisSession =
+				Number.isFinite(createdMs) && createdMs >= sessionStartMs;
+			const hasInsightMarker = (e.source_knowledge_ids ?? []).some((id) =>
+				id.startsWith('insight:'),
+			);
+			if (createdThisSession && hasInsightMarker) admitted++;
+			const confirmedThisSession = (e.confirmed_by ?? []).some(
+				(rec: { confirmed_at?: string }) => {
+					const ts =
+						typeof rec?.confirmed_at === 'string' ? rec.confirmed_at : '';
+					const ms = Date.parse(ts);
+					return Number.isFinite(ms) && ms >= sessionStartMs;
+				},
+			);
+			if (!createdThisSession && confirmedThisSession) reinforced++;
+		}
+		let rejected = 0;
+		try {
+			const rejectedLessons = await _internals.readRejectedLessons(directory);
+			rejected = rejectedLessons.filter((r: RejectedLesson) => {
+				const ms = Date.parse(r.rejected_at ?? '');
+				return Number.isFinite(ms) && ms >= sessionStartMs;
+			}).length;
+		} catch {
+			rejected = 0;
+		}
+		return { admitted, reinforced, rejected };
+	} catch {
+		return undefined;
+	}
+}
+
 // ─── Phase 2: Architect review ───────────────────────────────────────
 
 function buildReflectionDataSummary(data: SessionReflectionData): string {
 	const lines: string[] = [];
+	// Defensive defaults: tests and older callers may construct partial data.
+	const skillViolations = data.skillViolations ?? [];
+	const contradictionCandidates = data.contradictionCandidates ?? [];
 
 	lines.push('SESSION DATA SNAPSHOT');
 	lines.push(`Total tool calls: ${data.totalToolCalls}`);
@@ -280,7 +597,246 @@ function buildReflectionDataSummary(data: SessionReflectionData): string {
 		lines.push('');
 	}
 
+	if (data.knowledgeDelta) {
+		const kd = data.knowledgeDelta;
+		lines.push('KNOWLEDGE DELTA:');
+		lines.push(
+			`  - ${kd.sessionKnowledgeCreated} knowledge entries created this session.`,
+		);
+		if (kd.curation) {
+			lines.push(
+				`  - Curation (finalize batch): ${kd.curation.stored} stored, ${kd.curation.reinforced} reinforced, ${kd.curation.skipped} skipped, ${kd.curation.rejected} rejected, ${kd.curation.quarantined} quarantined.`,
+			);
+		}
+		if (
+			kd.admitted !== undefined ||
+			kd.reinforcedRealtime !== undefined ||
+			kd.rejectedCurator !== undefined
+		) {
+			lines.push(
+				`  - Realtime admission: ${kd.admitted ?? 0} admitted, ${kd.reinforcedRealtime ?? 0} reinforced, ${kd.rejectedCurator ?? 0} curator-rejected (from durable markers).`,
+			);
+		}
+		lines.push(
+			`  - FR-015 dedup: ${kd.dedupDropped} retro lesson(s) deduped as already-known${kd.dedupAvailable ? '' : ' (dedup unavailable — knowledge read failed)'}.`,
+		);
+		lines.push('');
+	}
+
+	if (skillViolations.length > 0) {
+		lines.push('SKILL COMPLIANCE SIGNALS:');
+		for (const s of skillViolations) {
+			lines.push(
+				`  - ${s.skillPath}: ${s.violations} violation(s) across ${s.total} use(s) [${s.scope}${s.tailBounded ? ', tail-bounded' : ''}]`,
+			);
+		}
+		lines.push('');
+	}
+
+	if (contradictionCandidates.length > 0) {
+		lines.push('CONTRADICTION CANDIDATES (advisory):');
+		for (const c of contradictionCandidates) {
+			lines.push(
+				`  - "${c.newLesson}" (id ${c.newEntryId}) ≈ "${c.conflictsWithLesson}" (id ${c.conflictsWithId}) [sim ${c.similarity}]`,
+			);
+		}
+		lines.push('');
+	}
+
 	return lines.join('\n');
+}
+
+/**
+ * Always-rendered signals block (issue #2077). Rendered UNCONDITIONALLY
+ * by close.ts (not gated by the narrative-report `hasSignals` check) so
+ * the "0 captured; N deduped" / NOOP line appears even in a clean
+ * session. Surfaces all six signal classes: knowledge delta, skill
+ * violations, contradiction candidates, negatives, drafted issues.
+ */
+export function buildSignalsBlock(data: SessionReflectionData): string {
+	const lines: string[] = [];
+	lines.push('## Session Signals');
+	lines.push('');
+
+	// Defensive defaults: tests and older callers may construct partial data.
+	const skillViolations = data.skillViolations ?? [];
+	const contradictionCandidates = data.contradictionCandidates ?? [];
+
+	// Knowledge delta — always emit, even when zero (the "report negatives"
+	// requirement; issue #2077 calls this "the single genuinely-absent
+	// capability"). Mem0's NOOP-as-first-class-outcome.
+	const kd = data.knowledgeDelta;
+	if (kd) {
+		lines.push('**Knowledge Delta**');
+		lines.push(
+			`- ${kd.sessionKnowledgeCreated} knowledge entries created this session.`,
+		);
+		if (kd.curation) {
+			lines.push(
+				`- Curation (finalize batch): ${kd.curation.stored} stored, ${kd.curation.reinforced} reinforced, ${kd.curation.skipped} skipped, ${kd.curation.rejected} rejected, ${kd.curation.quarantined} quarantined.`,
+			);
+		}
+		if (
+			kd.admitted !== undefined ||
+			kd.reinforcedRealtime !== undefined ||
+			kd.rejectedCurator !== undefined
+		) {
+			lines.push(
+				`- Realtime admission: ${kd.admitted ?? 0} admitted, ${kd.reinforcedRealtime ?? 0} reinforced, ${kd.rejectedCurator ?? 0} curator-rejected (from durable markers).`,
+			);
+			lines.push(
+				'- Realtime rejections (screened-out candidates) are not observable here — tracked in #1821.',
+			);
+		}
+		if (!kd.dedupAvailable) {
+			lines.push(
+				'- FR-015 dedup unavailable (knowledge read failed); drop count not meaningful.',
+			);
+		} else if (kd.sessionKnowledgeCreated === 0 && kd.dedupDropped === 0) {
+			lines.push('- 0 lessons captured; 0 deduped as already-known.');
+		} else {
+			lines.push(
+				`- FR-015 dedup: ${kd.dedupDropped} retro lesson(s) deduped as already-known.`,
+			);
+		}
+		lines.push('');
+	}
+
+	// Skill violations — scope-aware (issue #2077 critic item 8).
+	if (skillViolations.length > 0) {
+		const scopeLabel =
+			skillViolations[0]?.scope === 'session'
+				? 'this session'
+				: 'recent, all sessions (no session id)';
+		lines.push(`**Skill Compliance Signals** [${scopeLabel}]`);
+		for (const s of skillViolations) {
+			lines.push(
+				`- ${s.skillPath}: ${s.violations} violation(s) across ${s.total} use(s)${s.tailBounded ? ' (tail-bounded)' : ''}`,
+			);
+		}
+		lines.push('');
+	}
+
+	// Contradiction candidates — detect only, never auto-supersede.
+	if (contradictionCandidates.length > 0) {
+		lines.push(
+			'**Contradiction Candidates** (advisory — review before acting)',
+		);
+		for (const c of contradictionCandidates) {
+			lines.push(
+				`- "${c.newLesson}" (id ${c.newEntryId}) ≈ "${c.conflictsWithLesson}" (id ${c.conflictsWithId}) [sim ${c.similarity}] → candidate supersede`,
+			);
+		}
+		lines.push('');
+	}
+
+	// Issue candidates — deterministic, gated on minimal-reproduction evidence.
+	const reproBacked: { title: string; evidence: string }[] = [];
+	for (const gf of data.gateFailures.slice(0, 3)) {
+		reproBacked.push({
+			title: `Gate ${gf.gate} rejected on task ${gf.taskId} (${gf.count}x)`,
+			evidence: `gate-fail evidence (verdict: fail/REJECT), ${gf.count} occurrence(s)`,
+		});
+	}
+	for (const p of data.toolProblems.slice(0, 2)) {
+		if (p.failureCount > 0) {
+			reproBacked.push({
+				title: `Tool ${p.tool} failing (${p.failureCount}/${p.totalCalls}, ${Math.round(p.failureRate * 100)}%)`,
+				evidence: `tool failure rate ${Math.round(p.failureRate * 100)}% (${p.failureCount}/${p.totalCalls})`,
+			});
+		}
+	}
+	if (reproBacked.length > 0) {
+		lines.push('**Issue Candidates** (repro evidence verified)');
+		for (const r of reproBacked) {
+			lines.push(`- ${r.title} — repro evidence: ${r.evidence}`);
+		}
+		lines.push('');
+	}
+
+	return lines.join('\n').trimEnd();
+}
+
+/**
+ * Assemble a numbered action menu from reflection proposals (issue #2077
+ * Phase B). Advisory only — application happens in a later user turn via
+ * the named existing tools. Under full-auto the "reply with numbers"
+ * prompt is suppressed (reported-only) so the run is not blocked waiting
+ * on human input. Returns '' when there are no proposals.
+ */
+export function buildActionMenu(
+	proposals: ReflectionActionProposal[],
+	fullAuto: boolean,
+): string {
+	if (proposals.length === 0) return '';
+	const lines: string[] = [];
+	// Under full-auto there is no human to reply, so do NOT emit the
+	// "reply with numbers" prompt — report the proposals only, with a note
+	// that application happens in a later turn (issue #2077 safety constraint).
+	lines.push(
+		fullAuto
+			? '**Proposed actions** (reported-only — full-auto):'
+			: '**Proposed actions** (reply with numbers, or "none"):',
+	);
+	proposals.forEach((p, i) => {
+		lines.push(` [${i + 1}] ${p.label} → ${p.routing}`);
+	});
+	if (fullAuto) {
+		lines.push('_Apply in a later turn via the listed tools._');
+	}
+	return lines.join('\n');
+}
+
+/**
+ * Build action proposals from gathered signals (issue #2077 Phase B).
+ * The `capture` kind is intentionally absent (issue #2077 critic item 7):
+ * aggregate curation counts cannot derive per-lesson outcomes, and
+ * re-proposing quarantined lessons would fail the actionability gate
+ * identically when applied. A menu item guaranteed to be rejected is
+ * worse than no menu item.
+ */
+export function buildActionProposals(
+	data: SessionReflectionData,
+): ReflectionActionProposal[] {
+	// Defensive defaults: tests and older callers may construct partial data.
+	const contradictionCandidates = data.contradictionCandidates ?? [];
+	const skillViolations = data.skillViolations ?? [];
+	const proposals: ReflectionActionProposal[] = [];
+	for (const c of contradictionCandidates) {
+		proposals.push({
+			kind: 'supersede',
+			label: `SUPERSEDE ${c.conflictsWithId} with newer entry (contradiction candidate, sim ${c.similarity})`,
+			detail: `"${c.newLesson}" (id ${c.newEntryId}) appears to contradict "${c.conflictsWithLesson}" (id ${c.conflictsWithId}).`,
+			routing: '/swarm curate',
+		});
+	}
+	for (const gf of data.gateFailures.slice(0, 3)) {
+		proposals.push({
+			kind: 'file_issue',
+			label: `FILE issue: "Gate ${gf.gate} rejected on task ${gf.taskId}" (repro verified)`,
+			detail: `Gate ${gf.gate} rejected ${gf.count}x on task ${gf.taskId}. Repro evidence: gate-fail verdict.`,
+			routing: 'gh issue create',
+		});
+	}
+	for (const p of data.toolProblems.slice(0, 2)) {
+		if (p.failureCount > 0) {
+			proposals.push({
+				kind: 'file_issue',
+				label: `FILE issue: "Tool ${p.tool} failing ${Math.round(p.failureRate * 100)}%" (repro verified)`,
+				detail: `Tool ${p.tool}: ${p.failureCount}/${p.totalCalls} failures (${Math.round(p.failureRate * 100)}%).`,
+				routing: 'gh issue create',
+			});
+		}
+	}
+	for (const s of skillViolations) {
+		proposals.push({
+			kind: 'draft_skill',
+			label: `DRAFT skill change: ${s.skillPath} (${s.violations} violations)`,
+			detail: `Skill ${s.skillPath} had ${s.violations} violation(s) across ${s.total} use(s) this session.`,
+			routing: 'skill_improve',
+		});
+	}
+	return proposals;
 }
 
 const REFLECTION_SYSTEM_PROMPT = `You are the architect reviewing a completed swarm session. Your job is to analyze what happened and produce a concise, actionable report for the human operator.
@@ -301,6 +857,7 @@ Based on everything that happened in this session, should any existing skills be
 - Workarounds the agents had to use
 - Knowledge gaps the agents exposed
 - Conventions the session revealed that aren't captured in any skill
+If no skill changes are warranted, say so explicitly — capturing nothing is a valid outcome. Do not invent recommendations to fill the section.
 
 ## Process Improvements
 What should the swarm do differently next time? Dispatch patterns, gate configurations, agent routing, phase structure — anything the architect should learn from this session.
@@ -382,6 +939,10 @@ function buildDeterministicReport(data: SessionReflectionData): string {
 	}
 	lines.push('');
 
+	// Issue #2077: the signals block is NOT embedded here. It is returned
+	// separately as `signalsReport` and rendered unconditionally by close.ts
+	// (independent of the hasSignals gate), so embedding it inline in the
+	// deterministic architectReport would duplicate it in the finalize output.
 	return lines.join('\n');
 }
 
@@ -394,6 +955,17 @@ export interface SessionReflectionInput {
 	sessionId?: string;
 	signal?: AbortSignal;
 	delegate?: SkillImproverLLMDelegate;
+	/** Issue #2077: knowledge-delta surface (close-time curation counts + dedup state). */
+	knowledgeDelta?: KnowledgeDelta;
+	/** Issue #2077: session start (ISO), used to scope session-created entries. */
+	sessionStart?: string;
+	/**
+	 * Issue #2077: configured dedup threshold (upper bound of the contradiction
+	 * band). Read from `config.dedup_threshold` so a user-tuned threshold (e.g.
+	 * 0.8) does not cause advisory false negatives for pairs in [0.6, 0.8) that
+	 * can coexist in the active store. Defaults to 0.6 (the schema default).
+	 */
+	dedupThreshold?: number;
 }
 
 export async function runSessionReflection(
@@ -408,6 +980,33 @@ export async function runSessionReflection(
 	);
 	const gateFailures = await gatherGateFailures(input.directory);
 
+	// Issue #2077: advisory signal gatherers (read-only, fail-open, invoked
+	// through the _internals seam so tests inject fakes without mock.module).
+	const skillViolations = _internals.gatherSkillViolations(
+		input.directory,
+		input.sessionId,
+	);
+	const contradictionCandidates =
+		await _internals.gatherContradictionCandidates(
+			input.directory,
+			input.sessionStart,
+			input.dedupThreshold ?? DEFAULT_DEDUP_THRESHOLD,
+		);
+	const realtimeCounts = await _internals.gatherRealtimeAdmissionCounts(
+		input.directory,
+		input.sessionStart,
+	);
+	const knowledgeDelta: KnowledgeDelta | undefined = input.knowledgeDelta
+		? {
+				...input.knowledgeDelta,
+				admitted: realtimeCounts?.admitted ?? input.knowledgeDelta.admitted,
+				reinforcedRealtime:
+					realtimeCounts?.reinforced ?? input.knowledgeDelta.reinforcedRealtime,
+				rejectedCurator:
+					realtimeCounts?.rejected ?? input.knowledgeDelta.rejectedCurator,
+			}
+		: undefined;
+
 	const data: SessionReflectionData = {
 		timestamp: new Date().toISOString(),
 		totalToolCalls: totalCalls,
@@ -417,7 +1016,18 @@ export async function runSessionReflection(
 		gateFailures,
 		lessonsFromRetros: lessons,
 		errorTaxonomy: taxonomy,
+		knowledgeDelta,
+		skillViolations,
+		contradictionCandidates,
 	};
+
+	// Issue #2077: the signals block + action proposals are computed ONCE and
+	// returned on BOTH the llm and deterministic paths. close.ts renders
+	// `signalsReport` unconditionally (not gated by the narrative-report
+	// hasSignals check) so the "0 captured; N deduped" / NOOP line appears
+	// even in a clean session.
+	const signalsReport = buildSignalsBlock(data);
+	const actionProposals = buildActionProposals(data);
 
 	const delegate =
 		input.delegate ??
@@ -432,7 +1042,13 @@ export async function runSessionReflection(
 				input.signal,
 			);
 			if (report && report.trim().length > 0) {
-				return { data, architectReport: report.trim(), source: 'llm' };
+				return {
+					data,
+					architectReport: report.trim(),
+					signalsReport,
+					actionProposals,
+					source: 'llm',
+				};
 			}
 		} catch {
 			// LLM failed — fall through to deterministic
@@ -442,6 +1058,8 @@ export async function runSessionReflection(
 	return {
 		data,
 		architectReport: buildDeterministicReport(data),
+		signalsReport,
+		actionProposals,
 		source: 'deterministic',
 	};
 }
@@ -470,4 +1088,17 @@ export const _internals = {
 	gatherGateFailures,
 	buildReflectionDataSummary,
 	buildDeterministicReport,
+	// Issue #2077 advisory gatherers + their read-only dependencies.
+	// Tests reassign these (restored in afterEach) to inject fakes without
+	// mock.module. The gatherers reference `_internals.*` at call time, so
+	// reassignment here is observed by runSessionReflection.
+	gatherSkillViolations,
+	gatherContradictionCandidates,
+	gatherRealtimeAdmissionCounts,
+	buildSignalsBlock,
+	buildActionMenu,
+	buildActionProposals,
+	readSkillUsageEntriesTail,
+	readKnowledge,
+	readRejectedLessons,
 };

--- a/tests/unit/commands/close-reflection-menu.test.ts
+++ b/tests/unit/commands/close-reflection-menu.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Issue #2077 — handleCloseCommand action-menu wiring.
+ *
+ * Verifies AC-3 (finalize output ends with a numbered action menu) and
+ * AC-4 (under full-auto the menu is reported-only, no prompt) at the
+ * command level — i.e. that close.ts actually renders the signals block
+ * and the menu into the return string, not just that buildActionMenu
+ * works in isolation.
+ *
+ * Uses _internals DI seam. No mock.module usage.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+// ── Import under test ────────────────────────────────────────────────
+const { handleCloseCommand, _internals: closeInternals } = await import(
+	'../../../src/commands/close.js'
+);
+// Import the reflection _internals so we can inject the gather fns.
+const { _internals: reflectionInternals } = await import(
+	'../../../src/services/session-reflection.js'
+);
+
+// ── Save real _internals ─────────────────────────────────────────────
+const realAcquireFinalizeLock = closeInternals.acquireFinalizeLock;
+const realLoadPluginConfigWithMeta = closeInternals.loadPluginConfigWithMeta;
+const realCurateAndStoreSwarm = closeInternals.curateAndStoreSwarm;
+const realCheckHivePromotions = closeInternals.checkHivePromotions;
+const realGetGitRepositoryStatus = closeInternals.getGitRepositoryStatus;
+const realResetToMainAfterMerge = closeInternals.resetToMainAfterMerge;
+const realResetToRemoteBranch = closeInternals.resetToRemoteBranch;
+const realResetSwarmStatePreservingSingletons =
+	closeInternals.resetSwarmStatePreservingSingletons;
+const realDetectFullAuto = closeInternals.detectFullAuto;
+const realGatherSkillViolations = reflectionInternals.gatherSkillViolations;
+const realGatherContradictionCandidates =
+	reflectionInternals.gatherContradictionCandidates;
+const realGatherRealtimeAdmissionCounts =
+	reflectionInternals.gatherRealtimeAdmissionCounts;
+
+let testDir: string;
+
+function swarmDir(): string {
+	return path.join(testDir, '.swarm');
+}
+
+function makeConfig(): Record<string, unknown> {
+	return {
+		config: {
+			knowledge: {
+				enabled: true,
+				hive_enabled: false,
+				auto_promote_days: 90,
+				swarm_max_entries: 100,
+				hive_max_entries: 200,
+				max_inject_count: 5,
+				delegate_max_inject_count: 8,
+				inject_char_budget: 2000,
+				max_lesson_display_chars: 120,
+				dedup_threshold: 0.6,
+				scope_filter: ['global'],
+				rejected_max_entries: 20,
+				validation_enabled: true,
+				evergreen_confidence: 0.9,
+				evergreen_utility: 0.8,
+				low_utility_threshold: 0.3,
+				min_retrievals_for_utility: 3,
+				schema_version: 1,
+				directive_min_confidence: 0.75,
+				same_project_weight: 1.0,
+				cross_project_weight: 0.5,
+				min_encounter_score: 0.1,
+				initial_encounter_score: 1.0,
+				encounter_increment: 0.1,
+				max_encounter_score: 10.0,
+				default_max_phases: 10,
+				todo_max_phases: 3,
+				sweep_enabled: true,
+				enrichment: { max_calls_per_day: 10, quota_window: 'utc' },
+			},
+			curator: { enabled: true, postmortem_enabled: false },
+			skill_improver: {
+				enabled: false,
+				max_calls_per_day: 10,
+				trigger: 'manual',
+				targets: ['skills', 'spec', 'architect_prompt', 'knowledge'],
+				write_mode: 'proposal',
+				require_user_approval: true,
+				quota_window: 'utc',
+				allow_deterministic_fallback: true,
+			},
+		},
+		loadedFromFile: null,
+	};
+}
+
+function installDefaultMocks(): void {
+	const mockRelease = mock(async () => {});
+	closeInternals.acquireFinalizeLock = mock(async () => ({
+		acquired: true,
+		release: mockRelease,
+	}));
+	closeInternals.loadPluginConfigWithMeta = () => makeConfig();
+	closeInternals.curateAndStoreSwarm = mock(async () => ({
+		stored: 0,
+		reinforced: 0,
+		skipped: 0,
+		rejected: 0,
+		quarantined: 0,
+	}));
+	closeInternals.checkHivePromotions = mock(async () => ({
+		new_promotions: 0,
+		encounters_incremented: 0,
+		advancements: 0,
+		total_hive_entries: 0,
+	}));
+	closeInternals.getGitRepositoryStatus = () => ({
+		isRepo: false,
+		reason: 'not_git_repo',
+		message: 'fatal: not a git repository',
+	});
+	closeInternals.resetToMainAfterMerge = () => ({
+		success: true,
+		targetBranch: 'origin/main',
+		previousBranch: 'main',
+		message: 'Already on main',
+		branchDeleted: false,
+		warnings: [],
+	});
+	closeInternals.resetToRemoteBranch = () => ({
+		success: true,
+		targetBranch: 'main',
+		localBranch: 'main',
+		message: 'Already aligned with remote',
+		alreadyAligned: true,
+		prunedBranches: [],
+		warnings: [],
+	});
+	closeInternals.resetSwarmStatePreservingSingletons = () => {};
+	// Default: not full-auto.
+	closeInternals.detectFullAuto = () => false;
+	// Default gatherers: empty (clean session).
+	reflectionInternals.gatherSkillViolations = () => [];
+	reflectionInternals.gatherContradictionCandidates = async () => [];
+	reflectionInternals.gatherRealtimeAdmissionCounts = async () => undefined;
+}
+
+function restoreInternals(): void {
+	closeInternals.acquireFinalizeLock = realAcquireFinalizeLock;
+	closeInternals.loadPluginConfigWithMeta = realLoadPluginConfigWithMeta;
+	closeInternals.curateAndStoreSwarm = realCurateAndStoreSwarm;
+	closeInternals.checkHivePromotions = realCheckHivePromotions;
+	closeInternals.getGitRepositoryStatus = realGetGitRepositoryStatus;
+	closeInternals.resetToMainAfterMerge = realResetToMainAfterMerge;
+	closeInternals.resetToRemoteBranch = realResetToRemoteBranch;
+	closeInternals.resetSwarmStatePreservingSingletons =
+		realResetSwarmStatePreservingSingletons;
+	closeInternals.detectFullAuto = realDetectFullAuto;
+	reflectionInternals.gatherSkillViolations = realGatherSkillViolations;
+	reflectionInternals.gatherContradictionCandidates =
+		realGatherContradictionCandidates;
+	reflectionInternals.gatherRealtimeAdmissionCounts =
+		realGatherRealtimeAdmissionCounts;
+}
+
+describe('handleCloseCommand — session-reflection action menu (#2077)', () => {
+	beforeEach(() => {
+		testDir = canonicalMkdtemp('close-reflection-menu-');
+		mkdirSync(swarmDir(), { recursive: true });
+		installDefaultMocks();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+		restoreInternals();
+	});
+
+	it('surfaces the Knowledge Delta signals block even in a clean session (NOOP line)', async () => {
+		const result = await handleCloseCommand(testDir, []);
+		// The signals block renders unconditionally — the "0 captured; 0 deduped"
+		// line must appear even when nothing happened (issue #2077 signal class 4).
+		expect(result).toContain('## Session Signals');
+		expect(result).toContain('Knowledge Delta');
+	});
+
+	it('renders a numbered action menu when proposals exist (AC-3)', async () => {
+		// Inject a contradiction candidate so buildActionProposals produces a
+		// supersede proposal, which surfaces as a numbered menu item.
+		reflectionInternals.gatherContradictionCandidates = async () => [
+			{
+				newLesson: 'always lock the file before writing data to it',
+				newEntryId: 'n1',
+				conflictsWithId: 'o1',
+				conflictsWithLesson: 'never lock the file before writing data',
+				similarity: 0.5,
+			},
+		];
+		const result = await handleCloseCommand(testDir, []);
+		expect(result).toContain('**Proposed actions**');
+		expect(result).toContain('[1]');
+		expect(result).toContain('SUPERSEDE');
+		expect(result).toContain('/swarm curate');
+		// Not full-auto → the reply prompt is present.
+		expect(result).toContain('reply with numbers');
+	});
+
+	it('suppresses the reply prompt under full-auto (AC-4)', async () => {
+		closeInternals.detectFullAuto = () => true;
+		reflectionInternals.gatherContradictionCandidates = async () => [
+			{
+				newLesson: 'always lock the file before writing data to it',
+				newEntryId: 'n1',
+				conflictsWithId: 'o1',
+				conflictsWithLesson: 'never lock the file before writing data',
+				similarity: 0.5,
+			},
+		];
+		// sessionID must be passed via the options parameter (3rd arg) so
+		// ctx.fullAuto is computed (it is guarded by options.sessionID).
+		const result = await handleCloseCommand(testDir, [], {
+			sessionID: 's1',
+		});
+		expect(result).toContain('**Proposed actions**');
+		// Full-auto → reported-only, NO "reply with numbers" prompt.
+		expect(result).not.toContain('reply with numbers');
+		expect(result.toLowerCase()).toContain('reported-only');
+	});
+
+	it('does not render a menu when there are no proposals', async () => {
+		// Clean session, no gate failures, no tool problems, no contradictions.
+		const result = await handleCloseCommand(testDir, []);
+		expect(result).not.toContain('**Proposed actions**');
+	});
+});

--- a/tests/unit/commands/close.test.ts
+++ b/tests/unit/commands/close.test.ts
@@ -1860,9 +1860,9 @@ describe('handleCloseCommand', () => {
 					'utf-8',
 				);
 
-				expect(result).not.toContain('knowledge entries created this session');
-				expect(result).not.toContain('skill_improve');
-				expect(summary).not.toContain('knowledge entries created this session');
+				expect(result).not.toContain('Consider running skill_improve');
+				expect(result).not.toContain('skill_generate');
+				expect(summary).not.toContain('Consider running skill_improve');
 			});
 
 			it('counts knowledge entries at and after session start while ignoring older and invalid timestamps', async () => {


### PR DESCRIPTION
Closes #2077

## Summary

`/swarm finalize`'s session-reflection stage now surfaces the session signals it was already computing but discarding, and presents a numbered action menu after the destructive finalize stages complete. This is wiring + surfacing work — **no new mutation operations, no new store fields, no rebuild** of the existing memory/learning/skill-usage machinery.

### Reflection report (Phase A — advisory compute, zero new writes)

A new **Session Signals** block renders unconditionally in the finalize output (so it appears even in a clean / NOOP session), covering six signal classes:

- **Knowledge Delta** — entries created this session, close-time curation counts (stored/reinforced/skipped/rejected/quarantined), realtime admission counts (admitted/reinforced/rejected recovered read-only from durable markers), and the FR-015 dedup drop count (previously dropped invisibly). Reports `0 lessons captured; 0 deduped as already-known.` in the clean case.
- **Skill Compliance Signals** — top skills by violation this session, read-only from `.swarm/skill-usage.jsonl`, scope-labeled and tail-bounded.
- **Contradiction Candidates** — sub-dedup-threshold negation-divergent knowledge pairs, detected (not acted on) using the existing Jaccard bigram primitives. Supersession is surfaced only as a menu item the user opts into, never automatic.
- **Issue Candidates** — drafted GitHub issue bodies for problems backed by reproduction evidence.
- **Negatives** — explicit "0 captured" reporting (the previously-absent NOOP outcome).
- **Prompt fix** — `REFLECTION_SYSTEM_PROMPT`'s Skill Recommendations section now includes "capturing nothing is a valid outcome" (previously existed only for Problems).

### Action menu (Phase B — post-lock, advisory)

After `finalize.lock` is released, the finalize output ends with a numbered action menu assembled from the reflection proposals, each routing to an existing tool (`/swarm curate`, `gh issue create`, `skill_improve`). Application happens in a later user turn — no new mutation pipeline, no writes inside finalize. Under full-auto the menu is reported-only (no "reply with numbers" prompt).

### How DrainSummary counts are recovered

The in-memory `DrainSummary` is discarded at `src/index.ts` (issue #1821), but the outcomes persist on the entries themselves. This PR recovers them read-only:
- **admitted** = entries created this session with an `insight:` provenance marker.
- **reinforced** = pre-existing entries with a `confirmed_by` record stamped this session.
- **rejected** = curator-path rejections this session, from `.swarm/knowledge-rejected.jsonl`.

Realtime rejections (screened-out candidates) remain unobservable and are flagged in the report as tracked by #1821.

## Invariant audit

- **1 (plugin init):** not touched.
- **2 (runtime portability):** not touched — bundle portability + shape tests pass (12/12).
- **3 (subprocesses):** not touched — `'gh issue create'` is a label string only; no spawn added.
- **4 (.swarm containment):** not touched — gather functions read only existing `.swarm/` artifacts; no new writes.
- **5 (plan durability):** not touched.
- **6 (test_runner safety):** not touched — validation used per-file shell isolation.
- **7 (test writing):** touched — new tests use `bun:test`, `_internals` DI (no `mock.module`), `canonicalMkdtemp` from `tests/helpers/tmpdir.ts` (FR-011). New files < 500 lines. `scripts/check-test-file-cap.sh`: 0 violations (over-cap `close.test.ts` held at 2326 lines, not grown).
- **8 (session state):** not touched.
- **9 (guardrails/retry):** not touched.
- **10 (chat/system msg):** not touched.
- **11 (tool registration):** not touched — `bun run drift:check`: no drift.
- **12 (release/cache):** touched — release fragment added; no version files hand-edited.

## Safety

- **Zero new writes / zero new mutation ops / zero new store fields.** All gather functions are read-only.
- **Detect-only contradiction detection** — traced detection → report text → menu label; no write/supersede call. Supersession is operationally deletion and is an opt-in menu item only.
- **No acting inside the lock.** The menu is advisory text; application is a later user turn.
- **Contradiction detector uses band + negation polarity** (`[0.45, dedup_threshold)` from config + negation divergence), not the dedup threshold itself — the only shape that can coexist in the active store.
- **fullAuto computed once**, guarded by `sessionID`.

## Test plan

```
$ bun run typecheck        # tsc --noEmit — exit 0
$ bun run build            # exit 0
$ bun run drift:check      # ✅ No drift — exit 0
$ node node_modules/@biomejs/biome/bin/biome ci .   # clean
$ bash scripts/check-test-file-cap.sh   # 0 violations
$ bash scripts/check-test-tmpdir.sh     # 0 violations
$ bash scripts/check-test-clock.sh      # 0 new violations
$ bun test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts  # 12 pass
$ bun test src/services/session-reflection.test.ts src/services/session-reflection.signals.test.ts src/services/session-reflection.signals-report.test.ts  # 47 pass
```

Close tests (per-file isolation per AGENTS.md invariant 6): 25 files, 0 fail.
- `close.test.ts`: 76 pass (one assertion updated to distinguish the skill-compilation hint from the new signals-block delta line; file held at 2326 lines — not grown).
- `close-reflection-menu.test.ts` (new): 4 pass — AC-3 (menu appears), AC-4 (full-auto suppresses prompt), NOOP signals block, no-menu-when-no-proposals.

## Validation lineage

Independent plan-critic (Kimi K3, 12 items incorporated pre-implementation), implementation reviewer (Kimi K2.7, APPROVE), final critic (Kimi K3, NEEDS_REVISION — 4 items addressed and re-validated).