### PR TITLE
fix(pr-review): preserve frozen trigger evidence

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -1057,7 +1057,11 @@ the complete ledger with `write_pr_review_trigger_eval`; its rows use the stable
 trigger IDs below. Every `MATCHED` row includes its returned `source_batch_id`
 and `source_lane_id`; every `NOT_TRIGGERED` row must omit both fields. Missing,
 extra, duplicate, malformed, or incorrectly provenanced rows make persistence
-fail and Phase 4 BLOCKED. The tool atomically writes
+fail and Phase 4 BLOCKED. Evidence is frozen by the first micro dispatch and is
+authoritative thereafter. The final writer may omit its duplicate `evidence`
+fields; if it includes reworded evidence, the writer ignores that copy and
+persists the frozen values. It still requires the exact frozen classifications,
+plus provenance for every `MATCHED` row. The tool atomically writes
 `.swarm/pr-review/<run_id>/trigger-eval.json`, separate from `findings.jsonl`;
 pass the exact reviewed merge-base as `base_sha`, the exact live base branch
 tip/ref used to compute it as `base_ref`, and the same `pr_head_sha` to the

--- a/docs/releases/pending/pr-review-frozen-trigger-evidence.md
+++ b/docs/releases/pending/pr-review-frozen-trigger-evidence.md
@@ -1,0 +1,18 @@
+# PR-review frozen trigger evidence finalization
+
+## What changed
+
+- `write_pr_review_trigger_eval` now accepts omitted or reworded duplicate evidence and persists the authoritative evidence frozen by the first micro dispatch.
+- Exact classifications, matched-lane provenance, ownership, revision, head, base, and lane-floor checks remain fail-closed.
+
+## Why
+
+Final review agents could regenerate semantically equivalent evidence text after all micro lanes completed. Byte-for-byte digest comparison then rejected the final receipt, leaving the workflow unable to complete even though classifications and provenance were valid.
+
+## Migration
+
+None. Existing callers may continue sending evidence; callers can also omit it at finalization.
+
+## Breaking changes and known caveats
+
+None.

--- a/src/background/pr-review-trigger-contract.ts
+++ b/src/background/pr-review-trigger-contract.ts
@@ -527,7 +527,7 @@ export interface ParsedPrReviewTriggerReceipt {
 }
 
 /**
- * Bind every micro dispatch and the final receipt to one semantic ledger.
+ * Bind every micro dispatch to one semantic ledger at bind time.
  * Callers pass rows after exact-set validation; the tuple representation makes
  * the identity stable and independent of post-dispatch provenance fields.
  */

--- a/src/background/pr-review-trigger-contract.ts
+++ b/src/background/pr-review-trigger-contract.ts
@@ -128,11 +128,33 @@ export const PrReviewPersistedInputRowSchema = z.discriminatedUnion('result', [
 		.strict(),
 ]);
 
+export const PrReviewWriterInputRowSchema = z.discriminatedUnion('result', [
+	z
+		.object({
+			trigger_id: TriggerIdSchema,
+			result: z.literal('MATCHED'),
+			evidence: TriggerEvidenceSchema.optional(),
+			source_batch_id: z.string().trim().min(1),
+			source_lane_id: z.string().trim().min(1),
+		})
+		.strict(),
+	z
+		.object({
+			trigger_id: TriggerIdSchema,
+			result: z.literal('NOT_TRIGGERED'),
+			evidence: TriggerEvidenceSchema.optional(),
+		})
+		.strict(),
+]);
+
 export type PrReviewInlineTriggerRow = z.infer<
 	typeof PrReviewInlineTriggerRowSchema
 >;
 export type PrReviewPersistedInputRow = z.infer<
 	typeof PrReviewPersistedInputRowSchema
