### PR TITLE
fix(pr-review): bind trigger-eval run_id and make receipt immutable

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -1851,6 +1851,21 @@ are:
    This is the recovery path when the wake budget has suspended and the
    architect cannot make further tool progress.
 
+A second, unrelated stranding class is **trigger-ledger drift**. This is not a
+fetch/checkout problem: it means a later micro-lane's trigger_evaluation
+disagrees with the canonical ledger frozen by the first micro dispatch. The run
+fails closed in two places, with different strictness — at ledger bind time
+`bindPrReviewTriggerLedger` rejects a trigger_evaluation whose frozen-row digest
+(`trigger_id`, `result`, and `evidence` together) differs from the first
+dispatch's, and at receipt finalize time `write_pr_review_trigger_eval` rejects
+rows whose per-family `result` (classification) differs from the frozen ledger.
+The finalize gate is deliberately narrower than the bind gate: evidence may be
+omitted or reworded at the receipt, but classifications must still agree. If a
+later dispatch genuinely cannot converge with the frozen ledger, the exits are
+the abort paths listed above (`abort_pr_workflow` or `/swarm abort-pr-workflow`),
+or re-dispatching the disagreeing lane so its trigger_evaluation converges with
+the frozen ledger before re-binding.
+
 Abort is a recovery tool, not a coverage shortcut. Use it only when the
 bind/checkout path is genuinely unreachable; never use it to skip a
 coverage obligation that is merely expensive or inconvenient.

--- a/docs/releases/pending/2004-pr-workflow-controller-deadlocks.md
+++ b/docs/releases/pending/2004-pr-workflow-controller-deadlocks.md
@@ -11,7 +11,9 @@
   from provenance-free `NOT_TRIGGERED` families. Only matched families launch
   micro lanes; strict schema-v2 counts and provenance are shared by dispatch,
   persistence, and gate readers. The first micro dispatch freezes the exact
-  ledger across later batches and the final receipt, while legacy
+  ledger (classifications and evidence) across every later micro dispatch; the
+  final receipt re-validates per-family classifications against the frozen
+  ledger but does not require byte-identical evidence, while legacy
   v1/unversioned reads remain preserved.
 - Candidate ingestion and workflow coverage now share one semantic row
   contract for exact marker headers and fields, fenced-content isolation,

--- a/docs/releases/pending/pr-review-trigger-eval-run-binding.md
+++ b/docs/releases/pending/pr-review-trigger-eval-run-binding.md
@@ -1,0 +1,20 @@
+# PR-review trigger-eval receipt immutability and run binding
+
+## What changed
+
+- The PR-review trigger-evaluation receipt (`.swarm/pr-review/<run_id>/trigger-eval.json`) is now immutable after first consumption. A repeat write under the same `run_id` fails closed instead of silently replacing the prior receipt, and the receipt is bound to a single `run_id` for the session (mirroring the existing `prReviewArtifactRunId` binding for the findings artifact).
+- The trigger-eval `run_id` and the findings-artifact `run_id` must now agree, since both live under the same `.swarm/pr-review/<run_id>/` directory. A mismatch fails closed at the writer pre-check and at the gate boundary.
+- The stale `bindPrReviewTriggerLedger` block message no longer claims the ledger must be byte-identical "and the final receipt" — PR #2121 narrowed the final receipt to a per-family classification check, so only the per-micro-dispatch ledger must remain identical.
+- The `swarm-pr-review` skill's "Aborting an unrecoverable review" section now documents trigger-ledger drift as a second stranding class with the same abort exits.
+
+## Why
+
+The receipt is a tamper-evident coverage proof consumed once per review run. Before this change, `run_id` was never bound to the gate state and the destination write clobbered on rename, so a repeat write could replace an already-consumed receipt (and several receipts under different self-chosen `run_id` values could persist within one session). Closes #2124, #2125, #2126.
+
+## Migration
+
+None. The new `prReviewTriggerEvalRunId` gate-state field is optional and additive; older persisted gate state reads cleanly through the existing `.passthrough()` schema. Existing callers are unaffected — the `write_pr_review_trigger_eval` tool passes its `run_id` argument through automatically.
+
+## Breaking changes and known caveats
+
+- A repeat `write_pr_review_trigger_eval` call for an already-persisted receipt (same `run_id`) now hard-fails with a recovery hint to abort the workflow via `abort_pr_workflow` / `/swarm abort-pr-workflow`. This is intentional (the receipt was already persisted); retry after a crash should only occur if the destination was never written.

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -10,7 +10,6 @@ import {
 	candidateHeaderFamily,
 	normalizeCandidateArtifact,
 	type RowFormatFamily,
-	removeCandidateCodeFences,
 	selectCandidateHeader,
 	splitPipeFields,
 } from '../background/candidate-contract.js';
