### PR TITLE
fix(pr-review): salvage valid discovery rows instead of discarding lanes

### DIFF
--- a/docs/releases/pending/pr-review-discovery-salvage.md
+++ b/docs/releases/pending/pr-review-discovery-salvage.md
@@ -1,0 +1,71 @@
+# Salvage valid PR-review discovery rows instead of discarding whole lanes
+
+## What changed
+
+- A PR-review discovery artifact is now **normalized once** before every consumer
+  reads it. `normalizeCandidateArtifact` (`src/background/candidate-contract.ts`)
+  repairs an absent canonical header by synthesizing it in front of the first
+  marker-bearing row, and is applied at the coverage site, the candidate-id
+  extraction site, and the `parse_lane_candidates` tool boundary.
+- A malformed row no longer discards a lane's valid findings. Coverage is
+  established from the valid rows; defective rows are reported as diagnostics.
+  Duplicate `candidate_id`s remain non-salvageable, because the inventory they
+  feed is asserted globally unique.
+- A defective `[CLEAN]` attestation no longer discards the candidate rows beside
+  it (`src/background/candidate-parser.ts`) — a bad attestation discredits the
+  attestation, not independently validated findings.
+- A zero-findings lane that emitted a well-formed `[CLEAN]` but omitted the header
+  is now repaired. This was the single lane that blocked a real run across four
+  attempts.
+- The explorer output contract (`src/tools/dispatch-lanes.ts`) now teaches
+  `\|` escaping, leads with a worked example, and states the `[CLEAN]` row shape.
+- The row family is resolved by one mode-first rule
+  (`resolvePrReviewRowFamily`), so coverage and extraction can no longer disagree
+  about which family an artifact contains.
+- Repaired lanes are recorded as `salvagedWorkflowLanes` on the durable delegation
+  ledger, so a salvaged artifact stays distinguishable from a well-formed one.
+
+## Why
+
+Measured on a real run (reconstructed from `.swarm/background-delegations.jsonl`):
+99.3 minutes, 31 lane dispatches, 16 errored lane instances, **59 substantive
+findings discarded, 0 artifacts persisted**. Zero of those failures were analysis
+failures — every one was a text-formatting failure on the positional
+pipe-delimited candidate protocol, validated with no salvage.
+
+Because the gate fails the whole workflow on any unresolved micro source, a single
+lane that found nothing and said so correctly — but omitted one header line —
+ended the run.
+
+## Migration steps
+
+None. No configuration, schema migration, or persisted-state change is required.
+`salvagedWorkflowLanes` is an optional field on existing ledger records.
+
+## Breaking changes
+
+None at the API level. Four previously-pinned validation behaviours were
+deliberately relaxed, each with its reasoning recorded in the corresponding test:
+
+- an absent canonical header is repaired rather than fatal, when at least one
+  valid row or a well-formed lane-bound `[CLEAN]` is present;
+- a valid row followed by a malformed row now establishes coverage;
+- a headerless `[CLEAN]` establishes coverage;
+- a lane whose *second* row carries a mislabeled lane value is no longer
+  discarded when a correctly-labeled row already covers the dimension.
+
+The proof-of-work bar is unchanged: coverage still requires a semantically valid
+row whose lane matches, or a `[CLEAN]` clearing its `coverage_scope` and
+`evidence` length floors. A wrong or late header, a foreign-lane attestation, and
+duplicate candidate ids all still fail closed.
+
+## Known caveats
+
+- Lanes that produce no text at all (`stale`, `cancelled`, or left `running`)
+  cannot be salvaged by construction.
+- A zero-findings lane that wraps its `[CLEAN]` in a markdown code fence remains
+  unsalvageable, because fence-stripping removes the trigger before it is read.
+- The emission-hardening half is validated for delivery into the lane prompt, not
+  for lane compliance, which is not unit-testable.
+
+These and the remaining follow-on items are tracked in #2114.

--- a/src/background/candidate-contract.ts
+++ b/src/background/candidate-contract.ts
@@ -141,6 +141,118 @@ export function removeCandidateCodeFences(text: string): string {
 	return lines.join('\n');
 }
 
+export interface NormalizedCandidateArtifact {
+	/** Fence-stripped text, with a canonical header synthesized when salvageable. */
+	text: string;
+	/** True when a canonical header was supplied by this normalizer. */
+	synthesizedHeader: boolean;
+}
+
+/** Every canonical header family declared on any line of `source`. */
+function declaredCanonicalFamilies(source: string): RowFormatFamily[] {
+	const families: RowFormatFamily[] = [];
+	for (const line of source.split(/\r?\n/)) {
+		const family = candidateHeaderFamily(
+			splitPipeFields(line).map((field) => field.trim()),
+		);
+		if (family && !families.includes(family)) families.push(family);
+	}
+	return families;
+}
+
+/**
+ * Normalize a lane artifact ONCE so every consumer parses byte-identical text.
+ *
+ * Coverage validation and candidate-id extraction previously applied the header
+ * rule in two separate places, so a repair applied to one could not be seen by
+ * the other — a lane could be judged "covered" while contributing zero findings
+ * to the inventory. Both callers now route through this function.
+ *
+ * A missing header is repaired; a *wrong* or *late* header is not, so genuine
+ * contract violations still fail closed:
+ *  - a leading canonical header (either family) is left alone, preserving
+ *    `expected-family-mismatch`;
+ *  - a canonical header that exists but does not lead is left alone, preserving
+ *    "a later valid header cannot rescue a malformed first marker";
+ *  - only a total absence of any canonical header, together with at least one
+ *    valid marker-bearing row, is repaired.
+ *
+ * KNOWN RESIDUAL: the two row families are both nine fields and differ only in
+ * the meaning of positions 6 and 7 (`evidence_summary`/`impact_context` versus
+ * `invariant_violated`/`evidence_summary`), neither of which is structurally
+ * distinguishable. A headerless lane that emits the other family's field order
+ * is therefore repaired into the expected family and its two prose fields are
+ * transposed. Callers surface `synthesizedHeader` so this is auditable.
+ */
+export function normalizeCandidateArtifact(
+	rawText: string,
+	fallbackFamily: RowFormatFamily,
+): NormalizedCandidateArtifact {
+	const text = removeCandidateCodeFences(rawText);
+	const header = selectCandidateHeader(text.split(/\r?\n/));
+	if (header?.markerBearing && header.family !== null) {
+		return { text, synthesizedHeader: false };
+	}
+	// A canonical header that survives fence-stripping but does not lead is a
+	// genuine contract violation: a later valid header still cannot rescue a
+	// malformed first marker.
+	if (declaredCanonicalFamilies(text).length > 0) {
+		return { text, synthesizedHeader: false };
+	}
+	// A header that existed only inside a code fence was deleted before it could
+	// be read. Honour the family it declared: if that disagrees with the expected
+	// family the artifact must still fail closed, but if it agrees there is
+	// nothing to protect and refusing would discard the lane's findings for no
+	// reason.
+	if (
+		declaredCanonicalFamilies(rawText).some(
+			(family) => family !== fallbackFamily,
+		)
+	) {
+		return { text, synthesizedHeader: false };
+	}
+	// A lane proves it did the work with EITHER a valid candidate row or a valid
+	// zero-findings [CLEAN] attestation. Triggering only on candidate rows would
+	// leave a lane that correctly found nothing permanently unsalvageable — and a
+	// single unresolved micro lane blocks an entire PR-review run.
+	const lines = text.split(/\r?\n/);
+	// The TRIGGER asks whether the lane produced anything worth keeping.
+	const hasSalvageableRow = lines.some((line) => {
+		if (analyzeCandidateLine(line, fallbackFamily)?.valid === true) return true;
+		const fields = splitPipeFields(line).map((field) => field.trim());
+		if (fields[0] !== CLEAN_MARKER) return false;
+		return analyzeCleanFields(fields, fallbackFamily).valid;
+	});
+	if (!hasSalvageableRow) return { text, synthesizedHeader: false };
+	// The INSERTION POINT is the first marker-bearing line, valid or not —
+	// deliberately not the first *valid* row. selectCandidateHeader takes the
+	// first marker-bearing line as authoritative, so inserting after a malformed
+	// marker would leave that malformed line as the header and fail the artifact
+	// anyway. Placing the header above it demotes it to a data row, which is then
+	// rejected on its own merits while its valid siblings survive. This matters:
+	// headerless (9/16) co-occurring with an unescaped pipe (7/16) is the single
+	// most likely recurrence shape.
+	// Cannot be -1: hasSalvageableRow above only returns true for a line whose
+	// first field is one of these two markers, so at least one such line exists.
+	const firstSalvageableIndex = lines.findIndex((line) => {
+		const marker = splitPipeFields(line)[0]?.trim();
+		return marker === CANDIDATE_MARKER || marker === CLEAN_MARKER;
+	});
+	// Insert the header immediately before the first salvageable row, not at the
+	// top. Prepending would push the explorer's leading prose BELOW the header,
+	// where every prose line is counted as a malformed row — which both inflates
+	// the diagnostics and trips the CLEAN attestation's zero-malformed-rows rule,
+	// defeating the repair it was supposed to enable.
+	return {
+		text: [
+			...lines.slice(0, firstSalvageableIndex),
+			CANDIDATE_HEADERS[fallbackFamily],
+			...lines.slice(firstSalvageableIndex),
+		].join('\n'),
+		synthesizedHeader: true,
+	};
+}
+
 export type CandidateFieldName =
 	(typeof CANDIDATE_FIELDS)[RowFormatFamily][number];
 

--- a/src/background/candidate-parser.ts
+++ b/src/background/candidate-parser.ts
@@ -9,6 +9,7 @@ import {
 	type CandidateSeverity,
 	candidateDiagnosticPreview,
 	isCandidateLookingShortRow,
+	normalizeCandidateArtifact,
 	type RowFormatFamily,
 	removeCandidateCodeFences,
 	type CleanAttestationRecord as SharedCleanAttestationRecord,
@@ -931,7 +932,12 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 		formatFamiliesDetected.add(cleanAttestation.row_format_family);
 	}
 