+>;
+export type PrReviewWriterInputRow = z.infer<
+	typeof PrReviewWriterInputRowSchema
 >;
 
 interface ValidatedTriggerLedger<TRow> {
@@ -296,6 +318,21 @@ export function validatePrReviewPersistedInputLedger(
 			input,
 			PrReviewPersistedInputRowSchema,
 			'Invalid persisted trigger ledger',
+		),
+	);
+}
+
+export function validatePrReviewWriterInputLedger(
+	input: unknown,
+): ValidatedTriggerLedger<PrReviewWriterInputRow> {
+	assertExactTriggerIdSet(input);
+	assertNoLegacyNoMatchResult(input);
+	assertMatchedRowsHaveProvenance(input);
+	return summarizeTriggerRows(
+		parseRows(
+			input,
+			PrReviewWriterInputRowSchema,
+			'Invalid final-writer trigger ledger',
 		),
 	);
 }

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -6,10 +6,10 @@ import { readLaneOutput } from '../background/lane-output-store.js';
 import { findByBatchId } from '../background/pending-delegations.js';
 import {
 	buildPrReviewTriggerReceiptV2,
-	PrReviewPersistedInputRowSchema,
-	prReviewTriggerLedgerDigest,
+	PrReviewWriterInputRowSchema,
 	validatePrReviewInlineTriggerLedger,
 	validatePrReviewPersistedInputLedger,
+	validatePrReviewWriterInputLedger,
 } from '../background/pr-review-trigger-contract.js';
 import {
 	resolveExactMergeBase,
@@ -77,7 +77,7 @@ const WritePrReviewTriggerEvalArgsSchema = z
 			.trim()
 			.regex(/^(?!-)[A-Za-z0-9][A-Za-z0-9._/-]{0,255}$/)
 			.optional(),
-		rows: z.array(PrReviewPersistedInputRowSchema).min(1),
+		rows: z.array(PrReviewWriterInputRowSchema).min(1),
 	})
 	.strict();
 