@@ -475,6 +474,13 @@ export interface PrWorkflowGateState {
 	/** Canonical ordered semantic ledger frozen by the first micro dispatch. */
 	prReviewTriggerLedger?: PrReviewInlineTriggerRow[];
 	prReviewTriggerEvalPath?: string;
+	/**
+	 * The run_id bound to the trigger-evaluation receipt at first consumption.
+	 * Mirrors `prReviewArtifactRunId`: once set, a subsequent receipt under a
+	 * different run_id is rejected, and it must agree with the findings artifact
+	 * run_id (both live under `.swarm/pr-review/<run_id>/`). Closes issue #2124.
+	 */
+	prReviewTriggerEvalRunId?: string;
 	prReviewValidationBatches?: PrReviewValidationBatchRecord[];
 	/** Keyed by validation batch id. See `PrReviewBatchCoherenceRecord`. */
 	prReviewBatchCoherence?: Record<string, PrReviewBatchCoherenceRecord>;
@@ -846,6 +852,7 @@ const PrWorkflowGateStateSchema = z
 			.length(PR_REVIEW_REQUIRED_TRIGGER_IDS.length)
 			.optional(),
 		prReviewTriggerEvalPath: z.string().min(1).optional(),
+		prReviewTriggerEvalRunId: z.string().min(1).optional(),
 		prReviewValidationBatches: z
 			.array(PrReviewValidationBatchRecordSchema)
 			.max(MAX_WORKFLOW_BATCHES)
@@ -3480,17 +3487,45 @@ async function assertPrFeedbackPublicationArmed(
 export async function markPrReviewTriggerEvaluationComplete(
 	directory: string,
 	sessionID: string,
+	runId: string,
 	artifactPath: string,
 ): Promise<PrWorkflowGateState> {
 	const state = await assertPrReviewBaseCoverageSettled(directory, sessionID);
+	const normalizedRunId = runId.trim();
+	if (!normalizedRunId) {
+		throw new Error('BLOCKED: PR_REVIEW trigger artifact run_id is required');
+	}
 	const normalizedPath = artifactPath.trim();
 	if (!normalizedPath) {
 		throw new Error('BLOCKED: PR_REVIEW trigger artifact path is required');
+	}
+	// The receipt is consumed once and bound to a single run_id for the session.
+	// Mirrors the `prReviewArtifactRunId` equality check used for the findings
+	// artifact at `assertPrReviewArtifactBoundary`, closing issue #2124.
+	if (
+		state.prReviewTriggerEvalRunId &&
+		state.prReviewTriggerEvalRunId !== normalizedRunId
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW trigger evaluation is already bound to run "${state.prReviewTriggerEvalRunId}"`,
+		);
+	}
+	// The trigger-eval receipt and the findings artifact share one
+	// `.swarm/pr-review/<run_id>/` directory, so their run_ids must agree once
+	// either is bound.
+	if (
+		state.prReviewArtifactRunId &&
+		state.prReviewArtifactRunId !== normalizedRunId
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW trigger evaluation run_id must match the findings artifact run "${state.prReviewArtifactRunId}"`,
+		);
 	}
 	const nextState: PrWorkflowGateState = {
 		...state,
 		updatedAt: isoNow(),
 		prReviewTriggerEvalPath: normalizedPath,
+		prReviewTriggerEvalRunId: normalizedRunId,
 	};
 	await persistState(directory, nextState);
 	return nextState;
@@ -3529,7 +3564,7 @@ export async function bindPrReviewTriggerLedger(
 			prReviewTriggerLedgerDigest(ledger.rows)
 		) {
 			throw new Error(
-				'BLOCKED: PR_REVIEW trigger_evaluation must remain exactly identical across every micro dispatch and the final receipt',
+				'BLOCKED: PR_REVIEW trigger_evaluation must remain exactly identical across every micro dispatch',
 			);
 		}
 		return state;
@@ -3620,6 +3655,17 @@ export async function assertPrReviewArtifactBoundary(
 	if (state.prReviewArtifactRunId && state.prReviewArtifactRunId !== runId) {
 		throw new Error(
 			`BLOCKED: PR_REVIEW artifacts are already bound to run "${state.prReviewArtifactRunId}"`,
+		);
+	}
+	// The findings artifact and the trigger-eval receipt share one
+	// `.swarm/pr-review/<run_id>/` directory; once the trigger-eval run_id is
+	// bound, findings must use the same run (issue #2124).
+	if (
+		state.prReviewTriggerEvalRunId &&
+		state.prReviewTriggerEvalRunId !== runId
+	) {
+		throw new Error(
+			`BLOCKED: PR_REVIEW findings must use the same run as the trigger evaluation "${state.prReviewTriggerEvalRunId}"`,
 		);
 	}
 	const expectedFindingIds = derivePrReviewCandidateInventory(

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -136,6 +136,25 @@ export async function executeWritePrReviewTriggerEval(
 			`PR_REVIEW trigger evaluation head mismatch: expected ${gateState.prHeadSha}, received ${parsed.data.pr_head_sha}`,
 		);
 	}
+	// Fail fast on a run_id that disagrees with an already-bound run, before the
+	// expensive classification/provenance validation. Mirrors the findings writer
+	// pre-check (`write-pr-review-artifact.ts`) and closes issue #2124.
+	if (
+		gateState.prReviewArtifactRunId &&
+		gateState.prReviewArtifactRunId !== parsed.data.run_id
+	) {
+		return failure(
+			`PR_REVIEW trigger evaluation run_id must match the findings artifact run "${gateState.prReviewArtifactRunId}"`,
+		);
+	}
+	if (
+		gateState.prReviewTriggerEvalRunId &&
+		gateState.prReviewTriggerEvalRunId !== parsed.data.run_id
+	) {
+		return failure(
+			`PR_REVIEW trigger evaluation is already bound to run "${gateState.prReviewTriggerEvalRunId}"`,
+		);
+	}
 	try {
 		await assertPrReviewBaseCoverageSettled(directory, sessionID);
 	} catch (error) {
@@ -385,6 +404,20 @@ export async function executeWritePrReviewTriggerEval(
 	} catch (error) {
 		return failure(error instanceof Error ? error.message : String(error));
 	}
+	// The receipt is a tamper-evident coverage proof consumed once per run. A
+	// repeat write for the same run_id must NOT silently replace the prior
+	// receipt: `fs.rename` clobbers an existing destination, so refuse an existing
+	// destination before writing. This guard closes the single-session retry
+	// threat (#2124's scope): tool calls within a session are serialized, so the
+	// check-then-rename has no intra-session race. A residual cross-session
+	// TOCTOU remains (two sessions writing the same path concurrently) — that is
+	// out of scope and is also bounded by the per-run binding above. Recovery is
+	// `abort_pr_workflow` (see "Aborting an unrecoverable review" in the skill).
+	if (fs.existsSync(destination)) {
+		return failure(
+			`PR_REVIEW trigger evaluation receipt already exists for run "${parsed.data.run_id}" and cannot be overwritten; abort the workflow with abort_pr_workflow to restart`,
+		);
+	}
 
 	const parent = path.dirname(destination);
 	const tempPath = path.join(parent, `.trigger-eval.${randomUUID()}.tmp`);
@@ -408,6 +441,7 @@ export async function executeWritePrReviewTriggerEval(
 	await markPrReviewTriggerEvaluationComplete(
 		directory,
 		sessionID,
+		parsed.data.run_id,
 		relativePath.split(path.sep).join('/'),
 	);
 

--- a/tests/unit/commands/pr-feedback-transition.test.ts
+++ b/tests/unit/commands/pr-feedback-transition.test.ts
@@ -25,7 +25,7 @@ import {
 } from '../hooks/pr-workflow-gate.test-fixtures.js';
 
 const PR_URL = 'https://github.com/owner/repo/pull/155';
-const RUN_ID = 'review-boundaries';
+const RUN_ID = 'test-run';
 
 beforeEach(setupPrWorkflowGateFixtures);
 afterEach(async () => {

--- a/tests/unit/hooks/pr-workflow-gate.test-fixtures.ts
+++ b/tests/unit/hooks/pr-workflow-gate.test-fixtures.ts
@@ -363,6 +363,7 @@ export async function establishReviewPrerequisitesWithConsolidatedMicroLane(
 	await markPrReviewTriggerEvaluationComplete(
 		tempDir,
 		SESSION_ID,
+		'test-run',
 		triggerRelative,
 	);
 	return { consolidatedCandidateId, baseCandidateIds };
@@ -417,6 +418,7 @@ export async function establishReviewPrerequisites(): Promise<void> {
 	await markPrReviewTriggerEvaluationComplete(
 		tempDir,
 		SESSION_ID,
+		'test-run',
 		triggerRelative,
 	);
 }
@@ -555,6 +557,7 @@ export async function establishReviewPrerequisitesWithOverlappingBaseRetry(): Pr
 	await markPrReviewTriggerEvaluationComplete(
 		tempDir,
 		SESSION_ID,
+		'test-run',
 		triggerRelative,
 	);
 
@@ -693,6 +696,7 @@ export async function establishReviewPrerequisitesWithMislabeledSingletonLane():
 	await markPrReviewTriggerEvaluationComplete(
 		tempDir,
 		SESSION_ID,
+		'test-run',
 		triggerRelative,
 	);
 	return { normalCandidateIds, coveringCandidateId, mislabeledCandidateId };

--- a/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-council.test.ts
@@ -253,6 +253,7 @@ async function establishReviewPrerequisites(): Promise<void> {
 	await markPrReviewTriggerEvaluationComplete(
 		directory,
 		SESSION_ID,
+		'run',
 		triggerRelative,
 	);
 }

--- a/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
@@ -175,6 +175,9 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 		);
 		expect(driftedDispatch.success).toBe(false);
 		expect(driftedDispatch.message).toContain('exactly identical');
+		// #2126: the final-receipt clause was removed; only classifications must
+		// match at the receipt, so the message must not mention the final receipt.
+		expect(driftedDispatch.message).not.toContain('and the final receipt');
 
 		const evidenceDrift = structuredClone(ledger);
 		evidenceDrift[0].evidence = 'different evidence for the same result';
@@ -185,6 +188,7 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 		);
 		expect(evidenceDispatch.success).toBe(false);
 		expect(evidenceDispatch.message).toContain('exactly identical');
+		expect(evidenceDispatch.message).not.toContain('and the final receipt');
 		expect(createdSessions).toBe(2);
 
 		const writerRows = resultDrift.map((row) =>

--- a/tests/unit/tools/write-pr-review-artifact.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact.test.ts
@@ -141,7 +141,9 @@ async function persistPrReviewBatch(
 	}
 }
 
-async function establishPrReviewPrerequisites(): Promise<void> {
+async function establishPrReviewPrerequisites(
+	runId: string = 'test-run',
+): Promise<void> {
 	await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
 		prHeadSha: HEAD_SHA,
 	});
@@ -182,11 +184,7 @@ async function establishPrReviewPrerequisites(): Promise<void> {
 			source_lane_id: `micro-lane-${index}`,
 		});
 	}
-	const triggerRelative = path.join(
-		'pr-review',
-		'test-run',
-		'trigger-eval.json',
-	);
+	const triggerRelative = path.join('pr-review', runId, 'trigger-eval.json');
 	const triggerAbsolute = path.join(directory, '.swarm', triggerRelative);
 	await fs.mkdir(path.dirname(triggerAbsolute), { recursive: true });
 	await fs.writeFile(
@@ -197,13 +195,14 @@ async function establishPrReviewPrerequisites(): Promise<void> {
 	await markPrReviewTriggerEvaluationComplete(
 		directory,
 		SESSION_ID,
+		runId,
 		triggerRelative,
 	);
 }
 
 describe('write_pr_review_artifact', () => {
 	test('ARTIFACT-ORDER regression: requires explorer, reviewer, then critic checkpoints', async () => {
-		await establishPrReviewPrerequisites();
+		await establishPrReviewPrerequisites('coverage-order');
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
 		);
@@ -241,7 +240,15 @@ describe('write_pr_review_artifact', () => {
 			),
 		).rejects.toThrow(/prior post_explorer checkpoint/i);
 		await expect(
-			fs.stat(path.join(directory, '.swarm', 'pr-review', 'coverage-order')),
+			fs.stat(
+				path.join(
+					directory,
+					'.swarm',
+					'pr-review',
+					'coverage-order',
+					'findings.jsonl',
+				),
+			),
 		).rejects.toThrow();
 		await expect(
 			executeWritePrReviewArtifact(
@@ -272,7 +279,7 @@ describe('write_pr_review_artifact', () => {
 	});
 
 	test('ARTIFACT-VERDICT regression: persists only reviewer and critic-authoritative dispositions', async () => {
-		await establishPrReviewPrerequisites();
+		await establishPrReviewPrerequisites('review-boundaries');
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
 		);

--- a/tests/unit/tools/write-pr-review-trigger-eval-run-binding.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-run-binding.test.ts
@@ -1,0 +1,456 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import type { PrReviewInlineTriggerRow } from '../../../src/background/pr-review-trigger-contract';
+import {
+	activatePrWorkflow,
+	assertPrReviewArtifactBoundary,
+	bindPrReviewBase,
+	bindPrReviewTriggerLedger,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	markPrReviewTriggerEvaluationComplete,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+	readPrWorkflowGateState,
+} from '../../../src/hooks/pr-workflow-gate';
+import {
+	executeWritePrReviewTriggerEval,
+	PR_REVIEW_TRIGGER_DEFINITIONS,
+	_internals as writerInternals,
+} from '../../../src/tools/write-pr-review-trigger-eval';
+
+// Issue #2124: the trigger-evaluation receipt must be immutable after
+// consumption — run_id is bound to the gate state (mirroring
+// prReviewArtifactRunId) and the destination write is fail-closed (no clobber).
+// This file covers: (A) a second write under a different run_id is rejected,
+// (B) a repeat write under the same run_id is rejected and the receipt is not
+// replaced, (C) cross-consistency with the findings artifact run_id, (D) the
+// gate-level binding throw via a direct mark call, and (E) forward-compat: an
+// older state without prReviewTriggerEvalRunId reads cleanly and the first
+// consumption binds the run.
+
+const tempDirs: string[] = [];
+const SESSION_ID = 'trigger-eval-run-binding';
+const HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'review-revision';
+const REVIEW_SCOPE = `complete PR diff def456...${HEAD_SHA}`;
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+const originalGateRevisionDigest =
+	gateInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveRevisionDigest =
+	writerInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveMergeBase = writerInternals.resolveMergeBase;
+
+function tempRoot(): string {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), 'trigger-eval-bind-')));
+	tempDirs.push(root);
+	return root;
+}
+
+function artifactPath(root: string, runId: string): string {
+	return join(root, '.swarm', 'pr-review', runId, 'trigger-eval.json');
+}
+
+function rows() {
+	return PR_REVIEW_TRIGGER_DEFINITIONS.map((definition, index) => ({
+		trigger_id: definition.id,
+		result: 'MATCHED' as const,
+		evidence: `frozen distinct evidence for ${definition.id}`,
+		source_batch_id: `micro-batch-${Math.floor(index / 8)}`,
+		source_lane_id: `lane-${index}`,
+	}));
+}
+
+function inlineRows(
+	input: ReadonlyArray<PrReviewInlineTriggerRow> = rows(),
+): PrReviewInlineTriggerRow[] {
+	return input.map(({ trigger_id, result, evidence }) => ({
+		trigger_id,
+		result,
+		evidence,
+	}));
+}
+
+function writerArgs(runId: string) {
+	return {
+		run_id: runId,
+		pr_head_sha: HEAD_SHA,
+		base_ref: 'origin/main',
+		base_sha: 'def456',
+		rows: rows(),
+	};
+}
+
+async function recordCompletedLane(
+	root: string,
+	input: {
+		batchId: string;
+		laneId: string;
+		workflowLane: string;
+		mode: 'swarm-pr-review:base' | 'swarm-pr-review:micro';
+		ownedWorkflowLanes?: string[];
+	},
+): Promise<void> {
+	const correlationId = `${input.batchId}-${input.laneId}-session`;
+	const header =
+		input.mode === 'swarm-pr-review:base'
+			? '[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence'
+			: '[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+	const cleanRows = (input.ownedWorkflowLanes ?? [input.workflowLane])
+		.map(
+			(family) =>
+				`[CLEAN] | ${family} | exact reviewed diff | no candidate survived the focused review`,
+		)
+		.join('\n');
+	const text = `${header}\n${cleanRows}`;
+	await recordPendingDelegation(root, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `${input.batchId}-call`,
+		normalizedAgent: 'explorer',
+		swarmPrefixedAgent: 'explorer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: input.batchId,
+		laneId: input.laneId,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		ownedWorkflowLanes: input.ownedWorkflowLanes,
+		workspace: {
+			directory: root,
+			gitHead: HEAD_SHA,
+			dirtyHash: null,
+			prHeadSha: HEAD_SHA,
+			scope: REVIEW_SCOPE,
+		},
+	});
+	const stored = storeLaneOutput(root, {
+		batchId: input.batchId,
+		laneId: input.laneId,
+		agent: 'explorer',
+		role: 'explorer',
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: REVISION_DIGEST,
+		scope: REVIEW_SCOPE,
+		source: 'collect_lane_results',
+		text,
+	});
+	await appendDelegationTransition(root, correlationId, {
+		status: 'completed',
+		result: {
+			text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			outputRef: stored.ref,
+		},
+	});
+}
+
+async function establishBoundReviewGate(root: string): Promise<void> {
+	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	writerInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	writerInternals.resolveMergeBase = () => 'def456';
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+	await activatePrWorkflow(root, SESSION_ID, 'PR_REVIEW');
+	await bindPrReviewBase(root, SESSION_ID, {
+		prHeadSha: HEAD_SHA,
+		baseRef: 'origin/main',
+		baseSha: 'def456',
+	});
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(root, SESSION_ID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: HEAD_SHA,
+	});
+	for (const lane of baseLanes) {
+		await recordCompletedLane(root, {
+			batchId: 'base-all',
+			laneId: lane.laneId,
+			workflowLane: lane.workflowLane,
+			mode: 'swarm-pr-review:base',
+		});
+	}
+	await bindPrReviewTriggerLedger(root, SESSION_ID, inlineRows());
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		await recordCompletedLane(root, {
+			batchId: `micro-batch-${Math.floor(index / 8)}`,
+			laneId: `lane-${index}`,
+			workflowLane,
+			mode: 'swarm-pr-review:micro',
+		});
+	}
+}
+
+afterEach(() => {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	gateInternals.resolvePrWorkflowRevisionDigest = originalGateRevisionDigest;
+	writerInternals.resolvePrWorkflowRevisionDigest =
+		originalResolveRevisionDigest;
+	writerInternals.resolveMergeBase = originalResolveMergeBase;
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+async function writeTriggerEval(
+	root: string,
+	runId: string,
+): Promise<{ success: boolean; message: string }> {
+	const raw = await executeWritePrReviewTriggerEval(writerArgs(runId), root, {
+		sessionID: SESSION_ID,
+	});
+	try {
+		const parsed = JSON.parse(raw);
+		return { success: parsed.success === true, message: parsed.message ?? '' };
+	} catch {
+		return { success: false, message: raw };
+	}
+}
+
+describe('write_pr_review_trigger_eval — run_id binding + fail-closed receipt (#2124)', () => {
+	test('a second write under a different run_id is rejected and the bound run/path are unchanged', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		const before = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(before?.prReviewTriggerEvalRunId).toBeUndefined();
+		expect(before?.prReviewTriggerEvalPath).toBeUndefined();
+
+		const first = await writeTriggerEval(root, 'run-A');
+		expect(first.success).toBe(true);
+		expect(existsSync(artifactPath(root, 'run-A'))).toBe(true);
+
+		const afterFirst = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(afterFirst?.prReviewTriggerEvalRunId).toBe('run-A');
+		expect(afterFirst?.prReviewTriggerEvalPath).toBe(
+			'pr-review/run-A/trigger-eval.json',
+		);
+
+		const second = await writeTriggerEval(root, 'run-B');
+		expect(second.success).toBe(false);
+		expect(second.message).toContain('already bound to run');
+		expect(second.message).toContain('run-A');
+
+		// The rejected write must not have created a run-B receipt or changed state.
+		expect(existsSync(artifactPath(root, 'run-B'))).toBe(false);
+		const afterSecond = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(afterSecond?.prReviewTriggerEvalRunId).toBe('run-A');
+		expect(afterSecond?.prReviewTriggerEvalPath).toBe(
+			'pr-review/run-A/trigger-eval.json',
+		);
+	});
+
+	test('a repeat write under the same run_id is rejected fail-closed and the receipt is not replaced', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		const first = await writeTriggerEval(root, 'run-same');
+		expect(first.success).toBe(true);
+		const receiptPath = artifactPath(root, 'run-same');
+		const originalContent = readFileSync(receiptPath, 'utf-8');
+		const originalMtime = statMtimeMs(receiptPath);
+
+		const second = await writeTriggerEval(root, 'run-same');
+		expect(second.success).toBe(false);
+		expect(second.message).toContain('already exists for run');
+
+		// The receipt on disk is byte-identical and was not rewritten.
+		expect(readFileSync(receiptPath, 'utf-8')).toBe(originalContent);
+		expect(statMtimeMs(receiptPath)).toBe(originalMtime);
+	});
+
+	test('cross-consistency: a trigger-eval write is rejected when the findings artifact is bound to a different run', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		// Simulate the findings artifact having already bound a different run_id
+		// by editing the durable state directly (the findings persistence path
+		// is too heavy to drive here; the state field is what the guard reads).
+		const stateRel = gateInternals.workflowGateStateRelativePath(SESSION_ID);
+		const stateAbs = join(root, '.swarm', stateRel);
+		const state = JSON.parse(readFileSync(stateAbs, 'utf-8'));
+		state.prReviewArtifactRunId = 'findings-run';
+		writeFileSync(stateAbs, JSON.stringify(state));
+		gateInternals.resetTrackedStateCache();
+
+		const result = await writeTriggerEval(root, 'trigger-run');
+		expect(result.success).toBe(false);
+		expect(result.message).toContain('findings artifact run');
+		expect(result.message).toContain('findings-run');
+		expect(existsSync(artifactPath(root, 'trigger-run'))).toBe(false);
+	});
+});
+
+describe('markPrReviewTriggerEvaluationComplete — run binding (#2124)', () => {
+	test('a direct second mark call under a different run_id throws and leaves the bound run intact', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		await markPrReviewTriggerEvaluationComplete(
+			root,
+			SESSION_ID,
+			'gate-run-A',
+			'pr-review/gate-run-A/trigger-eval.json',
+		);
+		const afterFirst = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(afterFirst?.prReviewTriggerEvalRunId).toBe('gate-run-A');
+
+		await expect(
+			markPrReviewTriggerEvaluationComplete(
+				root,
+				SESSION_ID,
+				'gate-run-B',
+				'pr-review/gate-run-B/trigger-eval.json',
+			),
+		).rejects.toThrow('already bound to run');
+
+		// Forward-compat: an older state shape (field absent) is the first-write
+		// branch; re-reading confirms the bound run survived the rejected call.
+		const afterReject = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(afterReject?.prReviewTriggerEvalRunId).toBe('gate-run-A');
+	});
+
+	test('forward-compat: a state persisted without prReviewTriggerEvalRunId reads cleanly and the first mark binds the run', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		// Strip the field to emulate an older state written before this fix.
+		const stateRel = gateInternals.workflowGateStateRelativePath(SESSION_ID);
+		const stateAbs = join(root, '.swarm', stateRel);
+		const state = JSON.parse(readFileSync(stateAbs, 'utf-8'));
+		delete state.prReviewTriggerEvalRunId;
+		writeFileSync(stateAbs, JSON.stringify(state));
+		gateInternals.resetTrackedStateCache();
+
+		const reloaded = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(reloaded?.prReviewTriggerEvalRunId).toBeUndefined();
+
+		// First consumption must NOT throw (field unset → first-write branch).
+		await markPrReviewTriggerEvaluationComplete(
+			root,
+			SESSION_ID,
+			'compat-run',
+			'pr-review/compat-run/trigger-eval.json',
+		);
+		const after = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(after?.prReviewTriggerEvalRunId).toBe('compat-run');
+	});
+
+	test('findings-side cross-consistency: assertPrReviewArtifactBoundary rejects a different run once the trigger-eval run is bound', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		// Bind the trigger-eval run first (the normal production order).
+		await markPrReviewTriggerEvaluationComplete(
+			root,
+			SESSION_ID,
+			'boundary-run-A',
+			'pr-review/boundary-run-A/trigger-eval.json',
+		);
+
+		// A findings boundary check under a DIFFERENT run must fail closed
+		// before the candidate-inventory derivation runs.
+		await expect(
+			assertPrReviewArtifactBoundary(
+				root,
+				SESSION_ID,
+				'boundary-run-B',
+				'post_explorer',
+				[],
+			),
+		).rejects.toThrow(
+			'findings must use the same run as the trigger evaluation',
+		);
+
+		// The matching run passes the cross-check: it is rejected by a LATER gate
+		// (the artifact/inventory reader), never by the run-mismatch check, which
+		// proves the cross-check is what rejected the other run and does not
+		// over-fire on the matching run.
+		const matchingError = await assertPrReviewArtifactBoundary(
+			root,
+			SESSION_ID,
+			'boundary-run-A',
+			'post_explorer',
+			[],
+		).catch((error: unknown) => (error instanceof Error ? error.message : ''));
+		expect(matchingError).not.toContain('same run as the trigger evaluation');
+	});
+
+	test('mark rejects when the findings artifact run_id is already bound to a different run', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+
+		// Simulate the findings artifact having already bound a different run_id.
+		const stateRel = gateInternals.workflowGateStateRelativePath(SESSION_ID);
+		const stateAbs = join(root, '.swarm', stateRel);
+		const state = JSON.parse(readFileSync(stateAbs, 'utf-8'));
+		state.prReviewArtifactRunId = 'findings-bound-run';
+		writeFileSync(stateAbs, JSON.stringify(state));
+		gateInternals.resetTrackedStateCache();
+
+		// A direct mark call under a mismatched run must throw the cross-consistency
+		// error (the mark-level guard, distinct from the writer pre-check).
+		await expect(
+			markPrReviewTriggerEvaluationComplete(
+				root,
+				SESSION_ID,
+				'trigger-run',
+				'pr-review/trigger-run/trigger-eval.json',
+			),
+		).rejects.toThrow('must match the findings artifact run');
+
+		// The rejected call must not have bound the trigger-eval run or path.
+		const after = await readPrWorkflowGateState(root, SESSION_ID);
+		expect(after?.prReviewTriggerEvalRunId).toBeUndefined();
+		expect(after?.prReviewTriggerEvalPath).toBeUndefined();
+	});
+});
+
+function statMtimeMs(p: string): number {
+	return statSync(p).mtimeMs;
+}


