### PR TITLE
fix(drift-check): remediate skill-assertion detector false positives

### DIFF
--- a/docs/releases/pending/fr-2069-skill-assertion-remediation.md
+++ b/docs/releases/pending/fr-2069-skill-assertion-remediation.md
@@ -1,0 +1,17 @@
+## Skill-assertion drift detector false-positive remediation
+
+Closes #2069.
+
+### What changed
+- FR-001: Negated assertions (.not.toContain, .not.toMatch) are now skipped
+- FR-002: toMatch(/regex/) assertions evaluated as compiled regex patterns via new RegExp(source, flags).test(skillContent) instead of literal substring includes(). Malformed regexes produce assertionKind malformed-regex.
+- FR-003: Detector skips its own tests/unit/scripts/ directory and filters string-literal content
+- FR-004: Attribution requires the exact assertion line to chain off a confirmed skill variable (no +/-2 window)
+- FR-005: Four regression fixtures added (negation, regex, self-exclusion, attribution)
+- FR-006: Skill-assertion findings emit at notice severity (non-blocking). SKILL_ASSERTIONS_STRICT=1 for opt-in hard-fail.
+
+### Why
+The detector emitted 68 false-positive findings (zero genuine) on PR #2065, training reviewers to ignore its signal.
+
+### Migration
+No migration required. Set SKILL_ASSERTIONS_STRICT=1 to restore hard-fail behavior.

--- a/scripts/check-skill-assertions.ts
+++ b/scripts/check-skill-assertions.ts
@@ -43,6 +43,8 @@ export interface BrokenAssertion {
 	line: number;
 	skillFile: string;
 	phrase: string;
+	/** Kind of assertion that was checked. 'toContain' = literal substring; 'toMatch' = compiled-regex; 'malformed-regex' = toMatch whose pattern failed to compile. */
+	assertionKind: 'toContain' | 'toMatch' | 'malformed-regex';
 }
 
 /** All findings from a run. */
