### PR TITLE
fix(prm): count escalation strikes per occurrence, not per detection (#2134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,10 +489,10 @@ Configure via:
     "enabled": true,
     "pattern_thresholds": {
       "repetition_loop": 2,
-      "ping_pong": 4,
+      "ping_pong": 2,
       "expansion_drift": 3,
       "stuck_on_test": 3,
-      "context_thrash": 5
+      "context_thrash": 10
     }
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -723,7 +723,7 @@ guidance to the agent before a hard stop.
 | `pattern_thresholds.ping_pong` | number (≥ 1) | `2` | Occurrences before an alternating A→B→A delegation pattern targeting the same file is flagged. |
 | `pattern_thresholds.expansion_drift` | number (≥ 1) | `3` | Occurrences before successive plans whose unique-target scope grows by more than 50% are flagged. |
 | `pattern_thresholds.stuck_on_test` | number (≥ 1) | `3` | Occurrences before an edit → test-fail → edit-same-file cycle is flagged. |
-| `pattern_thresholds.context_thrash` | number (≥ 1) | `3` | Consecutive steps before a monotonically increasing unique-target set (no plateaus) is flagged. |
+| `pattern_thresholds.context_thrash` | number (≥ 1) | `10` | Consecutive steps before a monotonically increasing unique-target set (no plateaus) is flagged. Raised from `3` in #2134: three consecutive new targets is indistinguishable from an agent simply reading three files. |
 | `escalation_enabled` | boolean | `true` | Enable the count-based escalation ladder (advisory → hard stop) once a pattern's threshold is met repeatedly. |
 | `max_trajectory_lines` | number (≥ 10) | `1000` | Maximum trajectory entries retained per session before older entries are evicted. |
 | `detection_timeout_ms` | number (≥ 10) | `100` | Bounded time budget for a single pattern-detection pass; detection is skipped (fail-open) if it would exceed this. |
@@ -741,6 +741,44 @@ guidance to the agent before a hard stop.
   }
 }
 ```
+
+### How the escalation ladder counts (issue #2134)
+
+A strike is recorded per **occurrence**, not per detection. Detectors re-emit the
+same ongoing episode on every tool call with a growing end step — a coder reading
+one more file extends its single `context_thrash` run — so PRM keeps a per-session
+ledger of the episodes that have already struck. A match earns a strike only when
+it is a **new episode**, or when the episode it belongs to has grown by another
+full `pattern_thresholds` worth of occurrences since it last struck. A single tool
+call can never advance the ladder by more than one rung.
+
+An agent that genuinely keeps going still reaches the hard stop, because the
+growth rung keeps firing. At default thresholds an unbroken `repetition_loop`
+strikes at 2, 4 and 6 occurrences; a `context_thrash` run strikes at 10, 20 and 30
+consecutive brand-new targets with no revisits. What can no longer happen is a
+hard stop earned by making tool calls rather than by repeating the behaviour.
+
+### Clearing a stuck escalation
+
+PRM escalation state is per session and entirely in memory — it is never written
+to `.swarm/session/state.json`, and a rehydrated session always starts at level 0.
+Two things clear it:
+
+- **A new delegation with a declared scope.** When a Task dispatch claims a coder
+  scope binding, the child session's PRM state is reset, so a coder never inherits
+  a previous delegation's escalation level or an armed hard-stop token. A dispatch
+  that never declares a scope (`SCOPE_NOT_DECLARED`) does not reach that reset.
+- **`/swarm reset-session`.** Clears escalation counts, both hard-stop tokens, the
+  trajectory cursor, and the episode ledger for every tracked agent session, while
+  preserving the plan, evidence, and knowledge stores.
+
+```bash
+/swarm reset-session
+```
+
+To disable the ladder entirely while leaving pattern detection and its telemetry
+in place, set `prm.escalation_enabled` to `false`; to turn PRM off altogether, set
+`prm.enabled` to `false`.
 
 ## Phase Complete Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -752,6 +752,15 @@ it is a **new episode**, or when the episode it belongs to has grown by another
 full `pattern_thresholds` worth of occurrences since it last struck. A single tool
 call can never advance the ladder by more than one rung.
 
+Strikes are also counted per **behaviour**, not per pattern type. A pattern that
+names a single target — `repetition_loop`, `ping_pong`, `stuck_on_test` — gets its
+own 1→2→3 ladder for that target, so repeating yourself once each on three
+different files is three level-1 advisories rather than a hard stop; reaching the
+hard stop takes three strikes against *the same* target. Patterns that report a
+growing set of targets (`context_thrash`, `expansion_drift`) keep one ladder for
+the pattern, because a per-target ladder would restart on every tool call and they
+could never escalate at all.
+
 An agent that genuinely keeps going still reaches the hard stop, because the
 growth rung keeps firing. At default thresholds an unbroken `repetition_loop`
 strikes at 2, 4 and 6 occurrences; a `context_thrash` run strikes at 10, 20 and 30

--- a/docs/releases/pending/2134-prm-episode-gate.md
+++ b/docs/releases/pending/2134-prm-episode-gate.md
@@ -66,6 +66,25 @@ otherwise the test would still pass with those detectors fully disarmed.
   they could never escalate, the same fail-open shape the per-detector containment
   review caught earlier.
 
+  Three defects found reviewing that change are fixed with it. The advisory
+  dedupe key was still scoped to the pattern type, so with every target at level 1
+  exactly **one** advisory was delivered per pattern for the whole session and
+  every later target's guidance was dropped — the agent was neither stopped nor
+  told; it is now scoped to the ladder (40 distinct repeating files: 1 advisory
+  before, 40 after). `detectRepetitionLoop` recovered its `(agent, action, target)`
+  tuple with `key.split('|')`, truncating any target containing a pipe — and since
+  targets are now whole shell commands, `bun test 2>&1 | head`, `| tail` and
+  `| wc -l` all collapsed onto one ladder and hard-stopped in six steps; the tuple
+  is now carried rather than re-split. And the ladder map is bounded at 256 with
+  FIFO eviction, matching the episode ledger it mirrors.
+
+  **Known trade-off:** a pathology spread thinly across many targets no longer
+  reaches a hard stop. This is inherent to the precision/recall trade the issue
+  asks for — a benign eight-module coder loop and a distributed ping-pong are
+  numerically identical (16 vs 15 ladders, each struck once), so no spread
+  threshold separates them. The agent is advised per distinct behaviour instead of
+  being blocked.
+
 - **Shell commands are no longer collapsed onto their first word.**
   `extractTarget` in `src/hooks/trajectory-logger.ts` returned a bash command's
   first word as the trajectory target, so `bun test src/a`, `bun run lint` and

--- a/docs/releases/pending/2134-prm-episode-gate.md
+++ b/docs/releases/pending/2134-prm-episode-gate.md
@@ -52,6 +52,20 @@ otherwise the test would still pass with those detectors fully disarmed.
 
 ## Also
 
+- **The ladder counts strikes per behaviour, not per pattern type.** It keyed on
+  `match.pattern` alone, so unrelated occurrences accumulated into one count: a
+  coder that read-then-re-read three *different* files scored three
+  `repetition_loop` strikes and hit the hard stop without having repeated itself
+  even twice on any single file. Measured on a realistic read → edit → run-test →
+  re-read → re-run-test loop across modules: hard stop at step 11. Now
+  `resolveLadderKey` gives a pattern that names a single target its own ladder for
+  that target, so the same trajectory never stops and stays at level 1, while
+  three strikes against *the same* target still hard-stops at step 6. Patterns
+  reporting a growing target set (`context_thrash`, `expansion_drift`) keep one
+  ladder for the pattern — a per-target ladder would restart every tool call and
+  they could never escalate, the same fail-open shape the per-detector containment
+  review caught earlier.
+
 - **Shell commands are no longer collapsed onto their first word.**
   `extractTarget` in `src/hooks/trajectory-logger.ts` returned a bash command's
   first word as the trajectory target, so `bun test src/a`, `bun run lint` and

--- a/docs/releases/pending/2134-prm-episode-gate.md
+++ b/docs/releases/pending/2134-prm-episode-gate.md
@@ -114,6 +114,36 @@ otherwise the test would still pass with those detectors fully disarmed.
   three files, so the old default fired on essentially every healthy coder session
   and told an agent doing nothing wrong to "restrict file access".
 
+- **Trajectory entries no longer persist secrets in command values.** Widening
+  `target` from a first word to a whole 200-char command widened what
+  `.swarm/trajectories/*.jsonl` and evidence/replay store, and the existing
+  redaction only matched sensitive KEY names — useless for
+  `curl -H "Authorization: Bearer …"`, where the secret is the value. `target`,
+  `args_summary`, `intent` and the `description` fallback now all run the shared
+  `redactSecrets` detector plus a module-local URL-credential pattern, over a
+  bounded 4 KB scan window (the shared detector's lazy private-key pattern is
+  quadratic against repeated unterminated `BEGIN … PRIVATE KEY` markers, and this
+  runs on the per-tool-call path).
+
+  Ordering is load-bearing: the command is **bounded first, redacted second**.
+  Redacting first was a defect caught in review — a placeholder is longer than
+  the span it replaces, so redaction pushed a ~200-char command's tail past the
+  bound and truncation cut the part that made two commands *different*,
+  collapsing them onto one target even when the secret was not the differing
+  text. That is the same false-`repetition_loop` failure this issue exists to
+  close. When redaction still overflows the bound, the target carries a digest of
+  the bounded raw command so distinctness is preserved by construction.
+
+  The URL-credential pattern is deliberately local to the trajectory logger:
+  `SECRET_PATTERNS.length` in `src/memory/redaction.ts` feeds
+  `computeRedactionPolicyVersion`, a memory-cohort compatibility value that fails
+  closed, so growing that array would invalidate every already-linked cohort.
+
+- **Episode-ledger eviction is now least-recently-struck.** `Map.set` on an
+  existing key preserves its original position, so the 256-entry FIFO bound
+  evicted by oldest-first-seen and could drop the very episode an agent was
+  actively tripping. Delete-then-set moves a re-struck episode to the back.
+
 ## Docs
 
 `docs/configuration.md` now documents how the ladder counts, and how to clear a

--- a/docs/releases/pending/2134-prm-episode-gate.md
+++ b/docs/releases/pending/2134-prm-episode-gate.md
@@ -1,0 +1,87 @@
+# PRM: count escalation strikes per occurrence, not per detection (#2134)
+
+## What
+
+A `coder` subagent could be denied on essentially every tool call with
+
+```
+🛑 PRM HARD STOP: Pattern escalation maximum reached.
+```
+
+including on read-only calls, with no level-1 or level-2 guidance ever delivered.
+Reading five distinct files — the most ordinary thing a coder does — was enough to
+arm the deny token.
+
+The PRM 3-strike ladder counted **detections** rather than **occurrences**. A
+detector re-emits the same ongoing episode on every tool call with a growing end
+step: a coder reading one more file extends its single `context_thrash` run, and a
+sliding window extends its single `repetition_loop`. The trajectory cursor could
+never suppress that, because the episode's end step always advances past it. So
+one episode was counted three times and reached level 3 within three tool calls.
+
+Two independent defects produced it, both fixed here.
+
+- **`detectPatterns` in-tick dedup was a no-op for the case it documented.** Its
+  key included the volatile `stepRange[1]`, so one repetition episode emitted
+  `[1,2]`, `[1,3]`, `[1,4]`, `[1,5]` — four distinct keys, four surviving matches,
+  four strikes, and a first-ever occurrence hard-stopping inside a single tool
+  call. The key now uses the episode's **start** step; the surviving match keeps
+  the widest range.
+
+- **A continuing episode re-struck on every tool call.** `toolAfter` now consults
+  a per-session episode ledger (`prmStruckEpisodes`, keyed `pattern|startStep`). A
+  match strikes only when it is a new episode, or when its episode has gained
+  another full threshold's worth of occurrences since it last struck; at most one
+  strike per pattern type is recorded per tick. Suppressed matches are dropped
+  completely — no advisory, no telemetry, no replay, and no pattern-persistence
+  tally (a single episode previously reached the default `min_support` of 3 on its
+  own and promoted a "learned" insight the agent had exhibited exactly once).
+
+**Containment is not weakened, and this is pinned per detector.** Both strike
+grounds are load-bearing: only `repetition_loop` and `expansion_drift` advance an
+episode's start step as it runs. `ping_pong` pins it at the first delegation,
+`stuck_on_test` assigns `cycleStart` once, and `context_thrash` moves `runStart`
+only when the monotonic run *breaks* — which a sustained thrash never does. A
+start-step rule alone would have let those three strike exactly once and never
+reach level 2 or 3. Regression tests drive each of the five detectors to level 3
+independently — `repetition_loop` hard-stops at step 6, `context_thrash` and
+`expansion_drift` at step 30. `ping_pong` and `stuck_on_test` assert their OWN
+strike counts reaching 3 (at steps 10 and 19 respectively) rather than relying on
+the `repetition_loop` co-firing that hard-stops those trajectories at step 7 —
+otherwise the test would still pass with those detectors fully disarmed.
+
+## Also
+
+- **Shell commands are no longer collapsed onto their first word.**
+  `extractTarget` in `src/hooks/trajectory-logger.ts` returned a bash command's
+  first word as the trajectory target, so `bun test src/a`, `bun run lint` and
+  `bunx tsc --noEmit` were all the target `bun`. PRM's `repetition_loop` keys on
+  `agent|action|target` at default threshold 2, so a coder doing ordinary,
+  entirely different work read as the same action repeated. Measured on this repo,
+  twelve distinct `bun …` commands hard-stopped the session by the seventh call —
+  the reported symptom, surviving every other fix here. The reporter's environment
+  is a Python project, where `python` / `pytest` / `pip` collapse identically. The
+  target is now the whole whitespace-normalized command, bounded to 200 chars: an
+  agent genuinely re-running the SAME command still produces an identical target
+  and is still detected.
+
+- **Escalation state now resets at delegation start.** `agentSessions` entries are
+  never removed when a delegated session ends (`sessionEnded` clears scope
+  bindings only; `endAgentSession` is reached solely from `/swarm close` and the
+  Lean Turbo runner), so a coder session that ended with `prmHardStopPending`
+  armed left a live deny token behind — and reusing that sessionID denied the next
+  delegation's *first* tool call. `taskMetadata` now resets the child session's PRM
+  state once per Task dispatch that claims a coder scope binding, guarded on the
+  dispatch `callID` because `message.part.updated` fires repeatedly for the same
+  part and an unguarded reset would disarm PRM for the whole delegation.
+
+- **`prm.pattern_thresholds.context_thrash` default `3` → `10`** (tuning).
+  `detectContextThrash` flags a run of consecutive steps that each introduce a
+  brand-new target; three such steps is indistinguishable from an agent reading
+  three files, so the old default fired on essentially every healthy coder session
+  and told an agent doing nothing wrong to "restrict file access".
+
+## Docs
+
+`docs/configuration.md` now documents how the ladder counts, and how to clear a
+stuck escalation (`/swarm reset-session`, or simply a new delegation).

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2329,14 +2329,17 @@ export const PrmConfigSchema = z.object({
 			ping_pong: z.number().min(1).default(2),
 			expansion_drift: z.number().min(1).default(3),
 			stuck_on_test: z.number().min(1).default(3),
-			context_thrash: z.number().min(1).default(3),
+			// Issue #2134 (tuning): was 3, which fired on any agent that read three
+			// files in a row. Keep in sync with `DEFAULT_THRESHOLDS` in
+			// `src/prm/pattern-detector.ts`.
+			context_thrash: z.number().min(1).default(10),
 		})
 		.default(() => ({
 			repetition_loop: 2,
 			ping_pong: 2,
 			expansion_drift: 3,
 			stuck_on_test: 3,
-			context_thrash: 3,
+			context_thrash: 10,
 		})),
 	max_trajectory_lines: z.number().min(10).default(1000),
 	escalation_enabled: z.boolean().default(true),

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -44,6 +44,7 @@ import {
 import { loadPlanJsonOnly, savePlan } from '../plan/manager';
 import { computeParallelVerdict } from '../plan/parallel-verdict';
 import { derivePlanId } from '../plan/utils.js';
+import { resetPrmSessionState } from '../prm/index.js';
 import {
 	canonicalWorkspaceIdentity,
 	clearExactScopeBinding,
@@ -2442,6 +2443,26 @@ export function createDelegationGateHook(
 			'coder',
 			directory,
 		);
+		// Issue #2134: a delegation start is a fresh coder run, so it starts from a
+		// clean PRM escalation ladder.
+		//
+		// `agentSessions` entries are never removed when a delegated session ends —
+		// `sessionEnded` below clears scope bindings only, and `endAgentSession` is
+		// reached solely from `/swarm close` and the Lean Turbo runner. A coder
+		// session that ended while `prmHardStopPending` was armed therefore left a
+		// live DENY token in the map; if that sessionID was reused, the next
+		// delegation's very FIRST tool call was denied with "Pattern escalation
+		// maximum reached" — the symptom reported in #2134, surviving restarts
+		// because it never depended on disk state at all.
+		//
+		// Guarded on the dispatch callID: `taskMetadata` is driven by
+		// `message.part.updated`, which fires repeatedly for the same Task part
+		// while the child runs. Resetting unconditionally would clear the ladder on
+		// every update and disarm PRM for the whole delegation.
+		if (childSession.prmDelegationCallId !== input.callID) {
+			childSession.prmDelegationCallId = input.callID;
+			resetPrmSessionState(childSession, input.childSessionID);
+		}
 		childSession.currentTaskId = claimed.taskId;
 		childSession.declaredCoderScope = [...claimed.files];
 	};

--- a/src/hooks/trajectory-logger.ts
+++ b/src/hooks/trajectory-logger.ts
@@ -156,6 +156,27 @@ function deriveAction(tool: string): string {
 }
 
 /**
+ * Upper bound on a shell command used as a trajectory target (issue #2134).
+ *
+ * Matches `MAX_SANITIZED_LENGTH` in `src/prm/pattern-detector.ts`, which is what
+ * the detectors truncate a target to when rendering a course correction — so a
+ * target is never stored longer than the value that can be reported back.
+ */
+const MAX_COMMAND_TARGET_LENGTH = 200;
+
+/**
+ * Normalizes a shell command into a stable trajectory target: whitespace
+ * collapsed (so a heredoc or a line-continued command matches its single-line
+ * equivalent) and bounded in length.
+ */
+function normalizeCommandTarget(command: string): string {
+	const normalized = command.trim().replace(/\s+/g, ' ');
+	return normalized.length > MAX_COMMAND_TARGET_LENGTH
+		? `${normalized.slice(0, MAX_COMMAND_TARGET_LENGTH - 3)}...`
+		: normalized;
+}
+
+/**
  * Extracts the target from tool arguments.
  *
  * @param tool - Tool name
@@ -191,14 +212,24 @@ function extractTarget(tool: string, args?: Record<string, unknown>): string {
 		toolLower === 'execute' ||
 		toolLower === 'command'
 	) {
-		// Try to extract from command field
+		// Try to extract from command field.
+		//
+		// Issue #2134: this used to return the command's FIRST WORD ("git" from
+		// "git commit"). That collapsed every shell command sharing a driver onto
+		// one target, so `bun test src/a`, `bun run lint` and `bunx tsc --noEmit`
+		// were indistinguishable — and PRM's `repetition_loop` (default threshold
+		// 2, on the tuple `agent|action|target`) read a coder doing ordinary,
+		// entirely different work as the same action over and over. Measured on
+		// this repo: twelve distinct `bun …` commands drove the escalation ladder
+		// to a HARD STOP by the seventh call. On a Python project the same thing
+		// happens with `python` / `pytest` / `pip`, and with `git` anywhere.
+		//
+		// The whole normalized command is the correct target: an agent genuinely
+		// stuck re-running the SAME command still produces an identical target and
+		// is still detected, while distinct commands stay distinct.
 		const command = args.command;
-		if (typeof command === 'string' && command.length > 0) {
-			// Return first word of command as target (e.g., "git" from "git commit")
-			const firstWord = command.split(/\s+/)[0] || '';
-			if (firstWord.length > 0) {
-				return firstWord;
-			}
+		if (typeof command === 'string' && command.trim().length > 0) {
+			return normalizeCommandTarget(command);
 		}
 
 		// Try description field
@@ -210,13 +241,11 @@ function extractTarget(tool: string, args?: Record<string, unknown>): string {
 				: description;
 		}
 
-		// Try args field (generic fallback)
+		// Try args field (generic fallback). Same issue #2134 reasoning as the
+		// `command` field above — a first word collapses unrelated invocations.
 		const argsStr = args.args;
-		if (typeof argsStr === 'string' && argsStr.length > 0) {
-			const firstWord = argsStr.split(/\s+/)[0] || '';
-			if (firstWord.length > 0) {
-				return firstWord;
-			}
+		if (typeof argsStr === 'string' && argsStr.trim().length > 0) {
+			return normalizeCommandTarget(argsStr);
 		}
 	}
 

--- a/src/hooks/trajectory-logger.ts
+++ b/src/hooks/trajectory-logger.ts
@@ -177,10 +177,14 @@ const URL_CREDENTIALS_PATTERN =
 /**
  * How much of a string value is scanned for secrets.
  *
- * Comfortably above the 50-char slice `summarizeArgs` emits and the 100-char
- * slice `extractIntent` emits, so the redacted output is identical to a full
- * scan for any realistic input, while bounding the cost of running ~14 regexes
- * over every string arg of every tool call.
+ * Comfortably above the 50-char slice `summarizeArgs` emits and the 100/200-char
+ * slices `extractIntent` emits, so a secret that starts inside the emitted
+ * prefix is matched even when it extends well past it, while bounding the cost
+ * of running ~14 regexes over every string arg of every tool call.
+ *
+ * It is NOT equivalent to a full scan: a pattern that needs a terminator beyond
+ * the window (a >4 KB PEM in `write.content`) will not match. `redactCommandSecrets`
+ * handles that specific case by truncating at a surviving BEGIN marker.
  */
 const REDACTION_SCAN_WINDOW = 4096;
 