### PR DESCRIPTION
Closes #2124, #2125, #2126

## Summary

Three follow-ups from PR #2121, all in the PR-review trigger ledger/eval subsystem, closed in one coherent change:

- **#2124 (tech-debt/guardrails):** The trigger-evaluation receipt (`.swarm/pr-review/<run_id>/trigger-eval.json`) was rewritable after consumption. `run_id` was never bound to the gate state, and the write path's `rename` clobbered an existing destination — so a repeat write could replace an already-consumed receipt, and several receipts under different self-chosen `run_id` values could persist within one session. **Fix:** add a `prReviewTriggerEvalRunId` gate-state field (mirroring the findings artifact's `prReviewArtifactRunId`); reject a second consumption under a different `run_id`; require the trigger-eval `run_id` to agree with the findings-artifact `run_id` (both share `.swarm/pr-review/<run_id>/`); fail-closed the destination write (refuse an existing receipt instead of clobbering).
- **#2126 (bug/guardrails):** `bindPrReviewTriggerLedger` threw a stale message claiming the ledger must be "exactly identical across every micro dispatch **and the final receipt**" — but PR #2121 removed the final-receipt digest comparison (only classifications must match at the receipt). **Fix:** drop the stale clause.
- **#2125 (docs):** The "Aborting an unrecoverable review" section only documented fetch/checkout stranding. **Fix:** add a "trigger-ledger drift" paragraph naming both stranding sites (bind-time frozen-row digest, finalize-time per-family classification) and the abort exits.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed.
- 2 (runtime portability): not touched — no `bun:` imports, no entry-shape change; `node:fs`/`node:crypto` usage unchanged.
- 3 (subprocesses): not touched — no spawn calls changed.
- 4 (.swarm containment): not touched — receipt still lives under `.swarm/pr-review/<run_id>/`; `validateSwarmPath` unchanged. Evidence: `src/tools/write-pr-review-trigger-eval.ts` destination resolved via `validateSwarmPath`.
- 5 (plan durability): not touched — the new `prReviewTriggerEvalRunId` field is optional/additive; the gate-state schema is `.passthrough()` (`pr-workflow-gate.ts:911`) so older persisted state reads cleanly (zero migration, verified by the forward-compat test).
- 6 (test_runner safety): not touched — no `test_runner` scope change.
- 7 (test writing): touched — new test file `tests/unit/tools/write-pr-review-trigger-eval-run-binding.test.ts` is <500 lines, uses `bun:test`, real-exports DI via `_internals`/`_test_exports`, restores in `afterEach`. Evidence: file is 452 lines; biome ci clean.
- 8 (session state): touched — new `prReviewTriggerEvalRunId` is session-scoped (keyed via the existing per-session gate state). Evidence: `markPrReviewTriggerEvaluationComplete` reads/writes the session-bound state.
- 9 (guardrails/retry): touched — the new BLOCKED throws are fail-closed guards, not retry-affecting. Evidence: 3 new gate/writer guards + tests.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tool added/removed; only the `write_pr_review_trigger_eval` internals changed.
- 12 (release/cache): touched — added `docs/releases/pending/pr-review-trigger-eval-run-binding.md` (unique slug); version files untouched; reconciled a stale claim in `2004-pr-workflow-controller-deadlocks.md`.