-	const acceptedCandidates = cleanErrorCode ? [] : candidates;
+	// A defective CLEAN attestation discredits the attestation, never the
+	// candidate rows: every candidate here was independently validated by
+	// analyzeCandidateFields. Discarding them made one malformed trailing row
+	// destroy an entire lane's findings. The attestation itself stays gated
+	// below on `!cleanErrorCode && candidates.length === 0`.
+	const acceptedCandidates = candidates;
 	const parseErrors = parseErrorDetails.length;
 
 	const envelope = buildInvocationEnvelope(
@@ -1003,7 +1009,23 @@ export function parseAndPersist(
 	flags: ParseFlags,
 	options: ParsePersistOptions,
 ): ParseResultWithSidecar {
-	const result = parseCandidates(input, flags);
+	// Normalize at this tool boundary for the same reason the PR-review gate does:
+	// otherwise an artifact the gate accepts as covered could still be refused
+	// here, leaving the caller unable to retrieve findings from a lane that had
+	// already been credited. Scope note: it is specifically HEADER REPAIR that stays
+	// boundary-only — parseCandidates itself never synthesizes a header, so the two
+	// boundaries that consume artifacts on a caller's behalf agree while the pure
+	// parser does not silently rewrite input. Candidate acceptance is a separate
+	// question and DID change for every consumer: a defective [CLEAN] no longer
+	// discards independently validated candidate rows (see acceptedCandidates).
+	const normalizedInput = flags.expected_family
+		? {
+				...input,
+				text: normalizeCandidateArtifact(input.text, flags.expected_family)
+					.text,
+			}
+		: input;
+	const result = parseCandidates(normalizedInput, flags);
 
 	try {
 		appendToSidecar(

--- a/src/background/pending-delegations.ts
+++ b/src/background/pending-delegations.ts
@@ -179,6 +179,13 @@ export interface BackgroundDelegationResult {
 	outputArtifactError?: string;
 	transcriptIncomplete?: boolean;
 	messageCount?: number;
+	/**
+	 * Workflow lanes whose discovery artifact was accepted only after repair — a
+	 * synthesized canonical header, or valid rows retained beside malformed ones.
+	 * Recorded on the durable ledger so a repaired lane stays distinguishable from
+	 * a well-formed one after the fact, which is where post-mortems actually look.
+	 */
+	salvagedWorkflowLanes?: string[];
 }
 
 export interface BackgroundTerminalResult {
@@ -272,8 +279,47 @@ const ResultSchema = z
 		outputArtifactError: z.string().optional(),
 		transcriptIncomplete: z.boolean().optional(),
 		messageCount: z.number().optional(),
+		// Must be declared here: this schema is .strict() and readDelegations
+		// safeParse-skips any record it rejects, so an undeclared field would make
+		// the entire terminal transition invisible to every reader — turning a
+		// successfully salvaged lane into one that appears never to have completed.
+		salvagedWorkflowLanes: z.array(z.string()).optional(),
 	})
 	.strict();
+
+/**
+ * Compile-time parity guard between the TypeScript interface and the `.strict()`
+ * schema above.
+ *
+ * `appendRecord` writes without validating while `readDelegations`
+ * safeParse-skips anything the schema rejects, so a field declared on the
+ * interface but missing from the schema is written to disk and then silently
+ * invisible to every reader — dropping the whole record, not just the field.
+ * That is not a hypothetical: it shipped once during this change and made
+ * completed lanes read back as `pending`.
+ *
+ * Mutual assignability makes `tsc` reject the next occurrence for free, which is
+ * a strictly stronger rung than another runtime test.
+ */
+// Compared by KEY, deliberately. Mutual assignability does not work here: an
+// optional field present on one side and absent from the other still satisfies
+// `extends` in both directions, so an assignability guard would silently pass on
+// exactly the drift that caused the bug.
+type FieldsMissingFromResultSchema = Exclude<
+	keyof BackgroundDelegationResult,
+	keyof z.infer<typeof ResultSchema>
+>;
+type FieldsMissingFromResultInterface = Exclude<
+	keyof z.infer<typeof ResultSchema>,
+	keyof BackgroundDelegationResult
+>;
+const _RESULT_SCHEMA_MATCHES_INTERFACE: [
+	FieldsMissingFromResultSchema,
+	FieldsMissingFromResultInterface,
+] extends [never, never]
+	? true
+	: false = true;
+void _RESULT_SCHEMA_MATCHES_INTERFACE;
 
 const WorkspaceSchema = z
 	.object({

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -8,6 +8,7 @@ import {
 	CANDIDATE_HEADERS,
 	CLEAN_TEMPLATES,
 	candidateHeaderFamily,
+	normalizeCandidateArtifact,
 	type RowFormatFamily,
 	removeCandidateCodeFences,
 	selectCandidateHeader,
@@ -134,7 +135,16 @@ export interface PrReviewLaneValidationFailure {
 }
 
 export type PrReviewLaneValidationResult =
-	| { ok: true }
+	| {
+			ok: true;
+			/**
+			 * Workflow lanes accepted only after repair — a synthesized canonical
+			 * header, or valid rows retained beside malformed ones. Structural rather
+			 * than log-only, so a repaired artifact is programmatically
+			 * distinguishable from a well-formed one.
+			 */
+			salvaged?: readonly string[];
+	  }
 	| { ok: false; failure: PrReviewLaneValidationFailure };
 
 export interface PrReviewDiscoveryLaneValidationInput {
@@ -4972,6 +4982,12 @@ export const _test_exports = {
 	minimumConsolidatedLaneCover,
 	analyzePrReviewBatchRecordIntegrity,
 	MAX_COVER_UNIVERSE_BITS,
+	// Exposed so a regression test can assert the coverage verdict and the
+	// candidate-id extraction agree on the same artifact — the split-brain that
+	// let a lane be judged "covered" while contributing zero findings.
+	extractCandidateIds,
+	parseCanonicalCandidateRows,
+	resolvePrReviewRowFamily,
 	workflowGateStateRelativePath,
 	workflowGateStateLockRelativePath,
 	workflowCheckoutMutationLockRelativePath,
@@ -6490,6 +6506,7 @@ function derivePrReviewCandidateInventory(
 						artifact.text,
 						source.workflowLane,
 						recordOwnedLanes,
+						source.mode,
 					))
 			)
 				continue;
@@ -6500,9 +6517,7 @@ function derivePrReviewCandidateInventory(
 				candidateIds.push(
 					...extractCandidateIds(
 						artifact.text,
-						source.mode === 'swarm-pr-review:micro'
-							? 'micro_lane'
-							: 'base_explorer',
+						resolvePrReviewRowFamily(source.workflowLane, source.mode),
 						source.creditedLanes,
 					),
 				);
@@ -6550,6 +6565,39 @@ function appendBoundedCandidateIssue(issues: string[], message: string): void {
 	}
 }
 
+/**
+ * Single source of truth for a PR-review lane's row family.
+ *
+ * Coverage validation and id extraction previously derived this separately (one
+ * from the dispatch mode, one from lane membership). Because the artifact
+ * normalizer's output depends on the family, any disagreement would reintroduce
+ * the very coverage/inventory split this normalization exists to remove.
+ */
+function resolvePrReviewRowFamily(
+	workflowLane: string | undefined,
+	mode?: string,
+): RowFormatFamily {
+	// MODE FIRST, deliberately. The dispatch output contract tells a lane which
+	// row family to emit purely from the mode (dispatch-lanes.ts: base -> base row
+	// family; micro and council -> micro row family), so the mode is the ground
+	// truth about what the artifact will contain. Deriving from the lane label
+	// instead lets a council lane named after a base dimension resolve one way at
+	// the coverage site and the other way at the extraction site — the exact
+	// coverage/inventory split this normalization exists to remove.
+	if (mode === 'swarm-pr-review:base') return 'base_explorer';
+	if (mode === 'swarm-pr-review:micro' || mode === 'swarm-pr-review:council') {
+		return 'micro_lane';
+	}
+	// No mode available: fall back to lane membership. Base dimension ids are a
+	// closed set, so anything outside it is a micro/trigger lane.
+	return workflowLane !== undefined &&
+		PR_REVIEW_BASE_DIMENSION_IDS.includes(
+			workflowLane as PrReviewBaseDimensionId,
+		)
+		? 'base_explorer'
+		: 'micro_lane';
+}
+
 function parseCanonicalCandidateRows(
 	text: string,
 	fallbackFamily: RowFormatFamily,
@@ -6557,8 +6605,8 @@ function parseCanonicalCandidateRows(
 	const rows: CanonicalCandidateArtifactRow[] = [];
 	const issues: string[] = [];
 	let headerFamily: RowFormatFamily | null = null;
-	for (const [index, line] of removeCandidateCodeFences(text)
-		.split(/\r?\n/)
+	for (const [index, line] of normalizeCandidateArtifact(text, fallbackFamily)
+		.text.split(/\r?\n/)
 		.entries()) {
 		const fields = splitPipeFields(line).map((field) => field.trim());
 		const detectedHeaderFamily = candidateHeaderFamily(fields);
@@ -8023,6 +8071,7 @@ function workflowArtifactHasContractMarker(
 			artifact.text,
 			coveredLane,
 			coveredLanes,
+			expectedMode,
 		),
 	}));
 	if (coverageAnalyses.some(({ analysis }) => !analysis.covered)) {
@@ -8053,6 +8102,7 @@ function workflowArtifactHasContractMarker(
 				artifact.text,
 				coveredLane,
 				coveredLanes,
+				expectedMode,
 			);
 			if (evidence === null) continue;
 			const priorLane = seenEvidence.get(evidence);
@@ -8067,6 +8117,12 @@ interface PrReviewDiscoveryCoverageAnalysis {
 	covered: boolean;
 	evidence: string | null;
 	issues: string[];
+	/**
+	 * True when coverage required a synthesized canonical header. Surfaced so a
+	 * repaired artifact is auditable rather than silently indistinguishable from
+	 * a well-formed one.
+	 */
+	salvaged: boolean;
 	failurePredicate?: Extract<
 		PrReviewLaneValidationPredicate,
 		'discovery.header' | 'discovery.row' | 'discovery.coverage'
@@ -8077,14 +8133,18 @@ function analyzePrReviewDiscoveryArtifact(
 	text: string,
 	expectedWorkflowLane: string,
 	ownedWorkflowLanes: readonly string[] = [expectedWorkflowLane],
+	mode?: string,
 ): PrReviewDiscoveryCoverageAnalysis {
-	const fallbackFamily: RowFormatFamily = PR_REVIEW_BASE_DIMENSION_IDS.includes(
-		expectedWorkflowLane as PrReviewBaseDimensionId,
-	)
-		? 'base_explorer'
-		: 'micro_lane';
+	// `mode` is threaded in so this site and the extraction site
+	// (derivePrReviewCandidateInventory) resolve the row family from the SAME
+	// input. Without it, a council lane named after a base dimension resolves
+	// base_explorer here and micro_lane there, and the artifact can be judged
+	// covered while contributing nothing to the inventory.
+	const fallbackFamily = resolvePrReviewRowFamily(expectedWorkflowLane, mode);
 	const issues: string[] = [];
-	const canonicalText = removeCandidateCodeFences(text);
+	const normalized = normalizeCandidateArtifact(text, fallbackFamily);
+	const canonicalText = normalized.text;
+	const salvaged = normalized.synthesizedHeader;
 	const header = selectCandidateHeader(canonicalText.split(/\r?\n/));
 	if (
 		header === null ||
@@ -8099,6 +8159,7 @@ function analyzePrReviewDiscoveryArtifact(
 			covered: false,
 			evidence: null,
 			issues,
+			salvaged,
 			failurePredicate: 'discovery.header',
 		};
 	}
@@ -8141,14 +8202,36 @@ function analyzePrReviewDiscoveryArtifact(
 			`row ${detail.row_index + 1} field ${detail.field}: ${detail.message}`,
 		);
 	}
-	if (parsed.error || parsed.diagnostics.parse_error_details.length > 0) {
+	const hasParseFailure =
+		Boolean(parsed.error) || parsed.diagnostics.parse_error_details.length > 0;
+	// Duplicate candidate ids are the one row defect that is never salvaged: the
+	// inventory they feed is asserted globally unique, so admitting them would
+	// convert a recoverable lane defect into a late workflow-wide failure.
+	//
+	// Checked against the EXTRACTOR's rows rather than the parser's diagnostics.
+	// The parser drops an out-of-ownership row before its duplicate detector runs,
+	// so a reused id spread across one owned and one foreign row produces no
+	// duplicate diagnostic at all — while extractCandidateIds deliberately keeps
+	// both rows (an unscoped extraction is intentional so inconsistent lane
+	// labelling never silently drops a real candidate). Reading the extractor's
+	// output is the only check that sees exactly what assertNoDuplicates will.
+	const extractedCandidateIds = parseCanonicalCandidateRows(
+		canonicalText,
+		fallbackFamily,
+	).rows.map((row) => row.candidateId);
+	const hasDuplicateCandidateId =
+		new Set(extractedCandidateIds).size !== extractedCandidateIds.length;
+	if (hasDuplicateCandidateId) {
 		return {
 			covered: false,
 			evidence: null,
 			issues,
+			salvaged,
 			failurePredicate: 'discovery.row',
 		};
 	}
+	// Otherwise a malformed row is a diagnostic, not a verdict: valid rows that
+	// establish coverage are retained and the defective ones are reported.
 	const matchingCandidate = parsed.candidates.find(
 		(candidate) =>
 			(candidate.lane ?? candidate.micro_lane) === expectedWorkflowLane,
@@ -8167,6 +8250,7 @@ function analyzePrReviewDiscoveryArtifact(
 				matchingCandidate.confidence,
 			].join('\0'),
 			issues,
+			salvaged,
 		};
 	}
 	const clean = parsed.clean_attestation;
@@ -8180,13 +8264,17 @@ function analyzePrReviewDiscoveryArtifact(
 			covered: true,
 			evidence: `${clean.coverage_scope}\0${clean.evidence}`,
 			issues,
+			salvaged,
 		};
 	}
 	return {
 		covered: false,
 		evidence: null,
 		issues,
-		failurePredicate: 'discovery.coverage',
+		salvaged,
+		// Preserve today's predicate: a row-level defect is still reported as
+		// such once it turns out no valid row could establish coverage.
+		failurePredicate: hasParseFailure ? 'discovery.row' : 'discovery.coverage',
 	};
 }
 
@@ -8238,8 +8326,34 @@ export function validatePrReviewDiscoveryLaneCompletion(
 			artifact.text,
 			workflowLane,
 			ownedWorkflowLanes,
+			input.expected.mode,
 		),
 	}));
+	// A lane that is covered but carried defects is the whole point of salvage —
+	// and also the one case the failure path never reports, because diagnostics
+	// are only rendered for lanes that fail. Record them here so a repaired or
+	// partially-dropped artifact is never silently indistinguishable from a
+	// clean one.
+	//
+	// The returned `salvaged` list is the PRODUCTION signal: the caller persists it
+	// as `salvagedWorkflowLanes` on the durable delegation ledger, which is what a
+	// post-mortem actually reads. The `warn` below is debug-gated — `utils/logger.ts`
+	// returns early unless `process.env.OPENCODE_SWARM_DEBUG === '1'` exactly, so any
+	// other value (including `true`) leaves it silent — and is therefore a developer
+	// convenience only. Do not treat it as the observability guarantee, and do not
+	// weaken the ledger write on the assumption the log covers it.
+	const salvagedLanes: string[] = [];
+	for (const { workflowLane, analysis } of analyses) {
+		if (!analysis.covered) continue;
+		if (!analysis.salvaged && analysis.issues.length === 0) continue;
+		salvagedLanes.push(workflowLane);
+		const reason = analysis.salvaged
+			? `canonical ${resolvePrReviewRowFamily(workflowLane, input.expected.mode)} header was absent and was synthesized from valid marker rows`
+			: 'one or more rows were dropped as malformed or out-of-ownership';
+		warn(
+			`[pr-workflow-gate] discovery artifact salvaged: batch=${input.record.batchId ?? '(missing)'} lane=${input.record.laneId ?? '(missing)'} workflow_lane=${workflowLane} — ${reason}; retained coverage from the valid rows. Dropped-row diagnostics: ${analysis.issues.join('; ') || '(none)'}`,
+		);
+	}
 	const failedCoverage = analyses.find(({ analysis }) => !analysis.covered);
 	if (failedCoverage) {
 		return failedLaneValidation(
@@ -8263,7 +8377,9 @@ export function validatePrReviewDiscoveryLaneCompletion(
 			seenEvidence.set(analysis.evidence, workflowLane);
 		}
 	}
-	return { ok: true };
+	return salvagedLanes.length > 0
+		? { ok: true, salvaged: salvagedLanes }
+		: { ok: true };
 }
 
 /** Require at least one semantically valid discovery row or CLEAN attestation. */
@@ -8271,11 +8387,13 @@ export function prReviewDiscoveryArtifactCoversLane(
 	text: string,
 	expectedWorkflowLane: string,
 	ownedWorkflowLanes: readonly string[] = [expectedWorkflowLane],
+	mode?: string,
 ): boolean {
 	return analyzePrReviewDiscoveryArtifact(
 		text,
 		expectedWorkflowLane,
 		ownedWorkflowLanes,
+		mode,
 	).covered;
 }
 
@@ -8283,11 +8401,13 @@ function extractLaneCoverageEvidenceText(
 	text: string,
 	expectedWorkflowLane: string,
 	ownedWorkflowLanes: readonly string[] = [expectedWorkflowLane],
+	mode?: string,
 ): string | null {
 	return analyzePrReviewDiscoveryArtifact(
 		text,
 		expectedWorkflowLane,
 		ownedWorkflowLanes,
+		mode,
 	).evidence;
 }
 

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -2,7 +2,9 @@ import { createHash } from 'node:crypto';
 import pLimit from 'p-limit';
 import { z } from 'zod';
 import {
+	CANDIDATE_FIELD_COUNT,
 	CANDIDATE_HEADERS,
+	CLEAN_FIELD_COUNT,
 	CLEAN_TEMPLATES,
 } from '../background/candidate-contract.js';
 import {
@@ -226,17 +228,32 @@ const PR_WORKFLOW_LANE_CHECKLISTS: Readonly<Record<string, string>> = {
 		'challenge the closeout evidence, omissions, false confidence, severity, scope, and publication readiness',
 };
 
-const EXPLORER_CANDIDATE_FORMAT_SUFFIX = `
+/**
+ * Exported so a test can assert the RENDERED contract, not its source text: the
+ * pipe-escaping rule is a backslash inside a template literal, where a single
+ * backslash is silently dropped and would instruct lanes to emit the exact
+ * character that breaks row parsing.
+ */
+export const EXPLORER_CANDIDATE_FORMAT_SUFFIX = `
 
 IMPORTANT — OUTPUT FORMAT REQUIREMENT:
-You MUST emit your findings as a pipe-delimited [CANDIDATE] table.
-Emit the marker-bearing header first, then one unprefixed data row per finding.
+You MUST emit your findings as a pipe-delimited [CANDIDATE] table. The FIRST
+[CANDIDATE]-prefixed line is the literal column header, copied verbatim with the
+field NAMES as its values; data rows follow it.
+
+WORKED EXAMPLE — copy this shape exactly. The first line is the header, not a finding:
+${CANDIDATE_HEADERS.base_explorer}
+[CANDIDATE] | example-lane-001 | example-lane | MEDIUM | correctness | src/a.ts:12 | claim without pipes | evidence without pipes | impact without pipes | HIGH
 
 Standard explorer format (use unless the prompt specifies micro-lane work):
 ${CANDIDATE_HEADERS.base_explorer}
 
 Micro-lane format (use when the prompt references invariant checking or micro_lane, or for swarm-pr-review:council discovery):
 ${CANDIDATE_HEADERS.micro_lane}
+
+Every data row has exactly ${CANDIDATE_FIELD_COUNT} fields after the marker. A
+literal pipe inside any field MUST be written as \\| — an unescaped | starts a
+new field, and the row is then rejected as malformed.
 
 Candidate IDs must be globally unique across the run; prefix them with the
 exact workflow_lane value from this dispatch.
@@ -245,6 +262,9 @@ If a standard explorer finds zero issues, emit its header followed by exactly:
 ${CLEAN_TEMPLATES.base_explorer}
 If a micro-lane finds zero issues, emit its header followed by exactly:
 ${CLEAN_TEMPLATES.micro_lane}
+A [CLEAN] row has exactly ${CLEAN_FIELD_COUNT - 1} fields after the marker and NO
+confidence field. Emit it ONLY when the lane has zero findings — never alongside
+[CANDIDATE] rows.
 Write a substantive coverage_scope of at least 12 characters and concrete evidence of at least 20
 characters; bare header-only output is UNATTESTED for every PR-review lane.
 Do NOT use the default PROJECT/STRUCTURE output format for this dispatch.`;
@@ -2041,6 +2061,12 @@ async function collectOnce(
 					reviewScope: record.workspace?.scope ?? undefined,
 				},
 			});
+			if (validation.ok && validation.salvaged?.length) {
+				// Persist the repair on the durable ledger: a salvaged lane is
+				// accepted, so nothing downstream would otherwise record that its
+				// artifact needed fixing.
+				prospectiveResult.salvagedWorkflowLanes = [...validation.salvaged];
+			}
 			if (!validation.ok) {
 				terminalStatus = 'error';
 				const family =

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -241,6 +241,7 @@ export async function executeWritePrReviewTriggerEval(
 					outputArtifact.artifact.text,
 					ownedFamily,
 					recordOwnedLanes,
+					record.mode,
 				),
 			) ||
 			record.workspace?.prHeadSha !== parsed.data.pr_head_sha ||

--- a/tests/unit/background/candidate-contract.test.ts
+++ b/tests/unit/background/candidate-contract.test.ts
@@ -12,7 +12,10 @@ import {
 	type ArtifactInput,
 	parseCandidates,
 } from '../../../src/background/candidate-parser';
-import { prReviewDiscoveryArtifactCoversLane } from '../../../src/hooks/pr-workflow-gate';
+import {
+	_test_exports,
+	prReviewDiscoveryArtifactCoversLane,
+} from '../../../src/hooks/pr-workflow-gate';
 
 const DIGEST = 'a'.repeat(64);
 const BASE_HEADER =
@@ -144,18 +147,13 @@ describe('shared candidate and CLEAN semantics', () => {
 			'concurrency-state',
 			'M-1 | concurrency-state | HIGH | concurrency | src/a.ts:1 | claim | invariant | evidence | HIGH',
 		] as const,
-	])('rejects malformed or missing canonical headers identically for %s', (family, header, lane, row) => {
+	])('rejects a wrong canonical header but repairs an absent one for %s', (family, header, lane, row) => {
 		const misorderedHeader = header.replace(
 			'severity | category',
 			'category | severity',
 		);
-		const malformedArtifacts = [
-			`${header} | extra\n${row}`,
-			`${misorderedHeader}\n${row}`,
-			`[CANDIDATE] | ${row}`,
-		];
-		for (const text of malformedArtifacts) {
-			const parsed = parseCandidates(artifact(text), {
+		const parse = (text: string) =>
+			parseCandidates(artifact(text), {
 				accept_partial: false,
 				accept_degraded: false,
 				degraded: false,
@@ -165,10 +163,28 @@ describe('shared candidate and CLEAN semantics', () => {
 					? { expected_lane: lane }
 					: { expected_micro_lane: lane }),
 			});
+
+		// A header that is PRESENT but wrong (extra field, misordered fields) is a
+		// genuine contract violation and still fails closed at both boundaries.
+		for (const text of [
+			`${header} | extra\n${row}`,
+			`${misorderedHeader}\n${row}`,
+		]) {
+			const parsed = parse(text);
 			expect(parsed.candidates).toEqual([]);
 			expect(parsed.error_code).toBe('invalid-candidate-header');
 			expect(prReviewDiscoveryArtifactCoversLane(text, lane)).toBe(false);
 		}
+
+		// A header that is ABSENT, alongside a valid marker-bearing row, is now
+		// repaired so the lane's real findings survive (approved salvage). The raw
+		// parser still refuses it; only the PR-review boundary, which normalizes
+		// the artifact first, accepts.
+		const absentHeader = `[CANDIDATE] | ${row}`;
+		const parsedAbsent = parse(absentHeader);
+		expect(parsedAbsent.candidates).toEqual([]);
+		expect(parsedAbsent.error_code).toBe('invalid-candidate-header');
+		expect(prReviewDiscoveryArtifactCoversLane(absentHeader, lane)).toBe(true);
 	});
 
 	test('uses the shared exact header analyzer at both trust boundaries', () => {
@@ -387,13 +403,31 @@ describe('shared candidate and CLEAN semantics', () => {
 		).toBe(true);
 	});
 
-	test('rejects a candidate from a NOT_TRIGGERED micro family outside ownership', () => {
+	test('never credits a micro family outside ownership, even while salvaging', () => {
 		const text = `${MICRO_HEADER}\nM-AUTH | auth-identity-secrets | HIGH | security | src/auth.ts:1 | claim | invariant | auth evidence | HIGH\nM-PRIVACY | privacy-observability | HIGH | privacy | src/log.ts:1 | claim | invariant | privacy evidence | HIGH`;
+		// The owned row is real work and now establishes coverage (approved
+		// salvage) instead of being discarded because a foreign row sits beside it.
 		expect(
 			prReviewDiscoveryArtifactCoversLane(text, 'auth-identity-secrets', [
 				'auth-identity-secrets',
 			]),
-		).toBe(false);
+		).toBe(true);
+		// The integrity property that must NOT move: when a source is scoped to the
+		// lanes it owns, the out-of-ownership row is excluded from the credited
+		// inventory.
+		expect(
+			_test_exports.extractCandidateIds(text, 'micro_lane', [
+				'auth-identity-secrets',
+			]),
+		).toEqual(['M-AUTH']);
+		// Unscoped extraction is intentional for full-ownership sources (a
+		// subagent's inconsistent lane labelling must not silently drop a real
+		// candidate), so it keeps both rows. Pinned so the difference between the
+		// two shapes is explicit rather than accidental.
+		expect(_test_exports.extractCandidateIds(text, 'micro_lane')).toEqual([
+			'M-AUTH',
+			'M-PRIVACY',
+		]);
 		expect(
 			prReviewDiscoveryArtifactCoversLane(text, 'auth-identity-secrets', [
 				'auth-identity-secrets',
@@ -402,12 +436,18 @@ describe('shared candidate and CLEAN semantics', () => {
 		).toBe(true);
 	});
 
-	test('rejects an unprefixed short foreign row after a valid owned candidate', () => {
+	test('retains a valid owned candidate despite a short foreign row', () => {
 		const text = `${BASE_HEADER}\nC-OWNED | intent-architecture | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH\nC-FOREIGN | security-trust | HIGH`;
 		expect(
 			prReviewDiscoveryArtifactCoversLane(text, 'intent-architecture', [
 				'intent-architecture',
 			]),
-		).toBe(false);
+		).toBe(true);
+		// The malformed foreign row contributes nothing to the inventory.
+		expect(
+			_test_exports.extractCandidateIds(text, 'base_explorer', [
+				'intent-architecture',
+			]),
+		).toEqual(['C-OWNED']);
 	});
 });

--- a/tests/unit/background/candidate-parser-phase4-contract.test.ts
+++ b/tests/unit/background/candidate-parser-phase4-contract.test.ts
@@ -15,6 +15,7 @@ import {
 	parseAndPersist,
 	parseCandidates,
 } from '../../../src/background/candidate-parser';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const tempDirs: string[] = [];
 const digest = createHash('sha256').update('phase4').digest('hex');
@@ -288,5 +289,32 @@ describe('candidate parser Phase 4 contract', () => {
 		) as ReturnType<typeof parseCandidates> & { clean_attestation?: unknown };
 		expect(result.candidates).toEqual([]);
 		expect(result.clean_attestation).toBeUndefined();
+	});
+
+	test('parseAndPersist repairs an absent header while the pure parser does not', () => {
+		// The tool boundary normalizes so a caller cannot be refused findings from a
+		// lane the PR-review gate already credited. The pure parser deliberately does
+		// NOT synthesize a header, so the two must disagree on the same input — that
+		// asymmetry is the contract, and this pins both halves of it.
+		const headerless =
+			'[CANDIDATE] | M-1 | subprocess | HIGH | correctness | src/a.ts:1 | claim text | invariant text | evidence text | HIGH';
+		const parserFlags = flags({
+			expected_family: 'micro_lane',
+			expected_micro_lane: 'subprocess',
+		});
+
+		const pure = parseCandidates(input(headerless), parserFlags);
+		expect(pure.candidates).toEqual([]);
+		expect(pure.error_code).toBe('invalid-candidate-header');
+
+		// Use the shared canonicalizing helper: it closes the macOS
+		// /var -> /private/var symlink gap that FR-011 exists to enforce.
+		const boundaryRoot = canonicalMkdtemp('phase4-repair-');
+		tempDirs.push(boundaryRoot);
+		const boundary = parseAndPersist(input(headerless), parserFlags, {
+			projectRoot: boundaryRoot,
+		});
+		expect(boundary.candidates).toHaveLength(1);
+		expect(boundary.candidates[0].candidate_id).toBe('M-1');
 	});
 });

--- a/tests/unit/background/pending-delegations.test.ts
+++ b/tests/unit/background/pending-delegations.test.ts
@@ -244,4 +244,32 @@ describe('pending-delegations store', () => {
 		expect(second?.status).toBe('completed');
 		expect(findByCorrelationId(dir, 'ses_done')?.result?.text).toBe('done');
 	});
+
+	it('round-trips salvagedWorkflowLanes instead of dropping the whole record', async () => {
+		// ResultSchema is .strict() and readDelegations safeParse-skips records it
+		// rejects, while appendRecord writes without validating. An undeclared
+		// result field is therefore written to disk and then silently invisible to
+		// every reader — which would make a successfully salvaged PR-review lane
+		// look like one that never reached a terminal state.
+		await recordPendingDelegation(
+			dir,
+			input({ correlationId: 'ses_salvaged' }),
+		);
+		await appendDelegationTransition(dir, 'ses_salvaged', {
+			status: 'completed',
+			result: {
+				text: 'salvaged output',
+				chars: 15,
+				truncated: false,
+				digest: 'd'.repeat(64),
+				salvagedWorkflowLanes: ['correctness-state'],
+			},
+		});
+
+		const record = findByCorrelationId(dir, 'ses_salvaged');
+		expect(record?.status).toBe('completed');
+		expect(record?.result?.salvagedWorkflowLanes).toEqual([
+			'correctness-state',
+		]);
+	});
 });

--- a/tests/unit/hooks/pr-workflow-gate-candidate-semantics.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-candidate-semantics.test.ts
@@ -76,7 +76,7 @@ describe('PR-review candidate semantics at the coverage gate', () => {
 		expect(diagnostic).not.toContain('x'.repeat(1_000));
 	});
 
-	test('refuses coverage when a valid owned candidate is followed by a malformed owned candidate', async () => {
+	test('retains coverage when a valid owned candidate is followed by a malformed owned candidate', async () => {
 		await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
 		const [malformedDimension, ...remainingDimensions] =
 			PR_REVIEW_BASE_DIMENSION_IDS;
@@ -110,9 +110,23 @@ describe('PR-review candidate semantics at the coverage gate', () => {
 			remainingLanes,
 		);
 
+		// Approved salvage: one malformed row no longer destroys the lane's valid
+		// finding. The VALID row establishes coverage; the malformed row is
+		// reported as a diagnostic and contributes nothing to the inventory.
 		await expect(
 			assertPrReviewBaseCoverageSettled(tempDir, SESSION_ID),
-		).rejects.toThrow(/row 3 field severity: Invalid severity: URGENT/);
+		).resolves.toBeDefined();
+		expect(
+			_test_exports.extractCandidateIds(
+				[
+					BASE_HEADER,
+					`VALID | ${malformedDimension} | HIGH | correctness | src/a.ts:1 | valid claim | valid evidence | valid impact | HIGH`,
+					`MALFORMED | ${malformedDimension} | URGENT | correctness | src/a.ts:2 | dropped claim | dropped evidence | dropped impact | HIGH`,
+				].join('\n'),
+				'base_explorer',
+				[malformedDimension],
+			),
+		).toEqual(['VALID']);
 	});
 
 	test('Tier M preserves earlier valid evidence when a later retry is malformed', async () => {

--- a/tests/unit/hooks/pr-workflow-gate-discovery-salvage.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-discovery-salvage.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Discovery-artifact salvage (issue: PR-review workflow could not complete).
+ *
+ * A lane's findings used to be discarded wholesale when its output was merely
+ * mis-presented — a missing canonical header, or one malformed row beside valid
+ * ones. Measured on PR #2090: 14 lanes failed, 59 findings were thrown away, and
+ * none of the failures were analysis failures.
+ *
+ * Kept in a dedicated file because the sibling gate suites are close to the
+ * FR-006 500-line cap (scripts/check-test-file-cap.sh).
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+	analyzeCleanFields,
+	CANDIDATE_HEADERS,
+	normalizeCandidateArtifact,
+	splitPipeFields,
+} from '../../../src/background/candidate-contract.js';
+import {
+	_test_exports,
+	prReviewDiscoveryArtifactCoversLane,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { EXPLORER_CANDIDATE_FORMAT_SUFFIX } from '../../../src/tools/dispatch-lanes.js';
+
+const { extractCandidateIds, resolvePrReviewRowFamily } = _test_exports;
+
+const BASE_HEADER = CANDIDATE_HEADERS.base_explorer;
+const MICRO_HEADER = CANDIDATE_HEADERS.micro_lane;
+const BASE_LANE = 'correctness-state';
+const MICRO_LANE = 'concurrency-state';
+
+const baseRow = (id: string, lane = BASE_LANE) =>
+	`[CANDIDATE] | ${id} | ${lane} | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH`;
+const microRow = (id: string, lane = MICRO_LANE) =>
+	`[CANDIDATE] | ${id} | ${lane} | HIGH | concurrency | src/a.ts:1 | claim | invariant | evidence | HIGH`;
+
+describe('discovery artifact salvage', () => {
+	test('repairs an absent header and reports the repair', () => {
+		const text = `some prose the explorer wrote first\n${baseRow('C-1')}`;
+		const normalized = normalizeCandidateArtifact(text, 'base_explorer');
+		expect(normalized.synthesizedHeader).toBe(true);
+		// The header is inserted immediately before the first salvageable row, not
+		// at the top: prepending would push the explorer's leading prose below the
+		// header, where every prose line counts as a malformed row.
+		expect(normalized.text.split('\n')).toEqual([
+			'some prose the explorer wrote first',
+			BASE_HEADER,
+			baseRow('C-1'),
+		]);
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(true);
+	});
+
+	test('repairs a headerless zero-findings CLEAN attestation', () => {
+		// The shape that blocked the real PR #2090 run for three consecutive
+		// attempts: a lane that correctly found nothing, wrote a well-formed
+		// lane-bound CLEAN, and omitted only the canonical header. One unresolved
+		// micro source fails the entire workflow, so this single lane was the
+		// terminal blocker.
+		const clean = `[CLEAN] | ${MICRO_LANE} | all changed concurrency paths | no candidate survived caller and sibling checks`;
+		const text = `analysis prose from the lane\n${clean}`;
+		const normalized = normalizeCandidateArtifact(text, 'micro_lane');
+		expect(normalized.synthesizedHeader).toBe(true);
+		expect(prReviewDiscoveryArtifactCoversLane(text, MICRO_LANE)).toBe(true);
+		// A CLEAN lane legitimately contributes zero candidate ids.
+		expect(extractCandidateIds(text, 'micro_lane', [MICRO_LANE])).toEqual([]);
+	});
+
+	test('does not repair a CLEAN attestation bound to a different lane', () => {
+		const clean = `[CLEAN] | ${MICRO_LANE} | all changed concurrency paths | no candidate survived caller and sibling checks`;
+		expect(
+			prReviewDiscoveryArtifactCoversLane(clean, 'privacy-observability'),
+		).toBe(false);
+	});
+
+	test('refuses to repair when no marker-bearing row is valid', () => {
+		const text = 'prose only, no rows at all';
+		expect(
+			normalizeCandidateArtifact(text, 'base_explorer').synthesizedHeader,
+		).toBe(false);
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(false);
+	});
+
+	test('leaves a declared other-family header alone so family mismatch still fires', () => {
+		// A micro lane that declared the base family must not be silently promoted
+		// into the micro family by header synthesis.
+		const text = `${BASE_HEADER}\n${microRow('M-1')}`;
+		expect(
+			normalizeCandidateArtifact(text, 'micro_lane').synthesizedHeader,
+		).toBe(false);
+		expect(prReviewDiscoveryArtifactCoversLane(text, MICRO_LANE)).toBe(false);
+	});
+
+	test('does not let a later canonical header rescue a malformed first marker', () => {
+		const text = `[CANDIDATE] | not | a | header\n${BASE_HEADER}\n${baseRow('C-1')}`;
+		expect(
+			normalizeCandidateArtifact(text, 'base_explorer').synthesizedHeader,
+		).toBe(false);
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(false);
+	});
+
+	test('honours the family a fenced header declared, even though the fence deleted it', () => {
+		// Fence-stripping removes the header before it can be read, so the family it
+		// declared is recovered from the pre-strip source. A DIFFERENT family must
+		// still fail closed.
+		const conflicting = `\`\`\`text\n${BASE_HEADER}\n\`\`\`\n${microRow('M-1')}`;
+		expect(
+			normalizeCandidateArtifact(conflicting, 'micro_lane').synthesizedHeader,
+		).toBe(false);
+		expect(prReviewDiscoveryArtifactCoversLane(conflicting, MICRO_LANE)).toBe(
+			false,
+		);
+
+		// The SAME family declares nothing in conflict, so refusing would discard
+		// the lane's findings for no reason.
+		const agreeing = `\`\`\`text\n${MICRO_HEADER}\n\`\`\`\n${microRow('M-1')}`;
+		expect(
+			normalizeCandidateArtifact(agreeing, 'micro_lane').synthesizedHeader,
+		).toBe(true);
+		expect(prReviewDiscoveryArtifactCoversLane(agreeing, MICRO_LANE)).toBe(
+			true,
+		);
+	});
+
+	test('retains valid rows when another row is malformed', () => {
+		const text = [
+			BASE_HEADER,
+			baseRow('C-GOOD'),
+			`[CANDIDATE] | C-BAD | ${BASE_LANE} | NOT_A_SEVERITY | correctness | src/a.ts:2 | claim | evidence | impact | HIGH`,
+		].join('\n');
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(true);
+		expect(extractCandidateIds(text, 'base_explorer', [BASE_LANE])).toEqual([
+			'C-GOOD',
+		]);
+	});
+
+	test('never salvages duplicate candidate ids', () => {
+		// The inventory these feed is asserted globally unique, so admitting them
+		// would convert a lane defect into a late workflow-wide failure.
+		const text = [BASE_HEADER, baseRow('C-DUP'), baseRow('C-DUP')].join('\n');
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(false);
+	});
+
+	test('never salvages an id reused across an owned and a foreign row', () => {
+		// Regression: the duplicate check once read the parser's diagnostics, but a
+		// foreign-lane row is dropped before the parser's duplicate detector runs,
+		// so no duplicate diagnostic existed — while extraction (deliberately
+		// unscoped) kept BOTH rows and the id collision surfaced later as a
+		// workflow-wide BLOCKED throw. The check must see what extraction sees.
+		const text = [
+			BASE_HEADER,
+			baseRow('C-DUP'),
+			baseRow('C-DUP', 'security-trust'),
+		].join('\n');
+		// Unscoped extraction is the production shape for full-ownership sources.
+		expect(extractCandidateIds(text, 'base_explorer')).toEqual([
+			'C-DUP',
+			'C-DUP',
+		]);
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(false);
+	});
+
+	test('retains candidates when the CLEAN attestation is defective', () => {
+		// A CLEAN row carrying a fourth field discredits the attestation, not the
+		// findings beside it.
+		const text = [
+			MICRO_HEADER,
+			microRow('M-1'),
+			`[CLEAN] | ${MICRO_LANE} | coverage scope text | evidence text that is long enough | MEDIUM`,
+		].join('\n');
+		expect(prReviewDiscoveryArtifactCoversLane(text, MICRO_LANE)).toBe(true);
+		expect(extractCandidateIds(text, 'micro_lane', [MICRO_LANE])).toEqual([
+			'M-1',
+		]);
+	});
+});
+
+describe('coverage and inventory cannot disagree (recurrence guardrail)', () => {
+	// The defect this pins: coverage validation and candidate-id extraction were
+	// two separate parses of the same artifact under different rules, so a lane
+	// could be judged "covered" while contributing zero findings — which would
+	// have shipped a green review reporting nothing on a PR full of findings.
+	const permutations: ReadonlyArray<readonly [string, string, string]> = [
+		['canonical', BASE_LANE, `${BASE_HEADER}\n${baseRow('C-1')}`],
+		['no header', BASE_LANE, baseRow('C-1')],
+		['prose then rows', BASE_LANE, `analysis prose\n${baseRow('C-1')}`],
+		[
+			'valid plus malformed',
+			BASE_LANE,
+			`${BASE_HEADER}\n${baseRow('C-1')}\n[CANDIDATE] | C-2 | ${BASE_LANE} | BAD | c | src/a.ts:2 | x | y | z | HIGH`,
+		],
+		[
+			'valid plus stray pipe row',
+			BASE_LANE,
+			`${BASE_HEADER}\n${baseRow('C-1')}\n[CANDIDATE] | C-3 | ${BASE_LANE} | HIGH | c | src/a.ts:3 | has | pipe | in | prose | HIGH`,
+		],
+		[
+			'foreign lane row',
+			BASE_LANE,
+			`${BASE_HEADER}\n${baseRow('C-1')}\n${baseRow('C-F', 'security-trust')}`,
+		],
+		[
+			'duplicate ids',
+			BASE_LANE,
+			`${BASE_HEADER}\n${baseRow('C-1')}\n${baseRow('C-1')}`,
+		],
+		['wrong family header', MICRO_LANE, `${BASE_HEADER}\n${microRow('M-1')}`],
+		['micro no header', MICRO_LANE, microRow('M-1')],
+		[
+			'markerless only',
+			BASE_LANE,
+			`C-1 | ${BASE_LANE} | HIGH | c | src/a.ts:1 | x | y | z | HIGH`,
+		],
+		['empty', BASE_LANE, ''],
+		[
+			'headerless malformed row before a valid one',
+			BASE_LANE,
+			`[CANDIDATE] | C-BAD | ${BASE_LANE} | HIGH | c | src/a.ts:1 | has | a | stray | pipe | HIGH\n${baseRow('C-OK')}`,
+		],
+		[
+			'headerless CLEAN',
+			MICRO_LANE,
+			`[CLEAN] | ${MICRO_LANE} | all changed concurrency paths | no candidate survived caller and sibling checks`,
+		],
+	];
+
+	for (const [name, lane, text] of permutations) {
+		test(`covered implies extractable findings — ${name}`, () => {
+			const covered = prReviewDiscoveryArtifactCoversLane(text, lane);
+			const ids = extractCandidateIds(text, resolvePrReviewRowFamily(lane), [
+				lane,
+			]);
+			// A CLEAN-attested lane legitimately yields zero ids — that is what a
+			// zero-findings attestation means — so the invariant is
+			// `covered ∧ ¬cleanAttested ⟹ ids > 0`. The exemption is derived from a
+			// VALIDATED, lane-matching attestation rather than any line that merely
+			// starts with the marker: a syntactic check would let a contrived
+			// fixture carrying a malformed [CLEAN] exempt itself and silently
+			// weaken the table.
+			const cleanAttested = text.split('\n').some((line) => {
+				const fields = splitPipeFields(line.trim()).map((f) => f.trim());
+				if (fields[0] !== '[CLEAN]') return false;
+				return analyzeCleanFields(fields, resolvePrReviewRowFamily(lane), lane)
+					.valid;
+			});
+			if (covered && !cleanAttested) expect(ids.length).toBeGreaterThan(0);
+		});
+	}
+
+	test('a defective CLEAN no longer discards the candidate rows beside it', () => {
+		// Pins the shared parser's acceptance behaviour through the gate boundary
+		// (coverage + id extraction) rather than by calling parseCandidates itself,
+		// so it exercises the path production uses. A CLEAN row carrying an extra
+		// confidence field discredits the attestation; the independently validated
+		// candidate row beside it must survive. Reverting
+		// `acceptedCandidates = candidates` in candidate-parser.ts fails this.
+		const text = [
+			BASE_HEADER,
+			baseRow('C-KEEP'),
+			`[CLEAN] | ${BASE_LANE} | all changed correctness paths | no candidate survived caller checks | HIGH`,
+		].join('\n');
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(true);
+		expect(extractCandidateIds(text, 'base_explorer', [BASE_LANE])).toEqual([
+			'C-KEEP',
+		]);
+	});
+
+	test('a headerless CLEAN covers its lane while contributing no ids', () => {
+		// The newly-reachable branch: covered with an empty inventory. Pinned so a
+		// future change that makes a CLEAN silently stop attesting is caught.
+		const text = `[CLEAN] | ${MICRO_LANE} | all changed concurrency paths | no candidate survived caller and sibling checks`;
+		expect(prReviewDiscoveryArtifactCoversLane(text, MICRO_LANE)).toBe(true);
+		expect(extractCandidateIds(text, 'micro_lane', [MICRO_LANE])).toEqual([]);
+	});
+
+	test('salvages a valid row that sits behind a malformed marker line', () => {
+		// Regression for the insertion-point choice: the header must go ABOVE the
+		// first marker-bearing line, not above the first VALID one. Otherwise the
+		// malformed marker stays authoritative and the whole artifact fails —
+		// exactly where headerless and unescaped-pipe failures overlap.
+		const text = `[CANDIDATE] | C-BAD | ${BASE_LANE} | HIGH | c | src/a.ts:1 | has | a | stray | pipe | HIGH\n${baseRow('C-OK')}`;
+		expect(prReviewDiscoveryArtifactCoversLane(text, BASE_LANE)).toBe(true);
+		expect(extractCandidateIds(text, 'base_explorer', [BASE_LANE])).toEqual([
+			'C-OK',
+		]);
+	});
+
+	test('both call sites derive the same row family for a lane', () => {
+		expect(resolvePrReviewRowFamily(BASE_LANE)).toBe('base_explorer');
+		expect(resolvePrReviewRowFamily(MICRO_LANE)).toBe('micro_lane');
+	});
+
+	test('a council lane named after a base dimension still resolves micro (M1)', () => {
+		// Regression for the last coverage/extraction divergence. Council lanes emit
+		// the MICRO row family whatever they are called, so a council lane labelled
+		// with a base dimension id must not resolve base_explorer at the coverage
+		// site while the extraction site resolves micro_lane — that mismatch let a
+		// lane be judged covered while contributing nothing to the inventory.
+		expect(resolvePrReviewRowFamily(BASE_LANE, 'swarm-pr-review:council')).toBe(
+			'micro_lane',
+		);
+		// Mode is authoritative over the lane label in both directions.
+		expect(resolvePrReviewRowFamily(MICRO_LANE, 'swarm-pr-review:base')).toBe(
+			'base_explorer',
+		);
+		// A micro-family artifact from a council lane named after a base dimension
+		// is now accepted, because coverage resolves the same family extraction will.
+		const text = microRow('M-1', BASE_LANE);
+		expect(
+			prReviewDiscoveryArtifactCoversLane(
+				text,
+				BASE_LANE,
+				[BASE_LANE],
+				'swarm-pr-review:council',
+			),
+		).toBe(true);
+		expect(extractCandidateIds(text, 'micro_lane', [BASE_LANE])).toEqual([
+			'M-1',
+		]);
+	});
+
+	test('resolves the dispatch-mode fallback the way each mode actually emits rows', () => {
+		// Sources without a workflowLane carry only a dispatch laneId, which is not
+		// a dimension id. The fallback must follow the dispatch output contract:
+		// council lanes emit the MICRO row family, not the base one. Getting this
+		// wrong re-opens the coverage/extraction split for council lanes.
+		expect(resolvePrReviewRowFamily(undefined, 'swarm-pr-review:base')).toBe(
+			'base_explorer',
+		);
+		expect(resolvePrReviewRowFamily(undefined, 'swarm-pr-review:micro')).toBe(
+			'micro_lane',
+		);
+		expect(resolvePrReviewRowFamily(undefined, 'swarm-pr-review:council')).toBe(
+			'micro_lane',
+		);
+	});
+});
+
+describe('explorer output contract as rendered', () => {
+	test('teaches escaping with a real backslash, not a dropped one', () => {
+		// `\|` in a template literal renders as a bare `|` — which would instruct
+		// lanes to emit precisely the character that splits a row into an extra
+		// field. This asserts the RENDERED string, which is what lanes receive.
+		expect(EXPLORER_CANDIDATE_FORMAT_SUFFIX).toContain('\\|');
+	});
+
+	test('leads with the canonical header and a worked example', () => {
+		const headerIndex = EXPLORER_CANDIDATE_FORMAT_SUFFIX.indexOf(BASE_HEADER);
+		expect(headerIndex).toBeGreaterThan(-1);
+		expect(EXPLORER_CANDIDATE_FORMAT_SUFFIX).toContain('WORKED EXAMPLE');
+		// The worked example must precede the per-family reference blocks, because
+		// a header restated only as a format spec was measured at ~1/6 compliance.
+		expect(
+			EXPLORER_CANDIDATE_FORMAT_SUFFIX.indexOf('WORKED EXAMPLE'),
+		).toBeLessThan(
+			EXPLORER_CANDIDATE_FORMAT_SUFFIX.indexOf('Micro-lane format'),
+		);
+	});
+
+	test('states the CLEAN row shape and its zero-findings-only rule', () => {
+		expect(EXPLORER_CANDIDATE_FORMAT_SUFFIX).toContain('NO\nconfidence field');
+		expect(EXPLORER_CANDIDATE_FORMAT_SUFFIX).toContain('never alongside');
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-lane-validation-predicates.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-lane-validation-predicates.test.ts
@@ -308,4 +308,34 @@ describe('PR review lane-local validation predicates', () => {
 		expect(message.length).toBeLessThanOrEqual(1_000);
 		expect(message).not.toContain('x'.repeat(1_000));
 	});
+
+	test('announces a salvaged artifact instead of accepting it silently', () => {
+		// A marker-bearing row with no canonical header — the shape that used to
+		// discard an entire lane's findings. It is now accepted, so the repair must
+		// be observable rather than indistinguishable from well-formed output.
+		const text = `[CANDIDATE] | C-1 | ${LANE} | HIGH | correctness | src/a.ts:1 | claim | evidence | impact | HIGH`;
+		const input = validInput();
+		input.result!.text = text;
+		input.result!.chars = text.length;
+		input.artifact!.text = text;
+		input.artifact!.chars = text.length;
+		input.artifact!.bytes = text.length;
+
+		// Asserted on the returned value rather than a console spy: the logger is
+		// mock.module'd by several sibling suites and OPENCODE_SWARM_DEBUG (which
+		// gates warn()) is mutated by many more, so a spy-based assertion passes in
+		// isolation and fails in a shared runner. A structural signal is both
+		// testable and consumable by callers.
+		const result = validatePrReviewDiscoveryLaneCompletion(input);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.salvaged).toEqual([LANE]);
+	});
+
+	test('does not mark a well-formed artifact as salvaged', () => {
+		const result = validatePrReviewDiscoveryLaneCompletion(validInput());
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.salvaged).toBeUndefined();
+	});
 });

--- a/tests/unit/hooks/pr-workflow-gate-review-validation-dedup.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-review-validation-dedup.test.ts
@@ -164,9 +164,24 @@ describe('pr-workflow-gate candidate inventory deduplication', () => {
 		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
 	});
 
-	test('rejects a mislabeled candidate in a singleton base lane at the coverage gate', async () => {
+	test('salvages a singleton base lane whose second row is lane-mislabeled', async () => {
+		// Intent change (approved salvage). The fixture is one correctly-labeled row
+		// plus a second, well-formed row for the same dispatch whose lane label has
+		// a typo — the fixture's own comment calls this "a realistic case of a
+		// subagent finding two issues in one dispatch and being inconsistent about
+		// the exact label on the second one".
+		//
+		// This previously threw 'Expected lane intent-architecture' and discarded
+		// BOTH findings. Coverage is still established only by the correctly-labeled
+		// row, so the proof-of-work bar has not moved; the mislabeled row is now a
+		// diagnostic rather than a lane-killer, and extraction (deliberately
+		// unscoped for full-ownership sources) still carries it into the inventory
+		// so the finding is reviewed instead of silently lost.
 		await expect(
 			establishReviewPrerequisitesWithMislabeledSingletonLane(),
-		).rejects.toThrow('Expected lane intent-architecture');
+		).resolves.toMatchObject({
+			coveringCandidateId: 'C-COVERING',
+			mislabeledCandidateId: 'C-MISLABELED',
+		});
 	});
 });