@@ -95,9 +95,9 @@ export async function executeWritePrReviewTriggerEval(
 	directory: string,
 	context: { sessionID?: string } = {},
 ): Promise<string> {
-	let triggerLedger: ReturnType<typeof validatePrReviewPersistedInputLedger>;
+	let writerLedger: ReturnType<typeof validatePrReviewWriterInputLedger>;
 	try {
-		triggerLedger = validatePrReviewPersistedInputLedger(
+		writerLedger = validatePrReviewWriterInputLedger(
 			typeof args === 'object' && args !== null
 				? (args as { rows?: unknown }).rows
 				: undefined,
@@ -113,14 +113,6 @@ export async function executeWritePrReviewTriggerEval(
 				.join('; ')}`,
 		);
 	}
-
-	const validatedRows = triggerLedger.rows;
-
-	// One dispatch tuple may back several rows only when the dispatched lane
-	// declared consolidated ownership of exactly those families; the per-row
-	// record validation below enforces ownership containment and all-owned
-	// artifact attestation, so a lane can never lend provenance to a family it
-	// did not declare and fully attest.
 
 	const sessionID = context.sessionID?.trim();
 	if (!sessionID) {
@@ -166,14 +158,42 @@ export async function executeWritePrReviewTriggerEval(
 			}`,
 		);
 	}
-	if (
-		prReviewTriggerLedgerDigest(frozenLedger.rows) !==
-		prReviewTriggerLedgerDigest(validatedRows)
-	) {
+	const classificationDrift = frozenLedger.rows
+		.filter((row, index) => writerLedger.rows[index]?.result !== row.result)
+		.map((row) => row.trigger_id);
+	if (classificationDrift.length > 0) {
 		return failure(
-			'PR_REVIEW trigger evaluation differs from the canonical ledger frozen across micro dispatches',
+			`PR_REVIEW trigger classification drift from the canonical ledger frozen across micro dispatches: ${classificationDrift.join(', ')}`,
 		);
 	}
+	let triggerLedger: ReturnType<typeof validatePrReviewPersistedInputLedger>;
+	try {
+		triggerLedger = validatePrReviewPersistedInputLedger(
+			frozenLedger.rows.map((frozenRow, index) => {
+				const writerRow = writerLedger.rows[index];
+				if (frozenRow.result === 'NOT_TRIGGERED') return frozenRow;
+				if (!writerRow || writerRow.result !== 'MATCHED') {
+					throw new Error(
+						`missing MATCHED provenance for ${frozenRow.trigger_id}`,
+					);
+				}
+				return {
+					...frozenRow,
+					source_batch_id: writerRow.source_batch_id,
+					source_lane_id: writerRow.source_lane_id,
+				};
+			}),
+		);
+	} catch (error) {
+		return failure(error instanceof Error ? error.message : String(error));
+	}
+	const validatedRows = triggerLedger.rows;
+
+	// One dispatch tuple may back several rows only when the dispatched lane
+	// declared consolidated ownership of exactly those families; the per-row
+	// record validation below enforces ownership containment and all-owned
+	// artifact attestation, so a lane can never lend provenance to a family it
+	// did not declare and fully attest.
 	const currentRevisionDigest = await resolveCurrentRevisionDigest(
 		directory,
 		parsed.data.pr_head_sha,
@@ -409,7 +429,7 @@ export async function executeWritePrReviewTriggerEval(
 export const write_pr_review_trigger_eval: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Persist the complete, exact-set PR-review trigger receipt after every MATCHED family has completed; NOT_TRIGGERED families remain provenance-free.',
+			'Persist the complete, exact-set PR-review trigger receipt after every MATCHED family has completed. Supply classifications and MATCHED provenance; evidence is optional and non-authoritative because the receipt reuses evidence frozen by the first micro dispatch. NOT_TRIGGERED families remain provenance-free.',
 		args: {
 			run_id: WritePrReviewTriggerEvalArgsSchema.shape.run_id,
 			pr_head_sha: WritePrReviewTriggerEvalArgsSchema.shape.pr_head_sha,

--- a/tests/unit/background/pr-review-trigger-contract.test.ts
+++ b/tests/unit/background/pr-review-trigger-contract.test.ts
@@ -5,6 +5,7 @@ import {
 	PR_REVIEW_TRIGGER_DEFINITIONS,
 	parsePrReviewTriggerReceipt,
 	validatePrReviewInlineTriggerLedger,
+	validatePrReviewWriterInputLedger,
 } from '../../../src/background/pr-review-trigger-contract';
 
 function inlineRows() {
@@ -144,6 +145,67 @@ describe('inline PR-review trigger ledger', () => {
 		expect(() => validatePrReviewInlineTriggerLedger(unknown)).toThrow(
 			'unknown',
 		);
+	});
+});
+
+describe('final-writer PR-review trigger ledger', () => {
+	test('accepts omitted or reworded evidence while preserving classification rules', () => {
+		const rows = persistedRows();
+		const omitted = rows.map(({ evidence: _evidence, ...row }) => row);
+		expect(validatePrReviewWriterInputLedger(omitted).matchedIds).toHaveLength(
+			4,
+		);
+		expect(
+			validatePrReviewWriterInputLedger(
+				rows.map((row) => ({ ...row, evidence: `reworded ${row.trigger_id}` })),
+			).matchedIds,
+		).toHaveLength(4);
+	});
+
+	test('rejects fallback, exact-set, and provenance violations', () => {
+		const valid = persistedRows();
+		const fallback = valid.map((row) =>
+			row.trigger_id === 'unclassified-risk'
+				? { trigger_id: row.trigger_id, result: 'NOT_TRIGGERED' as const }
+				: row,
+		);
+		expect(() => validatePrReviewWriterInputLedger(fallback)).toThrow(
+			'unclassified-risk',
+		);
+		expect(() => validatePrReviewWriterInputLedger(valid.slice(1))).toThrow(
+			'missing',
+		);
+		const duplicate = structuredClone(valid);
+		duplicate[1] = { ...duplicate[0] };
+		expect(() => validatePrReviewWriterInputLedger(duplicate)).toThrow(
+			'duplicate',
+		);
+		const unknown = structuredClone(valid) as Array<Record<string, unknown>>;
+		unknown[0].trigger_id = 'unknown-family';
+		expect(() => validatePrReviewWriterInputLedger(unknown)).toThrow('unknown');
+		const missingProvenance = valid.map((row) =>
+			row.result === 'MATCHED' ? { ...row, source_batch_id: undefined } : row,
+		);
+		expect(() => validatePrReviewWriterInputLedger(missingProvenance)).toThrow(
+			'require source_batch_id',
+		);
+		const notTriggeredIndex = valid.findIndex(
+			(row) => row.result === 'NOT_TRIGGERED',
+		);
+		const forbiddenProvenance = structuredClone(valid) as Array<
+			Record<string, unknown>
+		>;
+		forbiddenProvenance[notTriggeredIndex].source_batch_id = 'forbidden';
+		expect(() =>
+			validatePrReviewWriterInputLedger(forbiddenProvenance),
+		).toThrow();
+		expect(() =>
+			validatePrReviewWriterInputLedger(
+				valid.map((row, index) =>
+					index === 0 ? { ...row, evidence: '' } : row,
+				),
+			),
+		).toThrow();
 	});
 });
 

--- a/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
@@ -210,6 +210,9 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 			),
 		);
 		expect(writerResult.success).toBe(false);
-		expect(writerResult.message).toContain('differs from the canonical ledger');
+		expect(writerResult.message).toContain('classification drift');
+		expect(writerResult.message).toContain(resultDrift[0].trigger_id);
+		const afterWriter = await readPrWorkflowGateState(tempDir, SESSION_ID);
+		expect(afterWriter?.prReviewTriggerEvalPath).toBeUndefined();
 	});
 });