## Test plan

Validation run in the worktree at `origin/main` tip (`d06fb42d`):

- `bun run typecheck` → clean (`tsc --noEmit`, exit 0)
- `bunx biome ci` on all 11 changed files → clean (no errors; `--write --unsafe` applied for formatting)
- `bun run drift:check` → `✅ No drift detected`
- `grep -rn "and the final receipt" src/ tests/` → only the two `.not.toContain` pin assertions remain
- Targeted tests (per-file isolation, all green):
  - `write-pr-review-trigger-eval-run-binding.test.ts` (NEW, 7 tests) — run binding, fail-closed destination, cross-consistency (both directions), forward-compat migration, the #2124 mark-level guards
  - `write-pr-review-trigger-eval.test.ts` (9), `-ordering` (1), `-provenance` (6), `-validation` (8), `-registration` (1)
  - `write-pr-review-artifact.test.ts` (2) — fixture aligned to shared `<run_id>`
  - `dispatch-lanes-pr-review-micro-cycle.test.ts` (2) — #2126 message pin (`exactly identical` present, `and the final receipt` absent)
  - `dispatch-lanes-pr-review-council.test.ts` (4)
  - `pr-feedback-transition.test.ts` (8) — `RUN_ID` aligned to shared `<run_id>`
  - all `pr-workflow-gate-*` fixture-importing hook tests (base-diagnostics, candidate-semantics, review-item-coherence, feedback-batch-gc, review-validation-dedup, shell-wrappers, async-git-resolution, review-validation, shell-readonly, batch-gc) green
  - skill tests (`swarm-pr-review-dispatch-guidance`, `process-improvements-guidance`) green

## Review

Swarm workflow: independent implementation reviewer (Kimi K2.7) + final critic (Kimi K3), both fresh-context. Reviewer returned NEEDS_REVISION (3 items: stale release fragment, imprecise SKILL.md wording, missing findings-side test) — all fixed. Critic returned NEEDS_REVISION (3 items: dedicated release fragment, untested mark-level branch, TOCTOU comment overclaim) — all fixed, re-run returned **APPROVE**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