--- a/tests/unit/tools/dispatch-lanes-explorer-format.test.ts
+++ b/tests/unit/tools/dispatch-lanes-explorer-format.test.ts
@@ -156,4 +156,34 @@ describe('applyExplorerFormatSuffix', () => {
 		);
 		expect(result.errors.join('; ').length).toBeLessThan(300);
 	});
+
+	test('delivers the hardened format rules into the composed lane prompt', () => {
+		// Scope note: this asserts DELIVERY, not compliance. Whether a lane obeys
+		// the contract cannot be unit-tested — the measured evidence for that is the
+		// real-run replay in 08-test-results.md. What is testable, and what was
+		// previously untested, is that the three rules added after the PR #2090
+		// analysis actually reach the prompt a lane receives.
+		_internals.getGeneratedAgentNames = () => ['swarm_explorer'];
+		const [lane] = applyExplorerFormatSuffix([
+			{ id: 'L1', agent: 'swarm_explorer', prompt: 'inspect the diff' },
+		]);
+
+		// 1. Pipe escaping — the rule that 3 of the 14 real failures needed. Must
+		// carry a literal backslash: `\|` in a template literal renders as a bare
+		// `|`, which would instruct lanes to emit the character that breaks a row.
+		expect(lane.prompt).toContain('\\|');
+		// 2. A worked example, placed before the per-family reference blocks. A
+		// header restated only as a format spec measured ~1/6 compliance.
+		expect(lane.prompt).toContain('WORKED EXAMPLE');
+		expect(lane.prompt.indexOf('WORKED EXAMPLE')).toBeLessThan(
+			lane.prompt.indexOf('Micro-lane format'),
+		);
+		// 3. The [CLEAN] shape — no confidence field, zero-findings only. A
+		// confidence appended to CLEAN caused 4 of the real failures.
+		expect(lane.prompt).toContain('NO\nconfidence field');
+		expect(lane.prompt).toContain('never alongside');
+		// The example id obeys the uniqueness rule stated below it, so a lane that
+		// copies it verbatim cannot collide at assertNoDuplicates.
+		expect(lane.prompt).toContain('example-lane-001 | example-lane');
+	});
 });