@@ -159,8 +161,14 @@ function scanDirForReferences(
 	for (const entry of entries) {
 		const full = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
-			// Skip node_modules and .git
-			if (entry.name === 'node_modules' || entry.name === '.git') continue;
+			// Skip node_modules, .git, and the detector's own test directory (FR-003):
+			// the skill-assertion detector must not scan its own test files.
+			if (
+				entry.name === 'node_modules' ||
+				entry.name === '.git' ||
+				entry.name === 'scripts'
+			)
+				continue;
 			scanDirForReferences(full, skillRel, slug, out);
 		} else if (entry.isFile() && entry.name.endsWith('.test.ts')) {
 		if (fs.readFileSync(full, 'utf-8').includes(slug)) {
@@ -171,35 +179,228 @@ function scanDirForReferences(
 }
 
 /**
- * Extract toContain and toMatch assertion phrases from a test file.
- * Returns an array of { line, phrase } for each assertion found.
+ * Parse a JavaScript regex literal starting at index `start` (which must point
+ * at the opening `/`). Properly handles escaped slashes and character classes.
+ * Returns { source, flags } on success, or { malformed: true, source, flags }
+ * if the literal is unterminated.
  */
-function extractAssertions(testFile: string): Array<{ line: number; phrase: string }> {
+function parseRegexLiteral(s: string, start: number): { source: string; flags: string } | { malformed: true; source: string; flags: string } {
+	if (s[start] !== '/') return { malformed: true, source: '', flags: '' };
+	let i = start + 1;
+	let inClass = false;
+	while (i < s.length) {
+		const ch = s[i]!;
+		if (ch === '\\') {
+			i += 2;
+			continue;
+		}
+		if (ch === '[') {
+			inClass = true;
+		} else if (ch === ']' && inClass) {
+			inClass = false;
+		} else if (ch === '/' && !inClass) {
+			const source = s.slice(start + 1, i);
+			let j = i + 1;
+			while (j < s.length && /[A-Za-z]/.test(s[j]!)) j++;
+			return { source, flags: s.slice(i + 1, j) };
+		}
+		i++;
+	}
+	return { malformed: true, source: s.slice(start + 1), flags: '' };
+}
+
+/**
+ * Extract the phrase from a .toMatch(...) argument on a given line.
+ * Handles three forms: /regex/, "string", 'string'.
+ * Returns { phrase, flags, kind } where kind is 'toMatch' or 'malformed-regex'.
+ * flags is the regex flags string (e.g. "i" for case-insensitive); empty for string forms.
+ */
+function extractToMatchPhrase(
+	line: string,
+	startIdx: number,
+): { phrase: string; flags: string; kind: 'toMatch' | 'malformed-regex' } | null {
+	// Skip past '(' and any whitespace before the argument
+	let i = startIdx + 1;
+	while (i < line.length && /\s/.test(line[i]!)) i++;
+	if (i >= line.length) return null;
+
+	const ch = line[i]!;
+
+	// Regex literal: /
+	if (ch === '/') {
+		const result = parseRegexLiteral(line, i);
+		if (!result) return null;
+		if ('malformed' in result && result.malformed) {
+			return { phrase: result.source, flags: result.flags, kind: 'malformed-regex' };
+		}
+		return { phrase: result.source, flags: result.flags, kind: 'toMatch' };
+	}
+
+	// Double-quoted string
+	if (ch === '"') {
+		let j = i + 1;
+		while (j < line.length) {
+			const c = line[j]!;
+			if (c === '\\' && j + 1 < line.length) {
+				j += 2;
+				continue;
+			}
+			if (c === '"') {
+				return { phrase: line.slice(i + 1, j), flags: '', kind: 'toMatch' };
+			}
+			j++;
+		}
+		return null;
+	}
+
+	// Single-quoted string
+	if (ch === "'") {
+		let j = i + 1;
+		while (j < line.length) {
+			const c = line[j]!;
+			if (c === '\\' && j + 1 < line.length) {
+				j += 2;
+				continue;
+			}
+			if (c === "'") {
+				return { phrase: line.slice(i + 1, j), flags: '', kind: 'toMatch' };
+			}
+			j++;
+		}
+		return null;
+	}
+
+	return null;
+}
+
+/**
+ * Finds all string-literal regions (single-quoted, double-quoted, template)
+ * in a given line. Each region is { start, end } where end is the closing
+ * quote/backtick position (inclusive).
+ */
+function findStringRegions(line: string): Array<{ start: number; end: number }> {
+	const regions: Array<{ start: number; end: number }> = [];
+	let i = 0;
+	while (i < line.length) {
+		const ch = line[i]!;
+		if (ch === '\\') {
+			i += 2;
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			const quote = ch;
+			const start = i;
+			i++;
+			while (i < line.length) {
+				if (line[i] === '\\') {
+					i += 2;
+					continue;
+				}
+				if (line[i] === quote) {
+					regions.push({ start, end: i });
+					i++;
+					break;
+				}
+				i++;
+			}
+		} else if (ch === '`') {
+			const start = i;
+			i++;
+			while (i < line.length && line[i] !== '`') {
+				if (line[i] === '\\') {
+					i += 2;
+					continue;
+				}
+				if (line[i] === '$' && line[i + 1] === '{') {
+					// Template expression — skip to matching }
+					i += 2;
+					let depth = 1;
+					while (i < line.length && depth > 0) {
+						if (line[i] === '{') depth++;
+						else if (line[i] === '}') depth--;
+						i++;
+					}
+				} else {
+					i++;
+				}
+			}
+			if (i < line.length) {
+				regions.push({ start, end: i });
+				i++;
+			}
+		} else {
+			i++;
+		}
+	}
+	return regions;
+}
+
+/**
+ * Returns true if position `pos` in `line` falls inside a string literal
+ * (single-quoted, double-quoted, or template literal). Used by extractAssertions
+ * to skip phrases from fixture strings that merely look like assertions (FR-003).
+ */
+function isInsideStringLiteral(line: string, pos: number): boolean {
+	const regions = findStringRegions(line);
+	for (const reg of regions) {
+		// Check: start <= pos <= end (pos is within the string literal)
+		if (reg.start <= pos && pos <= reg.end) return true;
+	}
+	return false;
+}
+
+/**
+ * Extract toContain and toMatch assertion phrases from a test file.
+ * Returns an array of { line, phrase, kind } for each assertion found.
+ */
+function extractAssertions(
+	testFile: string,
+): Array<{ line: number; phrase: string; flags: string; kind: 'toContain' | 'toMatch' | 'malformed-regex' }> {
 	const content = fs.readFileSync(testFile, 'utf-8');
 	const lines = content.split('\n');
-	const results: Array<{ line: number; phrase: string }> = [];
+	const results: Array<{ line: number; phrase: string; flags: string; kind: 'toContain' | 'toMatch' | 'malformed-regex' }> = [];
 
-	// Match: .toContain('...') or .toMatch(/.../)
-	// capturing the string or regex content inside the parens
-	const toContainRe = /\.toContain\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
-	// toMatch can have a regex literal \/(.*?)\/ or a string '...' or "..."
-	const toMatchRe = /\.toMatch\s*\(\s*(?:\/(.*?)\/|"([^"]+)"|'([^']+)')\s*\)/g;
+	// toContain: captures the string content inside the parentheses
+	const toContainRe = /\.toContain\s*\(\s*(['"`])((?:[^'"`\\]|\\.)*)\1\s*\)/g;
+
+	// Regex to detect negated assertions — lines where .not precedes toContain/toMatch
+	// in any chained form. A negated assertion never constitutes evidence that a
+	// phrase must be present and must be skipped (FR-001).
+	const negatedAssertionRe =
+		/\.not\.(?:\w+(?:\.\w+)*\.)?\s*(?:toContain|toMatch)\s*\(/;
 
 	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+		const line = lines[i]!;
+		// Skip lines with negated .not.toContain / .not.toMatch
+		if (negatedAssertionRe.test(line)) continue;
 		// toContain
 		let m: RegExpExecArray | null;
 		while ((m = toContainRe.exec(line)) !== null) {
-			results.push({ line: i + 1, phrase: m[1] });
+			// Skip matches inside string literals (FR-003): phrases inside
+			// fixture template strings must not be treated as real assertions.
+			if (isInsideStringLiteral(line, m.index)) continue;
+			// m[1] is the quote char, m[2] is the content between quotes
+			const phrase = m[2] ?? '';
+			if (phrase) {
+				results.push({ line: i + 1, phrase, flags: '', kind: 'toContain' });
+			}
 		}
 		toContainRe.lastIndex = 0;
 
-		// toMatch with regex or string
-		while ((m = toMatchRe.exec(line)) !== null) {
-			const phrase = m[1] ?? m[2] ?? m[3] ?? '';
-			if (phrase) results.push({ line: i + 1, phrase });
+		// toMatch: find each .toMatch( occurrence and extract the phrase
+		// using the escape-aware parser (parseRegexLiteral for /regex/, string
+		// extraction for "string" and 'string')
+		const toMatchCallRe = /\.toMatch\s*\(/g;
+		while ((m = toMatchCallRe.exec(line)) !== null) {
+			// Skip matches inside string literals (FR-003)
+			if (isInsideStringLiteral(line, m.index)) continue;
+			const openParenIdx = m.index + m[0]!.length - 1; // position of '('
+			const result = extractToMatchPhrase(line, openParenIdx);
+			if (result) {
+				results.push({ line: i + 1, phrase: result.phrase, flags: result.flags, kind: result.kind });
+			}
 		}
-		toMatchRe.lastIndex = 0;
+		toMatchCallRe.lastIndex = 0;
 	}
 
 	return results;
@@ -253,12 +454,20 @@ function checkAssertionsAgainstSkill(
 		}
 		const callBody = fileContent.slice(callStart, i - 1); // exclude the closing ')'
 
-		// Extract the first string literal in the call body — that is the path arg.
-		// Handles 'path', "path", `path` with escapes.
-		const firstStringRe = /(['"`])((?:[^'"`\\]|\\.)*)\1/;
-		const strMatch = firstStringRe.exec(callBody);
-		if (!strMatch) continue;
-		const filePath = strMatch[2]!;
+		// Extract every string literal in the call body and pick the one that
+		// looks like an .md file path. Handle escapes inside the literal.
+		// For `readFileSync(join(process.cwd(), '.claude/skills/...'))`, the
+		// path is the only string ending in '.md'.
+		const allStringsRe = /(['"`])((?:[^'"`\\]|\\.)*)\1/g;
+		let filePath: string | null = null;
+		let m: RegExpExecArray | null;
+		while ((m = allStringsRe.exec(callBody)) !== null) {
+			const candidate = m[2]!;
+			if (candidate.endsWith('.md')) {
+				filePath = candidate;
+			}
+		}
+		if (filePath === null) continue;
 		if (referencesSkillPath(filePath, slug) && filePath.endsWith('.md')) {
 			// Direct readFileSync: always a valid skill variable
 			confirmedSkillVariables.set(varName, true);
@@ -370,23 +579,61 @@ function checkAssertionsAgainstSkill(
 	const broken: BrokenAssertion[] = [];
 	const assertions = extractAssertions(testFile);
 
-	for (const { line: assertionLine, phrase } of assertions) {
-		// Look at surrounding lines for a skill-assertion attribution comment
-		// or an expect(...) chaining off a tracked skill variable.
+	for (const { line: assertionLine, phrase, flags, kind } of assertions) {
+		// FR-004: attribute an assertion to a skill only when the EXACT assertion
+		// line itself (not a ±2 window) chains off a confirmed skill variable.
+		// Window-based proximity is never sufficient.
 		const lineIdx = assertionLine - 1;
-		const windowStart = Math.max(0, lineIdx - 2);
-		const windowEnd = Math.min(lines.length, lineIdx + 1);
-		const windowLines = lines.slice(windowStart, windowEnd + 1).join('\n');
+		const exactLine = lines[lineIdx] ?? '';
 
-		const isScopedToSkill =
-			skillExpectRe.test(windowLines) ||
-			// Fallback: explicit attribution comment
-			/\/\/\s*skill-assertion\s*:?/i.test(windowLines);
+		if (!skillExpectRe.test(exactLine)) continue;
 
-		if (!isScopedToSkill) continue;
-
-		if (!skillContent.includes(phrase)) {
-			broken.push({ testFile, line: assertionLine, skillFile, phrase });
+		// Evaluate the assertion based on its kind:
+		// - toContain: literal substring check
+		// - toMatch: compiled-regex check (phrase is a regex source)
+		// - malformed-regex: directly a broken assertion (parseRegexLiteral already determined it couldn't compile)
+		if (kind === 'malformed-regex') {
+			broken.push({
+				testFile,
+				line: assertionLine,
+				skillFile,
+				phrase,
+				assertionKind: 'malformed-regex',
+			});
+		} else if (kind === 'toMatch') {
+			try {
+				// eslint-disable-next-line no-new
+				new RegExp(phrase, flags); // validate compilation with flags
+				if (!new RegExp(phrase, flags).test(skillContent)) {
+					broken.push({
+						testFile,
+						line: assertionLine,
+						skillFile,
+						phrase,
+						assertionKind: 'toMatch',
+					});
+				}
+			} catch {
+				// Malformed regex source — treat as broken assertion
+				broken.push({
+					testFile,
+					line: assertionLine,
+					skillFile,
+					phrase,
+					assertionKind: 'malformed-regex',
+				});
+			}
+		} else {
+			// toContain: literal substring check
+			if (!skillContent.includes(phrase)) {
+				broken.push({
+					testFile,
+					line: assertionLine,
+					skillFile,
+					phrase,
+					assertionKind: 'toContain',
+				});
+			}
 		}
 	}
 
@@ -468,7 +715,7 @@ export function formatBrokenAssertions(
 		const msg =
 			`[skill-assertion] "${b.phrase}" — assertion in ${b.testFile}:${b.line} ` +
 			`references "${b.skillFile}" but phrase is no longer present`;
-		lines.push(`::error file=${b.testFile},line=${b.line}::${msg}`);
+		lines.push(`::notice file=${b.testFile},line=${b.line}::${msg}`);
 	}
 
 	return lines;
@@ -487,9 +734,13 @@ async function main(): Promise<void> {
 			console.log(line);
 		}
 		console.error(
-			`\nskill-assertions: check completed in ${elapsed}ms`,
+			`\nskill-assertions: check completed in ${elapsed}ms (advisory)`,
 		);
-		process.exit(1);
+		// FR-006: exit 0 by default (advisory, non-blocking). Set
+		// SKILL_ASSERTIONS_STRICT=1 to opt into hard-fail behavior.
+		if (process.env.SKILL_ASSERTIONS_STRICT === '1') {
+			process.exit(1);
+		}
 	}
 
 	if (result.changedSkillFiles.length > 0) {

--- a/scripts/drift-check.ts
+++ b/scripts/drift-check.ts
@@ -38,6 +38,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { collectToolRegistrationErrors } from './check-tool-registration';
+import { collectEventContractErrors } from './check-event-contract';
 import { detectDocsClaimDrift } from './drift-check-docs-claims';
 import { checkSkillAssertions, formatBrokenAssertions } from './check-skill-assertions';
 import { BUNDLED_PROJECT_SKILLS } from '../src/config/bundled-skills';
@@ -813,6 +814,27 @@ export function detectToolRegistrationDrift(): DriftFinding[] {
 }
 
 // ---------------------------------------------------------------------------
+// 3b) Event contract drift (issue #2029 AC6, reuse of
+//     scripts/check-event-contract.ts)
+//
+// ADVISORY ONLY here: drift-check is soft-warn by default
+// (`DRIFT_CHECK_ENFORCE`), so this detector surfaces annotations/PR comments
+// but does not block a merge on its own. The BLOCKING gate for AC6 is the
+// dedicated "Event contract check" step in .github/workflows/ci.yml, which
+// runs `bun run check:events` (collectEventContractErrors' hard-fail CLI)
+// unconditionally, with no enforce/warn env var.
+// ---------------------------------------------------------------------------
+
+export function detectEventContractDrift(): DriftFinding[] {
+	return collectEventContractErrors().map((message) => ({
+		category: 'event-contract',
+		severity: 'error' as const,
+		file: 'src/observability/catalog.ts',
+		message,
+	}));
+}
+
+// ---------------------------------------------------------------------------
 // 4) Command registry drift
 // ---------------------------------------------------------------------------
 
@@ -1284,6 +1306,7 @@ const DETECTORS: Array<[string, () => DriftFinding[]]> = [
 	['duplicate-slug', detectDuplicateSlugs],
 	['package-json-files', detectPackageJsonFilesDuplicates],
 	['tool', detectToolRegistrationDrift],
+	['event-contract', detectEventContractDrift],
 	['command', detectCommandDrift],
 	['agent', detectAgentDrift],
 	['docs-claim', detectDocsClaimDrift],

--- a/scripts/drift-check.ts
+++ b/scripts/drift-check.ts
@@ -38,7 +38,6 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { collectToolRegistrationErrors } from './check-tool-registration';
-import { collectEventContractErrors } from './check-event-contract';
 import { detectDocsClaimDrift } from './drift-check-docs-claims';
 import { checkSkillAssertions, formatBrokenAssertions } from './check-skill-assertions';
 import { BUNDLED_PROJECT_SKILLS } from '../src/config/bundled-skills';
@@ -814,27 +813,6 @@ export function detectToolRegistrationDrift(): DriftFinding[] {
 }
 
 // ---------------------------------------------------------------------------
-// 3b) Event contract drift (issue #2029 AC6, reuse of
-//     scripts/check-event-contract.ts)
-//
-// ADVISORY ONLY here: drift-check is soft-warn by default
-// (`DRIFT_CHECK_ENFORCE`), so this detector surfaces annotations/PR comments
-// but does not block a merge on its own. The BLOCKING gate for AC6 is the
-// dedicated "Event contract check" step in .github/workflows/ci.yml, which
-// runs `bun run check:events` (collectEventContractErrors' hard-fail CLI)
-// unconditionally, with no enforce/warn env var.
-// ---------------------------------------------------------------------------
-
-export function detectEventContractDrift(): DriftFinding[] {
-	return collectEventContractErrors().map((message) => ({
-		category: 'event-contract',
-		severity: 'error' as const,
-		file: 'src/observability/catalog.ts',
-		message,
-	}));
-}
-
-// ---------------------------------------------------------------------------
 // 4) Command registry drift
 // ---------------------------------------------------------------------------
 
@@ -1306,7 +1284,6 @@ const DETECTORS: Array<[string, () => DriftFinding[]]> = [
 	['duplicate-slug', detectDuplicateSlugs],
 	['package-json-files', detectPackageJsonFilesDuplicates],
 	['tool', detectToolRegistrationDrift],
-	['event-contract', detectEventContractDrift],
 	['command', detectCommandDrift],
 	['agent', detectAgentDrift],
 	['docs-claim', detectDocsClaimDrift],
@@ -1351,7 +1328,7 @@ export async function detectSkillAssertionDrift(
 	const result = await checkSkillAssertions(cwd);
 	return result.brokenAssertions.map((b) => ({
 		category: 'skill-assertion',
-		severity: 'error' as const,
+		severity: 'notice' as const,
 		file: b.testFile,
 		message:
 			`Test at ${b.testFile}:${b.line} asserts "${b.phrase}" ` +

--- a/tests/unit/scripts/check-skill-assertions-entrypoint.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-entrypoint.test.ts
@@ -14,13 +14,13 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	formatBrokenAssertions,
 	type SkillAssertionResult,
 } from '../../../scripts/check-skill-assertions';
 import { detectSkillAssertionDrift } from '../../../scripts/drift-check';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -33,7 +33,7 @@ const tempDirs: string[] = [];
 
 /** Create an isolated git repo for testing git-diff operations. */
 function makeGitRepo(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-assert-'));
+	const root = canonicalMkdtemp('skill-assert-');
 	// Init a bare git repo (required for `git diff HEAD` to work)
 	runGit(['init', '-q'], root);
 	// Set identity so git doesn't complain

--- a/tests/unit/scripts/check-skill-assertions-entrypoint.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-entrypoint.test.ts
@@ -1,0 +1,172 @@
+/**
+ * FR-002 / issue #1746 item 3 — skill-content pre-push check tests.
+ *
+ * SC-008: the skill check is invoked from the existing drift-check entry point,
+ *         and its findings format into valid GitHub Actions annotations.
+ *
+ * Split out of check-skill-assertions.test.ts under FR-006 (500-line cap): that
+ * file is over cap, so the issue-#2069 severity assertions could not grow it.
+ *
+ * These tests use real temp directories with real files (Tier 0 zero-mock pattern)
+ * so they exercise the actual assertion-extraction and phrase-checking logic.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	formatBrokenAssertions,
+	type SkillAssertionResult,
+} from '../../../scripts/check-skill-assertions';
+import { detectSkillAssertionDrift } from '../../../scripts/drift-check';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const GIT_TIMEOUT_MS = 15_000;
+
+/** Paths that must be cleaned up after each test. */
+const tempDirs: string[] = [];
+
+/** Create an isolated git repo for testing git-diff operations. */
+function makeGitRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-assert-'));
+	// Init a bare git repo (required for `git diff HEAD` to work)
+	runGit(['init', '-q'], root);
+	// Set identity so git doesn't complain
+	runGit(['config', 'user.email', 'test@test.com'], root);
+	runGit(['config', 'user.name', 'Test'], root);
+	// Create an initial commit so HEAD exists
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md'], root);
+	runGit(['commit', '-q', '-m', 'initial'], root);
+	tempDirs.push(root);
+	return root;
+}
+
+function runGit(args: string[], cwd: string): void {
+	const result = spawnSync('git', args, {
+		stdin: 'ignore',
+		cwd,
+		timeout: GIT_TIMEOUT_MS,
+	});
+	if (result.status !== 0) {
+		const errMsg = result.stderr?.toString() ?? '';
+		throw new Error(`git ${args.join(' ')} failed: ${errMsg.trim()}`);
+	}
+}
+
+/** Write a file relative to a root, creating parent dirs. */
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop()!;
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup
+		}
+	}
+});
+
+// ---------------------------------------------------------------------------
+// SC-008: skill check is invoked from existing drift-check entry point
+// ---------------------------------------------------------------------------
+
+describe('SC-008: skill check is part of drift-check.ts entry point', () => {
+	test('detectSkillAssertionDrift is called by runAllDetectors and returns findings', async () => {
+		// This test verifies that when drift-check.ts runs its full suite,
+		// it also calls the skill-assertion detector.  We test the exported
+		// detectSkillAssertionDrift directly since runAllDetectors requires
+		// the full repo context.
+		//
+		// We create a minimal scenario: a skill with a phrase, a test asserting
+		// it, then remove the phrase — and verify detectSkillAssertionDrift
+		// surfaces the broken assertion as a DriftFinding.
+
+		const repo = makeGitRepo();
+
+		writeFile(
+			repo,
+			'.opencode/skills/design-docs/SKILL.md',
+			'MODE: DESIGN_DOCS — this mode does NOT delegate to coder.',
+		);
+		runGit(['add', '.'], repo);
+		runGit(['commit', '-q', '-m', 'add skill'], repo);
+
+		writeFile(
+			repo,
+			'tests/unit/agents/design-docs.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/design-docs/SKILL.md'),
+  'utf-8',
+);
+describe('design-docs skill', () => {
+  test('does NOT delegate to coder', () => {
+    expect(content).toContain('does NOT delegate to coder');
+  });
+});
+`,
+		);
+
+		// Remove the phrase
+		writeFile(
+			repo,
+			'.opencode/skills/design-docs/SKILL.md',
+			'MODE: DESIGN_DOCS — delegates freely.',
+		);
+
+		const findings = await detectSkillAssertionDrift(repo);
+
+		const skillAssertionFindings = findings.filter(
+			(f) => f.category === 'skill-assertion',
+		);
+		expect(skillAssertionFindings).toHaveLength(1);
+		expect(skillAssertionFindings[0]!.severity).toBe('notice');
+		expect(skillAssertionFindings[0]!.message).toContain(
+			'does NOT delegate to coder',
+		);
+		expect(skillAssertionFindings[0]!.message).toContain(
+			'.opencode/skills/design-docs/SKILL.md',
+		);
+	});
+
+	test('formatBrokenAssertions produces valid GitHub Actions annotations', () => {
+		const result: SkillAssertionResult = {
+			changedSkillFiles: ['.opencode/skills/x/SKILL.md'],
+			brokenAssertions: [
+				{
+					testFile: 'tests/unit/agents/x.test.ts',
+					line: 14,
+					skillFile: '.opencode/skills/x/SKILL.md',
+					phrase: 'does NOT delegate',
+					assertionKind: 'toContain',
+				},
+			],
+		};
+		const lines = formatBrokenAssertions(result);
+		expect(lines).toHaveLength(1);
+		expect(lines[0]!).toContain('::notice');
+		expect(lines[0]!).toContain('tests/unit/agents/x.test.ts');
+		expect(lines[0]!).toContain('does NOT delegate');
+	});
+
+	test('formatBrokenAssertions returns empty array when no broken assertions', () => {
+		const result: SkillAssertionResult = {
+			changedSkillFiles: [],
+			brokenAssertions: [],
+		};
+		expect(formatBrokenAssertions(result)).toEqual([]);
+	});
+});

--- a/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
@@ -15,15 +15,15 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const GIT_TIMEOUT_MS = 15_000;
 const tempDirs: string[] = [];
 
 function makeGitRepo(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'attr-'));
+	const root = canonicalMkdtemp('attr-');
 	const runGit = (args: string[]) =>
 		spawnSync('git', args, {
 			cwd: root,

--- a/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
@@ -1,0 +1,119 @@
+/**
+ * FR-005 regression for the precise target attribution defect class.
+ *
+ * SC-005: a test file that loads both an architect prompt (variable P) and a
+ * skill (variable S) and asserts `expect(P).toContain('prompt phrase')` must
+ * NOT report 'prompt phrase' as a broken assertion against S (the assertion
+ * targets the prompt, not the skill).
+ *
+ * HEADER NOTE (unfixed-detector reproduction):
+ * The unfixed detector used a ±2 line window for attribution, which could
+ * mis-attribute an assertion to a different confirmed variable when both
+ * variables were nearby.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawn, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+
+const GIT_TIMEOUT_MS = 15_000;
+const tempDirs: string[] = [];
+
+function makeGitRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'attr-'));
+	const runGit = (args: string[]) =>
+		spawnSync('git', args, { cwd: root, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+	runGit(['init', '-q']);
+	runGit(['config', 'user.email', 'test@test.com']);
+	runGit(['config', 'user.name', 'Test']);
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md']);
+	runGit(['commit', '-q', '-m', 'initial']);
+	tempDirs.push(root);
+	return root;
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	const d = tempDirs.pop();
+	if (d) spawnSync('rm', ['-rf', d], { stdio: 'ignore' });
+});
+
+describe('SC-005: precise target attribution', () => {
+	test('assertion on prompt variable is NOT attributed to the skill', async () => {
+		const repo = makeGitRepo();
+		// Create a fake "architect prompt" file
+		mkdirSyncLocal(repo, 'src/agents/');
+		writeFile(
+			repo,
+			'src/agents/architect.ts',
+			'# ARCHITECT\n\nthis prompt contains architect-only phrase\n',
+		);
+		// Create a skill file (separate)
+		mkdirSyncLocal(repo, '.opencode/skills/test/');
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nskill content\n',
+		);
+
+		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['commit', '-q', '-m', 'add files'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+
+		// Test file that reads both the architect prompt AND the skill content
+		mkdirSyncLocal(repo, 'tests/unit/agents/');
+		writeFile(
+			repo,
+			'tests/unit/agents/two-vars.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const prompt = readFileSync(
+  join(process.cwd(), 'src/agents/architect.ts'),
+  'utf-8',
+);
+const skill = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('two-vars', () => {
+  test('prompt phrase', () => {
+    expect(prompt).toContain('architect-only phrase');
+  });
+  test('skill phrase', () => {
+    expect(skill).toContain('skill content');
+  });
+});
+`,
+		);
+
+		// Modify the skill so the detector runs
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nskill content updated\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		// SC-005: 'architect-only phrase' is asserted against `prompt`, not `skill`.
+		// It must NOT be reported as a broken assertion against the skill.
+		const promptPhraseBroken = result.brokenAssertions.find(
+			(b) => b.phrase === 'architect-only phrase',
+		);
+		expect(promptPhraseBroken).toBeUndefined();
+	});
+});
+
+function mkdirSyncLocal(root: string, relPath: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(full, { recursive: true });
+}

--- a/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
@@ -25,7 +25,11 @@ const tempDirs: string[] = [];
 function makeGitRepo(): string {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'attr-'));
 	const runGit = (args: string[]) =>
-		spawnSync('git', args, { cwd: root, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', args, {
+			cwd: root,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 	runGit(['init', '-q']);
 	runGit(['config', 'user.email', 'test@test.com']);
 	runGit(['config', 'user.name', 'Test']);
@@ -65,8 +69,16 @@ describe('SC-005: precise target attribution', () => {
 			'# TEST\n\nskill content\n',
 		);
 
-		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
-		spawnSync('git', ['commit', '-q', '-m', 'add files'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add files'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 
 		// Test file that reads both the architect prompt AND the skill content
 		mkdirSyncLocal(repo, 'tests/unit/agents/');
@@ -103,7 +115,9 @@ describe('two-vars', () => {
 		);
 
 		const result = await checkSkillAssertions(repo);
-		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		expect(result.changedSkillFiles).toContain(
+			'.opencode/skills/test/SKILL.md',
+		);
 		// SC-005: 'architect-only phrase' is asserted against `prompt`, not `skill`.
 		// It must NOT be reported as a broken assertion against the skill.
 		const promptPhraseBroken = result.brokenAssertions.find(

--- a/tests/unit/scripts/check-skill-assertions-false-positive-negation.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-negation.test.ts
@@ -14,15 +14,15 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const GIT_TIMEOUT_MS = 15_000;
 const tempDirs: string[] = [];
 
 function makeGitRepo(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neg-assert-'));
+	const root = canonicalMkdtemp('neg-assert-');
 	const runGit = (args: string[]) =>
 		spawnSync('git', args, {
 			cwd: root,

--- a/tests/unit/scripts/check-skill-assertions-false-positive-negation.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-negation.test.ts
@@ -1,0 +1,166 @@
+/**
+ * FR-005 regression for the negation defect class.
+ *
+ * SC-001: expect(skill).not.toContain('placeholder-X') adjacent to
+ * expect(skill).toContain('real-Y') must not report 'placeholder-X' as broken.
+ *
+ * HEADER NOTE (unfixed-detector reproduction):
+ * The unfixed detector (cycle 1) reported 'placeholder-X' as a broken
+ * assertion because the negation regex did not filter `.not.toContain`.
+ * After the fix (require optional chained access `(?:\w+(?:\.\w+)*\.)?`),
+ * the brokenAssertions array is empty for the negated assertion.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+
+const GIT_TIMEOUT_MS = 15_000;
+const tempDirs: string[] = [];
+
+function makeGitRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neg-assert-'));
+	const runGit = (args: string[]) =>
+		spawnSync('git', args, {
+			cwd: root,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+	runGit(['init', '-q']);
+	runGit(['config', 'user.email', 'test@test.com']);
+	runGit(['config', 'user.name', 'Test']);
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md']);
+	runGit(['commit', '-q', '-m', 'initial']);
+	tempDirs.push(root);
+	return root;
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const d = tempDirs.pop()!;
+		try {
+			fs.rmSync(d, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup
+		}
+	}
+});
+
+describe('SC-001: negated toContain does not produce false positives', () => {
+	test('placeholder-X not reported as broken when skill contains real-Y but not placeholder-X', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal-Y content here\n',
+		);
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+
+		writeFile(
+			repo,
+			'tests/unit/agents/negated.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('neg', () => {
+  test('placeholder-X NOT required', () => {
+    expect(content).not.toContain('placeholder-X');
+  });
+  test('real-Y required', () => {
+    expect(content).toContain('real-Y');
+  });
+});
+`,
+		);
+
+		// Remove real-Y so the positive assertion breaks
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nplaceholder-X content here\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+
+		// The negated assertion must NOT be reported as broken
+		const negPhrases = result.brokenAssertions
+			.map((b) => b.phrase)
+			.filter((p) => p === 'placeholder-X');
+		expect(negPhrases).toHaveLength(0);
+		// The positive assertion SHOULD be reported as broken
+		expect(result.brokenAssertions.some((b) => b.phrase === 'real-Y')).toBe(
+			true,
+		);
+	});
+
+	test('chained negation: .not.toMatch.toContain also excluded', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal phrase here\n',
+		);
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+
+		writeFile(
+			repo,
+			'tests/unit/agents/chained-neg.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('chained', () => {
+  test('not.toMatch.toContain chained', () => {
+    expect(content).not.toMatch.toContain('absent phrase');
+  });
+});
+`,
+		);
+
+		// The chained-negated assertion must NOT be reported even when the
+		// skill no longer contains the phrase being negated
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nabsent phrase removed\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.brokenAssertions).toHaveLength(0);
+	});
+});

--- a/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
@@ -1,0 +1,179 @@
+/**
+ * FR-005 regression for the regex semantic matching defect class.
+ *
+ * SC-002: expect(skill).toMatch(/foo-\d+/) — satisfied when skill contains 'build-123'.
+ * SC-003: expect(skill).toMatch(/foo-\d+/) — unsatisfied when skill only contains 'no digits here'.
+ * FR-002 malformed-regex fallback: a /foo[/ literal must produce a brokenAssertion
+ *   with assertionKind 'malformed-regex', not a crash and not a false positive.
+ *
+ * HEADER NOTE (unfixed-detector reproduction):
+ * The unfixed detector passed the regex SOURCE text (e.g. 'foo-\d+') to
+ * `skillContent.includes()`, which always fails because the literal source
+ * contains backslashes that don't appear in the content. After the fix,
+ * `new RegExp(source).test(skillContent)` is used.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawn, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+
+const GIT_TIMEOUT_MS = 15_000;
+const tempDirs: string[] = [];
+
+function makeGitRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'regex-assert-'));
+	const runGit = (args: string[]) =>
+		spawnSync('git', args, { cwd: root, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+	runGit(['init', '-q']);
+	runGit(['config', 'user.email', 'test@test.com']);
+	runGit(['config', 'user.name', 'Test']);
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md']);
+	runGit(['commit', '-q', '-m', 'initial']);
+	tempDirs.push(root);
+	return root;
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	const d = tempDirs.pop();
+	if (d) spawnSync('rm', ['-rf', d], { stdio: 'ignore' });
+});
+
+describe('SC-002 / SC-003 / FR-002: regex semantic matching', () => {
+	test('SC-002: matching regex satisfied → zero broken assertions', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nbuild-123 release\n',
+		);
+		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+
+		writeFile(
+			repo,
+			'tests/unit/agents/regex-satisfied.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('regex', () => {
+  test('build-N pattern', () => {
+    expect(content).toMatch(/build-\\d+/);
+  });
+});
+`,
+		);
+
+		// Modify the skill (without committing) so the detector runs.
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nbuild-123 release notes\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		// FR-002: regex matches the content → zero broken assertions
+		expect(result.brokenAssertions).toHaveLength(0);
+	});
+
+	test('SC-003: matching regex unsatisfied → one broken assertion with assertionKind toMatch', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nno digits here\n',
+		);
+		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+
+		writeFile(
+			repo,
+			'tests/unit/agents/regex-unsatisfied.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('regex', () => {
+  test('build-N pattern', () => {
+    expect(content).toMatch(/build-\\d+/);
+  });
+});
+`,
+		);
+
+		// Modify the skill (without committing) so the detector runs.
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nno digits here still\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		// FR-002: regex doesn't match → exactly one broken assertion
+		expect(result.brokenAssertions).toHaveLength(1);
+		expect(result.brokenAssertions[0]!.phrase).toBe('build-\\d+');
+		expect(result.brokenAssertions[0]!.assertionKind).toBe('toMatch');
+	});
+
+	test('FR-002 malformed-regex fallback: /foo[/ produces assertionKind malformed-regex', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nfoo bar\n',
+		);
+		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+
+		writeFile(
+			repo,
+			'tests/unit/agents/malformed-regex.test.ts',
+			`
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('regex', () => {
+  test('malformed', () => {
+    expect(content).toMatch(/foo[/);
+  });
+});
+`,
+		);
+
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nfoo bar baz\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		// FR-002 malformed: detector must not crash; if a finding is emitted,
+		// its assertionKind must be 'malformed-regex'
+		expect(result).toBeDefined();
+		if (result.brokenAssertions.length > 0) {
+			expect(result.brokenAssertions[0]!.assertionKind).toBe('malformed-regex');
+		}
+	});
+});

--- a/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
@@ -16,15 +16,15 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const GIT_TIMEOUT_MS = 15_000;
 const tempDirs: string[] = [];
 
 function makeGitRepo(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'regex-assert-'));
+	const root = canonicalMkdtemp('regex-assert-');
 	const runGit = (args: string[]) =>
 		spawnSync('git', args, {
 			cwd: root,

--- a/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
@@ -26,7 +26,11 @@ const tempDirs: string[] = [];
 function makeGitRepo(): string {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'regex-assert-'));
 	const runGit = (args: string[]) =>
-		spawnSync('git', args, { cwd: root, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', args, {
+			cwd: root,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 	runGit(['init', '-q']);
 	runGit(['config', 'user.email', 'test@test.com']);
 	runGit(['config', 'user.name', 'Test']);
@@ -56,8 +60,16 @@ describe('SC-002 / SC-003 / FR-002: regex semantic matching', () => {
 			'.opencode/skills/test/SKILL.md',
 			'# TEST\n\nbuild-123 release\n',
 		);
-		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
-		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 
 		writeFile(
 			repo,
@@ -85,7 +97,9 @@ describe('regex', () => {
 		);
 
 		const result = await checkSkillAssertions(repo);
-		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		expect(result.changedSkillFiles).toContain(
+			'.opencode/skills/test/SKILL.md',
+		);
 		// FR-002: regex matches the content → zero broken assertions
 		expect(result.brokenAssertions).toHaveLength(0);
 	});
@@ -97,8 +111,16 @@ describe('regex', () => {
 			'.opencode/skills/test/SKILL.md',
 			'# TEST\n\nno digits here\n',
 		);
-		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
-		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 
 		writeFile(
 			repo,
@@ -126,7 +148,9 @@ describe('regex', () => {
 		);
 
 		const result = await checkSkillAssertions(repo);
-		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		expect(result.changedSkillFiles).toContain(
+			'.opencode/skills/test/SKILL.md',
+		);
 		// FR-002: regex doesn't match → exactly one broken assertion
 		expect(result.brokenAssertions).toHaveLength(1);
 		expect(result.brokenAssertions[0]!.phrase).toBe('build-\\d+');
@@ -135,13 +159,17 @@ describe('regex', () => {
 
 	test('FR-002 malformed-regex fallback: /foo[/ produces assertionKind malformed-regex', async () => {
 		const repo = makeGitRepo();
-		writeFile(
-			repo,
-			'.opencode/skills/test/SKILL.md',
-			'# TEST\n\nfoo bar\n',
-		);
-		spawnSync('git', ['add', '.'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
-		spawnSync('git', ['commit', '-q', '-m', 'add skill'], { cwd: repo, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nfoo bar\n');
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
 
 		writeFile(
 			repo,
@@ -168,7 +196,9 @@ describe('regex', () => {
 		);
 
 		const result = await checkSkillAssertions(repo);
-		expect(result.changedSkillFiles).toContain('.opencode/skills/test/SKILL.md');
+		expect(result.changedSkillFiles).toContain(
+			'.opencode/skills/test/SKILL.md',
+		);
 		// FR-002 malformed: detector must not crash; if a finding is emitted,
 		// its assertionKind must be 'malformed-regex'
 		expect(result).toBeDefined();

--- a/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
@@ -1,0 +1,184 @@
+/**
+ * FR-005 regression for the self-exclusion defect class.
+ *
+ * SC-004: phrases inside the detector's own test file fixture template
+ * strings must NOT be reported as broken assertions against any changed skill.
+ *
+ * HEADER NOTE (unfixed-detector reproduction):
+ * The unfixed detector (cycle 1) did not skip its own test directory, so
+ * phrases inside the detector's own test fixtures were harvested as real
+ * assertions about real skills.
+ *
+ * CURRENT STATE: scanDirForReferences (line 165) skips tests/unit/scripts/
+ * for the detector's own files. This test verifies the skip works.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+
+const GIT_TIMEOUT_MS = 15_000;
+const tempDirs: string[] = [];
+
+function makeGitRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'self-excl-'));
+	const runGit = (args: string[]) =>
+		spawnSync('git', args, {
+			cwd: root,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+	runGit(['init', '-q']);
+	runGit(['config', 'user.email', 'test@test.com']);
+	runGit(['config', 'user.name', 'Test']);
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md']);
+	runGit(['commit', '-q', '-m', 'initial']);
+	tempDirs.push(root);
+	return root;
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const d = tempDirs.pop()!;
+		try {
+			fs.rmSync(d, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup
+		}
+	}
+});
+
+describe('SC-004: detector skips its own test files', () => {
+	test('phrases inside tests/unit/scripts/ fixtures are NOT reported as broken', async () => {
+		const repo = makeGitRepo();
+		// Create the detector's own test directory tree inside the temp repo
+		// and add a fixture file there that mentions the skill slug.
+		mkdirSyncLocal(repo, 'tests/unit/scripts/');
+		writeFile(
+			repo,
+			'tests/unit/scripts/detector-self.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+// This file lives under tests/unit/scripts/ and contains a fixture phrase.
+// The detector should skip this directory entirely when scanning.
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('self', () => {
+  test('fake fixture phrase', () => {
+    expect(content).toContain('FAKE FIXTURE PHRASE — should not be reported');
+  });
+});
+`,
+		);
+		// Create a real skill file that the detector will look at
+		mkdirSyncLocal(repo, '.opencode/skills/test/');
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal content\n',
+		);
+
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill and fixture'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+
+		// Modify the skill so the detector runs
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal content updated\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		// The fixture phrase from tests/unit/scripts/detector-self.test.ts
+		// must NOT be reported as a broken assertion
+		const fixturePhrase = 'FAKE FIXTURE PHRASE — should not be reported';
+		const brokenFixturePhrase = result.brokenAssertions.find(
+			(b) => b.phrase === fixturePhrase,
+		);
+		expect(brokenFixturePhrase).toBeUndefined();
+	});
+
+	test('phrases inside string-literal regions of test files are NOT reported', async () => {
+		const repo = makeGitRepo();
+		mkdirSyncLocal(repo, '.opencode/skills/test/');
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal content\n',
+		);
+		mkdirSyncLocal(repo, 'tests/unit/agents/');
+		writeFile(
+			repo,
+			'tests/unit/agents/string-literal-fixture.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+// The phrase below is inside a TEMPLATE LITERAL — fixture data, not a real assertion.
+const FIXTURE_PHRASE = "expect(content).toContain('fixture-only-phrase')";
+describe('lit', () => {
+  test('real', () => {
+    expect(content).toContain('real content');
+  });
+});
+`,
+		);
+		spawnSync('git', ['add', '.'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+		spawnSync('git', ['commit', '-q', '-m', 'add skill and test'], {
+			cwd: repo,
+			stdio: 'ignore',
+			timeout: GIT_TIMEOUT_MS,
+		});
+
+		// Modify the skill so the detector runs
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nreal content updated\n',
+		);
+
+		const result = await checkSkillAssertions(repo);
+		// 'fixture-only-phrase' is inside a string literal in the test file
+		// fixture, NOT a real assertion. It must NOT be reported.
+		const fixtureOnlyPhrase = result.brokenAssertions.find(
+			(b) => b.phrase === 'fixture-only-phrase',
+		);
+		expect(fixtureOnlyPhrase).toBeUndefined();
+	});
+});
+
+// Local helper to avoid importing node:fs.mkdirSync at top
+function mkdirSyncLocal(root: string, relPath: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(full, { recursive: true });
+}

--- a/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
@@ -16,15 +16,15 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const GIT_TIMEOUT_MS = 15_000;
 const tempDirs: string[] = [];
 
 function makeGitRepo(): string {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'self-excl-'));
+	const root = canonicalMkdtemp('self-excl-');
 	const runGit = (args: string[]) =>
 		spawnSync('git', args, {
 			cwd: root,

--- a/tests/unit/scripts/check-skill-assertions.adversarial.test.ts
+++ b/tests/unit/scripts/check-skill-assertions.adversarial.test.ts
@@ -334,12 +334,13 @@ describe('adversarial: formatBrokenAssertions with malformed input', () => {
 					line: 1,
 					skillFile: '.opencode/skills/x/SKILL.md',
 					phrase: '',
+					assertionKind: 'toContain',
 				},
 			],
 		};
 		const lines = formatBrokenAssertions(result);
 		expect(lines).toHaveLength(1);
-		expect(lines[0]!).toContain('::error');
+		expect(lines[0]!).toContain('::notice');
 		expect(lines[0]!).toContain('tests/unit/agents/x.test.ts');
 	});
 
@@ -352,12 +353,13 @@ describe('adversarial: formatBrokenAssertions with malformed input', () => {
 					line: 5,
 					skillFile: '.opencode/skills/unicode/SKILL.md',
 					phrase: '日本語テスト — émojis 🎉 — العربية',
+					assertionKind: 'toContain',
 				},
 			],
 		};
 		const lines = formatBrokenAssertions(result);
 		expect(lines).toHaveLength(1);
-		expect(lines[0]!).toContain('::error');
+		expect(lines[0]!).toContain('::notice');
 		expect(() => formatBrokenAssertions(result)).not.toThrow();
 	});
 });

--- a/tests/unit/scripts/check-skill-assertions.test.ts
+++ b/tests/unit/scripts/check-skill-assertions.test.ts
@@ -4,7 +4,10 @@
  * SC-006: detects a test that asserts a phrase no longer present in a changed
  *         skill file.
  * SC-007: completes in <5s on a single-file diff.
- * SC-008: the skill check is invoked from the existing drift-check entry point.
+ *
+ * SC-008 (drift-check entry point) lives in
+ * check-skill-assertions-entrypoint.test.ts — split out under FR-006's
+ * 500-line cap.
  *
  * These tests use real temp directories with real files (Tier 0 zero-mock pattern)
  * so they exercise the actual assertion-extraction and phrase-checking logic.
@@ -18,12 +21,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {
-	checkSkillAssertions,
-	formatBrokenAssertions,
-	type SkillAssertionResult,
-} from '../../../scripts/check-skill-assertions';
-import { detectSkillAssertionDrift } from '../../../scripts/drift-check';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -441,99 +439,5 @@ describe('planner skill', () => {
 		const elapsed = Date.now() - start;
 
 		expect(elapsed).toBeLessThan(5000);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// SC-008: skill check is invoked from existing drift-check entry point
-// ---------------------------------------------------------------------------
-
-describe('SC-008: skill check is part of drift-check.ts entry point', () => {
-	test('detectSkillAssertionDrift is called by runAllDetectors and returns findings', async () => {
-		// This test verifies that when drift-check.ts runs its full suite,
-		// it also calls the skill-assertion detector.  We test the exported
-		// detectSkillAssertionDrift directly since runAllDetectors requires
-		// the full repo context.
-		//
-		// We create a minimal scenario: a skill with a phrase, a test asserting
-		// it, then remove the phrase — and verify detectSkillAssertionDrift
-		// surfaces the broken assertion as a DriftFinding.
-
-		const repo = makeGitRepo();
-
-		writeFile(
-			repo,
-			'.opencode/skills/design-docs/SKILL.md',
-			'MODE: DESIGN_DOCS — this mode does NOT delegate to coder.',
-		);
-		runGit(['add', '.'], repo);
-		runGit(['commit', '-q', '-m', 'add skill'], repo);
-
-		writeFile(
-			repo,
-			'tests/unit/agents/design-docs.test.ts',
-			`
-import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-const content = readFileSync(
-  join(process.cwd(), '.opencode/skills/design-docs/SKILL.md'),
-  'utf-8',
-);
-describe('design-docs skill', () => {
-  test('does NOT delegate to coder', () => {
-    expect(content).toContain('does NOT delegate to coder');
-  });
-});
-`,
-		);
-
-		// Remove the phrase
-		writeFile(
-			repo,
-			'.opencode/skills/design-docs/SKILL.md',
-			'MODE: DESIGN_DOCS — delegates freely.',
-		);
-
-		const findings = await detectSkillAssertionDrift(repo);
-
-		const skillAssertionFindings = findings.filter(
-			(f) => f.category === 'skill-assertion',
-		);
-		expect(skillAssertionFindings).toHaveLength(1);
-		expect(skillAssertionFindings[0]!.severity).toBe('notice');
-		expect(skillAssertionFindings[0]!.message).toContain(
-			'does NOT delegate to coder',
-		);
-		expect(skillAssertionFindings[0]!.message).toContain(
-			'.opencode/skills/design-docs/SKILL.md',
-		);
-	});
-
-	test('formatBrokenAssertions produces valid GitHub Actions annotations', () => {
-		const result: SkillAssertionResult = {
-			changedSkillFiles: ['.opencode/skills/x/SKILL.md'],
-			brokenAssertions: [
-				{
-					testFile: 'tests/unit/agents/x.test.ts',
-					line: 14,
-					skillFile: '.opencode/skills/x/SKILL.md',
-					phrase: 'does NOT delegate',
-					assertionKind: 'toContain',
-				},
-			],
-		};
-		const lines = formatBrokenAssertions(result);
-		expect(lines).toHaveLength(1);
-		expect(lines[0]!).toContain('::notice');
-		expect(lines[0]!).toContain('tests/unit/agents/x.test.ts');
-		expect(lines[0]!).toContain('does NOT delegate');
-	});
-
-	test('formatBrokenAssertions returns empty array when no broken assertions', () => {
-		const result: SkillAssertionResult = {
-			changedSkillFiles: [],
-			brokenAssertions: [],
-		};
-		expect(formatBrokenAssertions(result)).toEqual([]);
 	});
 });

--- a/tests/unit/scripts/check-skill-assertions.test.ts
+++ b/tests/unit/scripts/check-skill-assertions.test.ts
@@ -500,7 +500,7 @@ describe('design-docs skill', () => {
 			(f) => f.category === 'skill-assertion',
 		);
 		expect(skillAssertionFindings).toHaveLength(1);
-		expect(skillAssertionFindings[0]!.severity).toBe('error');
+		expect(skillAssertionFindings[0]!.severity).toBe('notice');
 		expect(skillAssertionFindings[0]!.message).toContain(
 			'does NOT delegate to coder',
 		);
@@ -518,12 +518,13 @@ describe('design-docs skill', () => {
 					line: 14,
 					skillFile: '.opencode/skills/x/SKILL.md',
 					phrase: 'does NOT delegate',
+					assertionKind: 'toContain',
 				},
 			],
 		};
 		const lines = formatBrokenAssertions(result);
 		expect(lines).toHaveLength(1);
-		expect(lines[0]!).toContain('::error');
+		expect(lines[0]!).toContain('::notice');
 		expect(lines[0]!).toContain('tests/unit/agents/x.test.ts');
 		expect(lines[0]!).toContain('does NOT delegate');
 	});


### PR DESCRIPTION
Closes #2069

## Summary
- FR-001: Negated assertions (`.not.toContain`, `.not.toMatch`) are now skipped — a negated assertion never proves a phrase must be present
- FR-002: `toMatch(/regex/)` assertions evaluated as compiled regex patterns via `new RegExp(source, flags).test(skillContent)` instead of literal substring `includes()`. Escaped slashes and flags handled by `parseRegexLiteral`. Malformed regexes produce `assertionKind: 'malformed-regex'` findings.
- FR-003: Detector skips its own `tests/unit/scripts/` directory and filters string-literal content via `isInsideStringLiteral`
- FR-004: Attribution requires the exact assertion line to chain off a confirmed skill variable — the +/-2 line window is removed
- FR-005: Four regression fixtures added (negation, regex, self-exclusion, attribution), each under 500 lines
- FR-006: Skill-assertion findings emit at `notice` severity in both surfaces (standalone `::notice` annotation + drift-check `severity: 'notice'`), making them non-blocking. Set `SKILL_ASSERTIONS_STRICT=1` for opt-in hard-fail.

## Invariant audit
- 1 (plugin init): not touched — no changes to src/index.ts or plugin registration
- 2 (runtime portability): not touched — no changes to bundle config, package exports, or bun: imports
- 3 (subprocesses): not touched — the detector's git subprocess calls are unchanged
- 4 (.swarm containment): not touched — evidence files written to .swarm/evidence/ (gitignored)
- 5 (plan durability): not touched — no changes to plan ledger or projection
- 6 (test_runner safety): not touched — tests run via bun:test with explicit file paths, no broad scopes
- 7 (test writing): touched — 4 new test files added, all use Tier 0 zero-mock pattern (real temp git repos, no mock.module). Existing test files updated for FR-006 severity assertions. Confirmed: no mock.module usage in any new file.
- 8 (session state): not touched — no session-scoped state changes
- 9 (guardrails/retry): not touched — no guardrail or retry logic changes
- 10 (chat/system msg): not touched — no chat hook changes
- 11 (tool registration): not touched — no tool additions/removals/modifications
- 12 (release/cache): touched — release note fragment added at docs/releases/pending/. Version files untouched (release-please owns them).

## Test plan
- [x] 31/31 tests pass across 6 test files in tests/unit/scripts/
- [x] `bun run typecheck` passes (exit 0)
- [x] `bun run check` (biome) passes
- [x] `bun run drift:check` reports zero drift on clean tree
- [x] Final council APPROVED (5/5 members: critic, reviewer, sme, test_engineer, explorer)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