--- a/tests/unit/tools/write-pr-review-trigger-eval-ordering.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-ordering.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import type { PrReviewInlineTriggerRow } from '../../../src/background/pr-review-trigger-contract';
+import {
+	activatePrWorkflow,
+	bindPrReviewBase,
+	bindPrReviewTriggerLedger,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+} from '../../../src/hooks/pr-workflow-gate';
+import {
+	executeWritePrReviewTriggerEval,
+	PR_REVIEW_TRIGGER_DEFINITIONS,
+	_internals as writerInternals,
+} from '../../../src/tools/write-pr-review-trigger-eval';
+
+// Split from write-pr-review-trigger-eval.test.ts (500-line cap): regression
+// coverage for FB item F-002. The writer now pairs frozen vs writer rows BY
+// ARRAY INDEX (write-pr-review-trigger-eval.ts:161-168) and grafts provenance
+// by index (:172-185). That is only safe because exactTriggerRows
+// (pr-review-trigger-contract.ts:236-259) re-orders BOTH ledgers into
+// canonical PR_REVIEW_REQUIRED_TRIGGER_IDS order before comparison. This test
+// supplies writer rows in REVERSED order relative to the frozen ledger and
+// asserts pairing is still correct per trigger_id, not per array position.
+
+const tempDirs: string[] = [];
+const SESSION_ID = 'trigger-eval-session';
+const HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'review-revision';
+const REVIEW_SCOPE = `complete PR diff def456...${HEAD_SHA}`;
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+const originalGateRevisionDigest =
+	gateInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveRevisionDigest =
+	writerInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveMergeBase = writerInternals.resolveMergeBase;
+
+function tempRoot(): string {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), 'trigger-eval-')));
+	tempDirs.push(root);
+	return root;
+}
+
+function artifactPath(root: string, runId: string): string {
+	return join(root, '.swarm', 'pr-review', runId, 'trigger-eval.json');
+}
+
+function rows() {
+	return PR_REVIEW_TRIGGER_DEFINITIONS.map((definition, index) => ({
+		trigger_id: definition.id,
+		result: 'MATCHED' as const,
+		evidence: `frozen distinct evidence for ${definition.id}`,
+		source_batch_id: `micro-batch-${Math.floor(index / 8)}`,
+		source_lane_id: `lane-${index}`,
+	}));
+}
+
+function inlineRows(
+	input: ReadonlyArray<PrReviewInlineTriggerRow> = rows(),
+): PrReviewInlineTriggerRow[] {
+	return input.map(({ trigger_id, result, evidence }) => ({
+		trigger_id,
+		result,
+		evidence,
+	}));
+}
+
+async function recordCompletedLane(
+	root: string,
+	input: {
+		batchId: string;
+		laneId: string;
+		workflowLane: string;
+		mode: 'swarm-pr-review:base' | 'swarm-pr-review:micro';
+		ownedWorkflowLanes?: string[];
+	},
+): Promise<void> {
+	const correlationId = `${input.batchId}-${input.laneId}-session`;
+	const header =
+		input.mode === 'swarm-pr-review:base'
+			? '[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence'
+			: '[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+	const cleanRows = (input.ownedWorkflowLanes ?? [input.workflowLane])
+		.map(
+			(family) =>
+				`[CLEAN] | ${family} | exact reviewed diff | no candidate survived the focused review`,
+		)
+		.join('\n');
+	const text = `${header}\n${cleanRows}`;
+	await recordPendingDelegation(root, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `${input.batchId}-call`,
+		normalizedAgent: 'explorer',
+		swarmPrefixedAgent: 'explorer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: input.batchId,
+		laneId: input.laneId,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		ownedWorkflowLanes: input.ownedWorkflowLanes,
+		workspace: {
+			directory: root,
+			gitHead: HEAD_SHA,
+			dirtyHash: null,
+			prHeadSha: HEAD_SHA,
+			scope: REVIEW_SCOPE,
+		},
+	});
+	const stored = storeLaneOutput(root, {
+		batchId: input.batchId,
+		laneId: input.laneId,
+		agent: 'explorer',
+		role: 'explorer',
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: REVISION_DIGEST,
+		scope: REVIEW_SCOPE,
+		source: 'collect_lane_results',
+		text,
+	});
+	await appendDelegationTransition(root, correlationId, {
+		status: 'completed',
+		result: {
+			text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			outputRef: stored.ref,
+		},
+	});
+}
+
+async function establishBoundReviewGate(
+	root: string,
+	options: {
+		triggerLedger?: PrReviewInlineTriggerRow[];
+	} = {},
+): Promise<void> {
+	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	writerInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	writerInternals.resolveMergeBase = () => 'def456';
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+	await activatePrWorkflow(root, SESSION_ID, 'PR_REVIEW');
+	await bindPrReviewBase(root, SESSION_ID, {
+		prHeadSha: HEAD_SHA,
+		baseRef: 'origin/main',
+		baseSha: 'def456',
+	});
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(root, SESSION_ID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: HEAD_SHA,
+	});
+	for (const lane of baseLanes) {
+		await recordCompletedLane(root, {
+			batchId: 'base-all',
+			laneId: lane.laneId,
+			workflowLane: lane.workflowLane,
+			mode: 'swarm-pr-review:base',
+		});
+	}
+	await bindPrReviewTriggerLedger(
+		root,
+		SESSION_ID,
+		options.triggerLedger ?? inlineRows(),
+	);
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		await recordCompletedLane(root, {
+			batchId: `micro-batch-${Math.floor(index / 8)}`,
+			laneId: `lane-${index}`,
+			workflowLane,
+			mode: 'swarm-pr-review:micro',
+		});
+	}
+}
+
+afterEach(() => {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	gateInternals.resolvePrWorkflowRevisionDigest = originalGateRevisionDigest;
+	writerInternals.resolvePrWorkflowRevisionDigest =
+		originalResolveRevisionDigest;
+	writerInternals.resolveMergeBase = originalResolveMergeBase;
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('write_pr_review_trigger_eval — reversed writer-row ordering (F-002)', () => {
+	test('pairs writer rows by trigger identity, not array index, when writer rows arrive reversed', async () => {
+		const root = tempRoot();
+		const frozenRows = rows();
+		await establishBoundReviewGate(root, {
+			triggerLedger: inlineRows(frozenRows),
+		});
+
+		// Build writer rows in REVERSED order relative to the frozen ledger.
+		// Each writer row keeps its OWN trigger_id's source_batch_id/source_lane_id
+		// (as a real caller would), so a naive index-based graft would transplant
+		// provenance/evidence from the wrong trigger onto each row.
+		const writerRows = [...frozenRows]
+			.reverse()
+			.map(({ evidence: _evidence, ...row }) => row);
+
+		const response = JSON.parse(
+			await executeWritePrReviewTriggerEval(
+				{
+					run_id: 'review-reversed',
+					pr_head_sha: HEAD_SHA,
+					base_sha: 'def456',
+					base_ref: 'origin/main',
+					rows: writerRows,
+				},
+				root,
+				{ sessionID: SESSION_ID },
+			),
+		);
+
+		expect(response.success).toBe(true);
+
+		const outputPath = artifactPath(root, 'review-reversed');
+		expect(existsSync(outputPath)).toBe(true);
+		const artifact = JSON.parse(readFileSync(outputPath, 'utf-8'));
+		expect(artifact.rows).toHaveLength(PR_REVIEW_TRIGGER_DEFINITIONS.length);
+
+		const frozenById = new Map(frozenRows.map((row) => [row.trigger_id, row]));
+
+		// Load-bearing: every persisted row must carry the evidence and
+		// provenance frozen for ITS OWN trigger_id — not whatever landed at the
+		// same array index after reversal. In a naive index-paired world this
+		// would fail because reversing the writer rows shifts every index's
+		// counterpart to a different trigger_id (except any accidental
+		// palindromic midpoint), so a mismatch would surface across the set.
+		for (const persistedRow of artifact.rows) {
+			const expected = frozenById.get(persistedRow.trigger_id);
+			expect(expected).toBeDefined();
+			expect(persistedRow.evidence).toBe(expected?.evidence);
+			expect(persistedRow.source_batch_id).toBe(expected?.source_batch_id);
+			expect(persistedRow.source_lane_id).toBe(expected?.source_lane_id);
+		}
+
+		// Canonicalization is pinned: persisted rows follow
+		// PR_REVIEW_REQUIRED_TRIGGER_IDS order regardless of writer input order.
+		expect(
+			artifact.rows.map((row: { trigger_id: string }) => row.trigger_id),
+		).toEqual(PR_REVIEW_TRIGGER_DEFINITIONS.map((definition) => definition.id));
+	});
+});

--- a/tests/unit/tools/write-pr-review-trigger-eval.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval.test.ts
@@ -251,7 +251,11 @@ afterEach(() => {
 describe('write_pr_review_trigger_eval', () => {
 	test('writes the exact canonical trigger set atomically under .swarm', async () => {
 		const root = tempRoot();
-		await establishBoundReviewGate(root);
+		const frozenRows = rows();
+		await establishBoundReviewGate(root, {
+			triggerLedger: inlineRows(frozenRows),
+		});
+		const writerRows = frozenRows.map(({ evidence: _evidence, ...row }) => row);
 		const response = JSON.parse(
 			await executeWritePrReviewTriggerEval(
 				{
@@ -259,7 +263,7 @@ describe('write_pr_review_trigger_eval', () => {
 					pr_head_sha: HEAD_SHA,
 					base_sha: 'def456',
 					base_ref: 'origin/main',
-					rows: rows(),
+					rows: writerRows,
 				},
 				root,
 				{ sessionID: SESSION_ID },
@@ -281,6 +285,7 @@ describe('write_pr_review_trigger_eval', () => {
 			trigger_row: PR_REVIEW_TRIGGER_DEFINITIONS[0].trigger_row,
 			micro_lane: PR_REVIEW_TRIGGER_DEFINITIONS[0].micro_lane,
 			result: 'MATCHED',
+			evidence: frozenRows[0].evidence,
 		});
 		expect(artifact).toMatchObject({
 			base_ref: 'origin/main',
@@ -305,6 +310,10 @@ describe('write_pr_review_trigger_eval', () => {
 				.map((row) => row.trigger_id),
 			triggerLedger: inlineRows(mixedRows),
 		});
+		const rewordedRows = mixedRows.map((row) => ({
+			...row,
+			evidence: `final summary reworded ${row.trigger_id}`,
+		}));
 		const response = JSON.parse(
 			await executeWritePrReviewTriggerEval(
 				{
@@ -312,7 +321,7 @@ describe('write_pr_review_trigger_eval', () => {
 					pr_head_sha: HEAD_SHA,
 					base_sha: 'def456',
 					base_ref: 'origin/main',
-					rows: mixedRows,
+					rows: rewordedRows,
 				},
 				root,
 				{ sessionID: SESSION_ID },
@@ -331,6 +340,9 @@ describe('write_pr_review_trigger_eval', () => {
 			(row: { result: string }) => row.result === 'NOT_TRIGGERED',
 		);
 		expect(notTriggered).toHaveLength(7);
+		expect(
+			artifact.rows.map((row: { evidence: string }) => row.evidence),
+		).toEqual(mixedRows.map((row) => row.evidence));
 		expect(
 			notTriggered.every(
 				(row: Record<string, unknown>) =>


### PR DESCRIPTION
Reproduced from a user-provided PR-review runtime trace; no linked GitHub issue.

## Summary

- Stop `write_pr_review_trigger_eval` from aborting when the final agent omits or rewords evidence that was already frozen by the first micro dispatch.
- Preserve the frozen evidence as the sole authority while still requiring exact classifications and verified matched-lane provenance.
- Add real writer-path regressions, stricter classification-drift diagnostics, workflow guidance, and a pending release fragment.
- Follow-up review commit: correct the now-stale `prReviewTriggerLedgerDigest` docstring (this PR removed its final-receipt use) and add a regression test pinning the row-ordering guarantee the new index-based comparison depends on.

## Invariant audit

- 1 (plugin init): not touched - no initialization path changed; `repro:704` passed at 318.1 ms under the 400 ms tight deadline.
- 2 (runtime portability): touched - build, Node-ESM import, smoke, and package smoke passed.
- 3 (subprocesses): not touched - no subprocess call or wrapper changed.
- 4 (.swarm containment): touched - the receipt remains under `.swarm/pr-review/<run_id>/trigger-eval.json`; writer tests prove the contained path and no new path was added.
- 5 (plan durability): not touched - no plan ledger, projection, or checkpoint code changed.
- 6 (test_runner safety): not touched - validation used shell Bun commands and the isolated unit harness, never broad `test_runner`.
- 7 (test writing): touched - Bun tests cover omitted/reworded evidence, exact sets, provenance, fallback, and drift in `tests/unit/tools/write-pr-review-trigger-eval.test.ts`, `tests/unit/background/pr-review-trigger-contract.test.ts`, and `tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts`. The follow-up commit adds `tests/unit/tools/write-pr-review-trigger-eval-ordering.test.ts` (292 lines), which submits writer rows in reversed order and asserts, keyed by `trigger_id` rather than array index, that each persisted row keeps its own frozen evidence and its own `source_batch_id`/`source_lane_id`, plus canonical output ordering. `bun run check:test-file-cap` re-run after the addition: New-file violations 0, Ratchet violations 0; the largest touched test remains `write-pr-review-trigger-eval.test.ts` at 481 lines.
- 8 (session state): not touched - no session-scoped collection or global state changed.
- 9 (guardrails/retry): not touched - no retry, circuit, authorization, or guardrail path changed.
- 10 (chat/system msg): not touched - no message hook or system-message shape changed.
- 11 (tool registration): touched - tool schema/runtime validator changed together; registration check re-run on the follow-up commit reports 116 coherent tools, and the drift check passed.
- 12 (release/cache): touched - the required unique pending release fragment is present; version, changelog, manifest, install, and cache code are untouched. The follow-up commit changes only a doc comment and adds a test, so no additional fragment is required.

## Test plan

- [x] Red regression reproduced both original failures before implementation.
- [x] Focused and adjacent PR-review suites on the follow-up commit: `bun test` over `write-pr-review-trigger-eval-ordering`, `write-pr-review-trigger-eval`, `write-pr-review-trigger-eval-provenance`, `pr-review-trigger-contract`, and `dispatch-lanes-pr-review-micro-cycle` - 35 passed, 0 failed, 173 expect() calls across 5 files. (An earlier revision cited "49 passed" for an unspecified grouping; that figure is not reproduced by the exact command above, which replaces it.)
- [x] Swarm PR-review skill suites: 2 files passed; content assertions and drift check passed.
- [x] Typecheck, lint, tool registration, mock cleanup, test clock, runtime source refs, file cap, and `git diff --check` passed. Repository-wide invariant script reports only pre-existing allowlist/coverage debt in untouched files.
- [x] Re-run on the follow-up commit specifically: `git diff --check`, `bun run typecheck`, `bunx @biomejs/biome@2.3.14 ci .` (exit 0), `bun run build`, `bun run check:test-file-cap` (0 new-file, 0 ratchet), `bun run drift:check` (pre-existing soft-warns only, in skill files this commit does not touch), and `scripts/check-tool-registration.ts` (116 coherent tools). Every other battery in this section was measured on the original commit and was not re-run for a doc-comment plus one-test-file change.
- [x] Config surface: 1,971 passed, 4 platform skips, 0 failed (original commit).
- [x] Tool surface: 352 of 356 tool test files passed on the original commit; the follow-up adds one file for 357 total. The four failures reproduce identically on detached `origin/main` (Windows `EBUSY` in two consensus files and stale council-policy expectations in two files).
- [x] Legacy tests: 138 passed. Security: 163 passed, 4 skipped. Adversarial: 846 passed. (Original commit.)
- [x] Build, Node-ESM import, the local smoke script (10 passed), package smoke, and `repro:704` passed (original commit).

### What remote CI actually exercised

Correcting an overstatement in an earlier revision of this body. On the current head every check reports `pass`, but five jobs are deliberate no-ops on `pull_request`. Each carries a "Merge-queue-only" comment and gates every step on `github.event_name == 'merge_group'`: `coverage` (`.github/workflows/ci.yml:465-550`), `integration` (`:553-621`), `php-validation` (`:681-726`), `rust-sandbox-runner` (`:728-769`), and `smoke` (`:771-824`). Their runtimes corroborate it - coverage 3s, integration 4s, php-validation 5s, rust-sandbox-runner 4s, smoke 3-6s - against `package-check` at 1m12s and the unit shards at 3m54s-12m10s.

- Actually executed on this PR: `quality`, `drift`, `package-check`, `security`, `pr-standards`, and all 18 cross-platform `unit` shards (6 shards x 3 OSes, runtimes 3m54s-12m10s), plus the `detect-release` / `detect-paths` / `unit-passed` meta-jobs and the `check-duplicates` / `check-title` standards checks.
- Reported pass without executing: `coverage`, `integration`, `php-validation`, `rust-sandbox-runner`, and the CI `smoke` job (all three platforms). These run for real only in the merge queue; no `merge_group` run exists for this head. Note this is the CI `smoke` job, not the local smoke script cited in the test plan above.
- The earlier revision also wrote `package` for the real check name `package-check`.

## Pre-existing failures

- `bun test tests/integration --timeout 120000`: 620 passed / 212 failed on both this branch and detached `origin/main` at `e7e0029ffd704d18d2144fe0dc70a882b5cca83b`. This is a local measurement taken on the original commit and not re-run for the follow-up; the CI `integration` job is merge-queue-gated and does not exercise it on `pull_request`, so it cannot be corroborated from this PR's checks.
- `tests/unit/tools/consensus-mine-write-surface.test.ts`, `consensus-mine.test.ts`, `council-attempt-phase.test.ts`, and `council-attempt-task.test.ts` fail identically on the same detached base SHA.

## Migration

No migration required. Existing callers may keep sending evidence; finalization may now omit it, and any duplicate wording is non-authoritative.