--- a/tests/unit/tools/dispatch-lanes-pr-review-collection-validation.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-collection-validation.test.ts
@@ -9,7 +9,10 @@ import {
 	readLaneOutput,
 	storeLaneOutput,
 } from '../../../src/background/lane-output-store.js';
-import { recordPendingDelegation } from '../../../src/background/pending-delegations.js';
+import {
+	findByCorrelationId,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
 import {
 	_internals,
 	_test_exports,
@@ -305,5 +308,31 @@ describe('PR-review discovery validation during collection', () => {
 		expect(result.success).toBe(true);
 		expect(result.completed).toBe(1);
 		expect(result.lane_results[0].output).toBe('ordinary advisory prose');
+	});
+
+	test('persists salvagedWorkflowLanes to the ledger through the real collect path', async () => {
+		// End-to-end wiring guard. The pending-delegations round-trip test passes the
+		// field straight to appendDelegationTransition, so it cannot catch a break in
+		// the assignment inside collectOnce that actually derives it from
+		// validation.salvaged — this test drives the real collect path instead.
+		const session = 'session-salvage-ledger-salvage-lane';
+		await recordLane({
+			batch: 'salvage-ledger',
+			lane: 'salvage-lane',
+			mode: 'swarm-pr-review:base',
+			workflowLane: 'intent-architecture',
+			// Headerless but salvageable: one valid row, canonical header absent.
+			text: 'prose the explorer wrote first\n[CANDIDATE] | S-1 | intent-architecture | HIGH | correctness | src/a.ts:1 | claim text | evidence text | impact text | HIGH',
+		});
+
+		const result = await collect('salvage-ledger');
+		expect(result.success).toBe(true);
+		expect(result.completed).toBe(1);
+
+		const record = findByCorrelationId(directory, session);
+		expect(record?.status).toBe('completed');
+		expect(record?.result?.salvagedWorkflowLanes).toEqual([
+			'intent-architecture',
+		]);
 	});
 });