@@ -205,10 +209,19 @@ function fnv1aHex(text: string): string {
  * pattern over a command string.
  */
 function redactCommandSecrets(text: string): string {
-	return redactSecrets(text).replace(
+	const redacted = redactSecrets(text).replace(
 		URL_CREDENTIALS_PATTERN,
 		'$1[REDACTED:url_credentials]@',
 	);
+	// A key block whose END marker falls outside the scan window never matches
+	// the shared `private_key_block` pattern, so a surviving BEGIN marker means
+	// the material after it was NOT redacted — a 4.8 KB PEM in `write.content`
+	// leaves the header plus the first bytes of the key. Truncate from the
+	// marker: nothing after it in this window can be anything but key material.
+	const beginMarker = redacted.search(/-----BEGIN [A-Z ]*PRIVATE KEY-----/);
+	return beginMarker === -1
+		? redacted
+		: `${redacted.slice(0, beginMarker)}[REDACTED:private_key_block]`;
 }
 
 /**
@@ -254,15 +267,35 @@ function normalizeCommandTarget(command: string): string {
 			? `${normalized.slice(0, MAX_COMMAND_TARGET_LENGTH - 3)}...`
 			: normalized;
 	const redacted = redactCommandSecrets(bounded);
-	if (redacted.length <= MAX_COMMAND_TARGET_LENGTH) return redacted;
-	// A placeholder is longer than the span it replaces, so redaction can push a
-	// command that fitted back over the bound. Truncating here would cut the tail
-	// that made two commands different — the E-2 collapse this ordering exists to
-	// prevent, and it bites hardest when the secret is NOT the differing text.
-	// Re-bound, but carry a digest of the BOUNDED RAW string so distinctness is
-	// preserved by construction rather than by luck of where the cut lands.
-	const digest = fnv1aHex(bounded);
-	return `${redacted.slice(0, MAX_COMMAND_TARGET_LENGTH - 1 - digest.length)}#${digest}`;
+	if (redacted === bounded) return redacted;
+
+	// Redaction CHANGED the command, so the stored target is lossy and two
+	// different commands can now render identically. That is a collapse in the
+	// same false-`repetition_loop` family this issue exists to close, and it does
+	// not require a real credential: `env_secret` is case-insensitive, so
+	// `bun run build --cache_key=aaa` and `--cache_key=bbb` both become
+	// `bun run build --[REDACTED:env_secret]` and trip the detector at its
+	// default threshold of 2 on the second call.
+	//
+	// A digest of the pre-redaction (but post-bounding) string restores
+	// distinctness by construction, for every redacted target rather than only
+	// the ones that happened to overflow the length bound.
+	//
+	// It LEADS rather than trails because downstream truncation cuts tails:
+	// `sanitizeString` in `pattern-detector.ts` expands its input before
+	// length-checking it (`--bypass` becomes `--[REDACTED]`), so a trailing
+	// digest on a near-200-char target gets chopped and two distinct behaviours
+	// collapse onto one escalation ladder key.
+	//
+	// The deliberate trade: an agent re-running ONE command with a rotating
+	// credential no longer reads as a repetition. Those are genuinely different
+	// commands, and treating them as identical was an accident of redaction, not
+	// a signal worth keeping at the cost of false hard stops on ordinary work.
+	const prefix = `#${fnv1aHex(bounded)} `;
+	const room = MAX_COMMAND_TARGET_LENGTH - prefix.length;
+	const body =
+		redacted.length > room ? `${redacted.slice(0, room - 3)}...` : redacted;
+	return `${prefix}${body}`;
 }
 
 /**
@@ -376,12 +409,20 @@ function extractIntent(tool: string, args?: Record<string, unknown>): string {
 		return safeText;
 	}
 
-	// Check for description or task fields
+	// Check for description or task fields.
+	//
+	// Redacted for the same reason as the Task branch above: this lands in the
+	// SAME trajectory line as `target` and `args_summary`, so leaving it raw
+	// persisted verbatim what those two had just redacted — a `bash` call with
+	// `description: 'deploy using ghp_…'` wrote the token to
+	// `.swarm/trajectories/*.jsonl` while `args_summary` showed
+	// `[REDACTED:github_token]` on the same line.
 	const intentFields = ['description', 'task'];
 	for (const field of intentFields) {
 		const value = args[field];
 		if (typeof value === 'string' && value.length > 0) {
-			return value.length > 200 ? `${value.slice(0, 197)}...` : value;
+			const safe = redactCommandSecrets(value.slice(0, REDACTION_SCAN_WINDOW));
+			return safe.length > 200 ? `${safe.slice(0, 197)}...` : safe;
 		}
 	}
 

--- a/src/hooks/trajectory-logger.ts
+++ b/src/hooks/trajectory-logger.ts
@@ -11,6 +11,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { sanitizeTaskId } from '../evidence/manager';
+import { redactSecrets } from '../memory/redaction';
 import { appendTrajectoryEntry } from '../prm/trajectory-store';
 import { swarmState } from '../state';
 import { invalidateCachedArtifact } from '../utils/swarm-artifact-cache';
@@ -156,6 +157,61 @@ function deriveAction(tool: string): string {
 }
 
 /**
+ * Credentials embedded in a URL authority (`https://user:pass@host/…`).
+ *
+ * Deliberately LOCAL to this module rather than added to `SECRET_PATTERNS` in
+ * `src/memory/redaction.ts`: that array's LENGTH feeds
+ * `computeRedactionPolicyVersion`, a memory-cohort compatibility value that
+ * fails closed on mismatch, so growing it would invalidate every already-linked
+ * cohort until the user re-ran `/swarm memory link`. The trajectory logger has
+ * no cohort coupling, so it can close the leak here at zero policy-version cost.
+ * A change that genuinely owns the cohort bump should move this into the shared
+ * list.
+ *
+ * The userinfo segment is replaced wholesale — the username is as identifying as
+ * the password for a leaked credential pair.
+ */
+const URL_CREDENTIALS_PATTERN =
+	/\b([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^\s/@:]+:[^\s/@]+@/g;
+
+/**
+ * How much of a string value is scanned for secrets.
+ *
+ * Comfortably above the 50-char slice `summarizeArgs` emits and the 100-char
+ * slice `extractIntent` emits, so the redacted output is identical to a full
+ * scan for any realistic input, while bounding the cost of running ~14 regexes
+ * over every string arg of every tool call.
+ */
+const REDACTION_SCAN_WINDOW = 4096;
+
+/**
+ * FNV-1a 32-bit, hex. Not a security primitive — it exists so a redacted target
+ * that had to be re-truncated still differs when the underlying commands differ.
+ * A cheap non-cryptographic hash is the right tool: this runs on the
+ * per-tool-call path, and a collision costs at most one conflated repetition
+ * ladder, never a correctness or safety property.
+ */
+function fnv1aHex(text: string): string {
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < text.length; i++) {
+		hash ^= text.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * Runs the shared secret detector plus this module's local URL-credential
+ * pattern over a command string.
+ */
+function redactCommandSecrets(text: string): string {
+	return redactSecrets(text).replace(
+		URL_CREDENTIALS_PATTERN,
+		'$1[REDACTED:url_credentials]@',
+	);
+}
+
+/**
  * Upper bound on a shell command used as a trajectory target (issue #2134).
  *
  * Matches `MAX_SANITIZED_LENGTH` in `src/prm/pattern-detector.ts`, which is what
@@ -165,15 +221,48 @@ function deriveAction(tool: string): string {
 const MAX_COMMAND_TARGET_LENGTH = 200;
 
 /**
- * Normalizes a shell command into a stable trajectory target: whitespace
- * collapsed (so a heredoc or a line-continued command matches its single-line
- * equivalent) and bounded in length.
+ * Normalizes a shell command into a stable trajectory target: inline secrets
+ * redacted, whitespace collapsed (so a heredoc or a line-continued command
+ * matches its single-line equivalent), and bounded in length.
+ *
+ * PRR-001 (PR #2139 review): `target` is persisted verbatim to
+ * `.swarm/trajectories/{sid}.jsonl`, `.swarm/evidence/{taskId}/trajectory.jsonl`
+ * and replay artifacts. `summarizeArgs` redacts by KEY name, which does nothing
+ * for a command whose secret is in the VALUE — `curl -H "Authorization: Bearer …"`.
+ * Widening the target from a first word to the whole command widened that
+ * exposure, so the shared `redactSecrets` detector runs over it here.
+ *
+ * ORDER IS LOAD-BEARING: bound FIRST, redact second. Redacting first was a
+ * defect (Stage-B review of this fix): a placeholder like
+ * `[REDACTED:env_secret]` (21 chars) is longer than the span it replaces, so
+ * redaction PUSHED the tail of a ~200-char command past the length bound and
+ * truncation then cut the part that made two commands different — collapsing
+ * them onto one target even when the secret was not the differing text. That is
+ * exactly the false-`repetition_loop` failure this issue exists to close, and it
+ * contradicts the invariant this function documents below. Bounding first means
+ * the identity window is the same 200 bytes it was before redaction existed.
+ *
+ * The residual: a secret straddling the 200-char bound has its head inside the
+ * window and no longer matches, so a partial fragment is stored. That is the
+ * same exposure every other truncated field here already carries (`args_summary`
+ * cuts at 50), and it is strictly better than the pre-redaction behaviour.
  */
 function normalizeCommandTarget(command: string): string {
 	const normalized = command.trim().replace(/\s+/g, ' ');
-	return normalized.length > MAX_COMMAND_TARGET_LENGTH
-		? `${normalized.slice(0, MAX_COMMAND_TARGET_LENGTH - 3)}...`
-		: normalized;
+	const bounded =
+		normalized.length > MAX_COMMAND_TARGET_LENGTH
+			? `${normalized.slice(0, MAX_COMMAND_TARGET_LENGTH - 3)}...`
+			: normalized;
+	const redacted = redactCommandSecrets(bounded);
+	if (redacted.length <= MAX_COMMAND_TARGET_LENGTH) return redacted;
+	// A placeholder is longer than the span it replaces, so redaction can push a
+	// command that fitted back over the bound. Truncating here would cut the tail
+	// that made two commands different — the E-2 collapse this ordering exists to
+	// prevent, and it bites hardest when the secret is NOT the differing text.
+	// Re-bound, but carry a digest of the BOUNDED RAW string so distinctness is
+	// preserved by construction rather than by luck of where the cut lands.
+	const digest = fnv1aHex(bounded);
+	return `${redacted.slice(0, MAX_COMMAND_TARGET_LENGTH - 1 - digest.length)}#${digest}`;
 }
 
 /**
@@ -236,9 +325,14 @@ function extractTarget(tool: string, args?: Record<string, unknown>): string {
 		const description = args.description;
 		if (typeof description === 'string' && description.length > 0) {
 			// Return first 30 chars as target to differentiate commands
-			return description.length > 30
-				? `${description.slice(0, 27)}...`
-				: description;
+			// PRR-001 residual (Stage-B review): this fallback lands in the same
+			// JSONL line as `target`, so it carries the same redaction posture.
+			const safeDescription = redactCommandSecrets(
+				description.slice(0, REDACTION_SCAN_WINDOW),
+			);
+			return safeDescription.length > 30
+				? `${safeDescription.slice(0, 27)}...`
+				: safeDescription;
 		}
 
 		// Try args field (generic fallback). Same issue #2134 reasoning as the
@@ -272,10 +366,14 @@ function extractIntent(tool: string, args?: Record<string, unknown>): string {
 				: typeof description === 'string'
 					? description
 					: '';
-		if (text.length > 100) {
-			return `${text.slice(0, 97)}...`;
+		// PRR-001 residual (Stage-B review): `intent` is written to the same
+		// trajectory line as `target` and `args_summary`, and a Task prompt is
+		// free-form text that can quote a credential.
+		const safeText = redactCommandSecrets(text.slice(0, REDACTION_SCAN_WINDOW));
+		if (safeText.length > 100) {
+			return `${safeText.slice(0, 97)}...`;
 		}
-		return text;
+		return safeText;
 	}
 
 	// Check for description or task fields
@@ -660,8 +758,22 @@ function summarizeArgs(
 		if (value === null || value === undefined) {
 			summaries.push(`${key}:null`);
 		} else if (typeof value === 'string') {
-			// Truncate long string values
-			const truncated = value.length > 50 ? `${value.slice(0, 50)}...` : value;
+			// PRR-001 (PR #2139 review): key-name redaction above cannot see a secret
+			// carried in the VALUE — `command: 'curl -H "Authorization: Bearer …"'`
+			// has a non-sensitive key.
+			//
+			// Only the scan WINDOW is redacted, not the whole value. This runs on the
+			// per-tool-call hot path for EVERY string arg — including `write.content`
+			// and `task.prompt`, which can be megabytes — and `private_key_block`'s
+			// lazy `[\s\S]*?` is quadratic against repeated unterminated
+			// `-----BEGIN … PRIVATE KEY-----` markers (measured: 1.7s at 8k markers).
+			// The value is sliced to 50 chars anyway, so scanning a bounded prefix
+			// gives identical output for every input that is not adversarially
+			// constructed, at O(1) cost.
+			const window = value.slice(0, REDACTION_SCAN_WINDOW);
+			const redacted = redactCommandSecrets(window);
+			const truncated =
+				redacted.length > 50 ? `${redacted.slice(0, 50)}...` : redacted;
 			summaries.push(`${key}:"${truncated}"`);
 		} else if (typeof value === 'number' || typeof value === 'boolean') {
 			summaries.push(`${key}:${String(value)}`);

--- a/src/prm/__tests__/escalation.test.ts
+++ b/src/prm/__tests__/escalation.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'bun:test';
-import { createDefaultEscalationState, EscalationTracker } from '../escalation';
+import {
+	createDefaultEscalationState,
+	EscalationTracker,
+	resolveLadderKey,
+} from '../escalation';
 import type { EscalationState, PatternMatch } from '../types';
 
 // Mock telemetry module - must use correct relative path from __tests__/
@@ -236,13 +240,17 @@ describe('EscalationTracker', () => {
 			const state2 = tracker.getState();
 
 			expect(state1).not.toBe(state2);
-			expect(state1.patternCounts.get('repetition_loop')).toBe(1);
-			state1.patternCounts.set('repetition_loop', 99);
+			// Issue #2134 follow-up: the ladder is keyed per TARGET for a
+			// single-target pattern, so derive the key rather than assuming the
+			// bare pattern type.
+			const ladderKey = resolveLadderKey(match);
+			expect(state1.patternCounts.get(ladderKey)).toBe(1);
+			state1.patternCounts.set(ladderKey, 99);
 			state1.lastPatternDetected?.affectedAgents.push('mutated-agent');
 			state1.lastPatternDetected?.affectedTargets.push('mutated-target');
 
 			const freshState = tracker.getState();
-			expect(freshState.patternCounts.get('repetition_loop')).toBe(1);
+			expect(freshState.patternCounts.get(ladderKey)).toBe(1);
 			expect(freshState.lastPatternDetected?.affectedAgents).toEqual([
 				'agent-a',
 			]);
@@ -259,7 +267,9 @@ describe('EscalationTracker', () => {
 			tracker.recordDetection(match);
 			tracker.recordDetection(match);
 
-			expect(tracker.getState().patternCounts.get('repetition_loop')).toBe(2);
+			expect(
+				tracker.getState().patternCounts.get(resolveLadderKey(match)),
+			).toBe(2);
 
 			tracker.reset();
 

--- a/src/prm/__tests__/hard-stop-tokens.test.ts
+++ b/src/prm/__tests__/hard-stop-tokens.test.ts
@@ -52,12 +52,15 @@ function createMockConfig(): PrmConfig {
 	};
 }
 
-function createMatch(pattern: PatternMatch['pattern']): PatternMatch {
+function createMatch(
+	pattern: PatternMatch['pattern'],
+	stepRange: [number, number] = [1, 3],
+): PatternMatch {
 	return {
 		pattern,
 		severity: 'medium',
 		category: 'coordination_error',
-		stepRange: [1, 3],
+		stepRange,
 		description: `${pattern} detected`,
 		affectedAgents: ['coder'],
 		affectedTargets: ['src/foo.ts'],
@@ -186,17 +189,30 @@ describe('PRM hard-stop tokens (issue #2063 C2)', () => {
 		// match, so the trailing ping_pong match (count 1 ⇒ level 1 ⇒
 		// hardStop:false) overwrote the repetition_loop hard stop set two
 		// assignments earlier and the escalation vanished within a single tick.
+		//
+		// Issue #2134: the episode gate caps a single tick at ONE strike per
+		// pattern, so the three repetition_loop strikes that drive the ladder to
+		// level 3 must now arrive as three genuinely distinct, non-overlapping
+		// episodes across three ticks — not three matches crammed into one tick,
+		// which the gate would collapse to a single strike. The THIRD tick still
+		// carries a trailing ping_pong match (a different pattern, so it is not
+		// claimed by the repetition_loop strike and survives the same-tick gate)
+		// with a LATER stepRange so it sorts and is processed after the
+		// repetition_loop match — reproducing the exact same-tick ordering the
+		// original defect required.
 		const session = createSession();
 		installMocks(session, [
+			[createMatch('repetition_loop', [1, 3])], // 1st ⇒ level 1
+			[createMatch('repetition_loop', [4, 6])], // 2nd ⇒ level 2
 			[
-				createMatch('repetition_loop'),
-				createMatch('repetition_loop'),
-				createMatch('repetition_loop'), // 3rd ⇒ level 3 ⇒ hardStop
-				createMatch('ping_pong'), // 1st ⇒ level 1 ⇒ hardStop false
+				createMatch('repetition_loop', [7, 9]), // 3rd ⇒ level 3 ⇒ hardStop
+				createMatch('ping_pong', [10, 12]), // 1st ⇒ level 1 ⇒ hardStop false
 			],
 		]);
 		const { toolAfter } = createPrmHook(createMockConfig(), DIRECTORY);
 
+		await toolAfter({ sessionID: SESSION_ID });
+		await toolAfter({ sessionID: SESSION_ID });
 		await toolAfter({ sessionID: SESSION_ID });
 
 		expect(session.prmHardStopPending).toBe(true);
@@ -207,11 +223,14 @@ describe('PRM hard-stop tokens (issue #2063 C2)', () => {
 	});
 
 	test('level-3 arms BOTH tokens; the inject token is set, not merely mirrored', async () => {
+		// Issue #2134: three genuinely distinct, non-overlapping episodes — a
+		// repeated stepRange would be recognized as a re-report of the same
+		// episode and suppressed by the episode gate after the first strike.
 		const session = createSession();
 		installMocks(session, [
-			[createMatch('repetition_loop')],
-			[createMatch('repetition_loop')],
-			[createMatch('repetition_loop')],
+			[createMatch('repetition_loop', [1, 3])],
+			[createMatch('repetition_loop', [4, 6])],
+			[createMatch('repetition_loop', [7, 9])],
 		]);
 		const { toolAfter } = createPrmHook(createMockConfig(), DIRECTORY);
 
@@ -256,12 +275,17 @@ describe('PRM hard-stop tokens (issue #2063 C2)', () => {
 		// above but fails here: the deny token is legitimately cleared by the
 		// level-1 tick, and a mirrored inject token would be cleared with it —
 		// so an agent that was denied would never be told why.
+		//
+		// Issue #2134: the first three repetition_loop ticks use distinct,
+		// non-overlapping stepRanges so each is a genuinely new episode that
+		// clears the episode gate and strikes; a repeated stepRange would be
+		// suppressed as a re-report of the same episode after the first strike.
 		const session = createSession();
 		installMocks(session, [
-			[createMatch('repetition_loop')],
-			[createMatch('repetition_loop')],
-			[createMatch('repetition_loop')], // level 3 ⇒ both tokens armed
-			[createMatch('ping_pong')], // level 1, different pattern
+			[createMatch('repetition_loop', [1, 3])],
+			[createMatch('repetition_loop', [4, 6])],
+			[createMatch('repetition_loop', [7, 9])], // level 3 ⇒ both tokens armed
+			[createMatch('ping_pong', [10, 12])], // level 1, different pattern
 		]);
 		const { toolAfter } = createPrmHook(createMockConfig(), DIRECTORY);
 

--- a/src/prm/__tests__/helpers/episodes.ts
+++ b/src/prm/__tests__/helpers/episodes.ts
@@ -1,0 +1,49 @@
+import type { PatternMatch } from '../../types';
+
+/**
+ * Issue #2134 — shared fixture helpers for the PRM episode gate.
+ *
+ * The episode gate requires a match's `stepRange[0]` to advance past the
+ * PRIOR struck episode's `stepRange[1]` before the same pattern is allowed
+ * to strike again. A test that feeds the SAME fixed `stepRange` on every
+ * `detectPatterns()` call is modeling one ongoing episode being re-reported
+ * every tick — the gate now (correctly) recognizes that as a re-report and
+ * suppresses it after the first strike (no count increment, no advisory,
+ * no escalation). Any test that expects N strikes across N `toolAfter`
+ * calls must instead feed N genuinely distinct, non-overlapping episodes.
+ *
+ * `episodeAt` derives that fresh, non-overlapping `[start, end]` step range
+ * for a given 1-indexed tick: tick 1 => [1, 3], tick 2 => [4, 6], tick 3 =>
+ * [7, 9], etc. `createTickingDetectPatterns` wraps it into a drop-in
+ * `_internals.detectPatterns` replacement so call sites don't hand-roll the
+ * tick counter.
+ */
+export function episodeAt(tick: number): [number, number] {
+	return [tick * 3 - 2, tick * 3];
+}
+
+interface DetectPatternsResult {
+	matches: PatternMatch[];
+	detectionTimeMs: number;
+	patternsChecked: number;
+}
+
+/**
+ * Returns a `_internals.detectPatterns`-compatible function that, on each
+ * call, increments an internal tick counter and produces a single match
+ * (via `matchFactory`) whose `stepRange` is `episodeAt(tick)` — a fresh
+ * episode every call, per the module doc above.
+ */
+export function createTickingDetectPatterns(
+	matchFactory: (overrides: Partial<PatternMatch>) => PatternMatch,
+): () => DetectPatternsResult {
+	let tick = 0;
+	return () => {
+		tick += 1;
+		return {
+			matches: [matchFactory({ stepRange: episodeAt(tick) })],
+			detectionTimeMs: 5,
+			patternsChecked: 5,
+		};
+	};
+}

--- a/src/prm/__tests__/helpers/fixtures.ts
+++ b/src/prm/__tests__/helpers/fixtures.ts
@@ -1,0 +1,146 @@
+import type { _internals } from '../../index';
+import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../../types';
+import { createTickingDetectPatterns } from './episodes';
+
+/**
+ * Shared PRM test fixtures used by both `index.test.ts` and
+ * `integration.test.ts`. Identical/near-identical mock builders that used to
+ * be duplicated in each file live here — a non-test module does not count
+ * toward the FR-006 500-line test-file cap (`scripts/check-test-file-cap.ts`
+ * only matches `*.test.ts`).
+ */
+
+export function createMockConfig(
+	overrides: Partial<PrmConfig> = {},
+): PrmConfig {
+	return {
+		enabled: true,
+		pattern_thresholds: {
+			repetition_loop: 2,
+			ping_pong: 4,
+			expansion_drift: 3,
+			stuck_on_test: 3,
+			context_thrash: 5,
+		},
+		max_trajectory_lines: 100,
+		escalation_enabled: true,
+		detection_timeout_ms: 5000,
+		...overrides,
+	};
+}
+
+export function createMockPatternMatch(
+	pattern: PatternMatch['pattern'] = 'repetition_loop',
+	overrides: Partial<PatternMatch> = {},
+): PatternMatch {
+	return {
+		pattern,
+		severity: 'medium',
+		category: 'coordination_error',
+		stepRange: [1, 3],
+		description: `Test ${pattern} pattern detected`,
+		affectedAgents: ['coder'],
+		affectedTargets: ['src/foo.ts'],
+		occurrenceCount: 1,
+		...overrides,
+	};
+}
+
+/**
+ * Full mock `AgentSession` shape (superset of every field either test file
+ * needs). Extra fields beyond what a given test asserts on are harmless —
+ * no test in either file does a deep-equality check of the whole session
+ * object, only of specific PRM fields.
+ */
+export function createMockSession(sessionId: string, delegationActive = true) {
+	return {
+		sessionId,
+		agentName: 'test-agent',
+		lastToolCallTime: Date.now(),
+		lastAgentEventTime: Date.now(),
+		delegationActive,
+		activeInvocationId: 1,
+		lastInvocationIdByAgent: {},
+		windows: {},
+		lastCompactionHint: 0,
+		architectWriteCount: 0,
+		lastCoderDelegationTaskId: null,
+		currentTaskId: '1.1',
+		gateLog: new Map(),
+		reviewerCallCount: new Map(),
+		lastGateFailure: null,
+		partialGateWarningsIssuedForTask: new Set<string>(),
+		selfFixAttempted: false,
+		selfCodingWarnedAtCount: 0,
+		catastrophicPhaseWarnings: new Set<number>(),
+		qaSkipCount: 0,
+		qaSkipTaskIds: [],
+		taskWorkflowStates: new Map(),
+		stageBCompletion: new Map(),
+		taskCouncilApproved: new Map(),
+		lastGateOutcome: null,
+		declaredCoderScope: null,
+		lastScopeViolation: null,
+		scopeViolationDetected: false,
+		modifiedFilesThisCoderTask: [],
+		turboMode: false,
+		qaGateSessionOverrides: {},
+		fullAutoMode: false,
+		fullAutoInteractionCount: 0,
+		fullAutoDeadlockCount: 0,
+		fullAutoLastQuestionHash: null,
+		model_fallback_index: 0,
+		modelFallbackExhausted: false,
+		coderRevisions: 0,
+		revisionLimitHit: false,
+		loopDetectionWindow: [],
+		pendingAdvisoryMessages: [] as string[],
+		sessionRehydratedAt: 0,
+		lastPhaseCompleteTimestamp: 0,
+		lastPhaseCompletePhase: 0,
+		phaseAgentsDispatched: new Set<string>(),
+		lastCompletedPhaseAgentsDispatched: new Set<string>(),
+		// PRM fields
+		prmPatternCounts: new Map<string, number>(),
+		prmEscalationLevel: 0,
+		prmLastPatternDetected: null as PatternMatch | null,
+		prmTrajectoryStep: 0,
+		prmHardStopPending: false,
+		prmEscalationTracker: undefined,
+	};
+}
+
+/**
+ * Issue #2134 escalation-ladder tests (`integration.test.ts`) drive the same
+ * "distinct, non-overlapping episode per tick + fixed repetition_loop
+ * course-correction" mock setup from two different `describe` blocks that
+ * cannot see each other's local functions. Centralizing it here also lets
+ * both call sites share one definition instead of two byte-identical
+ * inline copies. `internals` is threaded in as a parameter (rather than
+ * imported directly) so this stays a pure builder with no coupling to the
+ * `_internals` singleton.
+ */
+export function setupEscalatingRepetitionMocks(
+	internals: typeof _internals,
+	sessId: string,
+	trajectory: TrajectoryEntry[],
+) {
+	const session = createMockSession(sessId);
+	internals.getAgentSession = () => session;
+	internals.readTrajectory = async () => trajectory;
+	internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+		createMockPatternMatch('repetition_loop', overrides),
+	);
+	internals.generateCourseCorrection = () => ({
+		alert: 'TRAJECTORY ALERT: repetition_loop detected',
+		category: 'coordination_error',
+		guidance: 'Stop the repetitive loop',
+		action: 'Consolidate changes and change approach immediately.',
+		pattern: 'repetition_loop',
+		stepRange: [1, 3],
+	});
+	internals.formatCourseCorrectionForInjection = (correction) => {
+		return `[TRAJECTORY ALERT] ${correction.alert}\n[CATEGORY] ${correction.category}\n[GUIDANCE] ${correction.guidance}\n[ACTION] ${correction.action}`;
+	};
+	return session;
+}

--- a/src/prm/__tests__/index.test.ts
+++ b/src/prm/__tests__/index.test.ts
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { EscalationTracker } from '../escalation';
 import { _internals, createPrmHook } from '../index';
 import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../types';
+import { createTickingDetectPatterns } from './helpers/episodes';
+import {
+	createMockConfig,
+	createMockPatternMatch,
+	createMockSession,
+} from './helpers/fixtures';
 
 // Original function references saved once at module load for save/restore
 const originalGetAgentSession = _internals.getAgentSession;
@@ -15,23 +21,6 @@ const originalCleanupOldTrajectoryFiles = _internals.cleanupOldTrajectoryFiles;
 const originalRecordReplayEntry = _internals.recordReplayEntry;
 const originalStartReplayRecording = _internals.startReplayRecording;
 const originalTelemetry = _internals.telemetry;
-
-function createMockConfig(overrides: Partial<PrmConfig> = {}): PrmConfig {
-	return {
-		enabled: true,
-		pattern_thresholds: {
-			repetition_loop: 2,
-			ping_pong: 4,
-			expansion_drift: 3,
-			stuck_on_test: 3,
-			context_thrash: 5,
-		},
-		max_trajectory_lines: 100,
-		escalation_enabled: true,
-		detection_timeout_ms: 5000,
-		...overrides,
-	};
-}
 
 function createMockTrajectory(): TrajectoryEntry[] {
 	return [
@@ -56,81 +45,6 @@ function createMockTrajectory(): TrajectoryEntry[] {
 			result: 'success',
 		},
 	];
-}
-
-function createMockPatternMatch(
-	pattern: PatternMatch['pattern'] = 'repetition_loop',
-	overrides: Partial<PatternMatch> = {},
-): PatternMatch {
-	return {
-		pattern,
-		severity: 'medium',
-		category: 'coordination_error',
-		stepRange: [1, 3],
-		description: 'Test pattern detected',
-		affectedAgents: ['coder'],
-		affectedTargets: ['src/foo.ts'],
-		occurrenceCount: 1,
-		...overrides,
-	};
-}
-
-function createMockSession(sessionId: string, delegationActive = true) {
-	return {
-		sessionId,
-		agentName: 'test-agent',
-		lastToolCallTime: Date.now(),
-		lastAgentEventTime: Date.now(),
-		delegationActive,
-		activeInvocationId: 1,
-		lastInvocationIdByAgent: {},
-		windows: {},
-		lastCompactionHint: 0,
-		architectWriteCount: 0,
-		lastCoderDelegationTaskId: null,
-		currentTaskId: '1.1',
-		gateLog: new Map(),
-		reviewerCallCount: new Map(),
-		lastGateFailure: null,
-		partialGateWarningsIssuedForTask: new Set<string>(),
-		selfFixAttempted: false,
-		selfCodingWarnedAtCount: 0,
-		catastrophicPhaseWarnings: new Set<number>(),
-		qaSkipCount: 0,
-		qaSkipTaskIds: [],
-		taskWorkflowStates: new Map(),
-		stageBCompletion: new Map(),
-		taskCouncilApproved: new Map(),
-		lastGateOutcome: null,
-		declaredCoderScope: null,
-		lastScopeViolation: null,
-		scopeViolationDetected: false,
-		modifiedFilesThisCoderTask: [],
-		turboMode: false,
-		qaGateSessionOverrides: {},
-		fullAutoMode: false,
-		fullAutoInteractionCount: 0,
-		fullAutoDeadlockCount: 0,
-		fullAutoLastQuestionHash: null,
-		model_fallback_index: 0,
-		modelFallbackExhausted: false,
-		coderRevisions: 0,
-		revisionLimitHit: false,
-		loopDetectionWindow: [],
-		pendingAdvisoryMessages: [],
-		sessionRehydratedAt: 0,
-		lastPhaseCompleteTimestamp: 0,
-		lastPhaseCompletePhase: 0,
-		phaseAgentsDispatched: new Set<string>(),
-		lastCompletedPhaseAgentsDispatched: new Set<string>(),
-		// PRM fields
-		prmPatternCounts: new Map(),
-		prmEscalationLevel: 0,
-		prmLastPatternDetected: null as PatternMatch | null,
-		prmTrajectoryStep: 0,
-		prmHardStopPending: false,
-		prmEscalationTracker: undefined,
-	};
 }
 
 /**
@@ -555,31 +469,16 @@ describe('createPrmHook', () => {
 		});
 
 		test('increments prmPatternCounts on subsequent detections', async () => {
-			// Issue #2134: two genuinely distinct, non-overlapping episodes. The
-			// episode gate requires a match's stepRange[0] to advance past the
-			// PRIOR struck episode's stepRange[1] before the same pattern can
-			// strike again — a repeated fixed stepRange would be recognized as a
-			// re-report of the already-struck episode and suppressed entirely
-			// (no count increment, no advisory), which is exactly the defect this
-			// gate exists to prevent for an ongoing single episode.
+			// Issue #2134: distinct, non-overlapping episodes per tick — see
+			// helpers/episodes.ts for why a repeated fixed stepRange won't do.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: tick === 1 ? [1, 3] : [4, 6],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', overrides),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -600,28 +499,16 @@ describe('createPrmHook', () => {
 		});
 
 		test('updates prmEscalationLevel from escalation tracker', async () => {
-			// Issue #2134: three genuinely distinct, non-overlapping episodes so
-			// each tick clears the episode gate and strikes — a fixed, repeated
-			// stepRange would suppress the 2nd and 3rd ticks as re-reports of the
-			// same episode and the level would never advance past 1.
+			// Issue #2134: distinct, non-overlapping episodes per tick — see
+			// helpers/episodes.ts for why a repeated fixed stepRange won't do.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: [tick * 3 - 2, tick * 3],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', overrides),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -686,28 +573,16 @@ describe('createPrmHook', () => {
 		});
 
 		test('sets prmHardStopPending on third detection', async () => {
-			// Issue #2134: three genuinely distinct, non-overlapping episodes so
-			// each tick clears the episode gate and strikes — a fixed, repeated
-			// stepRange would suppress the 2nd and 3rd ticks as re-reports of the
-			// same episode and the hard stop would never arm.
+			// Issue #2134: distinct, non-overlapping episodes per tick — see
+			// helpers/episodes.ts for why a repeated fixed stepRange won't do.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: [tick * 3 - 2, tick * 3],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', overrides),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -981,28 +856,16 @@ describe('createPrmHook', () => {
 		});
 
 		test('error in toolAfter does not affect subsequent calls', async () => {
-			// Issue #2134: two genuinely distinct, non-overlapping episodes so
-			// both ticks clear the episode gate and push an advisory — a fixed,
-			// repeated stepRange would suppress the 2nd tick as a re-report of the
-			// same episode and only one advisory would ever be pushed.
+			// Issue #2134: distinct, non-overlapping episodes per tick — see
+			// helpers/episodes.ts for why a repeated fixed stepRange won't do.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: tick === 1 ? [1, 3] : [4, 6],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', overrides),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',

--- a/src/prm/__tests__/index.test.ts
+++ b/src/prm/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { EscalationTracker } from '../escalation';
+import { EscalationTracker, resolveLadderKey } from '../escalation';
 import { _internals, createPrmHook } from '../index';
 import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../types';
 import { createTickingDetectPatterns } from './helpers/episodes';
@@ -613,11 +613,19 @@ describe('createPrmHook', () => {
 			const trajectory = createMockTrajectory();
 			const session = createMockSession(sessionId);
 
-			// Pre-populate PRM state as if session was being resumed
+			// Pre-populate PRM state as if session was being resumed.
+			//
+			// Issue #2134 follow-up: the tracker restores from `prmLadderCounts`,
+			// keyed by LADDER identity, NOT from `prmPatternCounts`, which stays
+			// keyed by pattern type as the observable tally. Seeding only the
+			// pattern-type map would restore nothing and this test would silently
+			// stop pinning restoration at all, so both are set and the ladder key is
+			// derived from the same match the hook will see.
+			const resumedMatch = createMockPatternMatch('repetition_loop');
 			session.prmPatternCounts = new Map([['repetition_loop', 2]]);
+			session.prmLadderCounts = new Map([[resolveLadderKey(resumedMatch), 2]]);
 			session.prmEscalationLevel = 2;
-			session.prmLastPatternDetected =
-				createMockPatternMatch('repetition_loop');
+			session.prmLastPatternDetected = resumedMatch;
 			session.prmHardStopPending = false;
 
 			_internals.getAgentSession = () => session;

--- a/src/prm/__tests__/index.test.ts
+++ b/src/prm/__tests__/index.test.ts
@@ -555,17 +555,31 @@ describe('createPrmHook', () => {
 		});
 
 		test('increments prmPatternCounts on subsequent detections', async () => {
+			// Issue #2134: two genuinely distinct, non-overlapping episodes. The
+			// episode gate requires a match's stepRange[0] to advance past the
+			// PRIOR struck episode's stepRange[1] before the same pattern can
+			// strike again — a repeated fixed stepRange would be recognized as a
+			// re-report of the already-struck episode and suppressed entirely
+			// (no count increment, no advisory), which is exactly the defect this
+			// gate exists to prevent for an ongoing single episode.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			_internals.detectPatterns = () => ({
-				matches: [match],
-				detectionTimeMs: 5,
-				patternsChecked: 5,
-			});
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: tick === 1 ? [1, 3] : [4, 6],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -586,17 +600,28 @@ describe('createPrmHook', () => {
 		});
 
 		test('updates prmEscalationLevel from escalation tracker', async () => {
+			// Issue #2134: three genuinely distinct, non-overlapping episodes so
+			// each tick clears the episode gate and strikes — a fixed, repeated
+			// stepRange would suppress the 2nd and 3rd ticks as re-reports of the
+			// same episode and the level would never advance past 1.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			_internals.detectPatterns = () => ({
-				matches: [match],
-				detectionTimeMs: 5,
-				patternsChecked: 5,
-			});
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: [tick * 3 - 2, tick * 3],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -661,17 +686,28 @@ describe('createPrmHook', () => {
 		});
 
 		test('sets prmHardStopPending on third detection', async () => {
+			// Issue #2134: three genuinely distinct, non-overlapping episodes so
+			// each tick clears the episode gate and strikes — a fixed, repeated
+			// stepRange would suppress the 2nd and 3rd ticks as re-reports of the
+			// same episode and the hard stop would never arm.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			_internals.detectPatterns = () => ({
-				matches: [match],
-				detectionTimeMs: 5,
-				patternsChecked: 5,
-			});
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: [tick * 3 - 2, tick * 3],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -945,17 +981,28 @@ describe('createPrmHook', () => {
 		});
 
 		test('error in toolAfter does not affect subsequent calls', async () => {
+			// Issue #2134: two genuinely distinct, non-overlapping episodes so
+			// both ticks clear the episode gate and push an advisory — a fixed,
+			// repeated stepRange would suppress the 2nd tick as a re-report of the
+			// same episode and only one advisory would ever be pushed.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createMockTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
 			const session = createMockSession(sessionId);
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => trajectory;
-			_internals.detectPatterns = () => ({
-				matches: [match],
-				detectionTimeMs: 5,
-				patternsChecked: 5,
-			});
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: tick === 1 ? [1, 3] : [4, 6],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',

--- a/src/prm/__tests__/integration.test.ts
+++ b/src/prm/__tests__/integration.test.ts
@@ -407,10 +407,41 @@ describe('PRM Integration Tests', () => {
 		});
 
 		test('processes multiple repetition loop cycles with escalating corrections', async () => {
+			// Issue #2134: three genuinely distinct, non-overlapping episodes —
+			// the episode gate caps a single occurrence at ONE strike, so three
+			// re-reports of a single ongoing episode (a fixed, repeated
+			// stepRange) would strike once and then be suppressed on ticks 2-3.
+			// Three real cycles are modeled as three ticks each carrying a match
+			// whose stepRange starts after the previous cycle's ended.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
-			const session = setupHappyPathMocks(sessionId, trajectory, [match]);
+			const session = createMockSession(sessionId);
+			_internals.getAgentSession = () => session;
+			_internals.readTrajectory = async () => trajectory;
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: [tick * 3 - 2, tick * 3],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
+			_internals.generateCourseCorrection = () => ({
+				alert: 'TRAJECTORY ALERT: repetition_loop detected',
+				category: 'coordination_error',
+				guidance: 'Stop the repetitive loop',
+				action: 'Consolidate changes and change approach immediately.',
+				pattern: 'repetition_loop',
+				stepRange: [1, 3],
+			});
+			_internals.formatCourseCorrectionForInjection = (correction) => {
+				return `[TRAJECTORY ALERT] ${correction.alert}\n[CATEGORY] ${correction.category}\n[GUIDANCE] ${correction.guidance}\n[ACTION] ${correction.action}`;
+			};
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -454,11 +485,51 @@ describe('PRM Integration Tests', () => {
 			);
 		});
 
+		/**
+		 * Issue #2134: the episode gate caps a single occurrence at ONE strike,
+		 * so each of these multi-tick tests needs each tick's match to be a
+		 * genuinely distinct, non-overlapping episode — not a re-report of the
+		 * same fixed stepRange, which the gate now recognizes as one episode and
+		 * suppresses after the first strike.
+		 */
+		function setupEscalatingRepetitionMocks(
+			sessId: string,
+			trajectory: TrajectoryEntry[],
+		) {
+			const session = createMockSession(sessId);
+			_internals.getAgentSession = () => session;
+			_internals.readTrajectory = async () => trajectory;
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: [tick * 3 - 2, tick * 3],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
+			_internals.generateCourseCorrection = () => ({
+				alert: 'TRAJECTORY ALERT: repetition_loop detected',
+				category: 'coordination_error',
+				guidance: 'Stop the repetitive loop',
+				action: 'Consolidate changes and change approach immediately.',
+				pattern: 'repetition_loop',
+				stepRange: [1, 3],
+			});
+			_internals.formatCourseCorrectionForInjection = (correction) => {
+				return `[TRAJECTORY ALERT] ${correction.alert}\n[CATEGORY] ${correction.category}\n[GUIDANCE] ${correction.guidance}\n[ACTION] ${correction.action}`;
+			};
+			return session;
+		}
+
 		test('2nd detection: stronger guidance, escalation level = 2', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
-			const session = setupHappyPathMocks(sessionId, trajectory, [match]);
+			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -480,8 +551,7 @@ describe('PRM Integration Tests', () => {
 		test('3rd detection: hard stop triggered, prmHardStopPending = true', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
-			const session = setupHappyPathMocks(sessionId, trajectory, [match]);
+			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -504,8 +574,7 @@ describe('PRM Integration Tests', () => {
 		test('hard stop telemetry only called on 3rd detection, not before', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
-			const session = setupHappyPathMocks(sessionId, trajectory, [match]);
+			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -781,16 +850,25 @@ describe('PRM Integration Tests', () => {
 			// Simulate trajectory that triggers repetition_loop
 			_internals.readTrajectory = async () => createRepetitionLoopTrajectory();
 
-			const repetitionMatch = createMockPatternMatch('repetition_loop', {
-				affectedAgents: ['coder'],
-				affectedTargets: ['src/foo.ts'],
-			});
-
-			_internals.detectPatterns = () => ({
-				matches: [repetitionMatch],
-				detectionTimeMs: 5,
-				patternsChecked: 5,
-			});
+			// Issue #2134: three genuinely distinct, non-overlapping episodes —
+			// the episode gate caps a single occurrence at ONE strike, so a fixed,
+			// repeated stepRange would suppress ticks 2-3 as re-reports of the
+			// same episode.
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							affectedAgents: ['coder'],
+							affectedTargets: ['src/foo.ts'],
+							stepRange: [tick * 3 - 2, tick * 3],
+						}),
+					],
+					detectionTimeMs: 5,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'REPETITION LOOP DETECTED',
 				category: 'coordination_error',
@@ -839,6 +917,14 @@ describe('PRM Integration Tests', () => {
 			// re-detection at the SAME level on a later tool call does not re-inject
 			// (escalation counting/telemetry still run). Escalation to a new level
 			// (distinct key) still injects.
+			//
+			// Issue #2134: the two ticks use distinct, non-overlapping stepRanges —
+			// two genuinely separate episodes — so BOTH clear the episode gate and
+			// strike (pattern counting must advance on both). Escalation is
+			// disabled so the level stays 0 across both strikes, which is the
+			// condition this test exercises: the cross-turn ADVISORY dedupe
+			// (same pattern@level) suppressing re-injection even though the
+			// underlying episode gate allowed the second strike through.
 			const config = createMockConfig({
 				enabled: true,
 				escalation_enabled: false, // hold level at 0 so the key stays constant
@@ -846,12 +932,19 @@ describe('PRM Integration Tests', () => {
 			const session = createMockSession('b1-cross-turn');
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => createRepetitionLoopTrajectory();
-			const match = createMockPatternMatch('repetition_loop');
-			_internals.detectPatterns = () => ({
-				matches: [match],
-				detectionTimeMs: 1,
-				patternsChecked: 5,
-			});
+			let tick = 0;
+			_internals.detectPatterns = () => {
+				tick += 1;
+				return {
+					matches: [
+						createMockPatternMatch('repetition_loop', {
+							stepRange: tick === 1 ? [1, 3] : [4, 6],
+						}),
+					],
+					detectionTimeMs: 1,
+					patternsChecked: 5,
+				};
+			};
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -896,8 +989,20 @@ describe('PRM Integration Tests', () => {
 			};
 			_internals.readTrajectory = () =>
 				Promise.resolve(createRepetitionLoopTrajectory());
+			// Issue #2134: sessionA's two ticks need distinct, non-overlapping
+			// episodes so the second tick clears the episode gate and strikes —
+			// a fixed, repeated stepRange would suppress it as a re-report of the
+			// same episode and sessionA.prmEscalationLevel would stay at 1.
+			// `sessionACallCount` (incremented once per toolAfter call, by
+			// `getAgentSession` above) doubles as a monotonic tick counter, so
+			// deriving the stepRange from it keeps sessionA's two episodes
+			// distinct without affecting sessionB, whose ledger starts fresh.
 			_internals.detectPatterns = () => ({
-				matches: [createMockPatternMatch('repetition_loop')],
+				matches: [
+					createMockPatternMatch('repetition_loop', {
+						stepRange: [sessionACallCount * 3 - 2, sessionACallCount * 3],
+					}),
+				],
 				detectionTimeMs: 5,
 				patternsChecked: 5,
 			});

--- a/src/prm/__tests__/integration.test.ts
+++ b/src/prm/__tests__/integration.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { _internals, createPrmHook } from '../index';
-import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../types';
+import type { PatternMatch, TrajectoryEntry } from '../types';
+import { createTickingDetectPatterns, episodeAt } from './helpers/episodes';
+import {
+	createMockConfig,
+	createMockPatternMatch,
+	createMockSession,
+	setupEscalatingRepetitionMocks,
+} from './helpers/fixtures';
 
 // Original function references saved once at module load for save/restore
 const originalGetAgentSession = _internals.getAgentSession;
@@ -14,26 +21,6 @@ const originalCleanupOldTrajectoryFiles = _internals.cleanupOldTrajectoryFiles;
 const originalRecordReplayEntry = _internals.recordReplayEntry;
 const originalStartReplayRecording = _internals.startReplayRecording;
 const originalTelemetry = _internals.telemetry;
-
-/**
- * Helper: Create default PRM config
- */
-function createMockConfig(overrides: Partial<PrmConfig> = {}): PrmConfig {
-	return {
-		enabled: true,
-		pattern_thresholds: {
-			repetition_loop: 2,
-			ping_pong: 4,
-			expansion_drift: 3,
-			stuck_on_test: 3,
-			context_thrash: 5,
-		},
-		max_trajectory_lines: 100,
-		escalation_enabled: true,
-		detection_timeout_ms: 5000,
-		...overrides,
-	};
-}
 
 /**
  * Helper: Create mock trajectory with repeated pattern for repetition_loop detection
@@ -180,83 +167,6 @@ function createStuckOnTestTrajectory(): TrajectoryEntry[] {
 			result: 'success',
 		},
 	];
-}
-
-/**
- * Helper: Create mock pattern match
- */
-function createMockPatternMatch(
-	pattern: PatternMatch['pattern'] = 'repetition_loop',
-	overrides: Partial<PatternMatch> = {},
-): PatternMatch {
-	return {
-		pattern,
-		severity: 'medium',
-		category: 'coordination_error',
-		stepRange: [1, 3],
-		description: `Test ${pattern} pattern detected`,
-		affectedAgents: ['coder'],
-		affectedTargets: ['src/foo.ts'],
-		occurrenceCount: 1,
-		...overrides,
-	};
-}
-
-/**
- * Helper: Create mock session with PRM state
- */
-function createMockSession(sessionId: string, delegationActive = true) {
-	return {
-		sessionId,
-		agentName: 'test-agent',
-		lastToolCallTime: Date.now(),
-		lastAgentEventTime: Date.now(),
-		delegationActive,
-		activeInvocationId: 1,
-		lastInvocationIdByAgent: {},
-		windows: {},
-		lastCompactionHint: 0,
-		architectWriteCount: 0,
-		lastCoderDelegationTaskId: null,
-		currentTaskId: '1.1',
-		gateLog: new Map(),
-		reviewerCallCount: new Map(),
-		lastGateFailure: null,
-		partialGateWarningsIssuedForTask: new Set(),
-		selfFixAttempted: false,
-		selfCodingWarnedAtCount: 0,
-		catastrophicPhaseWarnings: new Set(),
-		qaSkipCount: 0,
-		qaSkipTaskIds: [],
-		taskWorkflowStates: new Map(),
-		stageBCompletion: new Map(),
-		taskCouncilApproved: new Map(),
-		lastGateOutcome: null,
-		declaredCoderScope: null,
-		lastScopeViolation: null,
-		scopeViolationDetected: false,
-		modifiedFilesThisCoderTask: [],
-		turboMode: false,
-		qaGateSessionOverrides: {},
-		fullAutoMode: false,
-		fullAutoInteractionCount: 0,
-		fullAutoDeadlockCount: 0,
-		fullAutoLastQuestionHash: null,
-		model_fallback_index: 0,
-		modelFallbackExhausted: false,
-		coderRevisions: 0,
-		revisionLimitHit: false,
-		loopDetectionWindow: [],
-		pendingAdvisoryMessages: [] as string[],
-		sessionRehydratedAt: 0,
-		// PRM fields
-		prmPatternCounts: new Map<string, number>(),
-		prmEscalationLevel: 0,
-		prmLastPatternDetected: null as PatternMatch | null,
-		prmTrajectoryStep: 0,
-		prmHardStopPending: false,
-		prmEscalationTracker: undefined,
-	};
 }
 
 describe('PRM Integration Tests', () => {
@@ -407,41 +317,15 @@ describe('PRM Integration Tests', () => {
 		});
 
 		test('processes multiple repetition loop cycles with escalating corrections', async () => {
-			// Issue #2134: three genuinely distinct, non-overlapping episodes —
-			// the episode gate caps a single occurrence at ONE strike, so three
-			// re-reports of a single ongoing episode (a fixed, repeated
-			// stepRange) would strike once and then be suppressed on ticks 2-3.
-			// Three real cycles are modeled as three ticks each carrying a match
-			// whose stepRange starts after the previous cycle's ended.
+			// Issue #2134: three real cycles modeled as three distinct,
+			// non-overlapping episodes — see helpers/episodes.ts.
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const session = createMockSession(sessionId);
-			_internals.getAgentSession = () => session;
-			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: [tick * 3 - 2, tick * 3],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
-			_internals.generateCourseCorrection = () => ({
-				alert: 'TRAJECTORY ALERT: repetition_loop detected',
-				category: 'coordination_error',
-				guidance: 'Stop the repetitive loop',
-				action: 'Consolidate changes and change approach immediately.',
-				pattern: 'repetition_loop',
-				stepRange: [1, 3],
-			});
-			_internals.formatCourseCorrectionForInjection = (correction) => {
-				return `[TRAJECTORY ALERT] ${correction.alert}\n[CATEGORY] ${correction.category}\n[GUIDANCE] ${correction.guidance}\n[ACTION] ${correction.action}`;
-			};
+			const session = setupEscalatingRepetitionMocks(
+				_internals,
+				sessionId,
+				trajectory,
+			);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -463,6 +347,10 @@ describe('PRM Integration Tests', () => {
 		});
 	});
 
+	// Issue #2134: `setupEscalatingRepetitionMocks` (see helpers/fixtures.ts)
+	// feeds each tick a distinct, non-overlapping episode — see
+	// helpers/episodes.ts. Required for every test below that expects N
+	// strikes across N `toolAfter` calls.
 	describe('Test 2: Escalation protocol - 3-strike hard stop', () => {
 		test('1st detection: guidance injected, escalation level = 1', async () => {
 			const config = createMockConfig({ enabled: true });
@@ -485,51 +373,14 @@ describe('PRM Integration Tests', () => {
 			);
 		});
 
-		/**
-		 * Issue #2134: the episode gate caps a single occurrence at ONE strike,
-		 * so each of these multi-tick tests needs each tick's match to be a
-		 * genuinely distinct, non-overlapping episode — not a re-report of the
-		 * same fixed stepRange, which the gate now recognizes as one episode and
-		 * suppresses after the first strike.
-		 */
-		function setupEscalatingRepetitionMocks(
-			sessId: string,
-			trajectory: TrajectoryEntry[],
-		) {
-			const session = createMockSession(sessId);
-			_internals.getAgentSession = () => session;
-			_internals.readTrajectory = async () => trajectory;
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: [tick * 3 - 2, tick * 3],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
-			_internals.generateCourseCorrection = () => ({
-				alert: 'TRAJECTORY ALERT: repetition_loop detected',
-				category: 'coordination_error',
-				guidance: 'Stop the repetitive loop',
-				action: 'Consolidate changes and change approach immediately.',
-				pattern: 'repetition_loop',
-				stepRange: [1, 3],
-			});
-			_internals.formatCourseCorrectionForInjection = (correction) => {
-				return `[TRAJECTORY ALERT] ${correction.alert}\n[CATEGORY] ${correction.category}\n[GUIDANCE] ${correction.guidance}\n[ACTION] ${correction.action}`;
-			};
-			return session;
-		}
-
 		test('2nd detection: stronger guidance, escalation level = 2', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
+			const session = setupEscalatingRepetitionMocks(
+				_internals,
+				sessionId,
+				trajectory,
+			);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -551,7 +402,11 @@ describe('PRM Integration Tests', () => {
 		test('3rd detection: hard stop triggered, prmHardStopPending = true', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
+			const session = setupEscalatingRepetitionMocks(
+				_internals,
+				sessionId,
+				trajectory,
+			);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -574,7 +429,11 @@ describe('PRM Integration Tests', () => {
 		test('hard stop telemetry only called on 3rd detection, not before', async () => {
 			const config = createMockConfig({ enabled: true });
 			const trajectory = createRepetitionLoopTrajectory();
-			const session = setupEscalatingRepetitionMocks(sessionId, trajectory);
+			const session = setupEscalatingRepetitionMocks(
+				_internals,
+				sessionId,
+				trajectory,
+			);
 
 			const { toolAfter } = createPrmHook(config, directory);
 
@@ -850,25 +709,15 @@ describe('PRM Integration Tests', () => {
 			// Simulate trajectory that triggers repetition_loop
 			_internals.readTrajectory = async () => createRepetitionLoopTrajectory();
 
-			// Issue #2134: three genuinely distinct, non-overlapping episodes —
-			// the episode gate caps a single occurrence at ONE strike, so a fixed,
-			// repeated stepRange would suppress ticks 2-3 as re-reports of the
-			// same episode.
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							affectedAgents: ['coder'],
-							affectedTargets: ['src/foo.ts'],
-							stepRange: [tick * 3 - 2, tick * 3],
-						}),
-					],
-					detectionTimeMs: 5,
-					patternsChecked: 5,
-				};
-			};
+			// Issue #2134: distinct, non-overlapping episodes per tick — see
+			// helpers/episodes.ts.
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', {
+					affectedAgents: ['coder'],
+					affectedTargets: ['src/foo.ts'],
+					...overrides,
+				}),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'REPETITION LOOP DETECTED',
 				category: 'coordination_error',
@@ -918,13 +767,12 @@ describe('PRM Integration Tests', () => {
 			// (escalation counting/telemetry still run). Escalation to a new level
 			// (distinct key) still injects.
 			//
-			// Issue #2134: the two ticks use distinct, non-overlapping stepRanges —
-			// two genuinely separate episodes — so BOTH clear the episode gate and
-			// strike (pattern counting must advance on both). Escalation is
-			// disabled so the level stays 0 across both strikes, which is the
-			// condition this test exercises: the cross-turn ADVISORY dedupe
-			// (same pattern@level) suppressing re-injection even though the
-			// underlying episode gate allowed the second strike through.
+			// Issue #2134: distinct, non-overlapping episodes per tick (see
+			// helpers/episodes.ts) so both strikes clear the episode gate.
+			// Escalation is disabled so the level stays 0 across both strikes,
+			// which is the condition this test exercises: the cross-turn
+			// ADVISORY dedupe (same pattern@level) suppressing re-injection even
+			// though the underlying episode gate allowed the second strike through.
 			const config = createMockConfig({
 				enabled: true,
 				escalation_enabled: false, // hold level at 0 so the key stays constant
@@ -932,19 +780,9 @@ describe('PRM Integration Tests', () => {
 			const session = createMockSession('b1-cross-turn');
 			_internals.getAgentSession = () => session;
 			_internals.readTrajectory = async () => createRepetitionLoopTrajectory();
-			let tick = 0;
-			_internals.detectPatterns = () => {
-				tick += 1;
-				return {
-					matches: [
-						createMockPatternMatch('repetition_loop', {
-							stepRange: tick === 1 ? [1, 3] : [4, 6],
-						}),
-					],
-					detectionTimeMs: 1,
-					patternsChecked: 5,
-				};
-			};
+			_internals.detectPatterns = createTickingDetectPatterns((overrides) =>
+				createMockPatternMatch('repetition_loop', overrides),
+			);
 			_internals.generateCourseCorrection = () => ({
 				alert: 'ALERT',
 				category: 'coordination_error',
@@ -989,18 +827,13 @@ describe('PRM Integration Tests', () => {
 			};
 			_internals.readTrajectory = () =>
 				Promise.resolve(createRepetitionLoopTrajectory());
-			// Issue #2134: sessionA's two ticks need distinct, non-overlapping
-			// episodes so the second tick clears the episode gate and strikes —
-			// a fixed, repeated stepRange would suppress it as a re-report of the
-			// same episode and sessionA.prmEscalationLevel would stay at 1.
-			// `sessionACallCount` (incremented once per toolAfter call, by
-			// `getAgentSession` above) doubles as a monotonic tick counter, so
-			// deriving the stepRange from it keeps sessionA's two episodes
-			// distinct without affecting sessionB, whose ledger starts fresh.
+			// Issue #2134: `sessionACallCount` doubles as a monotonic tick, so
+			// episodeAt() keeps sessionA's two episodes distinct (see
+			// helpers/episodes.ts) without affecting sessionB's fresh ledger.
 			_internals.detectPatterns = () => ({
 				matches: [
 					createMockPatternMatch('repetition_loop', {
-						stepRange: [sessionACallCount * 3 - 2, sessionACallCount * 3],
+						stepRange: episodeAt(sessionACallCount),
 					}),
 				],
 				detectionTimeMs: 5,

--- a/src/prm/__tests__/issue-2134-episode-gate.test.ts
+++ b/src/prm/__tests__/issue-2134-episode-gate.test.ts
@@ -1,0 +1,491 @@
+/**
+ * PRM 3-strike escalation ladder — episode gate (issue #2134).
+ *
+ * Pre-fix, the ladder counted DETECTIONS, not OCCURRENCES: detectors re-emit
+ * the SAME ongoing episode on every tool call with a growing `stepRange[1]`,
+ * and the trajectory cursor (`detectPatterns(traj, cfg, lastProcessedStep)`)
+ * could never suppress that because the end step always advances. One
+ * ordinary episode got counted three times and armed the hard stop on a
+ * healthy session.
+ *
+ * The fix, pinned here:
+ *  1. `detectPatterns`' in-tick dedup key drops the volatile `stepRange[1]`
+ *     (pattern-detector.ts), so one episode collapses to one match per call.
+ *  2. `toolAfter` (index.ts) adds an EPISODE GATE keyed on
+ *     `session.prmStruckEpisodes: Map<episodeKey, occurrenceCountWhenItLastStruck>`,
+ *     where `episodeKey = "${pattern}|${stepRange[0]}"`. A match strikes when
+ *     EITHER (a) its episode key has no ledger entry ("new episode"), OR
+ *     (b) `occurrenceCount >= ledgerValue + resolvePatternThreshold(pattern)`
+ *     ("material growth"). (b) is load-bearing for `context_thrash`,
+ *     `ping_pong` and `stuck_on_test`, whose `stepRange[0]` does NOT advance
+ *     as the episode runs (only `repetition_loop` and `expansion_drift`
+ *     advance it) — without (b) those three would strike exactly once and
+ *     could never reach level 2 or 3.
+ *
+ * All step numbers cited below (hard-stop steps, ledger values) were
+ * empirically verified by driving the real detectors through `toolAfter`
+ * with the fixed production code at default thresholds (repetition_loop 2,
+ * ping_pong 2, expansion_drift 3, stuck_on_test 3, context_thrash 10).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { _internals, createPrmHook, resetPrmSessionState } from '../index';
+import { detectPatterns } from '../pattern-detector';
+import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../types';
+
+const originalGetAgentSession = _internals.getAgentSession;
+const originalReadTrajectory = _internals.readTrajectory;
+const originalGetInMemoryTrajectory = _internals.getInMemoryTrajectory;
+const originalCleanupOldTrajectoryFiles = _internals.cleanupOldTrajectoryFiles;
+const originalRecordReplayEntry = _internals.recordReplayEntry;
+const originalStartReplayRecording = _internals.startReplayRecording;
+const originalTelemetry = _internals.telemetry;
+
+const DIRECTORY = '/test/project';
+
+function mkConfig(): PrmConfig {
+	return {
+		enabled: true,
+		// Production defaults post issue #2134 tuning — pattern-detector.ts DEFAULT_THRESHOLDS.
+		pattern_thresholds: {
+			repetition_loop: 2,
+			ping_pong: 2,
+			expansion_drift: 3,
+			stuck_on_test: 3,
+			context_thrash: 10,
+		},
+		max_trajectory_lines: 10000,
+		escalation_enabled: true,
+		detection_timeout_ms: 5000,
+	};
+}
+
+function entry(
+	step: number,
+	agent: string,
+	action: string,
+	target: string,
+	result: 'success' | 'failure' = 'success',
+): TrajectoryEntry {
+	return {
+		step,
+		agent,
+		action,
+		target,
+		intent: 'x',
+		timestamp: new Date(2024, 0, 1, 0, 0, step).toISOString(),
+		result,
+	};
+}
+
+/**
+ * Fires `expansion_drift` repeatedly WITHOUT `context_thrash` or `repetition_loop`
+ * co-firing. Even blocks touch 2 unique targets (each hit >1x but with a DIFFERENT
+ * action each repeat, so no (agent,action,target) tuple repeats); odd blocks touch
+ * 5 brand-new targets — 2 vs 5 gives a 2.5x ratio (>1.5) every other boundary.
+ * Every target is scoped to its own block, so context_thrash's monotonic
+ * new-target run resets every block and never nears its threshold of 10.
+ */
+const EXPANSION_ACTIONS = ['inspect', 'scan', 'peek', 'probe', 'glance'];
+function buildExpansionOnlyBlocks(numBlocks: number): TrajectoryEntry[] {
+	const traj: TrajectoryEntry[] = [];
+	let step = 1;
+	for (let b = 0; b < numBlocks; b++) {
+		if (b % 2 === 0) {
+			const a = `anchor${b}-A.ts`;
+			const bb = `anchor${b}-B.ts`;
+			traj.push(entry(step++, 'coder', 'read', `src/${a}`));
+			traj.push(entry(step++, 'coder', EXPANSION_ACTIONS[b % 5], `src/${a}`));
+			traj.push(entry(step++, 'coder', 'read', `src/${bb}`));
+			traj.push(
+				entry(step++, 'coder', EXPANSION_ACTIONS[(b + 1) % 5], `src/${bb}`),
+			);
+			traj.push(
+				entry(step++, 'coder', EXPANSION_ACTIONS[(b + 2) % 5], `src/${a}`),
+			);
+		} else {
+			for (let k = 0; k < 5; k++)
+				traj.push(entry(step++, 'coder', 'read', `src/hi${b}-${k}.ts`));
+		}
+	}
+	return traj;
+}
+
+/** Minimal session stand-in mirroring hard-stop-tokens.test.ts's TokenTestSession, plus the #2134 ledger. */
+type EpisodeGateSession = {
+	delegationActive: boolean;
+	pendingAdvisoryMessages: string[];
+	prmPatternCounts: Map<string, number>;
+	prmEscalationLevel: number;
+	prmLastPatternDetected: PatternMatch | null;
+	prmTrajectoryStep: number;
+	prmHardStopPending: boolean;
+	prmHardStopInjectPending?: boolean;
+	prmInjectedAdvisoryKeys: Set<string>;
+	prmStruckEpisodes?: Map<string, number>;
+};
+
+function createSession(): EpisodeGateSession {
+	return {
+		delegationActive: true,
+		pendingAdvisoryMessages: [],
+		prmPatternCounts: new Map(),
+		prmEscalationLevel: 0,
+		prmLastPatternDetected: null,
+		prmTrajectoryStep: 0,
+		prmHardStopPending: false,
+		prmHardStopInjectPending: false,
+		prmInjectedAdvisoryKeys: new Set(),
+	};
+}
+
+type Registered = {
+	session: EpisodeGateSession;
+	trajectory: TrajectoryEntry[];
+};
+
+/**
+ * Installs the seam replacements shared by every hook-level test. `_internals.detectPatterns`
+ * is DELIBERATELY left untouched (real detectors). Untested seam branches (durable persistence,
+ * replay recording, real trajectory IO, telemetry) are stubbed — covered by index.test.ts /
+ * integration.test.ts, irrelevant to episode-gate math.
+ */
+function installMocks(registry: Map<string, Registered>): void {
+	_internals.getAgentSession = ((sessionID: string) =>
+		registry.get(sessionID)?.session) as typeof originalGetAgentSession;
+	_internals.getInMemoryTrajectory = ((sessionID: string) =>
+		registry.get(sessionID)?.trajectory ??
+		[]) as typeof originalGetInMemoryTrajectory;
+	_internals.readTrajectory = (async () => []) as typeof originalReadTrajectory;
+	_internals.cleanupOldTrajectoryFiles =
+		(async () => {}) as typeof originalCleanupOldTrajectoryFiles;
+	_internals.startReplayRecording = (async () =>
+		null) as typeof originalStartReplayRecording;
+	_internals.recordReplayEntry =
+		(async () => {}) as typeof originalRecordReplayEntry;
+	_internals.telemetry = {
+		...originalTelemetry,
+		prmPatternDetected: () => {},
+		prmCourseCorrectionInjected: () => {},
+		prmEscalationTriggered: () => {},
+		prmHardStop: () => {},
+		prmHardStopDelivered: () => {},
+	};
+}
+
+function restoreMocks(): void {
+	_internals.getAgentSession = originalGetAgentSession;
+	_internals.readTrajectory = originalReadTrajectory;
+	_internals.getInMemoryTrajectory = originalGetInMemoryTrajectory;
+	_internals.cleanupOldTrajectoryFiles = originalCleanupOldTrajectoryFiles;
+	_internals.recordReplayEntry = originalRecordReplayEntry;
+	_internals.startReplayRecording = originalStartReplayRecording;
+	_internals.telemetry = originalTelemetry;
+}
+
+type ToolAfter = (ctx: { sessionID: string }) => Promise<void>;
+
+/** Appends one trajectory entry for `sessionID` and drives a real toolAfter tick. */
+async function driveTick(
+	toolAfter: ToolAfter,
+	registry: Map<string, Registered>,
+	sessionID: string,
+	e: TrajectoryEntry,
+): Promise<void> {
+	registry.get(sessionID)?.trajectory.push(e);
+	await toolAfter({ sessionID });
+}
+
+/**
+ * Wires up ONE session (registry + mocks + a real hook) and returns short-hand drivers bound to
+ * it, so individual tests read as a plain sequence of ticks instead of repeated boilerplate.
+ */
+function setupSession(sessionID: string) {
+	const registry = new Map<string, Registered>();
+	const session = createSession();
+	registry.set(sessionID, { session, trajectory: [] });
+	installMocks(registry);
+	const { toolAfter } = createPrmHook(mkConfig(), DIRECTORY);
+	const tick = (e: TrajectoryEntry) =>
+		driveTick(toolAfter, registry, sessionID, e);
+	const n = async (
+		count: number,
+		entryFn: (step: number) => TrajectoryEntry,
+	) => {
+		for (let step = 1; step <= count; step++) await tick(entryFn(step));
+	};
+	return { session, registry, toolAfter, tick, n };
+}
+
+describe('detectPatterns (real, no mocks) — in-tick episode dedup (issue #2134)', () => {
+	test('5 identical entries in one call collapse to exactly one repetition_loop match, covering the widest step range', () => {
+		// Pre-fix, the dedup key included stepRange[1] (volatile), so the sliding window's 4 distinct
+		// end-step positions survived as 4 separate matches — the reproduction from the issue.
+		const traj: TrajectoryEntry[] = [];
+		for (let step = 1; step <= 5; step++)
+			traj.push(entry(step, 'coder', 'edit', 'src/a.ts'));
+		const result = detectPatterns(traj, mkConfig(), 0);
+		const reps = result.matches.filter((m) => m.pattern === 'repetition_loop');
+
+		expect(reps.length).toBe(1);
+		// Tie-break: on equal severity the WIDER step range wins.
+		expect(reps[0].stepRange).toEqual([1, 5]);
+	});
+
+	test('two genuinely distinct, non-overlapping repetition episodes still yield two matches', () => {
+		const traj: TrajectoryEntry[] = [];
+		let step = 1;
+		for (let i = 0; i < 2; i++)
+			traj.push(entry(step++, 'coderA', 'edit', 'src/a.ts'));
+		for (let i = 0; i < 12; i++)
+			traj.push(entry(step++, 'filler', 'read', `src/filler${i}.ts`));
+		for (let i = 0; i < 2; i++)
+			traj.push(entry(step++, 'coderB', 'edit', 'src/b.ts'));
+
+		const result = detectPatterns(traj, mkConfig(), 0);
+		const reps = result.matches.filter((m) => m.pattern === 'repetition_loop');
+
+		expect(reps.length).toBe(2);
+		expect(reps.map((m) => m.stepRange)).toEqual([
+			[1, 2],
+			[15, 16],
+		]);
+	});
+});
+
+describe('createPrmHook toolAfter — episode gate (issue #2134)', () => {
+	afterEach(restoreMocks);
+
+	test('regression: a healthy coder reading many distinct files never arms the hard stop', async () => {
+		// Pre-fix, detectContextThrash's re-emitted match walked a healthy session to level 3 in
+		// three tool calls. 25 ticks legitimately arms context_thrash's early rungs (level 1 @ 10,
+		// level 2 @ 20 — a monotonic 25-new-target run IS a real signal) but must stay below the
+		// empirically-verified hard-stop step of 30 (see the context_thrash containment test).
+		const { session, tick } = setupSession('healthy-coder');
+
+		const hardStopHistory: boolean[] = [];
+		for (let step = 1; step <= 25; step++) {
+			await tick(entry(step, 'coder', 'read', `src/file${step}.ts`));
+			hardStopHistory.push(session.prmHardStopPending);
+		}
+
+		expect(hardStopHistory.every((v) => v === false)).toBe(true);
+		expect(session.prmHardStopPending).toBe(false);
+		expect(session.prmEscalationLevel).toBeLessThan(3);
+	});
+
+	test('a continuing episode does not re-strike on sub-threshold growth; it strikes again once growth reaches a full threshold', async () => {
+		// Empirically verified: NOT "at most once" — the ledger value is an OCCURRENCE COUNT, so a
+		// still-growing episode re-strikes every time it gains another full threshold's worth of
+		// occurrences. What must hold: growth BELOW threshold is suppressed, AT/ABOVE strikes.
+		const { session, tick } = setupSession('sub-threshold-growth');
+
+		// steps 1,2: 2 occurrences of (coder,edit,a.ts) -> strikes (key `repetition_loop|1`, ledger=2).
+		await tick(entry(1, 'coder', 'edit', 'src/a.ts'));
+		await tick(entry(2, 'coder', 'edit', 'src/a.ts'));
+		expect(session.prmEscalationLevel).toBe(1);
+		expect(session.prmPatternCounts.get('repetition_loop')).toBe(1);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+
+		// step 3: unrelated single read of a different file — no repeated tuple.
+		await tick(entry(3, 'coder', 'read', 'src/other.ts'));
+		expect(session.prmEscalationLevel).toBe(1);
+		expect(session.prmHardStopPending).toBe(false);
+
+		// step 4: 3rd occurrence. Growth since last strike = 3-2=1, BELOW threshold 2 -> suppressed.
+		await tick(entry(4, 'coder', 'edit', 'src/a.ts'));
+		expect(session.prmEscalationLevel).toBe(1);
+		expect(session.prmPatternCounts.get('repetition_loop')).toBe(1);
+		expect(session.prmHardStopPending).toBe(false);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+
+		// step 5: 4th occurrence. Growth = 4-2=2, AT threshold -> strikes again.
+		await tick(entry(5, 'coder', 'edit', 'src/a.ts'));
+		expect(session.prmEscalationLevel).toBe(2);
+		expect(session.prmPatternCounts.get('repetition_loop')).toBe(2);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(4);
+	});
+
+	test('containment: repetition_loop — a genuinely stuck agent still escalates to a hard stop', async () => {
+		// Empirically verified: unbroken repetition (threshold 2) strikes at occurrence counts 2, 4,
+		// 6 -> level 1 @ step 2, level 2 @ step 4, hard stop (level 3) @ step 6.
+		const { session, tick, n } = setupSession('genuinely-stuck');
+
+		await n(5, (step) => entry(step, 'coder', 'edit', 'src/stuck.ts'));
+		expect(session.prmEscalationLevel).toBe(2);
+		expect(session.prmHardStopPending).toBe(false);
+
+		await tick(entry(6, 'coder', 'edit', 'src/stuck.ts'));
+
+		expect(session.prmEscalationLevel).toBe(3);
+		expect(session.prmHardStopPending).toBe(true);
+		expect(
+			session.prmPatternCounts.get('repetition_loop'),
+		).toBeGreaterThanOrEqual(3);
+	});
+
+	test('containment: context_thrash independently escalates to a hard stop', async () => {
+		// Empirically verified: an unbroken run of brand-new targets (threshold 10) strikes at
+		// run-lengths 10, 20, 30 -> hard stop @ step 30. Every strike here is earned via "material
+		// growth" (ground (b)) since runStart never advances — the rung added for this detector.
+		const { session, tick, n } = setupSession('context-thrash-stuck');
+
+		await n(29, (step) => entry(step, 'coder', 'read', `src/f${step}.ts`));
+		expect(session.prmHardStopPending).toBe(false);
+
+		await tick(entry(30, 'coder', 'read', 'src/f30.ts'));
+
+		expect(session.prmEscalationLevel).toBe(3);
+		expect(session.prmHardStopPending).toBe(true);
+		expect(
+			session.prmPatternCounts.get('context_thrash'),
+		).toBeGreaterThanOrEqual(3);
+	});
+
+	test('containment: ping_pong independently escalates to a hard stop', async () => {
+		// repetition_loop ALSO co-fires here and reaches ITS OWN hard stop first, @ step 7 — that
+		// alone would not prove ping_pong survived the gate. Driving to step 10 and asserting
+		// ping_pong's own strike count (empirically crosses 3 there) is what pins its containment.
+		const { session, n } = setupSession('ping-pong-stuck');
+
+		await n(10, (step) =>
+			entry(
+				step,
+				step % 2 === 1 ? 'architect' : 'coder',
+				'delegate',
+				'src/shared.ts',
+			),
+		);
+
+		expect(session.prmEscalationLevel).toBe(3);
+		expect(session.prmHardStopPending).toBe(true);
+		expect(session.prmPatternCounts.get('ping_pong')).toBeGreaterThanOrEqual(3);
+	});
+
+	test('containment: stuck_on_test independently escalates to a hard stop', async () => {
+		// repetition_loop ALSO co-fires (the edit half repeats the same tuple) and hard-stops first
+		// @ step 7. As with ping_pong, the load-bearing assertion is stuck_on_test's OWN strike
+		// count, which empirically crosses 3 @ step 19 on this trajectory.
+		const { session, n } = setupSession('stuck-on-test-stuck');
+
+		await n(19, (step) =>
+			step % 2 === 1
+				? entry(step, 'coder', 'edit', 'src/tested.ts')
+				: entry(step, 'coder', 'test', 'src/tested.ts', 'failure'),
+		);
+
+		expect(session.prmEscalationLevel).toBe(3);
+		expect(session.prmHardStopPending).toBe(true);
+		expect(
+			session.prmPatternCounts.get('stuck_on_test'),
+		).toBeGreaterThanOrEqual(3);
+	});
+
+	test('containment: expansion_drift independently escalates to a hard stop, isolated from context_thrash and repetition_loop', async () => {
+		// Unlike ping_pong/stuck_on_test above, buildExpansionOnlyBlocks fires NEITHER repetition_loop
+		// NOR context_thrash — every strike is unambiguously expansion_drift's own. Empirically
+		// verified: strikes @ steps 10, 20, 30 (occurrenceCount 1, 2, 3) -> hard stop @ step 30.
+		const { session, tick } = setupSession('expansion-drift-stuck');
+
+		for (const e of buildExpansionOnlyBlocks(12)) {
+			await tick(e);
+			if (session.prmHardStopPending) break;
+		}
+
+		expect(session.prmEscalationLevel).toBe(3);
+		expect(session.prmHardStopPending).toBe(true);
+		expect(session.prmPatternCounts.get('expansion_drift')).toBe(3);
+		expect(session.prmTrajectoryStep).toBe(30);
+		expect(session.prmPatternCounts.has('context_thrash')).toBe(false);
+		expect(session.prmPatternCounts.has('repetition_loop')).toBe(false);
+	});
+
+	test('two genuinely distinct, overlapping repetition_loop episodes on different targets both strike', async () => {
+		// Review finding 3: the old pattern-type-only ledger key let ONE struck episode suppress
+		// every other episode of that pattern type forever, regardless of target. Here an a.ts loop
+		// (key `repetition_loop|1`) and a b.ts loop starting mid-flight (key `repetition_loop|3`)
+		// overlap. Both must strike independently — proven by both distinct keys appearing in the
+		// ledger with their own counts, not merely the shared pattern tally advancing (which the
+		// pre-fix single-episode ledger could also produce from one episode re-striking alone).
+		const { session, tick } = setupSession('two-overlapping-episodes');
+
+		const seq: TrajectoryEntry[] = [
+			entry(1, 'coderA', 'edit', 'src/a.ts'),
+			entry(2, 'coderA', 'edit', 'src/a.ts'), // a.ts strikes: repetition_loop|1
+			entry(3, 'coderB', 'edit', 'src/b.ts'),
+			entry(4, 'coderA', 'edit', 'src/a.ts'),
+			entry(5, 'coderB', 'edit', 'src/b.ts'), // b.ts strikes: repetition_loop|3
+		];
+		for (const e of seq) await tick(e);
+
+		expect(session.prmPatternCounts.get('repetition_loop')).toBe(2);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|3')).toBe(2);
+	});
+
+	test('the episode ledger is session-scoped: two sessions do not share suppression', async () => {
+		const registry = new Map<string, Registered>();
+		const sessionA = createSession();
+		const sessionB = createSession();
+		registry.set('session-a', { session: sessionA, trajectory: [] });
+		registry.set('session-b', { session: sessionB, trajectory: [] });
+		installMocks(registry);
+		const { toolAfter } = createPrmHook(mkConfig(), DIRECTORY);
+
+		// Session A: 4 ticks on a.ts -> 2 strikes (level 2), ledger `repetition_loop|1` = 4
+		// (occurrenceCount, empirically verified).
+		for (let step = 1; step <= 4; step++) {
+			await driveTick(
+				toolAfter,
+				registry,
+				'session-a',
+				entry(step, 'coder', 'edit', 'src/a.ts'),
+			);
+		}
+		expect(sessionA.prmEscalationLevel).toBe(2);
+
+		// Session B starts fresh and deliberately arrives at the exact SAME episode key as session A
+		// ('repetition_loop|1'). If the ledger were shared (e.g. module-level instead of per-session),
+		// session B's first episode would be suppressed by session A's already-struck entry.
+		for (let step = 1; step <= 2; step++) {
+			await driveTick(
+				toolAfter,
+				registry,
+				'session-b',
+				entry(step, 'coder', 'edit', 'src/b.ts'),
+			);
+		}
+
+		expect(sessionB.prmEscalationLevel).toBe(1);
+		expect(sessionB.prmHardStopPending).toBe(false);
+		expect(sessionA.prmStruckEpisodes?.get('repetition_loop|1')).toBe(4);
+		expect(sessionB.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+	});
+
+	test('resetPrmSessionState clears the episode ledger; a reset does not leave a stale high-water mark', async () => {
+		const { session, tick, toolAfter } = setupSession('reset-session');
+
+		// Strike once: episode key `repetition_loop|1` (start step 1), ledger value = occurrenceCount 2.
+		await tick(entry(1, 'coder', 'edit', 'src/reset.ts'));
+		await tick(entry(2, 'coder', 'edit', 'src/reset.ts'));
+		expect(session.prmEscalationLevel).toBe(1);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+
+		resetPrmSessionState(session, 'reset-session');
+
+		expect(session.prmStruckEpisodes).toBeInstanceOf(Map);
+		expect(session.prmStruckEpisodes?.size).toBe(0);
+		expect(session.prmEscalationLevel).toBe(0);
+
+		// Replay the SAME 2-entry episode (trajectory untouched, cursor reset to 0 so detectPatterns
+		// re-derives it as "new"). A reset that failed to clear prmStruckEpisodes would compare fresh
+		// stepRange[0]=1 against the stale ledger entry, suppress it forever, and the session would
+		// stay wedged at level 0 despite having just been reset to "fresh".
+		await toolAfter({ sessionID: 'reset-session' });
+
+		expect(session.prmEscalationLevel).toBe(1);
+		expect(session.prmPatternCounts.get('repetition_loop')).toBe(1);
+		expect(session.prmHardStopPending).toBe(false);
+		expect(session.prmStruckEpisodes?.get('repetition_loop|1')).toBe(2);
+	});
+});

--- a/src/prm/__tests__/issue-2134-ladder-key.test.ts
+++ b/src/prm/__tests__/issue-2134-ladder-key.test.ts
@@ -1,0 +1,383 @@
+/**
+ * PRM 3-strike escalation ladder — ladder KEY regression (issue #2134 follow-up).
+ *
+ * Pre-fix, `EscalationTracker.recordDetection` keyed `patternCounts` by pattern
+ * TYPE alone (`patternCounts.get(match.pattern)`). Unrelated occurrences of the
+ * same pattern TYPE on unrelated targets therefore accumulated into ONE strike
+ * count: a coder that read-then-re-read three different files each produced its
+ * own `repetition_loop` match, but all three counted against a single
+ * "repetition_loop" ladder and hard-stopped at the third — without the coder
+ * having repeated itself even twice on any single file.
+ *
+ * The fix, pinned here: `resolveLadderKey(match)` in `../escalation` resolves
+ * the ladder identity a match strikes against.
+ *   - `affectedTargets.length === 1` -> `${pattern}|${target}` (per-target
+ *     ladder). `repetition_loop`, `ping_pong`, `stuck_on_test` each name the
+ *     single target they are about.
+ *   - otherwise -> bare `pattern` (per-pattern-type ladder, unchanged).
+ *     `context_thrash`/`expansion_drift` describe one episode over a GROWING
+ *     target set; a per-target key would mint a fresh ladder every tool call
+ *     and they could never escalate.
+ *
+ * `EscalationState.patternCounts` is `Map<string, number>` keyed by ladder key,
+ * not `Map<PatternType, number>`. `session.prmLadderCounts` mirrors it so a
+ * tracker rebuilt mid-session restores the same keyspace; `prmPatternCounts`
+ * stays keyed by bare pattern TYPE as the observable tally.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { EscalationTracker } from '../escalation';
+import {
+	_internals,
+	createPrmHook,
+	resetPrmSessionState,
+	resolveLadderKey,
+} from '../index';
+import type { PatternMatch, PrmConfig, TrajectoryEntry } from '../types';
+import { createMockConfig, createMockPatternMatch } from './helpers/fixtures';
+
+describe('resolveLadderKey', () => {
+	test('single-target match returns the template `pattern|target`', () => {
+		const match = createMockPatternMatch('repetition_loop', {
+			affectedTargets: ['src/a.ts'],
+		});
+		expect(resolveLadderKey(match)).toBe('repetition_loop|src/a.ts');
+	});
+
+	test('two single-target matches of the SAME pattern on DIFFERENT targets yield DIFFERENT keys', () => {
+		const a = createMockPatternMatch('repetition_loop', {
+			affectedTargets: ['src/a.ts'],
+		});
+		const b = createMockPatternMatch('repetition_loop', {
+			affectedTargets: ['src/b.ts'],
+		});
+		expect(resolveLadderKey(a)).not.toBe(resolveLadderKey(b));
+	});
+
+	test('a multi-target match (2+ affectedTargets) returns the bare pattern', () => {
+		const match = createMockPatternMatch('context_thrash', {
+			affectedTargets: ['src/a.ts', 'src/b.ts'],
+		});
+		expect(resolveLadderKey(match)).toBe('context_thrash');
+	});
+
+	test('two multi-target matches of the same pattern with DIFFERENT target sets yield the SAME key', () => {
+		const a = createMockPatternMatch('context_thrash', {
+			affectedTargets: ['src/a.ts', 'src/b.ts'],
+		});
+		const b = createMockPatternMatch('context_thrash', {
+			affectedTargets: ['src/c.ts', 'src/d.ts', 'src/e.ts'],
+		});
+		expect(resolveLadderKey(a)).toBe(resolveLadderKey(b));
+	});
+
+	test('a zero-target match falls through to the bare-pattern branch (defensive: never throws on affectedTargets[0])', () => {
+		const match = createMockPatternMatch('expansion_drift', {
+			affectedTargets: [],
+		});
+		expect(resolveLadderKey(match)).toBe('expansion_drift');
+	});
+
+	test('agents are NOT part of the key: two matches identical except affectedAgents yield the SAME key', () => {
+		const a = createMockPatternMatch('ping_pong', {
+			affectedTargets: ['src/shared.ts'],
+			affectedAgents: ['architect'],
+		});
+		const b = createMockPatternMatch('ping_pong', {
+			affectedTargets: ['src/shared.ts'],
+			affectedAgents: ['architect', 'coder', 'reviewer'],
+		});
+		expect(resolveLadderKey(a)).toBe(resolveLadderKey(b));
+	});
+});
+
+describe('EscalationTracker — ladder independence (issue #2134 follow-up)', () => {
+	test('repetition_loop struck once each on 3 different targets stays at level 1 x3 — no hard stop', () => {
+		// THE regression: pre-fix (bare-pattern key) this would be level 1, 2, 3
+		// and isHardStopPending() === true after the third call.
+		const tracker = new EscalationTracker('ladder-independence');
+
+		const r1 = tracker.recordDetection(
+			createMockPatternMatch('repetition_loop', {
+				affectedTargets: ['src/a.ts'],
+			}),
+		);
+		const r2 = tracker.recordDetection(
+			createMockPatternMatch('repetition_loop', {
+				affectedTargets: ['src/b.ts'],
+			}),
+		);
+		const r3 = tracker.recordDetection(
+			createMockPatternMatch('repetition_loop', {
+				affectedTargets: ['src/c.ts'],
+			}),
+		);
+
+		expect(r1.level).toBe(1);
+		expect(r2.level).toBe(1);
+		expect(r3.level).toBe(1);
+		expect(r1.hardStop).toBe(false);
+		expect(r2.hardStop).toBe(false);
+		expect(r3.hardStop).toBe(false);
+		expect(tracker.isHardStopPending()).toBe(false);
+	});
+
+	test('repetition_loop struck 3x on the SAME target still escalates to a hard stop (containment preserved)', () => {
+		const tracker = new EscalationTracker('containment-preserved');
+		const strike = () =>
+			tracker.recordDetection(
+				createMockPatternMatch('repetition_loop', {
+					affectedTargets: ['src/stuck.ts'],
+				}),
+			);
+
+		expect(strike().level).toBe(1);
+		expect(strike().level).toBe(2);
+		const third = strike();
+		expect(third.level).toBe(3);
+		expect(third.hardStop).toBe(true);
+		expect(tracker.isHardStopPending()).toBe(true);
+	});
+
+	test('a multi-target pattern (context_thrash) still escalates 1->2->3 across 3 detections despite a different target set each time', () => {
+		const tracker = new EscalationTracker('multi-target-escalates');
+
+		const r1 = tracker.recordDetection(
+			createMockPatternMatch('context_thrash', {
+				affectedTargets: ['src/a.ts', 'src/b.ts'],
+			}),
+		);
+		const r2 = tracker.recordDetection(
+			createMockPatternMatch('context_thrash', {
+				affectedTargets: ['src/c.ts', 'src/d.ts', 'src/e.ts'],
+			}),
+		);
+		const r3 = tracker.recordDetection(
+			createMockPatternMatch('context_thrash', {
+				affectedTargets: ['src/f.ts', 'src/g.ts'],
+			}),
+		);
+
+		expect(r1.level).toBe(1);
+		expect(r2.level).toBe(2);
+		expect(r3.level).toBe(3);
+		expect(r3.hardStop).toBe(true);
+		expect(tracker.isHardStopPending()).toBe(true);
+	});
+});
+
+describe('resetPrmSessionState — ladder keyspace', () => {
+	test('clears prmLadderCounts back to an empty Map', () => {
+		const session: {
+			prmEscalationTracker?: EscalationTracker;
+			prmInitialized?: boolean;
+			prmPatternCounts?: Map<string, number>;
+			prmEscalationLevel?: number;
+			prmLastPatternDetected?: unknown;
+			prmHardStopPending?: boolean;
+			prmHardStopInjectPending?: boolean;
+			prmTrajectoryStep?: number;
+			prmInjectedAdvisoryKeys?: Set<string>;
+			prmStruckEpisodes?: Map<string, number>;
+			prmLadderCounts?: Map<string, number>;
+			replayArtifactPath?: string | null;
+		} = {
+			prmLadderCounts: new Map([
+				['repetition_loop|src/a.ts', 4],
+				['context_thrash', 12],
+			]),
+		};
+
+		expect(session.prmLadderCounts.size).toBe(2);
+
+		resetPrmSessionState(session);
+
+		expect(session.prmLadderCounts).toBeInstanceOf(Map);
+		expect(session.prmLadderCounts?.size).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Hook-level: the user-reported workflow, real detectors (issue #2134 report)
+// ---------------------------------------------------------------------------
+
+const originalGetAgentSession = _internals.getAgentSession;
+const originalReadTrajectory = _internals.readTrajectory;
+const originalGetInMemoryTrajectory = _internals.getInMemoryTrajectory;
+const originalCleanupOldTrajectoryFiles = _internals.cleanupOldTrajectoryFiles;
+const originalRecordReplayEntry = _internals.recordReplayEntry;
+const originalStartReplayRecording = _internals.startReplayRecording;
+const originalTelemetry = _internals.telemetry;
+
+const DIRECTORY = '/test/project';
+
+function entry(
+	step: number,
+	agent: string,
+	action: string,
+	target: string,
+	result: 'success' | 'failure' = 'success',
+): TrajectoryEntry {
+	return {
+		step,
+		agent,
+		action,
+		target,
+		intent: 'x',
+		timestamp: new Date(2024, 0, 1, 0, 0, step).toISOString(),
+		result,
+	};
+}
+
+/**
+ * One "round" of the user-reported benign coder loop: read the module, read
+ * its test file, edit the module, run the tests, re-read the module, re-run
+ * the tests — 6 tool calls per module, a DIFFERENT module every round so
+ * `repetition_loop`'s per-target ladder key never crosses rounds.
+ */
+function roundEntries(
+	moduleIndex: number,
+	startStep: number,
+): TrajectoryEntry[] {
+	const src = `src/mod${moduleIndex}.ts`;
+	const testFile = `src/mod${moduleIndex}.test.ts`;
+	const runTests = `bun test ${testFile}`;
+	return [
+		entry(startStep, 'coder', 'read', src),
+		entry(startStep + 1, 'coder', 'read', testFile),
+		entry(startStep + 2, 'coder', 'edit', src),
+		entry(startStep + 3, 'coder', 'execute', runTests),
+		entry(startStep + 4, 'coder', 'read', src),
+		entry(startStep + 5, 'coder', 'execute', runTests),
+	];
+}
+
+type LadderTestSession = {
+	delegationActive: boolean;
+	pendingAdvisoryMessages: string[];
+	prmPatternCounts: Map<string, number>;
+	prmEscalationLevel: number;
+	prmLastPatternDetected: PatternMatch | null;
+	prmTrajectoryStep: number;
+	prmHardStopPending: boolean;
+	prmHardStopInjectPending?: boolean;
+	prmInjectedAdvisoryKeys: Set<string>;
+	prmStruckEpisodes?: Map<string, number>;
+	prmLadderCounts?: Map<string, number>;
+};
+
+function createSession(): LadderTestSession {
+	return {
+		delegationActive: true,
+		pendingAdvisoryMessages: [],
+		prmPatternCounts: new Map(),
+		prmEscalationLevel: 0,
+		prmLastPatternDetected: null,
+		prmTrajectoryStep: 0,
+		prmHardStopPending: false,
+		prmHardStopInjectPending: false,
+		prmInjectedAdvisoryKeys: new Set(),
+	};
+}
+
+type Registered = { session: LadderTestSession; trajectory: TrajectoryEntry[] };
+
+/** Seam pattern mirrors `issue-2134-episode-gate.test.ts`: real detectors, everything else stubbed. */
+function installMocks(registry: Map<string, Registered>): void {
+	_internals.getAgentSession = ((sessionID: string) =>
+		registry.get(sessionID)?.session) as typeof originalGetAgentSession;
+	_internals.getInMemoryTrajectory = ((sessionID: string) =>
+		registry.get(sessionID)?.trajectory ??
+		[]) as typeof originalGetInMemoryTrajectory;
+	_internals.readTrajectory = (async () => []) as typeof originalReadTrajectory;
+	_internals.cleanupOldTrajectoryFiles =
+		(async () => {}) as typeof originalCleanupOldTrajectoryFiles;
+	_internals.startReplayRecording = (async () =>
+		null) as typeof originalStartReplayRecording;
+	_internals.recordReplayEntry =
+		(async () => {}) as typeof originalRecordReplayEntry;
+	_internals.telemetry = {
+		...originalTelemetry,
+		prmPatternDetected: () => {},
+		prmCourseCorrectionInjected: () => {},
+		prmEscalationTriggered: () => {},
+		prmHardStop: () => {},
+		prmHardStopDelivered: () => {},
+	};
+}
+
+function restoreMocks(): void {
+	_internals.getAgentSession = originalGetAgentSession;
+	_internals.readTrajectory = originalReadTrajectory;
+	_internals.getInMemoryTrajectory = originalGetInMemoryTrajectory;
+	_internals.cleanupOldTrajectoryFiles = originalCleanupOldTrajectoryFiles;
+	_internals.recordReplayEntry = originalRecordReplayEntry;
+	_internals.startReplayRecording = originalStartReplayRecording;
+	_internals.telemetry = originalTelemetry;
+}
+
+function mkConfig(): PrmConfig {
+	return createMockConfig({
+		pattern_thresholds: {
+			repetition_loop: 2,
+			ping_pong: 2,
+			expansion_drift: 3,
+			stuck_on_test: 3,
+			context_thrash: 10,
+		},
+		max_trajectory_lines: 10000,
+	});
+}
+
+describe('createPrmHook toolAfter — realistic multi-module coder loop (issue #2134 follow-up)', () => {
+	afterEach(restoreMocks);
+
+	test('8 rounds of read/read/edit/execute/read/execute across 8 DIFFERENT modules never arms the hard stop', async () => {
+		// Empirically verified against the pre-fix (bare-pattern-keyed) ladder:
+		// each round strikes `repetition_loop` twice (the repeated read of the
+		// module, the repeated test-execute) on a NEW target every round, so a
+		// pattern-type-only ladder reaches its 3rd strike mid round 2 and hard
+		// stops. Ladder-keyed by `pattern|target`, each round's strikes land on
+		// their own fresh per-target ladder and never leave level 1.
+		const sessionID = 'multi-module-coder';
+		const registry = new Map<string, Registered>();
+		const session = createSession();
+		registry.set(sessionID, { session, trajectory: [] });
+		installMocks(registry);
+		const { toolAfter } = createPrmHook(mkConfig(), DIRECTORY);
+
+		const hardStopHistory: boolean[] = [];
+		const levelHistory: number[] = [];
+		let step = 1;
+		for (let moduleIndex = 1; moduleIndex <= 8; moduleIndex++) {
+			for (const e of roundEntries(moduleIndex, step)) {
+				registry.get(sessionID)?.trajectory.push(e);
+				await toolAfter({ sessionID });
+				hardStopHistory.push(session.prmHardStopPending);
+				levelHistory.push(session.prmEscalationLevel);
+			}
+			step += 6;
+		}
+
+		// Pre-fix reproduction: this exact trajectory hard-stopped mid round 2
+		// (repetition_loop's bare-pattern ladder hitting its 3rd cross-module
+		// strike). Post-fix it must never arm across all 48 ticks.
+		expect(hardStopHistory.every((v) => v === false)).toBe(true);
+		expect(session.prmHardStopPending).toBe(false);
+		expect(session.prmEscalationLevel).toBeLessThan(3);
+		expect(levelHistory.every((lvl) => lvl < 3)).toBe(true);
+
+		// Mirror keyspace check: the ladder counts are keyed by ladder identity
+		// (contains a `|` for the single-target repetition_loop strikes this
+		// trajectory produces every round), while the observable per-pattern
+		// tally stays keyed by bare pattern type.
+		expect(session.prmLadderCounts).toBeInstanceOf(Map);
+		expect(session.prmLadderCounts?.size).toBeGreaterThan(0);
+		const ladderKeys = [...(session.prmLadderCounts?.keys() ?? [])];
+		expect(ladderKeys.some((k) => k.includes('|'))).toBe(true);
+
+		expect(session.prmPatternCounts.size).toBeGreaterThan(0);
+		const patternCountKeys = [...session.prmPatternCounts.keys()];
+		expect(patternCountKeys.every((k) => !k.includes('|'))).toBe(true);
+	});
+});

--- a/src/prm/__tests__/issue-2134-ledger-bound.test.ts
+++ b/src/prm/__tests__/issue-2134-ledger-bound.test.ts
@@ -1,0 +1,237 @@
+/**
+ * PRM episode-ledger eviction (issue #2134, PRR-004 — PR #2139 review).
+ *
+ * `session.prmStruckEpisodes` in `src/prm/index.ts` is bounded at
+ * `MAX_TRACKED_EPISODES = 256`. Every strike now does `delete(key)` before
+ * `set(key, ...)`, so an episode that strikes AGAIN moves to the BACK of the
+ * Map's insertion order. Before that fix, `Map.set` on an existing key kept
+ * its ORIGINAL position, so the eviction loop below (`keys().next().value`,
+ * i.e. oldest-first) evicted an episode purely because it was struck first —
+ * even while it was still actively re-striking — as long as enough newer,
+ * inert episodes piled up around it. Delete-then-set makes eviction track
+ * least-recently-struck instead of first-struck.
+ *
+ * `_internals.detectPatterns` is replaced with a scripted stub returning one
+ * synthetic `PatternMatch` per tick (seam pattern mirrors
+ * `issue-2134-episode-gate.test.ts`'s `installMocks`/`restoreMocks`). This
+ * lets the test dictate exactly which episode key strikes on which tick,
+ * rather than reverse-engineering a real trajectory that produces the same
+ * sequence — the eviction-order property under test depends only on episode
+ * KEYS and OCCURRENCE COUNTS, not on which detector produced them.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { _internals, createPrmHook } from '../index';
+import type {
+	PatternMatch,
+	PrmConfig,
+	TaxonomyCategory,
+	TrajectoryEntry,
+} from '../types';
+
+const originalGetAgentSession = _internals.getAgentSession;
+const originalReadTrajectory = _internals.readTrajectory;
+const originalGetInMemoryTrajectory = _internals.getInMemoryTrajectory;
+const originalDetectPatterns = _internals.detectPatterns;
+const originalCleanupOldTrajectoryFiles = _internals.cleanupOldTrajectoryFiles;
+const originalRecordReplayEntry = _internals.recordReplayEntry;
+const originalStartReplayRecording = _internals.startReplayRecording;
+const originalTelemetry = _internals.telemetry;
+
+const DIRECTORY = '/test/project';
+
+function mkConfig(): PrmConfig {
+	return {
+		enabled: true,
+		pattern_thresholds: {
+			repetition_loop: 2,
+			ping_pong: 2,
+			expansion_drift: 3,
+			stuck_on_test: 3,
+			context_thrash: 10,
+		},
+		max_trajectory_lines: 100000,
+		escalation_enabled: true,
+		detection_timeout_ms: 5000,
+	};
+}
+
+type LedgerSession = {
+	delegationActive: boolean;
+	pendingAdvisoryMessages: string[];
+	prmPatternCounts: Map<string, number>;
+	prmEscalationLevel: number;
+	prmLastPatternDetected: PatternMatch | null;
+	prmTrajectoryStep: number;
+	prmHardStopPending: boolean;
+	prmHardStopInjectPending?: boolean;
+	prmInjectedAdvisoryKeys: Set<string>;
+	prmStruckEpisodes?: Map<string, number>;
+};
+
+function createSession(): LedgerSession {
+	return {
+		delegationActive: true,
+		pendingAdvisoryMessages: [],
+		prmPatternCounts: new Map(),
+		prmEscalationLevel: 0,
+		prmLastPatternDetected: null,
+		prmTrajectoryStep: 0,
+		prmHardStopPending: false,
+		prmHardStopInjectPending: false,
+		prmInjectedAdvisoryKeys: new Set(),
+	};
+}
+
+/** One fixed dummy trajectory entry — its content is irrelevant; only its
+ * non-empty length matters, so `toolAfter` advances `prmTrajectoryStep`. */
+const DUMMY_TRAJECTORY: TrajectoryEntry[] = [
+	{
+		step: 1,
+		agent: 'coder',
+		action: 'edit',
+		target: 'src/dummy.ts',
+		intent: 'x',
+		timestamp: new Date(2024, 0, 1).toISOString(),
+		result: 'success',
+	},
+];
+
+function match(
+	pattern: PatternMatch['pattern'],
+	startStep: number,
+	occurrenceCount: number,
+): PatternMatch {
+	const category: TaxonomyCategory =
+		pattern === 'repetition_loop'
+			? 'coordination_error'
+			: 'specification_error';
+	return {
+		pattern,
+		severity: 'medium',
+		category,
+		stepRange: [startStep, startStep],
+		description: `synthetic ${pattern} at ${startStep}`,
+		affectedAgents: ['coder'],
+		affectedTargets: [`src/synthetic-${startStep}.ts`],
+		occurrenceCount,
+	};
+}
+
+/** Installs the scripted seam. `nextMatch` is mutated by each test to drive
+ * exactly one match per `toolAfter` tick. */
+function installMocks(
+	session: LedgerSession,
+	nextMatch: { current: PatternMatch | null },
+) {
+	_internals.getAgentSession = ((_id: string) =>
+		session) as typeof originalGetAgentSession;
+	_internals.getInMemoryTrajectory = (() =>
+		DUMMY_TRAJECTORY) as typeof originalGetInMemoryTrajectory;
+	_internals.readTrajectory = (async () =>
+		DUMMY_TRAJECTORY) as typeof originalReadTrajectory;
+	_internals.detectPatterns = ((..._args: unknown[]) => ({
+		matches: nextMatch.current ? [nextMatch.current] : [],
+		detectionTimeMs: 0,
+		patternsChecked: 5,
+	})) as typeof originalDetectPatterns;
+	_internals.cleanupOldTrajectoryFiles =
+		(async () => {}) as typeof originalCleanupOldTrajectoryFiles;
+	_internals.startReplayRecording = (async () =>
+		null) as typeof originalStartReplayRecording;
+	_internals.recordReplayEntry =
+		(async () => {}) as typeof originalRecordReplayEntry;
+	_internals.telemetry = {
+		...originalTelemetry,
+		prmPatternDetected: () => {},
+		prmCourseCorrectionInjected: () => {},
+		prmEscalationTriggered: () => {},
+		prmHardStop: () => {},
+		prmHardStopDelivered: () => {},
+	};
+}
+
+function restoreMocks(): void {
+	_internals.getAgentSession = originalGetAgentSession;
+	_internals.readTrajectory = originalReadTrajectory;
+	_internals.getInMemoryTrajectory = originalGetInMemoryTrajectory;
+	_internals.detectPatterns = originalDetectPatterns;
+	_internals.cleanupOldTrajectoryFiles = originalCleanupOldTrajectoryFiles;
+	_internals.recordReplayEntry = originalRecordReplayEntry;
+	_internals.startReplayRecording = originalStartReplayRecording;
+	_internals.telemetry = originalTelemetry;
+}
+
+describe('PRM episode ledger — MAX_TRACKED_EPISODES eviction (issue #2134, PRR-004)', () => {
+	afterEach(restoreMocks);
+
+	test('the ledger never exceeds 256 entries across 300 distinct episodes', async () => {
+		const session = createSession();
+		const nextMatch: { current: PatternMatch | null } = { current: null };
+		installMocks(session, nextMatch);
+		const { toolAfter } = createPrmHook(mkConfig(), DIRECTORY);
+
+		for (let i = 1; i <= 300; i++) {
+			// Every tick is a brand-new episode key (`context_thrash|i`), so all
+			// 300 strike as "new episode" (ground (a) — no ledger entry yet).
+			nextMatch.current = match('context_thrash', i, 1);
+			await toolAfter({ sessionID: 'many-episodes' });
+		}
+
+		expect(session.prmStruckEpisodes).toBeInstanceOf(Map);
+		expect(session.prmStruckEpisodes?.size).toBeLessThanOrEqual(256);
+		// 300 distinct keys offered, cap 256 → exactly 256 survive.
+		expect(session.prmStruckEpisodes?.size).toBe(256);
+	});
+
+	test('a continuously re-striking episode survives eviction while inert episodes are evicted around it (delete-then-set)', async () => {
+		const session = createSession();
+		const nextMatch: { current: PatternMatch | null } = { current: null };
+		installMocks(session, nextMatch);
+		const { toolAfter } = createPrmHook(mkConfig(), DIRECTORY);
+
+		const STICKY_KEY = 'repetition_loop|0';
+
+		// 1) The sticky episode strikes first — as "new", it lands at the FRONT
+		// (oldest) of Map insertion order.
+		nextMatch.current = match('repetition_loop', 0, 2);
+		await toolAfter({ sessionID: 'sticky' });
+		expect(session.prmStruckEpisodes?.get(STICKY_KEY)).toBe(2);
+
+		// 2) 200 inert, never-repeated episodes pile up after it. Total ledger
+		// size (201) stays under the 256 cap — no eviction yet.
+		for (let i = 1; i <= 200; i++) {
+			nextMatch.current = match('context_thrash', i, 1);
+			await toolAfter({ sessionID: 'sticky' });
+		}
+		expect(session.prmStruckEpisodes?.size).toBe(201);
+		expect(session.prmStruckEpisodes?.has(STICKY_KEY)).toBe(true);
+
+		// 3) The sticky episode strikes AGAIN via material growth
+		// (occurrenceCount 2 -> 4, exactly `struckAtCount + threshold`).
+		// Delete-then-set moves its ledger entry to the BACK — the most
+		// recently struck position — without changing the map's size.
+		nextMatch.current = match('repetition_loop', 0, 4);
+		await toolAfter({ sessionID: 'sticky' });
+		expect(session.prmStruckEpisodes?.get(STICKY_KEY)).toBe(4);
+		expect(session.prmStruckEpisodes?.size).toBe(201);
+
+		// 4) 100 more inert episodes arrive. Ledger size grows past 256 and the
+		// eviction loop trims from the FRONT. Because the sticky episode was
+		// repositioned to the back in step 3, the entries evicted are the
+		// EARLIEST inert episodes (context_thrash|1 .. |45), never the sticky
+		// one — this is exactly the assertion that fails without
+		// delete-then-set, where the sticky entry never leaves the front and
+		// gets evicted the moment the map exceeds 256.
+		for (let i = 201; i <= 300; i++) {
+			nextMatch.current = match('context_thrash', i, 1);
+			await toolAfter({ sessionID: 'sticky' });
+		}
+
+		expect(session.prmStruckEpisodes?.size).toBe(256);
+		expect(session.prmStruckEpisodes?.has(STICKY_KEY)).toBe(true);
+		// The oldest surviving inert episodes are pushed out; the earliest ones
+		// from step 2 (context_thrash|1) are gone.
+		expect(session.prmStruckEpisodes?.has('context_thrash|1')).toBe(false);
+	});
+});

--- a/src/prm/__tests__/pattern-detector.test.ts
+++ b/src/prm/__tests__/pattern-detector.test.ts
@@ -11,6 +11,7 @@ import {
 	detectPingPong,
 	detectRepetitionLoop,
 	detectStuckOnTest,
+	resolvePatternThreshold,
 	sanitizeString,
 } from '../pattern-detector';
 import type { PrmConfig, TrajectoryEntry } from '../types';
@@ -19,9 +20,13 @@ import type { PrmConfig, TrajectoryEntry } from '../types';
 // Test Configuration & Helpers
 // =============================================================================
 
-/**
- * Default PRM config for tests
- */
+/** PRR-011: mirrors production's shipped default (no more hardcoded `3`). */
+const DEFAULT_CONTEXT_THRASH = resolvePatternThreshold(
+	{} as PrmConfig,
+	'context_thrash',
+);
+
+/** Default PRM config for tests. */
 function createDefaultConfig(overrides?: Partial<PrmConfig>): PrmConfig {
 	return {
 		enabled: true,
@@ -30,13 +35,24 @@ function createDefaultConfig(overrides?: Partial<PrmConfig>): PrmConfig {
 			ping_pong: 2,
 			expansion_drift: 3,
 			stuck_on_test: 3,
-			context_thrash: 3,
+			context_thrash: DEFAULT_CONTEXT_THRASH,
 		},
 		max_trajectory_lines: 1000,
 		escalation_enabled: true,
 		detection_timeout_ms: 5000,
 		...overrides,
 	};
+}
+
+/** Pre-#2134 boundary fixtures below intentionally pin a LOW threshold, not
+ * the shipped default (10) — kept local/explicit so the intent is obvious. */
+function withContextThrash(threshold: number): PrmConfig {
+	return createDefaultConfig({
+		pattern_thresholds: {
+			...createDefaultConfig().pattern_thresholds,
+			context_thrash: threshold,
+		},
+	});
 }
 
 /**
@@ -661,99 +677,31 @@ describe('detectExpansionDrift', () => {
 	});
 
 	test('handles trajectory with pending results', () => {
-		// Create trajectory with pending results that would otherwise trigger
-		const trajectory = createEntries([
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/a.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/b.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/a.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/b.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/a.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/c.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/d.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/e.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/f.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/f.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/g.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/h.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/i.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/j.ts',
-				result: 'pending',
-			},
-			{
-				agent: 'agent-a',
-				action: 'edit',
-				target: 'src/j.ts',
-				result: 'pending',
-			},
-		]);
+		// Create trajectory with pending results that would otherwise trigger.
+		// Same target sequence as the 'correctly reports step range' test above,
+		// just with every result set to 'pending' — built via .map() instead of
+		// 15 repeated object literals (behavior-preserving; see FR-006 note at
+		// the top of this file re: keeping this file from growing).
+		const letters = [
+			'a',
+			'b',
+			'a',
+			'b',
+			'a',
+			'c',
+			'd',
+			'e',
+			'f',
+			'f',
+			'g',
+			'h',
+			'i',
+			'j',
+			'j',
+		];
+		const trajectory = letters.map((l, i) =>
+			createEntry(i + 1, 'agent-a', 'edit', `src/${l}.ts`, 'pending'),
+		);
 		const config = createDefaultConfig();
 
 		const matches = detectExpansionDrift(trajectory, config);
@@ -1205,7 +1153,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/f.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/g.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1228,7 +1176,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/a.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/b.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1244,7 +1192,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/b.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/a.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1260,12 +1208,12 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/c.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/a.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
 		// Trajectory: [a, b, a, c, a] -> unique counts [1, 2, 2, 3, 3]
-		// No monotonic run of 3+ consecutive increases
+		// Longest monotonic run is 2 entries (a->b, then a->c) — below threshold 3
 		expect(matches).toHaveLength(0);
 	});
 
@@ -1274,7 +1222,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/a.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/b.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1321,7 +1269,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/f.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/g.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1370,7 +1318,7 @@ describe('detectContextThrash', () => {
 				result: 'pending',
 			},
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(3);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1388,7 +1336,7 @@ describe('detectContextThrash', () => {
 			{ agent: 'agent-a', action: 'edit', target: 'src/d.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/e.ts' },
 		]);
-		const config = createDefaultConfig();
+		const config = withContextThrash(5);
 
 		const matches = detectContextThrash(trajectory, config);
 
@@ -1397,7 +1345,9 @@ describe('detectContextThrash', () => {
 	});
 
 	test('does not trigger below threshold boundary', () => {
-		// Only 4 consecutive increases (threshold = 5) should NOT trigger
+		// Only 2 entries -> unique counts [1, 2], a monotonic run of length 2.
+		// That is below every threshold this suite exercises (min 3), including
+		// the shipped default (10) used here via createDefaultConfig().
 		const trajectory = createEntries([
 			{ agent: 'agent-a', action: 'edit', target: 'src/a.ts' },
 			{ agent: 'agent-a', action: 'edit', target: 'src/b.ts' },
@@ -1406,7 +1356,6 @@ describe('detectContextThrash', () => {
 
 		const matches = detectContextThrash(trajectory, config);
 
-		// 2 unique targets (1 increase) is below threshold of 3
 		expect(matches).toHaveLength(0);
 	});
 });

--- a/src/prm/__tests__/real-pipeline.test.ts
+++ b/src/prm/__tests__/real-pipeline.test.ts
@@ -8,11 +8,21 @@ import {
 } from '../../hooks/trajectory-logger';
 import { resetSwarmState, swarmState } from '../../state';
 import { createPrmHook, _internals as prmInternals } from '../index';
+import { resolvePatternThreshold } from '../pattern-detector';
 import {
 	clearTrajectoryCache,
 	getInMemoryTrajectory,
 	readTrajectory,
 } from '../trajectory-store';
+import type { PrmConfig } from '../types';
+
+// PRR-011 (PR #2139 review): pins the shipped `context_thrash` default so a
+// future silent change to `DEFAULT_THRESHOLDS` in pattern-detector.ts (or to
+// its `src/config/schema.ts` mirror) fails a test instead of drifting
+// unnoticed. Issue #2134 tuning raised this from 3 to 10.
+test('resolvePatternThreshold falls back to the shipped context_thrash default of 10 when config omits it', () => {
+	expect(resolvePatternThreshold({} as PrmConfig, 'context_thrash')).toBe(10);
+});
 
 describe('PRM real trajectory pipeline', () => {
 	let tempDir: string;
@@ -72,7 +82,11 @@ describe('PRM real trajectory pipeline', () => {
 					ping_pong: 2,
 					expansion_drift: 3,
 					stuck_on_test: 3,
-					context_thrash: 3,
+					// PRR-011: was 3 (stale pre-#2134 value); shipped default is 10.
+					// This test's assertions exercise repetition_loop only, so the
+					// exact value is otherwise inert here — kept in sync with
+					// production for hygiene (see the pinning test above).
+					context_thrash: 10,
 				},
 				max_trajectory_lines: 500,
 				escalation_enabled: true,

--- a/src/prm/__tests__/real-pipeline.test.ts
+++ b/src/prm/__tests__/real-pipeline.test.ts
@@ -115,7 +115,19 @@ describe('PRM real trajectory pipeline', () => {
 		clearTrajectoryCache(sessionId);
 		await prmHook.toolAfter({ sessionID: sessionId });
 		expect(getInMemoryTrajectory(sessionId)).toHaveLength(2);
-		expect(session.pendingAdvisoryMessages).toHaveLength(1);
+		// Issue #2134: this call re-derives the SAME repetition_loop episode
+		// (stepRange [1,2]) that already struck two calls ago — only
+		// `prmTrajectoryStep` was reset above to force a cache-miss disk re-read
+		// ("lastProcessedStep dedupe"); `session.prmStruckEpisodes` (the episode
+		// ledger) was deliberately left untouched, exactly as a real cold-start
+		// re-read would leave a session's history intact. The episode gate
+		// recognizes this is not a new occurrence and correctly suppresses it:
+		// zero NEW advisories, even though the naive step-cursor filter alone
+		// would have let it through again. This is the fix working as intended —
+		// before #2134 this assertion was 1, silently documenting the very defect
+		// (a cursor reset re-walking escalation for an episode already reported)
+		// that the episode ledger now closes.
+		expect(session.pendingAdvisoryMessages).toHaveLength(0);
 	});
 
 	test('resetSwarmState clears PRM trajectory cache and trajectory step counters', async () => {

--- a/src/prm/escalation.ts
+++ b/src/prm/escalation.ts
@@ -12,6 +12,16 @@ import type {
 } from './types';
 
 /**
+ * Upper bound on distinct escalation ladders tracked per session (issue #2134).
+ *
+ * The ladder is keyed per `(pattern, target)` for a single-target pattern, and
+ * targets are unbounded, so this map would otherwise grow without limit on a
+ * long-running session. Matches `MAX_TRACKED_EPISODES` in `index.ts`, which
+ * bounds the episode ledger for the same reason.
+ */
+const MAX_TRACKED_LADDERS = 256;
+
+/**
  * Resolves the LADDER key for a match — the identity whose 1→2→3 strike count
  * this detection belongs to (issue #2134 follow-up).
  *
@@ -177,8 +187,24 @@ export class EscalationTracker {
 		const currentCount = this._state.patternCounts.get(ladderKey) ?? 0;
 		const newCount = currentCount + 1;
 
-		// Update the ladder count
+		// Bound the map. A per-target ladder mints a key per (pattern, target) and
+		// targets are unbounded — a long architect session with no tool-call budget
+		// would otherwise grow this without limit on a hot, per-tool-call object,
+		// with each key carrying a target string up to 200 chars. Map preserves
+		// insertion order, so dropping from the front evicts the least recently
+		// FIRST-SEEN ladder. Mirrors `MAX_TRACKED_EPISODES` in `index.ts`, which
+		// bounds the episode ledger for exactly this reason.
+		//
+		// Re-inserting the key just updated keeps a still-active ladder at the back
+		// of the eviction order, so the ladder an agent is actively tripping is the
+		// last thing evicted rather than the first.
+		this._state.patternCounts.delete(ladderKey);
 		this._state.patternCounts.set(ladderKey, newCount);
+		while (this._state.patternCounts.size > MAX_TRACKED_LADDERS) {
+			const oldest = this._state.patternCounts.keys().next().value;
+			if (oldest === undefined) break;
+			this._state.patternCounts.delete(oldest);
+		}
 
 		// Update last pattern detected
 		this._state.lastPatternDetected = match;
@@ -236,6 +262,19 @@ export class EscalationTracker {
 	 */
 	getState(): EscalationState {
 		return cloneEscalationState(this._state);
+	}
+
+	/**
+	 * Returns a defensive copy of just the ladder counts (issue #2134 follow-up).
+	 *
+	 * `src/prm/index.ts` mirrors these onto the session after every strike so a
+	 * tracker rebuilt mid-session restores the same keyspace it counts in. Using
+	 * `getState()` there deep-cloned the whole state — including `stepRange`,
+	 * `affectedAgents` and `affectedTargets` of the last match — on the
+	 * per-tool-call hot path, for one field.
+	 */
+	getLadderCounts(): Map<string, number> {
+		return new Map(this._state.patternCounts);
 	}
 
 	/**

--- a/src/prm/escalation.ts
+++ b/src/prm/escalation.ts
@@ -12,6 +12,35 @@ import type {
 } from './types';
 
 /**
+ * Resolves the LADDER key for a match — the identity whose 1→2→3 strike count
+ * this detection belongs to (issue #2134 follow-up).
+ *
+ * The ladder used to be keyed by pattern TYPE alone, so unrelated occurrences
+ * accumulated into one count: a coder that read-then-re-read three different
+ * files produced three `repetition_loop` strikes on three different targets and
+ * hit the hard stop, even though it had not repeated itself even twice on any
+ * one of them. "Three strikes" has to mean "the same behaviour three times".
+ *
+ * A pattern reporting exactly ONE affected target gets a per-target ladder —
+ * `repetition_loop`, `ping_pong` and `stuck_on_test` all name the single file or
+ * target they are about, so that target IS the behaviour's identity.
+ *
+ * A pattern reporting a SET of targets keeps the per-pattern-type ladder.
+ * `context_thrash` and `expansion_drift` describe one ongoing episode over a
+ * growing collection of targets; keying those by target would mint a fresh
+ * ladder on every tool call and they could never escalate at all — the exact
+ * fail-open shape that the per-detector containment review caught the first time.
+ *
+ * Agents are deliberately not in the key. Escalation is about the work, not who
+ * did it, and `ping_pong` names two agents by construction.
+ */
+export function resolveLadderKey(match: PatternMatch): string {
+	return match.affectedTargets.length === 1
+		? `${match.pattern}|${match.affectedTargets[0]}`
+		: match.pattern;
+}
+
+/**
  * Creates a default EscalationState with all counters reset and flags cleared.
  * Exported for testing purposes.
  *
@@ -140,12 +169,16 @@ export class EscalationTracker {
 		correction: CourseCorrection | null;
 		hardStop: boolean;
 	} {
-		// Get current count for this pattern type
-		const currentCount = this._state.patternCounts.get(match.pattern) ?? 0;
+		// Get the current count for this match's LADDER identity — not for its
+		// pattern type. See `resolveLadderKey`: a single-target pattern gets a
+		// ladder per target, so repeating yourself once each on three different
+		// files is three level-1 advisories rather than a hard stop.
+		const ladderKey = resolveLadderKey(match);
+		const currentCount = this._state.patternCounts.get(ladderKey) ?? 0;
 		const newCount = currentCount + 1;
 
-		// Update the pattern count
-		this._state.patternCounts.set(match.pattern, newCount);
+		// Update the ladder count
+		this._state.patternCounts.set(ladderKey, newCount);
 
 		// Update last pattern detected
 		this._state.lastPatternDetected = match;

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -59,7 +59,7 @@ import {
 	formatCourseCorrectionForInjection,
 	generateCourseCorrection,
 } from './course-correction';
-import { EscalationTracker } from './escalation';
+import { EscalationTracker, resolveLadderKey } from './escalation';
 import { detectPatterns, resolvePatternThreshold } from './pattern-detector';
 import { recordReplayEntry, startReplayRecording } from './replay';
 import {
@@ -589,7 +589,17 @@ export function createPrmHook(
 				// injection once a (pattern, level) advisory has been delivered,
 				// until escalation advances to a new level (distinct key). This does
 				// NOT gate recordDetection/counts/telemetry/replay below.
-				const prmDedupeKey = `prm:${match.pattern}:${escalationLevel}`;
+				//
+				// Issue #2134 follow-up: the key is scoped to the LADDER, not the
+				// pattern type, because the ladder is now per-target. With a
+				// pattern-scoped key and every target sitting at level 1, exactly ONE
+				// advisory was delivered per pattern for the whole session and every
+				// subsequent target's guidance was silently dropped — the agent was
+				// neither stopped (per-target ladders escalate independently) nor
+				// told. Measured: 40 distinct repeating files produced 1 advisory.
+				// Scoping by ladder means each distinct behaviour is reported once per
+				// level, which is the invariant this dedupe was always meant to have.
+				const prmDedupeKey = `prm:${resolveLadderKey(match)}:${escalationLevel}`;
 				// Defensive: the field is initialized by ensureAgentSession, but
 				// guard so a session object lacking it (e.g. a minimal test mock)
 				// does not throw and abort the unconditional match-processing.
@@ -612,7 +622,7 @@ export function createPrmHook(
 				// Issue #2134 follow-up: mirror the tracker's LADDER counts onto the
 				// session so a tracker rebuilt later in this session restores the same
 				// keyspace it counts in. `getState()` already returns a defensive copy.
-				session.prmLadderCounts = escalationTracker.getState().patternCounts;
+				session.prmLadderCounts = escalationTracker.getLadderCounts();
 				session.prmEscalationLevel = escalationLevel;
 				session.prmLastPatternDetected = match;
 				tickHardStop = tickHardStop || hardStopPending;

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -406,16 +406,21 @@ export function createPrmHook(
 			}
 
 			for (const match of strikeable) {
-				struckEpisodes.set(
-					`${match.pattern}|${match.stepRange[0]}`,
-					match.occurrenceCount,
-				);
+				const episodeKey = `${match.pattern}|${match.stepRange[0]}`;
+				// PRR-004 (PR #2139 review): delete-then-set, so an episode that
+				// strikes AGAIN moves to the back of the insertion order. `Map.set`
+				// on an existing key preserves its original position, which made the
+				// bound below evict by oldest-FIRST-SEEN rather than least-recently-
+				// struck — able to drop the very episode an agent is still tripping
+				// while keeping 255 inert ones. Mirrors the ladder bound in
+				// `escalation.ts`.
+				struckEpisodes.delete(episodeKey);
+				struckEpisodes.set(episodeKey, match.occurrenceCount);
 			}
 			// Bound the ledger. Episode keys are minted per distinct start step, so a
 			// very long session with a sliding detection window accumulates them
 			// steadily. Map preserves insertion order, so dropping from the front
-			// evicts the oldest episodes — the ones a still-running session can no
-			// longer re-detect anyway, because the trajectory itself is truncated.
+			// evicts the least recently struck episode.
 			while (struckEpisodes.size > MAX_TRACKED_EPISODES) {
 				const oldest = struckEpisodes.keys().next().value;
 				if (oldest === undefined) break;

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -28,6 +28,7 @@ export {
 	detectPingPong,
 	detectRepetitionLoop,
 	detectStuckOnTest,
+	resolvePatternThreshold,
 } from './pattern-detector';
 // Types
 export type {
@@ -55,7 +56,7 @@ import {
 	generateCourseCorrection,
 } from './course-correction';
 import { EscalationTracker } from './escalation';
-import { detectPatterns } from './pattern-detector';
+import { detectPatterns, resolvePatternThreshold } from './pattern-detector';
 import { recordReplayEntry, startReplayRecording } from './replay';
 import {
 	cleanupOldTrajectoryFiles,
@@ -63,7 +64,7 @@ import {
 	getInMemoryTrajectory,
 	readTrajectory,
 } from './trajectory-store';
-import type { PatternType, PrmConfig } from './types';
+import type { PatternMatch, PatternType, PrmConfig } from './types';
 
 /**
  * Test-only dependency-injection seam — see `gitignore-warning.ts:_internals`.
@@ -134,6 +135,18 @@ interface SessionPrmState {
 	replayArtifactPath?: string | null;
 }
 
+/**
+ * Upper bound on `session.prmStruckEpisodes` (issue #2134).
+ *
+ * Episode keys are minted per distinct start step, so a long-running session
+ * with a sliding detection window accumulates them steadily and the map would
+ * otherwise grow without limit on a hot, per-tool-call session object. Generous
+ * relative to the default `max_trajectory_lines` of 1000: the trajectory a
+ * session can still re-detect against is itself truncated, so evicted keys
+ * belong to episodes that can no longer reappear.
+ */
+const MAX_TRACKED_EPISODES = 256;
+
 interface ResettablePrmSessionState {
 	prmEscalationTracker?: EscalationTracker;
 	prmInitialized?: boolean;
@@ -145,6 +158,8 @@ interface ResettablePrmSessionState {
 	prmHardStopInjectPending?: boolean;
 	prmTrajectoryStep?: number;
 	prmInjectedAdvisoryKeys?: Set<string>;
+	/** Issue #2134 — episode ledger; reset with the trajectory cursor it indexes. */
+	prmStruckEpisodes?: Map<string, number>;
 	replayArtifactPath?: string | null;
 }
 
@@ -166,6 +181,12 @@ export function resetPrmSessionState(
 	// Clear cross-turn injection-dedupe state so a reset re-evaluates patterns
 	// fresh (issue #1976 B1).
 	session.prmInjectedAdvisoryKeys = new Set();
+	// Issue #2134: the episode ledger holds trajectory STEP numbers and is only
+	// meaningful relative to `prmTrajectoryStep`, which this function just reset
+	// to 0. Leaving it populated would compare fresh step numbers against a stale
+	// high-water mark and suppress every subsequent strike — a reset intended to
+	// unwedge a session would instead disable its containment.
+	session.prmStruckEpisodes = new Map<string, number>();
 	session.replayArtifactPath = null;
 
 	if (sessionId) {
@@ -289,6 +310,111 @@ export function createPrmHook(
 				return;
 			}
 
+			/**
+			 * Issue #2134 — EPISODE GATE. Everything below this point treats a match
+			 * as "the agent did the bad thing AGAIN"; this is the filter that makes
+			 * that true.
+			 *
+			 * A detector re-emits the SAME ongoing episode on every tool call with a
+			 * growing `stepRange[1]`: a coder reading one more file extends its single
+			 * `context_thrash` run. The trajectory cursor
+			 * (`detectPatterns(..., lastProcessedStep)`) cannot suppress that, because
+			 * the episode's end step always advances past the cursor. So the ladder
+			 * counted one ordinary episode three times and reached level 3 — the hard
+			 * stop — within three tool calls of perfectly healthy work.
+			 *
+			 * A match may strike on exactly two grounds:
+			 *
+			 *   (a) NEW EPISODE — no ledger entry for its episode key. The key is
+			 *       `pattern|startStep`, because the START step is an episode's stable
+			 *       identity while the end step is a volatile "how far has it grown"
+			 *       cursor. Agents and targets are deliberately NOT in the key:
+			 *       `detectContextThrash` and `detectExpansionDrift` report the target
+			 *       SET accumulated so far (`pattern-detector.ts` — `affectedTargets`
+			 *       is built from a growing slice), so a target-bearing key would mint
+			 *       a fresh identity on every tool call and reproduce the exact bug
+			 *       this gate exists to close.
+			 *
+			 *   (b) MATERIAL GROWTH — the same episode has gained another full
+			 *       threshold's worth of occurrences since it last struck. This rung
+			 *       is load-bearing, not belt-and-braces: only `detectRepetitionLoop`
+			 *       and `detectExpansionDrift` advance `stepRange[0]` as an episode
+			 *       runs. `detectPingPong` pins it at the first delegation
+			 *       (`pattern-detector.ts` `delegateEntries[0].step`), `detectStuckOnTest`
+			 *       assigns `cycleStart` once and never reassigns it, and
+			 *       `detectContextThrash` only moves `runStart` when the monotonic run
+			 *       BREAKS — which a sustained thrash by definition never does. Without
+			 *       (b) those three patterns would strike exactly once and could never
+			 *       reach level 2 or 3: a guardrail permanently disarmed against its
+			 *       own worst case.
+			 *
+			 * Containment therefore holds for all five detectors. Worked examples at
+			 * default thresholds: an unbroken `repetition_loop` strikes at 2, 4 and 6
+			 * occurrences (hard stop by step 6); a `context_thrash` run strikes at 10,
+			 * 20 and 30 consecutive brand-new targets with zero revisits. What can no
+			 * longer happen is a hard stop earned by making tool calls rather than by
+			 * repeating the behaviour.
+			 *
+			 * At most ONE strike per pattern type per tick, mirroring the intent
+			 * documented on the detector's dedup: a single tool call must never
+			 * advance the ladder by more than one rung. When several genuinely
+			 * distinct episodes of one type surface together the EARLIEST is taken,
+			 * and the rest are simply not counted — the cursor advance below can put
+			 * an already-complete co-occurring episode below `lastProcessedStep`, so
+			 * it may never be re-detected. That is deliberate: the ladder measures
+			 * how insistently ONE behaviour continues, and an episode that is still
+			 * running keeps earning rungs through the growth ground above. Losing a
+			 * second, already-finished episode delays escalation by a tick or two at
+			 * worst; counting both would restore the multi-rung jump per tool call
+			 * that this gate exists to prevent.
+			 */
+			session.prmStruckEpisodes ??= new Map<string, number>();
+			const struckEpisodes = session.prmStruckEpisodes;
+			const strikeable: PatternMatch[] = [];
+			const claimedThisTick = new Set<string>();
+			for (const match of [...detectionResult.matches].sort(
+				(a, b) => a.stepRange[0] - b.stepRange[0],
+			)) {
+				if (claimedThisTick.has(match.pattern)) continue;
+				const episodeKey = `${match.pattern}|${match.stepRange[0]}`;
+				const struckAtCount = struckEpisodes.get(episodeKey);
+				if (struckAtCount !== undefined) {
+					const threshold = resolvePatternThreshold(config, match.pattern);
+					if (match.occurrenceCount < struckAtCount + threshold) continue;
+				}
+				claimedThisTick.add(match.pattern);
+				strikeable.push(match);
+			}
+
+			if (strikeable.length === 0) {
+				// Every match was a re-report of an already-reported episode that has
+				// not yet grown enough to earn the next rung. Advance the cursor so the
+				// next tick does not re-derive the same suppressed set, and leave BOTH
+				// hard-stop tokens untouched — this tick observed no new occurrence, so
+				// it must neither arm nor disarm them.
+				if (trajectory.length > 0) {
+					session.prmTrajectoryStep = trajectory[trajectory.length - 1].step;
+				}
+				return;
+			}
+
+			for (const match of strikeable) {
+				struckEpisodes.set(
+					`${match.pattern}|${match.stepRange[0]}`,
+					match.occurrenceCount,
+				);
+			}
+			// Bound the ledger. Episode keys are minted per distinct start step, so a
+			// very long session with a sliding detection window accumulates them
+			// steadily. Map preserves insertion order, so dropping from the front
+			// evicts the oldest episodes — the ones a still-running session can no
+			// longer re-detect anyway, because the trajectory itself is truncated.
+			while (struckEpisodes.size > MAX_TRACKED_EPISODES) {
+				const oldest = struckEpisodes.keys().next().value;
+				if (oldest === undefined) break;
+				struckEpisodes.delete(oldest);
+			}
+
 			// #1821 AC10: record pattern support for durable persistence.
 			// PLACEMENT IS LOAD-BEARING — this sits AFTER the no-match early return
 			// above, so the overwhelmingly common "tool call produced no pattern"
@@ -297,8 +423,14 @@ export function createPrmHook(
 			// Tallying is in-memory (no I/O, no lock, no knowledge-store access),
 			// but the persistable branch below DOES do a locked append. Support and
 			// cooldown gating keep that rare — see the comment on the append itself.
+			// Issue #2134: iterates the EPISODE-GATED set, not every re-emission.
+			// `recordPatternObservation` tallies support toward a durable insight
+			// candidate (default `min_support` 3), and a single continuing episode
+			// re-emitted on three consecutive tool calls used to reach that support
+			// on its own — promoting a "learned" pattern the agent had exhibited
+			// exactly once.
 			if (patternPersistence?.enabled) {
-				for (const match of detectionResult.matches) {
+				for (const match of strikeable) {
 					const observation = _internals.recordPatternObservation(
 						sessionID,
 						match,
@@ -410,8 +542,8 @@ export function createPrmHook(
 			 */
 			let tickHardStop = false;
 
-			// Process each pattern match
-			for (const match of detectionResult.matches) {
+			// Process each pattern match that cleared the episode gate above.
+			for (const match of strikeable) {
 				// Generate course correction
 				const correction = _internals.generateCourseCorrection(
 					match,

--- a/src/prm/index.ts
+++ b/src/prm/index.ts
@@ -19,7 +19,11 @@ export {
 	generateCourseCorrection,
 } from './course-correction';
 // Escalation
-export { createDefaultEscalationState, EscalationTracker } from './escalation';
+export {
+	createDefaultEscalationState,
+	EscalationTracker,
+	resolveLadderKey,
+} from './escalation';
 // Pattern detector
 export {
 	detectContextThrash,
@@ -64,7 +68,7 @@ import {
 	getInMemoryTrajectory,
 	readTrajectory,
 } from './trajectory-store';
-import type { PatternMatch, PatternType, PrmConfig } from './types';
+import type { PatternMatch, PrmConfig } from './types';
 
 /**
  * Test-only dependency-injection seam — see `gitignore-warning.ts:_internals`.
@@ -160,6 +164,8 @@ interface ResettablePrmSessionState {
 	prmInjectedAdvisoryKeys?: Set<string>;
 	/** Issue #2134 — episode ledger; reset with the trajectory cursor it indexes. */
 	prmStruckEpisodes?: Map<string, number>;
+	/** Issue #2134 follow-up — ladder counts; reset with the ledger. */
+	prmLadderCounts?: Map<string, number>;
 	replayArtifactPath?: string | null;
 }
 
@@ -187,6 +193,7 @@ export function resetPrmSessionState(
 	// high-water mark and suppress every subsequent strike — a reset intended to
 	// unwedge a session would instead disable its containment.
 	session.prmStruckEpisodes = new Map<string, number>();
+	session.prmLadderCounts = new Map<string, number>();
 	session.replayArtifactPath = null;
 
 	if (sessionId) {
@@ -505,12 +512,16 @@ export function createPrmHook(
 			if (!escalationTracker) {
 				// PRM escalation state is session-scoped and transient — resets on session start.
 				// This code reuses state from prior detections WITHIN the session, not across restarts.
+				// Issue #2134 follow-up: seeds from `prmLadderCounts`, NOT
+				// `prmPatternCounts`. The tracker counts by LADDER identity
+				// (`pattern|target`, or bare `pattern` for a growing target set) while
+				// `prmPatternCounts` stays keyed by pattern type as the observable
+				// tally. Seeding the ladder from pattern-type keys would restore every
+				// count under the wrong identity — silently resetting a target's real
+				// strike count to zero while inventing one for a key it never uses.
 				const initialState = session.prmLastPatternDetected
 					? {
-							patternCounts: new Map(session.prmPatternCounts.entries()) as Map<
-								PatternType,
-								number
-							>,
+							patternCounts: new Map(session.prmLadderCounts ?? []),
 							escalationLevel: session.prmEscalationLevel,
 							lastPatternDetected: session.prmLastPatternDetected,
 							hardStopPending: session.prmHardStopPending,
@@ -590,11 +601,18 @@ export function createPrmHook(
 					session.prmInjectedAdvisoryKeys.add(prmDedupeKey);
 				}
 
-				// Update session PRM state fields
+				// Update session PRM state fields. `prmPatternCounts` stays keyed by
+				// pattern TYPE — it is the observable per-pattern tally that telemetry
+				// and tests read, and is deliberately a different keyspace from the
+				// tracker's ladder counts mirrored just below.
 				session.prmPatternCounts.set(
 					match.pattern,
 					(session.prmPatternCounts.get(match.pattern) ?? 0) + 1,
 				);
+				// Issue #2134 follow-up: mirror the tracker's LADDER counts onto the
+				// session so a tracker rebuilt later in this session restores the same
+				// keyspace it counts in. `getState()` already returns a defensive copy.
+				session.prmLadderCounts = escalationTracker.getState().patternCounts;
 				session.prmEscalationLevel = escalationLevel;
 				session.prmLastPatternDetected = match;
 				tickHardStop = tickHardStop || hardStopPending;

--- a/src/prm/pattern-detector.ts
+++ b/src/prm/pattern-detector.ts
@@ -98,6 +98,17 @@ const DEFAULT_THRESHOLDS: Record<PatternType, number> = {
  * still-running episode once it has grown by another threshold's worth of
  * occurrences, so it must resolve the threshold exactly the way the detectors do
  * or the two layers disagree about what "another occurrence" means.
+ *
+ * The threshold is NOT in a single unit across detectors, and the ladder does not
+ * pretend otherwise — it is repeats for `repetition_loop`, run length for
+ * `context_thrash`, cycle count for `stuck_on_test`, alternating-entry count for
+ * `ping_pong` (whose `occurrenceCount` is ROUND TRIPS, i.e. half that unit, so it
+ * re-strikes at twice the nominal spacing), and a growth RATIO for
+ * `expansion_drift` (whose `occurrenceCount` is a float near 1.5–3.0, so the
+ * growth ground is effectively inert for it and its re-strikes come from the
+ * new-episode ground instead — its comparison window steps by `windowSize`, so
+ * its episode start step genuinely advances). Every one of the five is verified
+ * to still reach a hard stop; see `src/prm/__tests__/issue-2134-episode-gate.test.ts`.
  */
 export function resolvePatternThreshold(
 	config: PrmConfig,

--- a/src/prm/pattern-detector.ts
+++ b/src/prm/pattern-detector.ts
@@ -79,8 +79,32 @@ const DEFAULT_THRESHOLDS: Record<PatternType, number> = {
 	ping_pong: 2,
 	expansion_drift: 3,
 	stuck_on_test: 3,
-	context_thrash: 3,
+	// Issue #2134 (tuning): was 3. `detectContextThrash` flags a run of
+	// CONSECUTIVE steps that each introduce a brand-new target. Three such steps
+	// is indistinguishable from an agent simply reading three files, so the old
+	// default fired on essentially every healthy coder session and injected
+	// "Restrict file access" guidance at an agent that was doing nothing wrong.
+	// Ten consecutive new targets with zero revisits is the point at which
+	// "never converging on anything" becomes a real signal rather than noise.
+	// Keep in sync with `src/config/schema.ts` (`prm.pattern_thresholds`).
+	context_thrash: 10,
 };
+
+/**
+ * Resolves the configured occurrence threshold for a pattern type, falling back
+ * to the built-in default.
+ *
+ * Exported for the escalation ladder (issue #2134): the ladder re-strikes a
+ * still-running episode once it has grown by another threshold's worth of
+ * occurrences, so it must resolve the threshold exactly the way the detectors do
+ * or the two layers disagree about what "another occurrence" means.
+ */
+export function resolvePatternThreshold(
+	config: PrmConfig,
+	pattern: PatternType,
+): number {
+	return config.pattern_thresholds?.[pattern] ?? DEFAULT_THRESHOLDS[pattern];
+}
 
 /**
  * Detect repetition_loop pattern
@@ -527,6 +551,17 @@ export function detectPatterns(
 	// Deduplicate matches to prevent multiple escalation advances from a single toolAfter call.
 	// A trajectory with 3 identical entries would otherwise emit 3 matches (one per window position),
 	// causing escalation to jump multiple levels in a single invocation.
+	//
+	// Issue #2134: the key deliberately EXCLUDES `stepRange[1]`. It used to include
+	// it, which made the dedup a no-op for the exact case the comment above
+	// describes: `detectRepetitionLoop` slides a 10-entry window across every
+	// position, so one repetition episode emits `[1,2]`, `[1,3]`, `[1,4]`, … —
+	// four distinct keys under the old composition, four surviving matches, and
+	// four `recordDetection` calls that walked a first-ever occurrence straight to
+	// level 3 (hard stop) inside a single tool call, with no level-1 or level-2
+	// guidance ever delivered. The START step is the stable identity of an
+	// episode; the END step is a volatile "how far has it grown so far" cursor and
+	// must never participate in identity.
 	const severityRank: Record<PatternSeverity, number> = {
 		critical: 4,
 		high: 3,
@@ -536,19 +571,25 @@ export function detectPatterns(
 	const dedupedMatches = new Map<string, PatternMatch>();
 
 	for (const match of allMatches) {
-		// Create dedup key: pattern + affectedAgents + affectedTargets + stepRange
-		const key = `${match.pattern}-${match.affectedAgents.join(',')}-${match.affectedTargets.join(',')}-${match.stepRange[0]}-${match.stepRange[1]}`;
+		// Create dedup key: pattern + affectedAgents + affectedTargets + episode start
+		const key = `${match.pattern}-${match.affectedAgents.join(',')}-${match.affectedTargets.join(',')}-${match.stepRange[0]}`;
 		const existing = dedupedMatches.get(key);
 
 		if (!existing) {
 			dedupedMatches.set(key, match);
-		} else {
-			// Keep the more severe match when duplicates exist
-			const existingRank = severityRank[existing.severity] ?? 0;
-			const newRank = severityRank[match.severity] ?? 0;
-			if (newRank > existingRank) {
-				dedupedMatches.set(key, match);
-			}
+			continue;
+		}
+
+		// Keep the more severe match when duplicates exist; on equal severity keep
+		// the one covering the WIDER step range, so the surviving match reports the
+		// most complete view of the episode rather than an arbitrary window slice.
+		const existingRank = severityRank[existing.severity] ?? 0;
+		const newRank = severityRank[match.severity] ?? 0;
+		if (
+			newRank > existingRank ||
+			(newRank === existingRank && match.stepRange[1] > existing.stepRange[1])
+		) {
+			dedupedMatches.set(key, match);
 		}
 	}
 

--- a/src/prm/pattern-detector.ts
+++ b/src/prm/pattern-detector.ts
@@ -145,10 +145,26 @@ export function detectRepetitionLoop(
 		const windowStart = Math.max(0, i - windowSize + 1);
 		const window = trajectory.slice(windowStart, i + 1);
 
-		// Count (agent, action, target) combinations
+		// Count (agent, action, target) combinations.
+		//
+		// Issue #2134: the tuple is CARRIED in the value, not recovered by
+		// splitting the key. The key is still a `|`-joined string for cheap Map
+		// lookup, but `key.split('|')` truncated any target containing a pipe at
+		// its first one — and since `extractTarget` now returns the whole shell
+		// command for a bash call, piped commands are routine. Three different
+		// commands (`bun test | head`, `| tail`, `| wc -l`) all recovered the
+		// target `bun test 2>&1`, merged onto one escalation ladder, and produced
+		// a hard stop in six steps: the exact false positive this issue is about.
 		const counts = new Map<
 			string,
-			{ count: number; startStep: number; endStep: number }
+			{
+				count: number;
+				startStep: number;
+				endStep: number;
+				agent: string;
+				action: string;
+				target: string;
+			}
 		>();
 
 		for (const entry of window) {
@@ -163,14 +179,17 @@ export function detectRepetitionLoop(
 					count: 1,
 					startStep: entry.step,
 					endStep: entry.step,
+					agent: entry.agent,
+					action: entry.action,
+					target: entry.target,
 				});
 			}
 		}
 
 		// Check for combinations meeting threshold
-		for (const [key, data] of counts) {
+		for (const data of counts.values()) {
 			if (data.count >= threshold) {
-				const [agent, action, target] = key.split('|');
+				const { agent, action, target } = data;
 				const severity: PatternSeverity = data.count >= 3 ? 'high' : 'medium';
 
 				matches.push({

--- a/src/prm/types.ts
+++ b/src/prm/types.ts
@@ -124,8 +124,18 @@ export interface PrmConfig {
  * Per-session escalation tracking state
  */
 export interface EscalationState {
-	/** Pattern type to detection count mapping */
-	patternCounts: Map<PatternType, number>;
+	/**
+	 * Ladder identity to strike-count mapping.
+	 *
+	 * Keyed by `resolveLadderKey(match)` (issue #2134 follow-up), NOT by pattern
+	 * type: `pattern|target` for a single-target pattern, bare `pattern` for one
+	 * reporting a growing target set. Keying the ladder by pattern type alone let
+	 * unrelated occurrences on different files accumulate into a hard stop.
+	 *
+	 * Distinct from `AgentSessionState.prmPatternCounts`, which stays keyed by
+	 * pattern type as the observable per-pattern tally.
+	 */
+	patternCounts: Map<string, number>;
 	/** Current escalation level (0=none, 1=guidance, 2=strong guidance, 3=hard stop) */
 	escalationLevel: number;
 	/** Last pattern detected (if any) */

--- a/src/session/snapshot-reader.ts
+++ b/src/session/snapshot-reader.ts
@@ -277,6 +277,9 @@ export function deserializeAgentSession(
 		// against a stale high-water mark and silently suppress every strike for
 		// the rest of the run — PRM would go blind instead of merely resetting.
 		prmStruckEpisodes: new Map<string, number>(),
+		// (issue #2134 follow-up) Ladder counts are transient like the episode
+		// ledger they pair with; a resumed run re-earns its strikes.
+		prmLadderCounts: new Map<string, number>(),
 		// (issue #2063 B3/B5) Execution episodes are per-session by construction.
 		// A stale `in_progress` task carried in a snapshot must NOT arm a fresh
 		// session — arming requires an in-session execution attempt.

--- a/src/session/snapshot-reader.ts
+++ b/src/session/snapshot-reader.ts
@@ -271,6 +271,12 @@ export function deserializeAgentSession(
 		// PRM fields: reset on rehydrate so a resumed run re-evaluates patterns
 		// fresh (issue #1976 B1).
 		prmInjectedAdvisoryKeys: new Set(),
+		// (issue #2134) The episode ledger is keyed by trajectory STEP numbers,
+		// which restart from 0 for a rehydrated session (`prmTrajectoryStep: 0`
+		// above). Carrying it across a rehydrate would compare fresh step numbers
+		// against a stale high-water mark and silently suppress every strike for
+		// the rest of the run — PRM would go blind instead of merely resetting.
+		prmStruckEpisodes: new Map<string, number>(),
 		// (issue #2063 B3/B5) Execution episodes are per-session by construction.
 		// A stale `in_progress` task carried in a snapshot must NOT arm a fresh
 		// session — arming requires an in-session execution attempt.

--- a/src/state.ts
+++ b/src/state.ts
@@ -604,6 +604,19 @@ export interface AgentSessionState {
 	 */
 	prmStruckEpisodes?: Map<string, number>;
 	/**
+	 * Issue #2134 follow-up — mirror of the escalation tracker's LADDER counts,
+	 * keyed by `resolveLadderKey(match)` (`pattern|target`, or bare `pattern` for
+	 * a pattern reporting a growing target set).
+	 *
+	 * Deliberately separate from `prmPatternCounts`, which stays keyed by pattern
+	 * type as the observable per-pattern tally that telemetry and tests read. The
+	 * two are different keyspaces and must not be conflated: the tracker-rebuild
+	 * path below used to seed itself from `prmPatternCounts`, which would now
+	 * hand pattern-type keys to a ladder that counts by target and silently
+	 * mis-restore every count.
+	 */
+	prmLadderCounts?: Map<string, number>;
+	/**
 	 * Issue #2134 — dispatch identity of the delegation whose start already reset
 	 * this session's PRM state. Holds the Task tool `callID`, which is unique per
 	 * dispatch.
@@ -1730,6 +1743,9 @@ export function startAgentSession(
 		// Issue #2134: empty ledger — no episode has struck yet, so the first
 		// detection of any pattern type is always allowed to record strike 1.
 		prmStruckEpisodes: new Map<string, number>(),
+		// Issue #2134 follow-up: ladder counts start empty alongside the episode
+		// ledger they are advanced by.
+		prmLadderCounts: new Map<string, number>(),
 		// Issue #2063 B3/B5: no execution episode until this session actually
 		// attempts execution work.
 		executionEpisodeArmed: false,
@@ -2085,6 +2101,9 @@ export function ensureAgentSession(
 		}
 		if (!session.prmStruckEpisodes) {
 			session.prmStruckEpisodes = new Map<string, number>();
+		}
+		if (!session.prmLadderCounts) {
+			session.prmLadderCounts = new Map<string, number>();
 		}
 		if (session.executionEpisodeArmed === undefined) {
 			session.executionEpisodeArmed = false;

--- a/src/state.ts
+++ b/src/state.ts
@@ -580,6 +580,42 @@ export interface AgentSessionState {
 	 * fields, and this one is additive.
 	 */
 	prmHardStopInjectPending?: boolean;
+	/**
+	 * Issue #2134 — episode ledger for the escalation ladder.
+	 *
+	 * Maps an episode key (`patternType|startStep`) to the occurrence count that
+	 * episode had when it last recorded a strike. A detector re-emits the SAME
+	 * ongoing episode on every tool call with a growing `stepRange[1]` (a coder
+	 * reading more files extends one `context_thrash` run), and the trajectory
+	 * cursor cannot suppress that because the episode's end step always advances
+	 * past it. Counting each re-emission as a fresh strike walked ONE ordinary
+	 * episode from level 1 to level 3 in three tool calls and wedged healthy coder
+	 * sessions behind a hard stop.
+	 *
+	 * A match strikes when its episode is new, or when that episode has gained
+	 * another full threshold's worth of occurrences since it last struck. Both
+	 * rungs are needed: three of the five detectors never advance an episode's
+	 * start step while it runs, so without the growth rung they would strike
+	 * exactly once and could never reach level 2 or 3. See the EPISODE GATE
+	 * comment in `src/prm/index.ts` for the per-detector derivation.
+	 *
+	 * Optional for the same reason as `prmHardStopInjectPending`: ~25 existing
+	 * test/session literals enumerate the required PRM fields, and this is additive.
+	 */
+	prmStruckEpisodes?: Map<string, number>;
+	/**
+	 * Issue #2134 — dispatch identity of the delegation whose start already reset
+	 * this session's PRM state. Holds the Task tool `callID`, which is unique per
+	 * dispatch.
+	 *
+	 * The reset hook (`delegationGateHooks.taskMetadata`) is driven by
+	 * `message.part.updated`, which fires repeatedly for the SAME Task part as the
+	 * child runs. An unguarded reset there would clear the escalation ladder on
+	 * every part update and disarm PRM permanently — a fail-open far worse than
+	 * the wedge it is meant to prevent. Comparing against this field makes the
+	 * reset exactly once per dispatch.
+	 */
+	prmDelegationCallId?: string;
 	// NOTE (issue #2063 C2, reviewer round-4 REQUIRED 3): there is deliberately
 	// NO `prmHardStopDeliveredAt` field. A delivery timestamp was added here and
 	// stamped at the deny site, but it had zero readers and was never serialized,
@@ -1691,6 +1727,9 @@ export function startAgentSession(
 		// producer on every level-3 detection.
 		prmHardStopInjectPending: false,
 		prmInjectedAdvisoryKeys: new Set(),
+		// Issue #2134: empty ledger — no episode has struck yet, so the first
+		// detection of any pattern type is always allowed to record strike 1.
+		prmStruckEpisodes: new Map<string, number>(),
 		// Issue #2063 B3/B5: no execution episode until this session actually
 		// attempts execution work.
 		executionEpisodeArmed: false,
@@ -2043,6 +2082,9 @@ export function ensureAgentSession(
 		}
 		if (!session.prmInjectedAdvisoryKeys) {
 			session.prmInjectedAdvisoryKeys = new Set();
+		}
+		if (!session.prmStruckEpisodes) {
+			session.prmStruckEpisodes = new Map<string, number>();
 		}
 		if (session.executionEpisodeArmed === undefined) {
 			session.executionEpisodeArmed = false;

--- a/tests/unit/hooks/trajectory-logger-denied.test.ts
+++ b/tests/unit/hooks/trajectory-logger-denied.test.ts
@@ -184,7 +184,12 @@ describe('recordDeniedToolCall', () => {
 		const entries = readEntries(prmStorePath(sessionId));
 		expect(entries[0].intent).toBe('denied: UNCLASSIFIED');
 		expect(entries[0].action).toBe('execute');
-		expect(entries[0].target).toBe('curl');
+		// Issue #2134: the target is the whole normalized command, not its first
+		// word. First-word extraction collapsed every `curl …` / `bun …` / `git …`
+		// invocation onto one target and made PRM's repetition_loop read ordinary
+		// distinct work as the same action repeated. Redaction — this test's actual
+		// subject — is unaffected and still asserted below.
+		expect(entries[0].target).toBe('curl api');
 		expect(entries[0].args_summary).toContain('api_key:[REDACTED]');
 		expect(entries[0].args_summary).not.toContain('sk-secret-value');
 	});

--- a/tests/unit/hooks/trajectory-logger-redaction.test.ts
+++ b/tests/unit/hooks/trajectory-logger-redaction.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Secret-redaction coverage for the trajectory logger (PRR-001 — PR #2139
+ * review, issue #2134 follow-up).
+ *
+ * `normalizeCommandTarget` and `summarizeArgs` in `src/hooks/trajectory-logger.ts`
+ * now run the shared `redactSecrets` (`src/memory/redaction.ts`) over
+ * command/string VALUES before truncation. Before this fix, `summarizeArgs`
+ * only redacted by KEY name (`SENSITIVE_FIELDS`/`isSensitiveKey`), which does
+ * nothing for a secret carried in the VALUE of an innocuous key — e.g.
+ * `command: 'curl -H "Authorization: Bearer …"'` — and issue #2134 widened
+ * `target` from a shell command's first word to the WHOLE command, which
+ * widened that exposure into the persisted `target` field too.
+ *
+ * `target` is verified through the `_test_exports.extractTarget` Tier-0 seam
+ * (mirrors `trajectory-logger-target.test.ts`). `args_summary` is not exposed
+ * through that seam, so it is verified end-to-end through
+ * `createTrajectoryLoggerHook(...).toolAfter`, reading the persisted JSONL —
+ * mirroring `readTargets` in the sibling file.
+ *
+ * Lives in its own file per FR-006 (trajectory-logger-target.test.ts is
+ * already near the cap and must not grow for unrelated coverage).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_test_exports,
+	createTrajectoryLoggerHook,
+} from '../../../src/hooks/trajectory-logger';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const { extractTarget } = _test_exports;
+
+/**
+ * Mirrors `MAX_COMMAND_TARGET_LENGTH` in `src/hooks/trajectory-logger.ts` (not
+ * exported via `_test_exports`, and this suite may not edit production code to
+ * add it). Pinned here as a literal, same convention as
+ * `trajectory-logger-target.test.ts`.
+ */
+const MAX_COMMAND_TARGET_LENGTH = 200;
+
+describe('trajectory-logger secret redaction (PRR-001, issue #2134)', () => {
+	// ───────────────────────────────────────────────────────────────────────
+	// 1. Authorization: Bearer redaction in `target`.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a bash command with an Authorization: Bearer header redacts the token in the target', () => {
+		const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEF';
+		const target = extractTarget('bash', {
+			command: `curl -H "Authorization: Bearer ${token}" https://api.example.com/v1`,
+		});
+
+		expect(target).toContain('[REDACTED:authorization_bearer]');
+		expect(target).not.toContain(token);
+		expect(target).not.toContain('Bearer');
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 2. sk-... style key redaction in `target`.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a bash command with an sk-... style API key redacts the key in the target', () => {
+		const key = `sk-${'a1B2c3D4e5F6g7H8i9J0'.repeat(2)}`;
+		const target = extractTarget('bash', {
+			command: `curl -H "X-Api-Key: ${key}" https://api.example.com/v1`,
+		});
+
+		expect(target).toContain('[REDACTED:openai_api_key]');
+		expect(target).not.toContain(key);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 3. Redaction happens BEFORE truncation.
+	// ───────────────────────────────────────────────────────────────────────
+	test('redaction runs before truncation: a >200-char command with a secret that fits inside the bound never leaks raw token bytes', () => {
+		// Production bounds FIRST (raw text sliced to
+		// MAX_COMMAND_TARGET_LENGTH - 3 = 197 chars, "..." appended), THEN
+		// redacts. That ordering is load-bearing (see the docblock on
+		// `normalizeCommandTarget`), but it also means a secret that STRADDLES
+		// the 197-char cut only has its head inside the bounded window — the
+		// `authorization_bearer` pattern requires 12+ token chars and a
+		// straddling secret can leave fewer than that inside the window, so it
+		// does not match and a short raw fragment is stored. That residual is
+		// explicitly documented and accepted in production (`normalizeCommandTarget`
+		// docblock, "The residual: ..."), so it is not exercised here.
+		//
+		// This fixture instead pins the case the ordering fix actually targets:
+		// the full "Authorization: Bearer <token>" span sits ENTIRELY inside the
+		// 197-char window (filler placed so the secret ends well before the cut),
+		// while the overall raw command still exceeds
+		// MAX_COMMAND_TARGET_LENGTH so truncation genuinely runs. Redacting BEFORE
+		// truncating means no raw token byte survives regardless of where the
+		// eventual truncation cut lands.
+		const filler = 'x'.repeat(105);
+		const token = 'abcdefghijklmnopqrstuvwxyz0123456789';
+		const command = `echo ${filler} && curl -H "Authorization: Bearer ${token}" https://x.example.com`;
+		expect(command.length).toBeGreaterThan(MAX_COMMAND_TARGET_LENGTH);
+		// Precondition: the ENTIRE secret span sits before the 197-char bound
+		// (this is what distinguishes this fixture from the straddling residual
+		// case above).
+		const secretStart = command.indexOf('Authorization');
+		const secretEnd =
+			secretStart + 'Authorization: Bearer '.length + token.length;
+		expect(secretEnd).toBeLessThan(MAX_COMMAND_TARGET_LENGTH - 3);
+
+		const target = extractTarget('bash', { command });
+
+		expect(target).toContain('[REDACTED:authorization_bearer]');
+		// No fragment of the raw token may survive.
+		expect(target).not.toContain(token);
+		expect(target).not.toContain(token.slice(0, 5));
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 3b. Characterization of the documented straddling residual (NOT a
+	// regression test — pins the accepted tradeoff so a future change that
+	// widens the leak fails loudly instead of drifting silently).
+	//
+	// `normalizeCommandTarget` bounds BEFORE it redacts (load-bearing, see its
+	// docblock's "ORDER IS LOAD-BEARING" paragraph). When a secret straddles the
+	// 197-char cut, only its HEAD survives into the bounded text. The
+	// `authorization_bearer` pattern requires 12+ token chars after "Bearer ";
+	// a straddling match that leaves fewer than 12 chars inside the window does
+	// not match at all, so redaction silently does not fire and a short raw
+	// fragment of the token is persisted. The `normalizeCommandTarget` docblock
+	// calls this out explicitly ("The residual: a secret straddling the
+	// 200-char bound...") as accepted and strictly better than the pre-fix
+	// behavior (which leaked the fragment from EVERY long command, not just
+	// straddling ones). This test pins exactly how much survives so the bound
+	// on the leak is enforced, not just documented.
+	// ───────────────────────────────────────────────────────────────────────
+	test('CHARACTERIZATION (documented residual): a secret straddling the 197-char bound leaks a short raw fragment because the redaction pattern needs 12+ token chars to fire', () => {
+		const filler = 'x'.repeat(150);
+		const token = 'abcdefghijklmnopqrstuvwxyz0123456789';
+		const command = `echo ${filler} && curl -H "Authorization: Bearer ${token}" https://x.example.com`;
+		expect(command.length).toBeGreaterThan(MAX_COMMAND_TARGET_LENGTH);
+		// Precondition: the secret genuinely straddles the bound (its head is
+		// inside the 197-char window, its tail is cut away) — the opposite of
+		// the 3. fixture above.
+		const secretStart = command.indexOf('Authorization');
+		const secretHeadInWindow =
+			MAX_COMMAND_TARGET_LENGTH -
+			3 -
+			secretStart -
+			'Authorization: Bearer '.length;
+		expect(secretHeadInWindow).toBeGreaterThan(0);
+		expect(secretHeadInWindow).toBeLessThan(12); // below the pattern's 12-char floor
+
+		const target = extractTarget('bash', { command });
+
+		// The placeholder does NOT appear: the truncated match is too short for
+		// the `authorization_bearer` pattern to fire.
+		expect(target).not.toContain('[REDACTED:');
+		// The FULL token never survives.
+		expect(target).not.toContain(token);
+		// But a short raw fragment — bounded by how much of the token fit inside
+		// the pre-truncation window — does survive. This is the exact, bounded
+		// leak the docblock accepts; growing past it would be a regression.
+		expect(target).toContain(token.slice(0, secretHeadInWindow));
+		expect(target).not.toContain(token.slice(0, secretHeadInWindow + 1));
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 4. args_summary redacts a secret in a NON-sensitive key's value.
+	// ───────────────────────────────────────────────────────────────────────
+	describe('args_summary redaction via toolAfter', () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			resetSwarmState();
+			tempDir = canonicalMkdtemp('test-trajectory-redaction-');
+			fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		});
+
+		afterEach(() => {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+			resetSwarmState();
+		});
+
+		function readEntries(
+			taskId: string,
+		): Array<{ target: string; args_summary: string }> {
+			const trajectoryPath = path.join(
+				tempDir,
+				'.swarm',
+				'evidence',
+				taskId,
+				'trajectory.jsonl',
+			);
+			return fs
+				.readFileSync(trajectoryPath, 'utf-8')
+				.split('\n')
+				.filter((l) => l.trim().length > 0)
+				.map((l) => JSON.parse(l) as { target: string; args_summary: string });
+		}
+
+		test('a secret in the "command" value (a non-sensitive key) is redacted in args_summary, not just truncated', async () => {
+			const sessionId = 'session-redaction-regression';
+			startAgentSession(sessionId, 'coder');
+			const session = swarmState.agentSessions.get(sessionId);
+			if (!session) throw new Error('session not created');
+			session.delegationActive = true;
+			session.currentTaskId = 'redaction-e2e';
+
+			const hook = createTrajectoryLoggerHook(
+				{ enabled: true, max_lines: 500 },
+				tempDir,
+			);
+
+			const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEF';
+			await hook.toolAfter(
+				{
+					tool: 'bash',
+					sessionID: sessionId,
+					callID: 'call-1',
+					args: {
+						command: `curl -H "Authorization: Bearer ${token}" https://api.example.com`,
+					},
+				},
+				{ title: 'ok', output: 'done', metadata: { success: true } },
+			);
+
+			const [entry] = readEntries('redaction-e2e');
+			expect(entry).toBeDefined();
+			// Pre-fix, `command` (non-sensitive key) was truncated to 50 raw chars
+			// and emitted verbatim — this is the exact leak the fix closes.
+			expect(entry.args_summary).toContain('[REDACTED:authorization_bearer]');
+			expect(entry.args_summary).not.toContain(token);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 5. Guard against over-redaction: benign commands are unchanged, and the
+	//    repetition signal (same command -> same target) survives redaction.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a benign command with no secret is left byte-for-byte unchanged', () => {
+		const target = extractTarget('bash', {
+			command: 'bun test src/prm/__tests__/pattern-detector.test.ts',
+		});
+		expect(target).toBe('bun test src/prm/__tests__/pattern-detector.test.ts');
+	});
+
+	test('the same benign command run twice still produces the same target after redaction is applied', () => {
+		const first = extractTarget('bash', { command: 'git status --short' });
+		const second = extractTarget('bash', { command: 'git status --short' });
+		expect(first).toBe(second);
+		expect(first).toBe('git status --short');
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 6. URL-embedded credentials (PR #2139, `URL_CREDENTIALS_PATTERN`).
+	//
+	// The shared `redactSecrets` detector has no pattern for
+	// `scheme://user:pass@host`, so this module-local regex closes that gap.
+	// The userinfo segment is replaced WHOLESALE (username included) — the
+	// username of a leaked credential pair is as identifying as the password.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a git command with URL-embedded credentials redacts the userinfo but preserves scheme and host', () => {
+		const target = extractTarget('bash', {
+			command: 'git push https://user:pa55word@github.com/x/y.git',
+		});
+
+		expect(target).toContain('[REDACTED:url_credentials]');
+		expect(target).not.toContain('pa55word');
+		expect(target).not.toContain('user:pa55word');
+		// Scheme and host must survive — otherwise the target loses the
+		// information that actually differentiates one push destination from
+		// another.
+		expect(target).toContain('https://');
+		expect(target).toContain('github.com/x/y.git');
+		expect(target).toBe(
+			'git push https://[REDACTED:url_credentials]@github.com/x/y.git',
+		);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 7. E-2 anti-collapse: bound-then-redact can push a command back over
+	// MAX_COMMAND_TARGET_LENGTH, forcing a second truncation. If that second
+	// truncation cut plain text, two distinct commands whose only difference
+	// falls inside the cut region would collapse onto the same target — the
+	// exact false `repetition_loop` failure issue #2134 exists to prevent.
+	// The fix appends `#<8-hex fnv1a digest of the bounded RAW string>` so
+	// distinctness survives even when the visible (non-digest) text is
+	// byte-identical after the second truncation.
+	//
+	// Fixture calibrated (empirically, against this build) so that:
+	//   - both raw commands exceed MAX_COMMAND_TARGET_LENGTH,
+	//   - both share an identical secret-shaped span early in the command,
+	//   - redacting that span grows the string past the bound a second time,
+	//   - the re-truncated, non-digest portion of the two targets is
+	//     BYTE-IDENTICAL — so only the digest suffix can be doing the work of
+	//     keeping them apart.
+	// ───────────────────────────────────────────────────────────────────────
+	describe('E-2 anti-collapse: distinct >200-char commands with a shared early secret span', () => {
+		function buildCommand(tail: string): string {
+			const filler = 'y'.repeat(170);
+			return `echo --API_KEY=abcdefgh1 ${filler} ${tail}`;
+		}
+
+		const commandA = buildCommand('AAAAAAAAAAAAAAAAAAAA');
+		const commandB = buildCommand('BBBBBBBBBBBBBBBBBBBB');
+
+		test('fixture preconditions: both raw commands exceed the length bound and share an early secret span', () => {
+			expect(commandA.length).toBeGreaterThan(MAX_COMMAND_TARGET_LENGTH);
+			expect(commandB.length).toBeGreaterThan(MAX_COMMAND_TARGET_LENGTH);
+			expect(commandA.slice(0, 30)).toBe(commandB.slice(0, 30));
+			expect(commandA).not.toBe(commandB);
+		});
+
+		test('produces different targets, each bounded to MAX_COMMAND_TARGET_LENGTH, with an 8-hex digest suffix', () => {
+			const targetA = extractTarget('bash', { command: commandA });
+			const targetB = extractTarget('bash', { command: commandB });
+
+			expect(targetA.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+			expect(targetB.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+			expect(targetA).not.toBe(targetB);
+
+			const digestSuffix = /#[0-9a-f]{8}$/;
+			expect(targetA).toMatch(digestSuffix);
+			expect(targetB).toMatch(digestSuffix);
+
+			// The important assertion: strip the digest suffix and the visible
+			// text is identical — collapse is prevented ONLY by the digest, not
+			// by leftover plain-text differences that happened to survive the
+			// second truncation.
+			const withoutDigestA = targetA.replace(digestSuffix, '');
+			const withoutDigestB = targetB.replace(digestSuffix, '');
+			expect(withoutDigestA).toBe(withoutDigestB);
+
+			// No raw secret bytes and no raw tail bytes leak.
+			expect(targetA).not.toContain('abcdefgh1');
+			expect(targetB).not.toContain('abcdefgh1');
+			expect(targetA).toContain('[REDACTED:env_secret]');
+			expect(targetB).toContain('[REDACTED:env_secret]');
+		});
+
+		test('is deterministic: the same >200-char redacted-and-digested command produces the identical target twice', () => {
+			const first = extractTarget('bash', { command: commandA });
+			const second = extractTarget('bash', { command: commandA });
+			expect(first).toBe(second);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 8. `extractIntent` redacts a Bearer token carried in a Task tool prompt.
+	//
+	// `intent` is exposed only through the persisted JSONL (not via
+	// `_test_exports`), so this is verified end-to-end through
+	// `createTrajectoryLoggerHook(...).toolAfter`, mirroring the
+	// `args_summary` coverage above.
+	// ───────────────────────────────────────────────────────────────────────
+	describe('extractIntent redacts a Bearer token in a Task prompt', () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			resetSwarmState();
+			tempDir = canonicalMkdtemp('test-trajectory-redaction-intent-');
+			fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		});
+
+		afterEach(() => {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+			resetSwarmState();
+		});
+
+		function readEntries(
+			taskId: string,
+		): Array<{ target: string; intent: string }> {
+			const trajectoryPath = path.join(
+				tempDir,
+				'.swarm',
+				'evidence',
+				taskId,
+				'trajectory.jsonl',
+			);
+			return fs
+				.readFileSync(trajectoryPath, 'utf-8')
+				.split('\n')
+				.filter((l) => l.trim().length > 0)
+				.map((l) => JSON.parse(l) as { target: string; intent: string });
+		}
+
+		test('a Task tool prompt containing a Bearer token has the token redacted in the persisted intent', async () => {
+			const sessionId = 'session-redaction-intent';
+			startAgentSession(sessionId, 'coder');
+			const session = swarmState.agentSessions.get(sessionId);
+			if (!session) throw new Error('session not created');
+			session.delegationActive = true;
+			session.currentTaskId = 'redaction-intent-e2e';
+
+			const hook = createTrajectoryLoggerHook(
+				{ enabled: true, max_lines: 500 },
+				tempDir,
+			);
+
+			const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEF';
+			await hook.toolAfter(
+				{
+					tool: 'task',
+					sessionID: sessionId,
+					callID: 'call-intent-1',
+					args: {
+						subagent_type: 'coder',
+						prompt: `Use Authorization: Bearer ${token} to call the API`,
+					},
+				},
+				{ title: 'ok', output: 'done', metadata: { success: true } },
+			);
+
+			const [entry] = readEntries('redaction-intent-e2e');
+			expect(entry).toBeDefined();
+			expect(entry.intent).toContain('[REDACTED:authorization_bearer]');
+			expect(entry.intent).not.toContain(token);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 9. The `description` fallback of `extractTarget` (bash args with no
+	// `command`, only `description`) also redacts.
+	// ───────────────────────────────────────────────────────────────────────
+	test('the description fallback of extractTarget redacts a secret when no command field is present', () => {
+		const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEF';
+		const target = extractTarget('bash', {
+			description: `curl -H "Authorization: Bearer ${token}" https://api.example.com/v1`,
+		});
+
+		expect(target).not.toContain(token);
+		// The description fallback truncates to 30 chars AFTER redaction, so
+		// only the start of the placeholder is visible — but that start must
+		// be present, proving redaction ran rather than truncating raw text.
+		expect(target).toContain('[REDACTED:');
+	});
+});

--- a/tests/unit/hooks/trajectory-logger-redaction.test.ts
+++ b/tests/unit/hooks/trajectory-logger-redaction.test.ts
@@ -271,7 +271,10 @@ describe('trajectory-logger secret redaction (PRR-001, issue #2134)', () => {
 		// another.
 		expect(target).toContain('https://');
 		expect(target).toContain('github.com/x/y.git');
-		expect(target).toBe(
+		// The digest PREFIX is present because redaction changed the string; the
+		// visible remainder is the redacted command verbatim.
+		expect(target).toMatch(/^#[0-9a-f]{8} /);
+		expect(target.replace(/^#[0-9a-f]{8} /, '')).toBe(
 			'git push https://[REDACTED:url_credentials]@github.com/x/y.git',
 		);
 	});
@@ -282,9 +285,10 @@ describe('trajectory-logger secret redaction (PRR-001, issue #2134)', () => {
 	// truncation cut plain text, two distinct commands whose only difference
 	// falls inside the cut region would collapse onto the same target — the
 	// exact false `repetition_loop` failure issue #2134 exists to prevent.
-	// The fix appends `#<8-hex fnv1a digest of the bounded RAW string>` so
-	// distinctness survives even when the visible (non-digest) text is
-	// byte-identical after the second truncation.
+	// The fix PREFIXES `#<8-hex fnv1a digest of the bounded RAW string>` to every
+	// target whose text redaction changed, so distinctness survives even when the
+	// visible (non-digest) text is byte-identical. It leads rather than trails
+	// because downstream truncation (`sanitizeString`) cuts tails.
 	//
 	// Fixture calibrated (empirically, against this build) so that:
 	//   - both raw commands exceed MAX_COMMAND_TARGET_LENGTH,
@@ -318,16 +322,16 @@ describe('trajectory-logger secret redaction (PRR-001, issue #2134)', () => {
 			expect(targetB.length).toBe(MAX_COMMAND_TARGET_LENGTH);
 			expect(targetA).not.toBe(targetB);
 
-			const digestSuffix = /#[0-9a-f]{8}$/;
-			expect(targetA).toMatch(digestSuffix);
-			expect(targetB).toMatch(digestSuffix);
+			const digestPrefix = /^#[0-9a-f]{8} /;
+			expect(targetA).toMatch(digestPrefix);
+			expect(targetB).toMatch(digestPrefix);
 
 			// The important assertion: strip the digest suffix and the visible
 			// text is identical — collapse is prevented ONLY by the digest, not
 			// by leftover plain-text differences that happened to survive the
 			// second truncation.
-			const withoutDigestA = targetA.replace(digestSuffix, '');
-			const withoutDigestB = targetB.replace(digestSuffix, '');
+			const withoutDigestA = targetA.replace(digestPrefix, '');
+			const withoutDigestB = targetB.replace(digestPrefix, '');
 			expect(withoutDigestA).toBe(withoutDigestB);
 
 			// No raw secret bytes and no raw tail bytes leak.
@@ -432,5 +436,63 @@ describe('trajectory-logger secret redaction (PRR-001, issue #2134)', () => {
 		// only the start of the placeholder is visible — but that start must
 		// be present, proving redaction ran rather than truncating raw text.
 		expect(target).toContain('[REDACTED:');
+	});
+	// Redacted-span collapse (closeout critic finding A). Redaction is lossy, so
+	// two DIFFERENT commands can render identically once their differing span
+	// becomes one placeholder — a collapse in the same false-`repetition_loop`
+	// family issue #2134 exists to close, and it needs no real credential: the
+	// shared `env_secret` pattern is case-insensitive, so `--cache_key=` matches.
+	// Every redacted target therefore carries a digest of its pre-redaction text.
+	describe('redacted-span collapse', () => {
+		test('commands differing only in a rotated bearer token stay distinct', () => {
+			const targets = [
+				'curl -H "Authorization: Bearer AAAAAAAAAAAAAAAAAAAAAA" https://api.x/v1',
+				'curl -H "Authorization: Bearer BBBBBBBBBBBBBBBBBBBBBB" https://api.x/v1',
+				'curl -H "Authorization: Bearer CCCCCCCCCCCCCCCCCCCCCC" https://api.x/v1',
+			].map((command) => extractTarget('bash', { command }));
+
+			expect(new Set(targets).size).toBe(3);
+			for (const target of targets) {
+				expect(target).not.toContain('Bearer AAAA');
+				expect(target).toContain('[REDACTED:authorization_bearer]');
+			}
+		});
+
+		test('ordinary --cache_key= builds are not conflated by env_secret redaction', () => {
+			// No credential is involved: `cache_key` is an ordinary build
+			// identifier that the case-insensitive `env_secret` pattern matches.
+			// Pre-fix both rendered as `bun run build --[REDACTED:env_secret]`
+			// and tripped repetition_loop at its default threshold of 2.
+			const a = extractTarget('bash', {
+				command: 'bun run build --cache_key=aaaaaaaa1111',
+			});
+			const b = extractTarget('bash', {
+				command: 'bun run build --cache_key=bbbbbbbb2222',
+			});
+			expect(a).not.toBe(b);
+		});
+
+		test('the digest LEADS, so a tail truncation cannot strip it', () => {
+			// `sanitizeString` in the detector expands its input before length
+			// checking it, so a trailing digest on a near-bound target is cut and
+			// two distinct behaviours collapse onto one escalation ladder key.
+			const target = extractTarget('bash', {
+				command: 'curl -H "Authorization: Bearer AAAAAAAAAAAAAAAAAAAAAA"',
+			});
+			expect(target).toMatch(/^#[0-9a-f]{8} /);
+		});
+
+		test('a benign command gets no digest and is byte-identical to its input', () => {
+			expect(extractTarget('bash', { command: 'bun run lint' })).toBe(
+				'bun run lint',
+			);
+		});
+
+		test('an identical redacted command is stable across calls', () => {
+			const command = 'curl -H "Authorization: Bearer ZZZZZZZZZZZZZZZZZZZZ"';
+			expect(extractTarget('bash', { command })).toBe(
+				extractTarget('bash', { command }),
+			);
+		});
 	});
 });

--- a/tests/unit/hooks/trajectory-logger-target.test.ts
+++ b/tests/unit/hooks/trajectory-logger-target.test.ts
@@ -24,7 +24,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
-import { tmpdir } from 'node:os';
+
 import * as path from 'node:path';
 import {
 	_test_exports,
@@ -35,6 +35,7 @@ import {
 	startAgentSession,
 	swarmState,
 } from '../../../src/state';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 const { extractTarget } = _test_exports;
 
@@ -276,10 +277,10 @@ describe('extractTarget — command target normalization (issue #2134)', () => {
 
 		beforeEach(() => {
 			resetSwarmState();
-			tempDir = path.join(
-				tmpdir(),
-				`test-trajectory-target-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-			);
+			// canonicalMkdtemp closes the macOS /var -> /private/var symlink gap
+			// (FR-011) and supplies its own uniqueness, so no clock or RNG is
+			// needed here.
+			tempDir = canonicalMkdtemp('test-trajectory-target-');
 			fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
 		});
 

--- a/tests/unit/hooks/trajectory-logger-target.test.ts
+++ b/tests/unit/hooks/trajectory-logger-target.test.ts
@@ -1,0 +1,353 @@
+/**
+ * `extractTarget` command-target regression coverage (issue #2134).
+ *
+ * Before this fix, `extractTarget` returned a shell command's FIRST WORD as
+ * the trajectory target ("git" from "git commit"). Every command sharing a
+ * driver therefore collapsed onto one target, and PRM's `repetition_loop`
+ * detector — which keys on the tuple `agent|action|target` at default
+ * threshold 2 — read a coder doing ordinary, entirely different work as the
+ * same action repeated over and over. Measured on this repo with twelve
+ * completely distinct commands (`bun test src/prm/`, `bun run lint`,
+ * `bunx tsc --noEmit`, `bun run build`, …): the escalation ladder reached
+ * level 3 and armed the HARD STOP deny token by the seventh command.
+ *
+ * The fix adds `normalizeCommandTarget`: trim, collapse whitespace runs to a
+ * single space, truncate to 200 chars with a trailing `...`. This file pins
+ * that behavior directly against the `_test_exports.extractTarget` Tier 0
+ * seam, and separately proves the fix is actually WIRED through the public
+ * `toolAfter` hook end to end.
+ *
+ * Lives in its own file rather than extending `trajectory-logger.test.ts`,
+ * which is already over the FR-006 500-line cap; growing it would trip the
+ * diff-scoped ratchet (see `trajectory-logger-denied.test.ts` for the same
+ * rationale).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+	_test_exports,
+	createTrajectoryLoggerHook,
+} from '../../../src/hooks/trajectory-logger';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+
+const { extractTarget } = _test_exports;
+
+/**
+ * Mirrors `MAX_COMMAND_TARGET_LENGTH` in `src/hooks/trajectory-logger.ts`
+ * (not exported via `_test_exports`, and this suite may not edit production
+ * code to add it). Pinned here as a literal so a change to the production
+ * constant without a matching test update fails loudly rather than silently
+ * drifting.
+ */
+const MAX_COMMAND_TARGET_LENGTH = 200;
+
+describe('extractTarget — command target normalization (issue #2134)', () => {
+	// ───────────────────────────────────────────────────────────────────────
+	// 1. The regression: different commands sharing a first word must diverge.
+	// ───────────────────────────────────────────────────────────────────────
+	test('two different bash commands sharing a first word produce DIFFERENT targets', () => {
+		const testTarget = extractTarget('bash', {
+			command: 'bun test src/a.test.ts',
+		});
+		const lintTarget = extractTarget('bash', { command: 'bun run lint' });
+
+		// Pre-fix (first-word extraction) both of these collapsed to "bun" —
+		// this is the exact assertion that fails against the old behavior.
+		expect(testTarget).not.toBe(lintTarget);
+		expect(testTarget).toBe('bun test src/a.test.ts');
+		expect(lintTarget).toBe('bun run lint');
+	});
+
+	test('twelve distinct bun/git-style commands all produce distinct targets', () => {
+		const commands = [
+			'bun test src/prm/',
+			'bun run lint',
+			'bunx tsc --noEmit',
+			'bun run build',
+			'bun run check:test-file-cap',
+			'git status',
+			'git diff --stat',
+			'git add -A',
+			'git commit -m "wip"',
+			'git log --oneline -5',
+			'git push origin HEAD',
+			'bun run format',
+		];
+		const targets = commands.map((c) => extractTarget('bash', { command: c }));
+		const uniqueTargets = new Set(targets);
+		// Pre-fix, every "bun …" command collapsed to "bun" and every "git …"
+		// command collapsed to "git" — only 2 unique targets from 12 commands.
+		expect(uniqueTargets.size).toBe(commands.length);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 2. Guard against over-fixing: a genuine repeat must still look identical.
+	// ───────────────────────────────────────────────────────────────────────
+	test('the SAME command run twice produces the SAME target (stuck-loop signal preserved)', () => {
+		const first = extractTarget('bash', { command: 'bun test src/a.test.ts' });
+		const second = extractTarget('bash', {
+			command: 'bun test src/a.test.ts',
+		});
+		expect(first).toBe(second);
+		expect(first).toBe('bun test src/a.test.ts');
+	});
+
+	test('same command with shell tool alias ("shell") normalizes identically to "bash"', () => {
+		const bashTarget = extractTarget('bash', { command: 'bun run lint' });
+		const shellTarget = extractTarget('shell', { command: 'bun run lint' });
+		expect(bashTarget).toBe(shellTarget);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 3. Whitespace normalization.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a line-continued multi-line command normalizes to its single-line equivalent', () => {
+		// The literal backslash line-continuation characters are preserved (only
+		// WHITESPACE runs collapse) — so the single-line equivalent must include
+		// them too for the two to match post-normalization.
+		const multiline = 'bun test \\\n  src/a.test.ts \\\n  --watch';
+		const singleLine = 'bun test \\ src/a.test.ts \\ --watch';
+
+		const multilineTarget = extractTarget('bash', { command: multiline });
+		const singleLineTarget = extractTarget('bash', { command: singleLine });
+
+		expect(multilineTarget).toBe(singleLineTarget);
+		expect(multilineTarget).toBe('bun test \\ src/a.test.ts \\ --watch');
+	});
+
+	test('a multi-line command WITHOUT line-continuation backslashes normalizes to its true single-line form', () => {
+		const multiline = 'bun\n  test\n  src/a.test.ts';
+		const singleLine = 'bun test src/a.test.ts';
+
+		expect(extractTarget('bash', { command: multiline })).toBe(
+			extractTarget('bash', { command: singleLine }),
+		);
+		expect(extractTarget('bash', { command: multiline })).toBe(
+			'bun test src/a.test.ts',
+		);
+	});
+
+	test('a heredoc-style command with tabs and repeated blank lines collapses to single spaces', () => {
+		const messy = '  git   commit\t\t-m\n\n\n"multi   word\tmessage"  ';
+		const target = extractTarget('bash', { command: messy });
+		expect(target).toBe('git commit -m "multi word message"');
+		// No run of 2+ whitespace characters should survive normalization.
+		expect(target).not.toMatch(/\s{2,}/);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 4. Truncation boundary.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a command longer than 200 chars truncates to exactly 200 chars ending in "..."', () => {
+		const longCommand = `echo ${'a'.repeat(250)}`;
+		expect(longCommand.length).toBeGreaterThan(MAX_COMMAND_TARGET_LENGTH);
+
+		const target = extractTarget('bash', { command: longCommand });
+
+		expect(target.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+		expect(target.endsWith('...')).toBe(true);
+		expect(target).toBe(
+			`${longCommand.slice(0, MAX_COMMAND_TARGET_LENGTH - 3)}...`,
+		);
+	});
+
+	test('a command exactly at the 200-char boundary is left untouched (no truncation)', () => {
+		const exactCommand = `echo ${'b'.repeat(195)}`; // "echo " (5) + 195 = 200
+		expect(exactCommand.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+
+		const target = extractTarget('bash', { command: exactCommand });
+
+		expect(target).toBe(exactCommand);
+		expect(target.endsWith('...')).toBe(false);
+		expect(target.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+	});
+
+	test('a command one char over the boundary (201 chars) IS truncated', () => {
+		const overByOne = `echo ${'c'.repeat(196)}`; // 5 + 196 = 201
+		expect(overByOne.length).toBe(MAX_COMMAND_TARGET_LENGTH + 1);
+
+		const target = extractTarget('bash', { command: overByOne });
+
+		expect(target.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+		expect(target.endsWith('...')).toBe(true);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 5. Non-shell tools are unaffected by the command-target normalization.
+	// ───────────────────────────────────────────────────────────────────────
+	test('a read/edit-style call still targets the file path, not a normalized command', () => {
+		expect(extractTarget('read', { filePath: '/src/app.ts' })).toBe(
+			'/src/app.ts',
+		);
+		expect(extractTarget('edit', { filePath: '/src/app.ts' })).toBe(
+			'/src/app.ts',
+		);
+	});
+
+	test('a task call still targets its subagent_type, ignoring any command-shaped fields', () => {
+		expect(
+			extractTarget('task', {
+				subagent_type: 'coder',
+				// A command field on a non-shell tool must never be consulted.
+				command: 'bun test should-be-ignored',
+			}),
+		).toBe('coder');
+	});
+
+	test('a bash call with a filePath field prefers filePath over command (targetFields checked first)', () => {
+		// Documents existing precedence: targetFields are checked BEFORE the
+		// bash-specific command fallback, regardless of tool name.
+		expect(
+			extractTarget('bash', {
+				filePath: '/src/app.ts',
+				command: 'bun test src/a.test.ts',
+			}),
+		).toBe('/src/app.ts');
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 6. The `args`-string fallback is normalized the same way as `command`.
+	// ───────────────────────────────────────────────────────────────────────
+	test('the args-string fallback (no command field) is whitespace-normalized, not reduced to a first word', () => {
+		const target = extractTarget('bash', {
+			args: 'ls   -la   /tmp',
+		});
+		expect(target).toBe('ls -la /tmp');
+		expect(target).not.toBe('ls');
+	});
+
+	test('two different args-string fallback invocations sharing a first word produce distinct targets', () => {
+		const a = extractTarget('bash', { args: 'python script_a.py --flag' });
+		const b = extractTarget('bash', { args: 'python script_b.py --other' });
+		expect(a).not.toBe(b);
+	});
+
+	test('args-string fallback truncates at 200 chars like the command field', () => {
+		const longArgs = 'd'.repeat(250);
+		const target = extractTarget('bash', { args: longArgs });
+		expect(target.length).toBe(MAX_COMMAND_TARGET_LENGTH);
+		expect(target.endsWith('...')).toBe(true);
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// 7. Empty / whitespace-only command falls through rather than emitting a
+	//    blank or whitespace target.
+	// ───────────────────────────────────────────────────────────────────────
+	test('whitespace-only command falls through to the description fallback', () => {
+		const target = extractTarget('bash', {
+			command: '   ',
+			description: 'run the test suite',
+		});
+		expect(target).toBe('run the test suite');
+		expect(target).not.toBe('');
+		expect(target).not.toBe(' ');
+	});
+
+	test('whitespace-only command with no description falls through to the args fallback', () => {
+		const target = extractTarget('bash', {
+			command: '\t\n',
+			args: 'echo   hello',
+		});
+		expect(target).toBe('echo hello');
+	});
+
+	test('empty command, no description, no args produces an empty-string target (pinned real behavior)', () => {
+		const target = extractTarget('bash', { command: '' });
+		expect(target).toBe('');
+	});
+
+	test('command absent entirely (undefined) with no fallback fields also produces empty string', () => {
+		const target = extractTarget('bash', {});
+		expect(target).toBe('');
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// End-to-end wiring: prove the fix is actually reachable through the
+	// public toolAfter hook, not just the pure-function seam.
+	// ───────────────────────────────────────────────────────────────────────
+	describe('end-to-end via createTrajectoryLoggerHook', () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			resetSwarmState();
+			tempDir = path.join(
+				tmpdir(),
+				`test-trajectory-target-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			fs.mkdirSync(path.join(tempDir, '.swarm'), { recursive: true });
+		});
+
+		afterEach(() => {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+			resetSwarmState();
+		});
+
+		function readTargets(taskId: string): string[] {
+			const trajectoryPath = path.join(
+				tempDir,
+				'.swarm',
+				'evidence',
+				taskId,
+				'trajectory.jsonl',
+			);
+			return fs
+				.readFileSync(trajectoryPath, 'utf-8')
+				.split('\n')
+				.filter((l) => l.trim().length > 0)
+				.map((l) => (JSON.parse(l) as { target: string }).target);
+		}
+
+		test('two different bash tool calls through toolAfter write DIFFERENT target fields to the trajectory', async () => {
+			const sessionId = 'session-target-regression';
+			startAgentSession(sessionId, 'coder');
+			const session = swarmState.agentSessions.get(sessionId);
+			if (!session) throw new Error('session not created');
+			session.delegationActive = true;
+			session.currentTaskId = 'target-e2e';
+
+			const hook = createTrajectoryLoggerHook(
+				{ enabled: true, max_lines: 500 },
+				tempDir,
+			);
+
+			const output = {
+				title: 'ok',
+				output: 'done',
+				metadata: { success: true },
+			};
+
+			await hook.toolAfter(
+				{
+					tool: 'bash',
+					sessionID: sessionId,
+					callID: 'call-1',
+					args: { command: 'bun test src/a.test.ts' },
+				},
+				output,
+			);
+			await hook.toolAfter(
+				{
+					tool: 'bash',
+					sessionID: sessionId,
+					callID: 'call-2',
+					args: { command: 'bun run lint' },
+				},
+				output,
+			);
+
+			const targets = readTargets('target-e2e');
+			expect(targets.length).toBe(2);
+			// Pre-fix this reads ['bun', 'bun'] — the exact collapse issue #2134
+			// describes, which is what fed the false repetition_loop escalation.
+			expect(targets[0]).not.toBe(targets[1]);
+			expect(targets[0]).toBe('bun test src/a.test.ts');
+			expect(targets[1]).toBe('bun run lint');
+		});
+	});
+});


### PR DESCRIPTION
Closes #2134

## Summary

- **Root cause:** the PRM 3-strike escalation ladder counted *detections*, not *occurrences*. Detectors re-emit one ongoing episode on every tool call with a growing end step, and the cursor filter `stepRange[1] > lastProcessedStep` can never suppress that because the end step always advances past it. Reading **five distinct files** walked a healthy coder to level 3 and armed the hard-stop deny token. Denied calls are still appended to the trajectory, so the next allowed call re-detected the still-growing episode and re-armed it — the "completely blocked" symptom.

- **`detectPatterns` dedup was a no-op for the case its own comment described.** The key included the volatile `stepRange[1]`, so one repetition episode emitted `[1,2]`, `[1,3]`, `[1,4]`, `[1,5]` as four distinct keys — four strikes, and a *first-ever* occurrence hard-stopping inside a single tick with no level-1 or level-2 guidance ever delivered. The key now uses the episode's stable start step.

- **Episode-scoped strike accounting.** `toolAfter` consults a per-session ledger (`prmStruckEpisodes`, keyed `pattern|startStep`). A match strikes only when its episode is new, or when it has gained another full threshold's worth of occurrences. Max one strike per pattern type per tick; suppressed matches are dropped entirely, including their pattern-persistence tally (one episode previously reached the default `min_support` of 3 alone and promoted a "learned" insight the agent had exhibited exactly once).

- **Shell commands are no longer collapsed onto their first word.** `extractTarget` returned a bash command's first word, so `bun test src/a`, `bun run lint` and `bunx tsc --noEmit` were all the target `bun`, and `repetition_loop` (threshold 2 on `agent|action|target`) read ordinary distinct work as the same action repeated. Measured: **twelve different `bun …` commands hard-stopped a session by the seventh call.** The reporter's environment is a Python project, where `python`/`pytest`/`pip` collapse identically. Without this the reported symptom survived every other fix here.

- **Escalation state resets at delegation start.** `agentSessions` entries are never removed when a delegated session ends, so a coder that ended with the deny token armed left it live — and reusing that sessionID denied the next delegation's *literal first* tool call. Guarded on the dispatch `callID`, because `message.part.updated` fires repeatedly for the same part and an unguarded reset would disarm PRM for the whole delegation.

- **`context_thrash` default threshold 3 → 10** (tuning, called out as such). A three-step run of new targets is indistinguishable from an agent reading three files.

- **The ladder counts strikes per behaviour, not per pattern type.** It keyed on `match.pattern` alone, so unrelated occurrences accumulated into one count: a coder that read-then-re-read three *different* files scored three `repetition_loop` strikes and hit the hard stop without repeating itself even twice on any single file. Measured on a realistic read → edit → run-test → re-read → re-run-test loop across modules: **hard stop at step 11**. `resolveLadderKey` now gives a pattern that names a single target its own ladder for that target, so the same trajectory never stops and stays at level 1, while three strikes against the *same* target still hard-stops at step 6. Patterns reporting a growing target set keep one ladder for the pattern — a per-target ladder would restart every tool call and they could never escalate at all.

- **Three defects found reviewing that ladder change, fixed with it.** (a) The advisory dedupe key was still scoped to the pattern type, so with every target at level 1 exactly **one** advisory was delivered per pattern for the whole session and every later target's guidance was dropped — the agent was neither stopped nor told (40 distinct repeating files: 1 advisory before, 40 after). (b) `detectRepetitionLoop` recovered its `(agent, action, target)` tuple with `key.split('|')`, truncating any target containing a pipe — and since targets are now whole shell commands, `bun test 2>&1 | head`, `| tail` and `| wc -l` all collapsed onto one ladder and hard-stopped in six steps; the tuple is now carried rather than re-split. (c) The ladder map was unbounded while the episode ledger it mirrors is capped; bounded at 256 with FIFO eviction, and a `getState()` call that deep-cloned the whole state per match on the hot path was narrowed to `getLadderCounts()`.

- **Known trade-off, disclosed rather than papered over.** A pathology spread thinly across many targets no longer reaches a hard stop. This is inherent to the precision/recall trade the issue asks for: a benign eight-module coder loop and a distributed ping-pong are numerically identical (16 vs 15 ladders, each struck once), so no spread threshold separates them. The agent is advised per distinct behaviour instead of being blocked.

- **Containment is not weakened, and that is pinned per detector.** An independent review caught that an earlier version of the episode gate was a genuine fail-open: a start-step rule works only for `repetition_loop` and `expansion_drift`. `ping_pong` pins its start at the first delegation, `stuck_on_test` assigns `cycleStart` once, and `context_thrash` moves `runStart` only when the monotonic run *breaks* — which a sustained thrash never does. Those three would have struck exactly once and never reached level 2 or 3. The occurrence-growth strike ground closes that; all five are now verified to still reach a hard stop.

## Invariant audit

- 1 (plugin init): not touched - no change to `src/index.ts` plugin bootstrap, hook wiring, or initialization order; the diff contains no plugin entry point.
- 2 (runtime portability): not touched - the only new runtime logic is pure string handling (`normalizeCommandTarget`: trim/replace/slice) and in-memory `Map` bookkeeping. No new `node:` imports, no filesystem or path APIs added.
- 3 (subprocesses): not touched - `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns no matches.
- 4 (.swarm containment): not touched - no path construction changed. `trajectory-logger.ts` still writes through the existing `validateSwarmPath(...)` calls; only the *value* of the `target` field changed.
- 5 (plan durability): not touched - no plan read/write path modified; `src/plan/**` unchanged.
- 6 (test_runner safety): not touched - no change to the test_runner tool or its argument handling.
- 7 (test writing): **touched** - 2 new test files, 5 modified. Both new files are under the FR-006 500-line cap (491 and 353); `bun scripts/check-test-file-cap.ts` reports 0 new-file and 0 ratchet violations. Neither new file contains an `isWindows` early-exit guard, so both assert on every platform. Regression value proven by reverting the fix: 6/7 tests fail in the episode-gate file and 10/21 in the target file. The 5 modified files were reconciled by correcting fixture *episode identity* (a fixed `stepRange: [1,3]` replayed three times became three distinct ranges) — no assertion was weakened, deleted, or made vacuous, and no test clears `prmStruckEpisodes` to pass.
- 8 (session state): **touched** - two additive optional `AgentSessionState` fields. `prmStruckEpisodes` is wired end-to-end: declaration (`state.ts`), `startAgentSession` default, `ensureAgentSession` migration backfill, `ResettablePrmSessionState`, `resetPrmSessionState`, and the `snapshot-reader` rehydrate reset. It is deliberately **not** serialized by `snapshot-writer.ts` (which carries no `prm*` field at all): the ledger holds trajectory step numbers that restart at 0 on rehydrate, so persisting it would compare fresh steps against a stale high-water mark and blind PRM for the whole resumed run. `prmDelegationCallId` is produced and consumed at the single `taskMetadata` site and is deliberately excluded from `resetPrmSessionState` — clearing it inside the function the reset itself calls would make the next `part.updated` reset again, a reset storm that would disarm PRM for the entire delegation. `/swarm reset-session` clears both (it calls `resetPrmSessionState` per session, then `agentSessions.clear()`). The ledger is bounded at `MAX_TRACKED_EPISODES = 256` with FIFO eviction so it cannot grow without limit on a hot per-tool-call object.
- 9 (guardrails/retry): **touched** - this changes when the PRM hard-stop DENY token (`prmHardStopPending`, consumed in `guardrails/tool-before.ts`) is armed. The guardrail fires strictly less often, so containment was verified rather than assumed: each of the five detectors independently reaches level 3 under a sustained bad episode — `repetition_loop` at step 6, `context_thrash` and `expansion_drift` at step 30, with `ping_pong` and `stuck_on_test` asserting their **own** strike counts reaching 3 (steps 10 and 19) rather than relying on the `repetition_loop` co-firing that stops those trajectories at step 7. The one-shot deny/inject token semantics from #2063 C2 are unchanged and still pinned by `hard-stop-tokens.test.ts`; a tick where nothing strikes leaves both tokens untouched, arming and disarming neither.
- 10 (chat/system msg): **touched** - PRM course-correction advisories reach the model through `pushAdvisory` into `pendingAdvisoryMessages`. This change reduces their volume (one advisory per episode instead of one per tool call) but adds no new injection site and does not alter the message shape, the `[prm:<pattern>:<level>]` dedupe-key convention, or the drain contract in `messages-transform.ts`.
- 11 (tool registration): not touched - no tool added, removed, or renamed; the diff contains no tools directory, tool-map, or registry file.
- 12 (release/cache): **touched** - adds the required release-note fragment `docs/releases/pending/2134-prm-episode-gate.md`. No version bump, no cache-key or bundling change.

## Test plan

- [x] **CI green — all 22 checks pass**, including all 6 `unit` shards, `quality`, `pr-standards`, `coverage`, `integration`, `security`, `package-check`, and `smoke` on ubuntu/macos/windows.
- [x] `bun scripts/ci/run-unit-tests-local.ts` (the full CI-equivalent per-file unit gate, 2339 files) — exit 0.
- [x] Every `quality`-job gate run locally: `typecheck`, `biome ci .`, `check-mock-cleanup`, `check-tool-registration`, `check:runtime-src-refs`, `check:events`, `check-cross-contamination`, `check-test-clock`, `check:test-file-cap`, `check:gate-portability`, `check-test-tmpdir`, `check-bash-portability` — all pass.
- [x] `bun test src/prm/` — 247 pass, 0 fail (baseline before this change: 224 pass).
- [x] Rebased onto the latest `origin/main` (which had advanced by 2 commits) — the FR-006 ratchet had started reporting violations in three files this PR never touched, which was base drift, not a regression.
- [x] Every reviewer scenario re-measured after the fixes: piped commands 3 ladders / no stop (was stop@6), 40 files → 40 advisories (was 1), 400 distinct ladders capped at 256, benign 8-module loop never stops, same-target repetition still stops at step 6.
- [x] FR-006 ratchet held without weakening coverage: the two already-over-cap PRM test files were brought back under their baselines by extracting duplicated fixtures into `src/prm/__tests__/helpers/` (not `*.test.ts`, so not counted). `expect()` and test-block counts are byte-identical to `origin/main` (integration 73/17, index 59/32). The extraction was proven load-bearing, not vacuous: collapsing `episodeAt()` to a constant `[1, 3]` — the pre-fix behaviour of re-reporting one episode — fails 11 tests.
- [x] All 45 test files that directly reference the changed symbols (`prmStruckEpisodes`, `prmDelegationCallId`, `prmHardStopPending`, `prmTrajectoryStep`, `detectPatterns`, `resolvePatternThreshold`, `context_thrash`, `taskMetadata`, `deserializeAgentSession`) run individually — all pass except one proven pre-existing flake (below).
- [x] `bunx tsc --noEmit` — exit 0.
- [x] `bunx biome ci .` — exit 0.
- [x] `bun scripts/check-test-file-cap.ts` — 0 new-file violations, 0 ratchet violations.
- [x] Regression tests proven to fail pre-fix: 6/7 in `src/prm/__tests__/issue-2134-episode-gate.test.ts`, 10/21 in `tests/unit/hooks/trajectory-logger-target.test.ts`.
- [x] Per-detector containment verified against the real `createPrmHook` with real detectors — all five still reach `prmHardStopPending === true`.
- [x] Reported bug reproduced pre-fix and confirmed fixed: 5 distinct file reads armed the hard stop before; 25 do not now.
- [x] `tests/unit/hooks/delegation-gate-scope-preflight.test.ts` is a **pre-existing Windows flake** (`EBUSY: resource busy or locked` removing a temp dir in `afterEach`), not a regression: a clean `origin/main` worktree fails it 5 of 6 runs, while this branch failed 2 of 4.

## Notes for the reviewer

- Spotted in passing, deliberately **not** included to keep this diff scoped: `src/hooks/pr-workflow-gate.ts` has an unused `removeCandidateCodeFences` import that `biome --unsafe` wants to remove (a WARN, so `biome ci` still exits 0).
- The `context_thrash` threshold change is tuning, not a correctness fix. `detectContextThrash`'s "monotonic run of new targets" remains a coarse signal; the ladder no longer converts that coarseness into a block, but the detector itself was left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