--- a/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
@@ -291,7 +291,7 @@ describe('PR review council mechanical dispatch', () => {
 		);
 	});
 
-	test('rejects a marker header without a data row or lane-bound CLEAN attestation', () => {
+	test('rejects a marker header with no attestation but accepts a headerless CLEAN', () => {
 		expect(
 			prReviewDiscoveryArtifactCoversLane(
 				'[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence | impact | confidence',
@@ -300,9 +300,21 @@ describe('PR review council mechanical dispatch', () => {
 		).toBe(false);
 		const clean =
 			'[CLEAN] | intent-architecture | all changed architecture paths | no candidate survived caller and sibling checks';
+		// Intent change (approved salvage): a lane that correctly found nothing and
+		// said so, but omitted the canonical header, is now repaired rather than
+		// discarded. This exact shape — a well-formed lane-bound CLEAN with no
+		// header — failed three consecutive attempts on the real PR #2090 run and
+		// was the single lane that blocked it, because one unresolved micro source
+		// fails the whole workflow. The bar is unchanged: coverage_scope and
+		// evidence must still clear their length floors and the lane must match, so
+		// the header was never the thing proving work had been done.
 		expect(
 			prReviewDiscoveryArtifactCoversLane(clean, 'intent-architecture'),
-		).toBe(false);
+		).toBe(true);
+		// Still refused: a CLEAN whose lane does not match the expected lane.
+		expect(prReviewDiscoveryArtifactCoversLane(clean, 'security-trust')).toBe(
+			false,
+		);
 		expect(
 			prReviewDiscoveryArtifactCoversLane(
 				`[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence\n${clean}`,

--- a/tests/unit/tools/dispatch-lanes.test.ts
+++ b/tests/unit/tools/dispatch-lanes.test.ts
@@ -1147,7 +1147,7 @@ describe('executeDispatchLanesAsync and executeCollectLaneResults', () => {
 			'inspect runtime',
 		);
 		expect(promptAsyncCalls[0][0].body.parts[0].text).toContain(
-			'one unprefixed data row per finding',
+			'is the literal column header',
 		);
 		expect(promptAsyncCalls[0][0].body.parts[0].text).toContain(
 			'[CLEAN] | lane | coverage_scope | evidence',


### PR DESCRIPTION
Follow-on work tracked in #2114 (this PR does not close it).

## Summary

- A PR-review lane's findings were discarded wholesale when its output was merely
  mis-presented. Measured on a real run, reconstructed from
  `.swarm/background-delegations.jsonl`: **99.3 min, 31 lane dispatches, 16 errored
  lane instances, 59 substantive findings discarded, 0 artifacts persisted.** None
  of the failures were analysis failures — all were text-format failures on the
  positional pipe-delimited candidate protocol, validated with no salvage.
- Normalize the artifact **once** (`normalizeCandidateArtifact`) and apply it at
  every consumer, so coverage validation and candidate-id extraction can no longer
  disagree. Previously a lane could be judged covered while contributing zero
  findings to the inventory — which would surface as a green review reporting
  nothing.
- Repair an absent canonical header when at least one valid row **or** a well-formed
  lane-bound `[CLEAN]` attestation is present, inserting it before the first
  marker-bearing line. Tolerate malformed rows when valid rows establish coverage.
  Duplicate `candidate_id`s stay non-salvageable, checked against the extractor's
  rows so a foreign-lane row cannot hide a collision.
- Stop discarding valid candidates when a `[CLEAN]` attestation is defective — a bad
  attestation discredits the attestation, not independently validated findings.
- Resolve the row family by one **mode-first** rule, so the coverage and extraction
  sites share a derivation instead of computing it from different inputs.
- Record repaired lanes as `salvagedWorkflowLanes` on the durable delegation ledger,
  declared in the `.strict()` schema so the record is not silently dropped at read.
- Harden the explorer output contract: teach `\|` escaping (previously untaught
  though the parser supports it), lead with a worked example, state the `[CLEAN]`
  row shape.

**Result against the real artifacts: 9 of 16 errored lane instances now settle,
including the single lane whose repeated failure ended the run.**

**Four** previously-pinned validation behaviours were deliberately relaxed, each
flipped explicitly with its reasoning and real-run consequence recorded in the test
body: an absent header is repaired; a valid row followed by a malformed row
establishes coverage; a headerless `[CLEAN]` establishes coverage; and a lane whose
*second* row is lane-mislabeled is no longer discarded when a correctly-labeled row
already covers the dimension. The fourth was surfaced by CI rather than by local
scoping — see the note below.

The proof-of-work bar is unchanged: coverage still requires a semantically valid row
whose lane matches, or a `[CLEAN]` clearing its `coverage_scope` and `evidence`
length floors. A wrong or late header, a foreign-lane attestation, a cross-family
artifact, and duplicate candidate ids all still fail closed.

## Invariant audit

- 1 (plugin init): not touched - no init-path code changed; all changed functions run
  during PR-review execution, not plugin registration. Verified anyway:
  `node scripts/repro-704.mjs` → T1 500-file tight deadline resolved in **260.0 ms**
  (deadline 400 ms), T2 209.5 ms, T3 205.3 ms.
- 2 (runtime portability): touched - changed `src/` modules ship in `dist/index.js`.
  No `bun:` imports, no `Bun.*` calls, no plugin-entry-shape change; additions are
  plain TS plus one zod field. `bun run build` succeeded;
  `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`;
  `tests/unit/build/bundle-portability.test.ts` + `bundle-plugin-shape.test.ts` →
  **12 pass / 0 fail**. `dist/` not staged.
- 3 (subprocesses): not touched -
  `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("`
  → no matches; no external command introduced.
- 4 (.swarm containment): touched - `salvagedWorkflowLanes` is written into the
  existing `.swarm/background-delegations.jsonl` through the existing
  `appendDelegationTransition` path. No new file, directory, or path construction; no
  new `process.cwd()` caller.
- 5 (plan durability): not touched - no change to `plan-ledger.jsonl`, `plan.json`,
  `plan.md`, plan schema, ledger replay, projection, checkpoint import/export, or
  `get_approved_plan`. The delegation ledger is a separate store.
- 6 (test_runner safety): not touched - no `test_runner` invocation. Validation ran
  through `bun run test:unit:ci` (scoped) and direct `bun test` file lists.
- 7 (test writing): touched - 6 test files modified, 1 added
  (`pr-workflow-gate-discovery-salvage.test.ts`, **326 lines**, under the FR-006 500
  cap). `bun:test` only; **no new `mock.module`** — an initial console-spy assertion
  was deliberately replaced with a structural one because the logger is
  `mock.module`'d by sibling suites and `OPENCODE_SWARM_DEBUG` is mutated by many,
  making a spy pass in isolation and fail in a shared runner.
  `bash scripts/check-mock-cleanup.sh` → all files have proper cleanup and spread real
  exports (14 pre-existing, non-blocking). `bash scripts/check-test-file-cap.sh` →
  new-file violations 0, ratchet violations 0.
  `bash scripts/check-test-clock.sh` → new blocking violations 0.
- 8 (session state): not touched - no module-level state added, no session keying or
  eviction change.
- 9 (guardrails/retry): not touched - no retry, circuit-breaker, transient
  classification, or scope-binding change.
- 10 (chat/system msg): not touched - no `output.system` handling; the changed hook is
  the PR-workflow gate, not a chat/system-message transform.
- 11 (tool registration): not touched - no tool added, removed, or renamed; no
  `TOOL_NAMES` or `AGENT_TOOL_MAP` change. `bun run scripts/check-tool-registration.ts`
  → passed, 116 tools coherent.
- 12 (release/cache): touched - added
  `docs/releases/pending/pr-review-discovery-salvage.md`. `package.json#version`,
  `CHANGELOG.md`, and `.release-please-manifest.json` are untouched.

## Test plan

- [x] `bun run typecheck` → clean
- [x] `bun run lint:ci` → exit 0 (Biome 2.3.14, pinned to `package.json`)
- [x] `bun run build` + Node ESM import of `dist/index.js` → `dist import OK`
- [x] `node scripts/repro-704.mjs` → 260.0 ms against the 400 ms init deadline
- [x] `bun run test:unit:ci <7 touched suites>` → all exit 0 under the CI-equivalent gate
- [x] Affected suites incl. post-rebase overlap → **260 pass / 0 fail** across 20 files
- [x] `scripts/check-tool-registration.ts` → passed
- [x] `scripts/check-mock-cleanup.sh`, `check-test-clock.sh`, `check-test-file-cap.sh` → 0 new violations
- [x] Red-to-green replay against the 16 stored incident artifacts → 9 settle, 0
      coverage-vs-extraction disagreements
- [x] Recurrence guardrail proven to bite: deleting the `salvagedWorkflowLanes` schema
      line makes the new ledger round-trip test fail with
      `Expected "completed" / Received "pending"`
- [x] Independent implementation review (3 rounds) and final critic (2 rounds), both
      APPROVE. Five defects introduced by my own fixes were caught and closed by those
      gates.

### Correction after first CI run

The first push went red on `unit (ubuntu-latest, 5)`. Two suites asserted against
behaviour this PR changed and were **missed by my local scoping**, which used a
hand-picked file list rather than sweeping every suite touching the changed modules:

- `tests/unit/tools/dispatch-lanes.test.ts` pinned a phrase from the old output
  contract wording. Re-pinned to the new contract's substance (header-first rule and
  the pipe-escaping rule, asserted on the rendered string so a dropped backslash
  cannot pass).
- `tests/unit/hooks/pr-workflow-gate-review-validation-dedup.test.ts` pinned the
  fourth relaxed behaviour above.

Re-verified by running the CI-equivalent per-file gate
(`bun run test:unit:ci`) across **all 75** suites touching the changed modules —
0 failures — rather than a hand-picked subset. A plain directory run of those
suites reports ~124 failures, which is the repo's known cross-file pollution and
not the signal CI uses (CI runs files individually).

### Pre-existing failures

Proven on a clean `origin/main` worktree, not inherited silently:

- `bash scripts/check-invariants.sh` exits 1 with **749 ERROR lines on this branch and
  749 on clean `origin/main`** — identical. The errors name `tests/unit/tools/sast-scan*.test.ts`,
  which this PR does not touch, and the gate's own ratchet reports
  `Added in this PR: 0 | Unapproved: 0`. Host artifact, not a regression.
- `tests/unit/background/` → 81 fail on this branch vs 80 on clean `origin/main`. The
  +1 is this PR's new `round-trips salvagedWorkflowLanes` test joining the
  `pending-delegations store` suite, which fails **12/12 in a directory run and passes
  12/12 in isolation** — pre-existing cross-file pollution.
- `tests/unit/tools/` run wholesale → the known Windows `uv_spawn` host breakage,
  unrelated. The 11 dispatch-lanes / parse-lane suites covering the changed files all pass.
