### PR TITLE
fix(context-budget): key budget state by session and contain budget failures

### DIFF
--- a/docs/releases/pending/per-session-context-budget-state.md
+++ b/docs/releases/pending/per-session-context-budget-state.md
@@ -1,0 +1,53 @@
+# Context-budget state is per-session, and a budget failure no longer takes other injections with it
+
+## What
+
+Turning the context-budget check back on (#2119, #2129) made two latent defects reachable.
+Both are fixed here.
+
+**1. The budget reading leaked across sessions.** `swarmState.lastBudgetPct` and its
+denominator `lastBudgetTokens` were bare module-level scalars shared by every session in
+the plugin process. That was harmless only while the budget check threw on every call and
+left them pinned at `0`. Now that the check runs, the last session to transform overwrites
+them for everyone, and the consumers act on whatever they find:
+
+- `compaction-service` is enabled by default and evaluates after **every non-fast tool
+  call of every agent**. A busy session reporting 85% would fire the emergency tier inside
+  an unrelated, small session — and because that service keys its *hysteresis* per session,
+  the wrong session's state machine advanced on another session's number.
+- The `>= 50%` CONTEXT PRESSURE advisory was delivered to whichever session happened to
+  make the next tool call.
+- `/swarm status` could pair a percentage from one report with a denominator from another,
+  which is exactly the mismatch the denominator was added to prevent.
+
+They are now one per-session record, `lastBudgetBySession`, keyed by `sessionID` and
+FIFO-capped (AGENTS.md invariant 8). The pct and its denominator are written together in a
+single `setSessionBudget` call, so they can never be paired across reports. Consumers that
+*act* on a session read `getSessionBudgetPct` / `getSessionBudgetTokens`; `/swarm status`,
+which has no single session in scope, uses `getDisplayBudget()` — documented display-only,
+returning the most-pressured session's pct **and its own denominator** as a pair.
+
+**2. A budget failure silently removed unrelated injections.** Neither budget block was
+guarded, so anything thrown inside escaped to the hook-level catch at the bottom of the
+system-enhancer transform, skipping every remaining statement in that branch — the
+pre-flight binary advisory, the `coder`/`test_engineer` environment-profile injection, and
+the Path A unified-budget finalize. Both blocks now carry their own scoped `try/catch`
+with a debug-gated warning, matching the optional injections that follow them.
+
+**3. The budget warning was invisible to the budget it reports on.** Every other injection
+is metered through `tryInject`, which accumulates `actualDemand`; the warning used a raw
+`output.system.push`. Its tokens are now added to `actualDemand`. It is still deliberately
+*not* routed through `tryInject` — dropping an "out of budget" notice because you are over
+budget is the wrong failure mode — but the unified ledger that sizes the knowledge
+injector's share is no longer under-reported at exactly the moment context is tightest.
+
+## Migration
+
+None. No configuration changes, no schema changes, no API surface a consumer repository
+depends on.
+
+## Notes
+
+`resetSwarmState()` clears the new map, so `/swarm close` and test isolation behave as
+before. A regression test asserts that a session at 85% does not compact a different
+session; it fails if the consumer is pointed back at any cross-session aggregate.

--- a/src/hooks/system-enhancer.ts
+++ b/src/hooks/system-enhancer.ts
@@ -42,6 +42,7 @@ import {
 	hasActiveLeanTurbo,
 	hasActiveTurboMode,
 	setLiveContextWindow,
+	setSessionBudget,
 	swarmState,
 } from '../state';
 import {
@@ -1718,46 +1719,67 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 							: { ...defaultConfig, budgetTokens };
 
 						if (contextBudgetConfig.enabled !== false) {
-							const assembledSystemPrompt = output.system.join('\n');
-							const budgetReport = await getContextBudgetReport(
-								directory,
-								assembledSystemPrompt,
-								contextBudgetConfig,
-							);
-							swarmState.lastBudgetPct = budgetReport.budgetPct;
-							// Paired with the pct on the SAME statement sequence: a
-							// percentage alone cannot be turned back into a token
-							// estimate, and `/swarm status` renders both.
-							swarmState.lastBudgetTokens = contextBudgetConfig.budgetTokens;
-							telemetry.budgetUpdated(
-								_input.sessionID ?? 'unknown',
-								budgetReport.budgetPct,
-								'architect',
-							);
-							// Resolve the architect check BEFORE calling formatBudgetWarning.
-							// formatBudgetWarning has a side effect: under warningMode
-							// 'once'/'interval' it PERSISTS suppression state to
-							// .swarm/session/budget-state.json. Calling it on a non-architect
-							// turn and discarding the result burned the one-shot warning, so
-							// the architect — the only agent that can act on it — could never
-							// see it. (Latent until the budget check started running at all;
-							// see validateProjectDirectory, issue #1619 follow-up.)
-							const sessionId_cb = _input.sessionID;
-							const activeAgent_cb = sessionId_cb
-								? swarmState.activeAgent.get(sessionId_cb)
-								: null;
-							const isArchitect_cb =
-								!activeAgent_cb ||
-								stripKnownSwarmPrefix(activeAgent_cb) === 'architect';
-							const budgetWarning = isArchitect_cb
-								? await formatBudgetWarning(
-										budgetReport,
-										directory,
-										contextBudgetConfig,
-									)
-								: null;
-							if (budgetWarning) {
-								output.system.push(`[FOR: architect]\n${budgetWarning}`);
+							// Scoped try/catch, matching the two optional injections that
+							// follow. The budget report is advisory, so a failure here must
+							// cost only the budget warning — never the pre-flight binary
+							// advisory or the environment-profile injection below. Without
+							// it, a throw escapes to the hook-level catch and silently
+							// removes both from every turn.
+							try {
+								const assembledSystemPrompt = output.system.join('\n');
+								const budgetReport = await getContextBudgetReport(
+									directory,
+									assembledSystemPrompt,
+									contextBudgetConfig,
+								);
+								// Paired write, keyed by session. The pct and the denominator
+								// it was computed against must stay together, and a bare global
+								// would leak this session's pressure into every other session's
+								// compaction decision (AGENTS.md invariant 8).
+								setSessionBudget(
+									_input.sessionID ?? 'unknown',
+									budgetReport.budgetPct,
+									contextBudgetConfig.budgetTokens,
+								);
+								telemetry.budgetUpdated(
+									_input.sessionID ?? 'unknown',
+									budgetReport.budgetPct,
+									'architect',
+								);
+								// Resolve the architect check BEFORE calling formatBudgetWarning.
+								// formatBudgetWarning has a side effect: under warningMode
+								// 'once'/'interval' it PERSISTS suppression state to
+								// .swarm/session/budget-state.json. Calling it on a non-architect
+								// turn and discarding the result burned the one-shot warning, so
+								// the architect — the only agent that can act on it — could never
+								// see it. (Latent until the budget check started running at all;
+								// see validateProjectDirectory, issue #1619 follow-up.)
+								const sessionId_cb = _input.sessionID;
+								const activeAgent_cb = sessionId_cb
+									? swarmState.activeAgent.get(sessionId_cb)
+									: null;
+								const isArchitect_cb =
+									!activeAgent_cb ||
+									stripKnownSwarmPrefix(activeAgent_cb) === 'architect';
+								const budgetWarning = isArchitect_cb
+									? await formatBudgetWarning(
+											budgetReport,
+											directory,
+											contextBudgetConfig,
+										)
+									: null;
+								if (budgetWarning) {
+									// Deliberately NOT routed through tryInject: dropping an
+									// "out of budget" notice because you are over budget is the
+									// wrong failure mode. Its tokens are still added to
+									// actualDemand so the unified ledger stays honest — this is
+									// otherwise the one injection invisible to the budget it
+									// reports on.
+									actualDemand += estimateTokens(budgetWarning);
+									output.system.push(`[FOR: architect]\n${budgetWarning}`);
+								}
+							} catch (error) {
+								warn('Context budget check failed:', error);
 							}
 						}
 
@@ -2623,39 +2645,50 @@ ${sanitizeContextText(scopedHandoff.body)}`;
 						: { ...defaultConfig_b, budgetTokens: budgetTokens_b };
 
 					if (contextBudgetConfig_b.enabled !== false) {
-						const assembledSystemPrompt_b = output.system.join('\n');
-						const budgetReport_b = await getContextBudgetReport(
-							directory,
-							assembledSystemPrompt_b,
-							contextBudgetConfig_b,
-						);
-						swarmState.lastBudgetPct = budgetReport_b.budgetPct;
-						// Paired with the pct — see the Path A note.
-						swarmState.lastBudgetTokens = contextBudgetConfig_b.budgetTokens;
-						telemetry.budgetUpdated(
-							_input.sessionID ?? 'unknown',
-							budgetReport_b.budgetPct,
-							'architect',
-						);
-						// Architect check BEFORE the call — see the note on the Path A
-						// copy above: formatBudgetWarning persists suppression state, so
-						// calling it for a non-architect burns the one-shot warning.
-						const sessionId_cb_b = _input.sessionID;
-						const activeAgent_cb_b = sessionId_cb_b
-							? swarmState.activeAgent.get(sessionId_cb_b)
-							: null;
-						const isArchitect_cb_b =
-							!activeAgent_cb_b ||
-							stripKnownSwarmPrefix(activeAgent_cb_b) === 'architect';
-						const budgetWarning_b = isArchitect_cb_b
-							? await formatBudgetWarning(
-									budgetReport_b,
-									directory,
-									contextBudgetConfig_b,
-								)
-							: null;
-						if (budgetWarning_b) {
-							output.system.push(`[FOR: architect]\n${budgetWarning_b}`);
+						// Scoped try/catch — see the Path A block.
+						try {
+							const assembledSystemPrompt_b = output.system.join('\n');
+							const budgetReport_b = await getContextBudgetReport(
+								directory,
+								assembledSystemPrompt_b,
+								contextBudgetConfig_b,
+							);
+							// Paired, session-keyed write — see the Path A note.
+							setSessionBudget(
+								_input.sessionID ?? 'unknown',
+								budgetReport_b.budgetPct,
+								contextBudgetConfig_b.budgetTokens,
+							);
+							telemetry.budgetUpdated(
+								_input.sessionID ?? 'unknown',
+								budgetReport_b.budgetPct,
+								'architect',
+							);
+							// Architect check BEFORE the call — see the note on the Path A
+							// copy above: formatBudgetWarning persists suppression state, so
+							// calling it for a non-architect burns the one-shot warning.
+							const sessionId_cb_b = _input.sessionID;
+							const activeAgent_cb_b = sessionId_cb_b
+								? swarmState.activeAgent.get(sessionId_cb_b)
+								: null;
+							const isArchitect_cb_b =
+								!activeAgent_cb_b ||
+								stripKnownSwarmPrefix(activeAgent_cb_b) === 'architect';
+							const budgetWarning_b = isArchitect_cb_b
+								? await formatBudgetWarning(
+										budgetReport_b,
+										directory,
+										contextBudgetConfig_b,
+									)
+								: null;
+							if (budgetWarning_b) {
+								// See the Path A note: deliberately not routed through
+								// tryInject, but still counted into actualDemand.
+								actualDemand += estimateTokens(budgetWarning_b);
+								output.system.push(`[FOR: architect]\n${budgetWarning_b}`);
+							}
+						} catch (error) {
+							warn('Context budget check failed:', error);
 						}
 					}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,12 @@ import { buildDelegationCostFields } from './services/cost-accounting.js';
 import { scheduleVersionCheck } from './services/version-check.js';
 import { loadSnapshot } from './session/snapshot-reader.js';
 import { createSnapshotWriterHook } from './session/snapshot-writer.js';
-import { ensureAgentSession, getActiveWindow, swarmState } from './state';
+import {
+	ensureAgentSession,
+	getActiveWindow,
+	getSessionBudgetPct,
+	swarmState,
+} from './state';
 import { initTelemetry, startHeartbeatTracking, telemetry } from './telemetry';
 import { buildPluginToolObject } from './tools/plugin-registration';
 import { error, log, warn } from './utils';
@@ -2951,7 +2956,8 @@ async function initializeOpenCodeSwarm(
 				}
 
 				// v6.29: One-time 50% context pressure warning
-				if (swarmState.lastBudgetPct >= 50) {
+				const pressurePct = getSessionBudgetPct(input.sessionID);
+				if (pressurePct >= 50) {
 					const pressureSession = ensureAgentSession(
 						input.sessionID,
 						swarmState.activeAgent.get(input.sessionID) ?? ORCHESTRATOR_NAME,
@@ -2960,7 +2966,7 @@ async function initializeOpenCodeSwarm(
 						pressureSession.contextPressureWarningSent = true;
 						pushAdvisory(
 							pressureSession,
-							`CONTEXT PRESSURE: ${swarmState.lastBudgetPct.toFixed(1)}% of context window used. Prioritize completing the current task before starting new work.`,
+							`CONTEXT PRESSURE: ${pressurePct.toFixed(1)}% of context window used. Prioritize completing the current task before starting new work.`,
 						);
 					}
 				}

--- a/src/services/compaction-service.test.ts
+++ b/src/services/compaction-service.test.ts
@@ -10,6 +10,8 @@ import {
 } from '../state';
 import {
 	createCompactionService,
+	getCompactionMetrics,
+	MAX_TRACKED_COMPACTION_SESSIONS,
 	resetCompactionState,
 } from './compaction-service';
 
@@ -123,6 +125,39 @@ describe('compaction-service', () => {
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 		expect(injectCalls).toHaveLength(1);
 		expect(injectCalls[0].sessionId).toBe('s1');
+	});
+
+	// -------------------------------------------------------------------------
+	// Test 3c: sessionStates FIFO cap (AGENTS.md invariant 8)
+	// -------------------------------------------------------------------------
+	test('sessionStates is FIFO-capped: the oldest session is evicted under churn', async () => {
+		// Seed a session with real (non-zero) hysteresis state so eviction is
+		// observable: an evicted session re-reads as a fresh state (count 0).
+		const injectMessage = makeInjectSpy();
+		const service = createCompactionService(
+			defaultConfig,
+			tempDir,
+			injectMessage,
+		);
+		setSessionBudget('s-first', 45, 100000);
+		await service.toolAfter(
+			{ tool: 'bash', sessionID: 's-first' },
+			{ output: {} },
+		);
+		expect(injectCalls).toHaveLength(1); // observation tier fired
+		expect(getCompactionMetrics('s-first').compactionCount).toBe(1);
+
+		// Drive more than the cap of unique sessions through the create-on-read
+		// path (getCompactionMetrics -> getSessionState). 's-first' is the oldest
+		// entry, so it is the first to be evicted once the cap overflows.
+		for (let i = 0; i <= MAX_TRACKED_COMPACTION_SESSIONS; i++) {
+			getCompactionMetrics(`churn-${i}`);
+		}
+
+		// 's-first' was evicted: re-reading it creates a fresh state (count 0),
+		// proving the map is bounded and the oldest session was dropped rather
+		// than the map growing unbounded.
+		expect(getCompactionMetrics('s-first').compactionCount).toBe(0);
 	});
 
 	// -------------------------------------------------------------------------

--- a/src/services/compaction-service.test.ts
+++ b/src/services/compaction-service.test.ts
@@ -3,7 +3,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CompactionConfig } from '../config/schema';
-import { resetSwarmState, swarmState } from '../state';
+import {
+	getSessionBudgetPct,
+	resetSwarmState,
+	setSessionBudget,
+} from '../state';
 import {
 	createCompactionService,
 	resetCompactionState,
@@ -54,7 +58,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 35;
+		setSessionBudget('s1', 35, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -71,7 +75,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 40;
+		setSessionBudget('s1', 40, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -89,12 +93,36 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 60;
+		setSessionBudget('s1', 60, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
 		expect(injectCalls).toHaveLength(1);
 		expect(injectCalls[0].message).toContain('REFLECTION TIER');
+	});
+
+	// -------------------------------------------------------------------------
+	// Test 3b: cross-session isolation (AGENTS.md invariant 8)
+	// -------------------------------------------------------------------------
+	test('one session at emergency does not compact a different session', async () => {
+		const injectMessage = makeInjectSpy();
+		const service = createCompactionService(
+			defaultConfig,
+			tempDir,
+			injectMessage,
+		);
+		// 's1' is under real pressure; 's2' is a fresh, small session. While the
+		// budget was a bare module global this injected an emergency-tier message
+		// into 's2' — and advanced 's2's own hysteresis on 's1's number.
+		setSessionBudget('s1', 85, 100000);
+
+		await service.toolAfter({ tool: 'bash', sessionID: 's2' }, { output: {} });
+		expect(injectCalls).toHaveLength(0);
+
+		// ...and 's1' still compacts on its own turn.
+		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
+		expect(injectCalls).toHaveLength(1);
+		expect(injectCalls[0].sessionId).toBe('s1');
 	});
 
 	// -------------------------------------------------------------------------
@@ -107,7 +135,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 80;
+		setSessionBudget('s1', 80, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -125,7 +153,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 85;
+		setSessionBudget('s1', 85, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -145,7 +173,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 45;
+		setSessionBudget('s1', 45, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -170,7 +198,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 45;
+		setSessionBudget('s1', 45, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -191,7 +219,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 50;
+		setSessionBudget('s1', 50, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -213,7 +241,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 85;
+		setSessionBudget('s1', 85, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -232,7 +260,7 @@ describe('compaction-service', () => {
 		);
 
 		// First call at 40% — should fire
-		swarmState.lastBudgetPct = 40;
+		setSessionBudget('s1', 40, 100000);
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 		expect(injectCalls).toHaveLength(1);
 		expect(injectCalls[0].message).toContain('OBSERVATION TIER');
@@ -254,12 +282,12 @@ describe('compaction-service', () => {
 		);
 
 		// First call at 40% — fires
-		swarmState.lastBudgetPct = 40;
+		setSessionBudget('s1', 40, 100000);
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 		expect(injectCalls).toHaveLength(1);
 
 		// Second call at 46% — should fire again (46 > 40 + 5)
-		swarmState.lastBudgetPct = 46;
+		setSessionBudget('s1', 46, 100000);
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 		expect(injectCalls).toHaveLength(2);
 	});
@@ -274,8 +302,8 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		// swarmState.lastBudgetPct is already 0 from resetSwarmState()
-		expect(swarmState.lastBudgetPct).toBe(0);
+		// the per-session budget map is empty after resetSwarmState()
+		expect(getSessionBudgetPct('s1')).toBe(0);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -292,7 +320,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = -5;
+		setSessionBudget('s1', -5, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -309,7 +337,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 70;
+		setSessionBudget('s1', 70, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 
@@ -328,7 +356,7 @@ describe('compaction-service', () => {
 			tempDir,
 			injectMessage,
 		);
-		swarmState.lastBudgetPct = 80;
+		setSessionBudget('s1', 80, 100000);
 
 		await service.toolAfter({ tool: 'bash', sessionID: 's1' }, { output: {} });
 

--- a/src/services/compaction-service.ts
+++ b/src/services/compaction-service.ts
@@ -46,11 +46,27 @@ function makeInitialState(): CompactionState {
 // Isolates hysteresis thresholds so concurrent sessions don't suppress each other's compaction.
 const sessionStates = new Map<string, CompactionState>();
 
+// FIFO cap (AGENTS.md invariant 8). Mirrors MAX_TRACKED_BUDGET_SESSIONS in
+// state.ts: the budget map and this hysteresis map are the two per-session
+// records that drive compaction, so they share one bounded-growth contract.
+// Without this, the create-on-read in getSessionState below grew unbounded
+// under session churn while the budget map (capped at 500) evicted — leaving
+// the two maps free to desync (hysteresis without a budget record, or a
+// budget record whose hysteresis was silently dropped).
+export const MAX_TRACKED_COMPACTION_SESSIONS = 500;
+
 function getSessionState(sessionId: string): CompactionState {
 	let state = sessionStates.get(sessionId);
-	if (!state) {
-		state = makeInitialState();
-		sessionStates.set(sessionId, state);
+	if (state) return state;
+	state = makeInitialState();
+	sessionStates.set(sessionId, state);
+	// `set` just made `sessionId` the newest entry, so the FIFO oldest can never
+	// be `sessionId` here — the guard is defensive and mirrors setSessionBudget.
+	if (sessionStates.size > MAX_TRACKED_COMPACTION_SESSIONS) {
+		const oldest = sessionStates.keys().next().value;
+		if (oldest !== undefined && oldest !== sessionId) {
+			sessionStates.delete(oldest);
+		}
 	}
 	return state;
 }

--- a/src/services/compaction-service.ts
+++ b/src/services/compaction-service.ts
@@ -7,14 +7,15 @@
  *  - Reflection  (default 60%): re-summarise into tighter format
  *  - Emergency   (default 80%): hard truncation to system + current task + last N turns
  *
- * Consumes `swarmState.lastBudgetPct` (set by system-enhancer.ts after each budget calc).
+ * Consumes the per-session budget pct recorded by system-enhancer.ts after
+ * each budget calc (`getSessionBudgetPct`).
  * Never throws. Advisory system message injection via callback.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { CompactionConfig } from '../config/schema';
-import { swarmState } from '../state';
+import { getSessionBudgetPct } from '../state';
 export type { CompactionConfig };
 
 // ── Compaction state (module-level, resets on plugin reload) ─────────────────
@@ -129,7 +130,9 @@ export function createCompactionService(
 			if (!config.enabled) return;
 
 			// Read last known budget from swarmState (set by system-enhancer)
-			const budgetPct = swarmState.lastBudgetPct ?? 0;
+			// Per-session: another session's pressure must never trigger compaction
+			// here (AGENTS.md invariant 8).
+			const budgetPct = getSessionBudgetPct(_input.sessionID);
 			if (budgetPct <= 0) return; // No budget data yet
 
 			const sessionId = _input.sessionID;

--- a/src/services/status-service.ts
+++ b/src/services/status-service.ts
@@ -29,6 +29,7 @@ import {
 import { loadPlan } from '../plan/manager';
 import {
 	getActiveFullAutoSessionID,
+	getDisplayBudget,
 	hasActiveFullAuto,
 	hasActiveLeanTurbo,
 	hasActiveTurboMode,
@@ -283,10 +284,8 @@ export async function getStatusData(
 			agentCount,
 			isLegacy: false,
 			turboMode: hasActiveTurboMode(),
-			contextBudgetPct:
-				swarmState.lastBudgetPct > 0 ? swarmState.lastBudgetPct : null,
-			contextBudgetTokens:
-				swarmState.lastBudgetTokens > 0 ? swarmState.lastBudgetTokens : null,
+			contextBudgetPct: getDisplayBudget()?.pct ?? null,
+			contextBudgetTokens: getDisplayBudget()?.tokens ?? null,
 			compactionCount: metrics.compactionCount,
 			lastSnapshotAt: metrics.lastSnapshotAt,
 		};
@@ -303,10 +302,8 @@ export async function getStatusData(
 				agentCount: Object.keys(agents).length,
 				isLegacy: true,
 				turboMode: hasActiveTurboMode(),
-				contextBudgetPct:
-					swarmState.lastBudgetPct > 0 ? swarmState.lastBudgetPct : null,
-				contextBudgetTokens:
-					swarmState.lastBudgetTokens > 0 ? swarmState.lastBudgetTokens : null,
+				contextBudgetPct: getDisplayBudget()?.pct ?? null,
+				contextBudgetTokens: getDisplayBudget()?.tokens ?? null,
 				compactionCount: metrics.compactionCount,
 				lastSnapshotAt: metrics.lastSnapshotAt,
 			};
@@ -326,10 +323,8 @@ export async function getStatusData(
 				agentCount,
 				isLegacy: true,
 				turboMode: hasActiveTurboMode(),
-				contextBudgetPct:
-					swarmState.lastBudgetPct > 0 ? swarmState.lastBudgetPct : null,
-				contextBudgetTokens:
-					swarmState.lastBudgetTokens > 0 ? swarmState.lastBudgetTokens : null,
+				contextBudgetPct: getDisplayBudget()?.pct ?? null,
+				contextBudgetTokens: getDisplayBudget()?.tokens ?? null,
 				compactionCount: metrics.compactionCount,
 				lastSnapshotAt: metrics.lastSnapshotAt,
 			};
@@ -721,7 +716,7 @@ export function formatStatusMarkdown(status: StatusData): string {
 	if (status.contextBudgetPct !== null && status.contextBudgetPct > 0) {
 		const pct = status.contextBudgetPct.toFixed(1);
 		// Render the token estimate ONLY against the denominator the percentage
-		// was actually measured with (`swarmState.lastBudgetTokens`, written by
+		// was actually measured with (the per-session budget record, written by
 		// system-enhancer on the same statement as the pct). This used to
 		// back-compute from the hardcoded default, so a user on a 200k/1M model —
 		// or any user with a `model_limits` override — was shown a token figure

--- a/src/state.ts
+++ b/src/state.ts
@@ -816,19 +816,28 @@ export const swarmState = {
 	 */
 	generatedAgentNames: [] as string[],
 
-	/** Last known context budget percentage (0-100), updated by system-enhancer */
-	lastBudgetPct: 0,
-
 	/**
-	 * The DENOMINATOR `lastBudgetPct` was computed against, in tokens. Written
-	 * by system-enhancer at the same two statements that write `lastBudgetPct`,
-	 * because a percentage without its denominator cannot be turned back into a
-	 * token estimate. `/swarm status` used to reconstruct the estimate from a
-	 * hardcoded constant, so a user whose real denominator differed saw a token
-	 * figure that did not match the percentage next to it. 0 means "no budget
-	 * report has run yet".
+	 * Last known context budget per session — keyed by sessionID.
+	 *
+	 * `pct` is the budget percentage (0-100); `tokens` is the DENOMINATOR it was
+	 * computed against. They are stored together because a percentage without
+	 * its denominator cannot be turned back into a token estimate, and
+	 * `/swarm status` renders both — reading them from different sources would
+	 * show a token figure that does not match the percentage beside it.
+	 *
+	 * Keyed rather than global (AGENTS.md invariant 8). These were two bare
+	 * module-level scalars, which was harmless only while the budget check threw
+	 * on every call and left them pinned at 0. Now that the check runs, a bare
+	 * global leaks across sessions: a busy session reporting 85% would trip the
+	 * default-on compaction service's emergency tier — and the `>= 50%` CONTEXT
+	 * PRESSURE advisory — inside an unrelated small session. compaction-service
+	 * keys its *hysteresis* per session, so the wrong session's state machine
+	 * would advance on another session's number.
+	 *
+	 * Write via `setSessionBudget`, read via `getSessionBudgetPct` /
+	 * `getSessionBudgetTokens`; `/swarm status` uses `getDisplayBudget`.
 	 */
-	lastBudgetTokens: 0,
+	lastBudgetBySession: new Map<string, { pct: number; tokens: number }>(),
 
 	/**
 	 * Live `model.limit.context` per session — keyed by sessionID, recorded by
@@ -862,8 +871,7 @@ export function resetSwarmState(): void {
 	swarmState.activeAgent.clear();
 	swarmState.delegationChains.clear();
 	swarmState.pendingEvents = 0;
-	swarmState.lastBudgetPct = 0;
-	swarmState.lastBudgetTokens = 0;
+	swarmState.lastBudgetBySession.clear();
 	swarmState.liveContextWindows.clear();
 	swarmState.agentSessions.clear();
 	// Reset the opportunistic idle-sweep cooldown so a fresh process / test run
@@ -3246,6 +3254,7 @@ export function ensureSessionEnvironment(
 // "Module-level global state must have an explicit eviction strategy").
 // Values mirror MAX_TRACKED_SESSIONS in adversarial-detector.ts. The Map
 // preserves insertion order so `Map.keys().next()` is the FIFO oldest.
+export const MAX_TRACKED_BUDGET_SESSIONS = 500;
 export const MAX_TRACKED_CRITICAL_SHOWN = 500;
 export const MAX_TRACKED_KNOWLEDGE_ACKS = 5000;
 export const MAX_TRACKED_GATE_DENIALS = 500;
@@ -3291,6 +3300,55 @@ export function getLiveContextWindow(
 ): number | undefined {
 	if (!sessionID) return undefined;
 	return swarmState.liveContextWindows.get(sessionID);
+}
+
+/** Record this session's budget percentage and the denominator it was computed
+ *  against, FIFO-evicting the oldest entry if the cap is exceeded. The two are
+ *  written together so `/swarm status` can never pair a pct from one report
+ *  with a denominator from another. */
+export function setSessionBudget(
+	sessionID: string,
+	pct: number,
+	tokens: number,
+): void {
+	const map = swarmState.lastBudgetBySession;
+	if (map.has(sessionID)) map.delete(sessionID);
+	map.set(sessionID, { pct, tokens });
+	if (map.size > MAX_TRACKED_BUDGET_SESSIONS) {
+		const oldest = map.keys().next().value;
+		if (oldest !== undefined && oldest !== sessionID) {
+			map.delete(oldest);
+		}
+	}
+}
+
+/** This session's last budget percentage, or 0 if it has not been measured.
+ *  Consumers that ACT on a session (compaction, the context-pressure advisory)
+ *  MUST use this rather than any cross-session aggregate. */
+export function getSessionBudgetPct(sessionID: string | undefined): number {
+	if (!sessionID) return 0;
+	return swarmState.lastBudgetBySession.get(sessionID)?.pct ?? 0;
+}
+
+/** The denominator this session's percentage was computed against, or 0. */
+export function getSessionBudgetTokens(sessionID: string | undefined): number {
+	if (!sessionID) return 0;
+	return swarmState.lastBudgetBySession.get(sessionID)?.tokens ?? 0;
+}
+
+/** The most-pressured session's budget snapshot, for process-wide DISPLAY only
+ *  (`/swarm status` has no single session in scope). Returns the pct and its
+ *  OWN denominator as a pair, so the two figures shown side by side always come
+ *  from the same report. Null when nothing has been measured yet. Never use
+ *  this to decide whether to act on a particular session. */
+export function getDisplayBudget(): { pct: number; tokens: number } | null {
+	let best: { pct: number; tokens: number } | null = null;
+	for (const entry of swarmState.lastBudgetBySession.values()) {
+		if (entry.pct > 0 && (best === null || entry.pct > best.pct)) {
+			best = entry;
+		}
+	}
+	return best;
 }
 
 /** Set the critical shown ids for a session, FIFO-evicting the oldest entry

--- a/tests/unit/commands/cleanup-drift.test.ts
+++ b/tests/unit/commands/cleanup-drift.test.ts
@@ -330,11 +330,7 @@ test('singleton preservation drift guard (FR-020) — new singleton in swarmStat
 	// than survive a `/swarm close` (issue #1619). `liveContextWindows` is a Map
 	// and is `.clear()`ed rather than replaced, so it is not a cleared-sentinel
 	// value and does not appear here.
-	const expectedClearedOutside = [
-		'pendingEvents',
-		'lastBudgetPct',
-		'lastBudgetTokens',
-	];
+	const expectedClearedOutside = ['pendingEvents'];
 	if (clearedInPreserve.length > 0) {
 		throw new Error(
 			`DRIFT: preserved singleton(s) were cleared after resetSwarmStatePreservingSingletons: ${clearedInPreserve.join(', ')}`,

--- a/tests/unit/commands/reset.test.ts
+++ b/tests/unit/commands/reset.test.ts
@@ -9,7 +9,11 @@ import { join } from 'node:path';
 // The reset command does not import state; this suite verifies the real singleton
 // remains intact without a process-global state mock.
 import { handleResetCommand } from '../../../src/commands/reset';
-import { swarmState } from '../../../src/state';
+import {
+	getSessionBudgetPct,
+	setSessionBudget,
+	swarmState,
+} from '../../../src/state';
 
 describe('handleResetCommand', () => {
 	let tempDir: string;
@@ -321,7 +325,7 @@ describe('handleResetCommand', () => {
 			specWriterAgentNames: swarmState.specWriterAgentNames,
 			generatedAgentNames: swarmState.generatedAgentNames,
 			pendingEvents: swarmState.pendingEvents,
-			lastBudgetPct: swarmState.lastBudgetPct,
+			lastBudgetPct: getSessionBudgetPct('s1'),
 		};
 		try {
 			swarmState.opencodeClient = sentinelClient as never;
@@ -332,7 +336,7 @@ describe('handleResetCommand', () => {
 			swarmState.specWriterAgentNames = ['reset_spec_z'];
 			swarmState.generatedAgentNames = ['reset_gen_1', 'reset_gen_2'];
 			swarmState.pendingEvents = 999;
-			swarmState.lastBudgetPct = 42;
+			setSessionBudget('s1', 42, 128000);
 			swarmState.activeToolCalls.set('reset-test-call', { tool: 'y' });
 
 			const result = await handleResetCommand(tempDir, ['--confirm']);

--- a/tests/unit/commands/state-mock-transitive-stubs.ts
+++ b/tests/unit/commands/state-mock-transitive-stubs.ts
@@ -4,6 +4,15 @@
  * separately; these inert bindings keep unrelated hook modules loadable.
  */
 export const STATE_MOCK_TRANSITIVE_STUBS = {
+	// Per-session context budget. Reached transitively through index.ts and
+	// services/compaction-service.ts; a missing binding makes Bun throw
+	// "Export named 'getSessionBudgetPct' not found" at import time and fail
+	// the whole file before a single test runs.
+	getSessionBudgetPct: () => 0,
+	getSessionBudgetTokens: () => 0,
+	setSessionBudget: () => undefined,
+	getDisplayBudget: () => null,
+	MAX_TRACKED_BUDGET_SESSIONS: 500,
 	beginInvocation: () => undefined,
 	getActiveWindow: () => undefined,
 	advanceTaskState: () => undefined,

--- a/tests/unit/hooks/system-enhancer-budget-throw-containment.test.ts
+++ b/tests/unit/hooks/system-enhancer-budget-throw-containment.test.ts
@@ -1,0 +1,156 @@
+/**
+ * PRR-005 / O-002 regression — budget-check throw containment.
+ *
+ * One of PR #2141's three deliverables (O-002) wraps both Path A and Path B
+ * budget blocks in system-enhancer.ts in a scoped try/catch so that a throw
+ * inside the budget check (getContextBudgetReport / formatBudgetWarning) no
+ * longer escapes to the hook-level catch and silently skips the downstream
+ * injections in the same branch — the pre-flight binary advisory and the
+ * coder/test_engineer environment-profile injection.
+ *
+ * This test forces that exact throw and asserts the coder environment-profile
+ * injection still appears in output.system. Pre-fix the throw escaped and the
+ * env-profile injection was silently dropped on every turn the budget check
+ * failed — the agent lost its platform/command-policy context exactly when the
+ * budget was tightest.
+ *
+ * HOW THE THROW IS FORCED (no mock.module). getContextBudgetReport's first
+ * statement is `validateProjectDirectory(directory)`. We pass a directory the
+ * validator rejects on every platform — a Windows system location, which
+ * validateProjectDirectory flags via its dual path.win32/path.posix evaluation
+ * (src/utils/path-security.ts, issue #2129) regardless of host OS, so this is
+ * CI-safe on ubuntu/macOS/windows. This exercises the real throw path the
+ * scoped catch was added for, and — unlike a module mock — it cannot leak into
+ * sibling suites sharing Bun's test-runner process (AGENTS.md invariant 7).
+ *
+ * A positive control (`getSessionBudgetPct === 0`) proves the throw genuinely
+ * fired before `setSessionBudget`: without it, a silently-passing fixture would
+ * let the report run, record a non-zero pct, and the test would pass for the
+ * wrong reason (env-profile is present regardless when no throw occurs).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { PluginConfig } from '../../../src/config';
+import { createSystemEnhancerHook } from '../../../src/hooks/system-enhancer';
+import {
+	getSessionBudgetPct,
+	resetSwarmState,
+	swarmState,
+} from '../../../src/state';
+import { _internals as coChangeInternals } from '../../../src/tools/co-change-analyzer';
+
+// A directory validateProjectDirectory rejects on EVERY host (dual win32/posix
+// evaluation flags the Windows system segment unconditionally). It is
+// deliberately NON-EXISTENT so the hook's pre-budget reads (plan/knowledge via
+// readFileOrEmpty) return empty immediately instead of scanning a real tree.
+// Execution still reaches the budget block, where this directory makes
+// getContextBudgetReport throw exactly once.
+const REJECTED_DIR = 'C:\\Windows\\prr005-no-such-dir';
+
+const BUDGET_TOKENS = 100_000;
+
+describe('system-enhancer — budget-check throw no longer drops downstream injections (O-002)', () => {
+	const config = {
+		max_iterations: 5,
+		qa_retry_limit: 3,
+		inject_phase_reminders: true,
+		hooks: {
+			system_enhancer: true,
+			compaction: true,
+			agent_activity: true,
+			delegation_tracker: false,
+			delegation_gate: false,
+			agent_awareness_max_chars: 300,
+			delegation_max_chars: 1000,
+		},
+		automation: {
+			mode: 'manual',
+			capabilities: {
+				decision_drift_detection: false,
+				plan_sync: false,
+				phase_preflight: false,
+				config_doctor_on_startup: false,
+				config_doctor_autofix: false,
+				evidence_auto_summaries: false,
+			},
+		},
+		adversarial_detection: {
+			enabled: false,
+			policy: 'warn',
+			pairs: [['coder', 'reviewer']],
+		},
+		context_budget: {
+			enabled: true,
+			warn_threshold: 0.7,
+			critical_threshold: 0.9,
+			model_limits: { default: BUDGET_TOKENS },
+		},
+	} as unknown as PluginConfig;
+
+	// The hook's dark-matter block (system-enhancer.ts:849-882) UNCONDITIONALLY
+	// mkdir+writeFile `.swarm/dark-matter.md` under `directory` via the root-blind
+	// `validateSwarmPath`. For a REJECTED_DIR that resolves as a RELATIVE path on
+	// POSIX (`C:\Windows\...` is one backslash-delimited filename there), that
+	// mkdir would SUCCEED under the cwd and leave a stray directory in the repo
+	// tree (AGENTS.md invariant 4 spirit). Neutralize it through the call-time
+	// `_internals` DI seam (system-enhancer.ts:855-861 reads
+	// `coChangeInternals.detectDarkMatter` at call time so tests can mock it,
+	// writing-tests Invariant 7): a thrown detectDarkMatter is swallowed by the
+	// dark-matter try/catch, so no mkdir/write happens regardless of host.
+	let originalDetectDarkMatter: typeof coChangeInternals.detectDarkMatter;
+	beforeEach(() => {
+		resetSwarmState();
+		originalDetectDarkMatter = coChangeInternals.detectDarkMatter;
+		coChangeInternals.detectDarkMatter = async () => {
+			throw new Error(
+				'dark-matter write neutralized for throw-containment test',
+			);
+		};
+	});
+
+	afterEach(() => {
+		coChangeInternals.detectDarkMatter = originalDetectDarkMatter;
+		resetSwarmState();
+	});
+
+	it('still injects the coder environment profile when the budget check throws', async () => {
+		const sessionId = 'prr005-coder';
+		// The budget block runs for every agent; the env-profile injection below
+		// it is coder/test_engineer-gated. Set coder so the env-profile path is
+		// the downstream injection a pre-fix throw would have skipped.
+		swarmState.activeAgent.set(sessionId, 'coder');
+
+		const hook = createSystemEnhancerHook(config, REJECTED_DIR);
+		const transform = hook['experimental.chat.system.transform'] as (
+			input: { sessionID?: string },
+			output: { system: string[] },
+		) => Promise<void>;
+
+		const output = { system: ['seeded system prompt'] as string[] };
+
+		// The scoped try/catch must contain the throw — the hook resolves.
+		await expect(
+			transform({ sessionID: sessionId }, output),
+		).resolves.toBeUndefined();
+
+		// POSITIVE CONTROL: the throw happened before setSessionBudget ran, so no
+		// budget was recorded for this session. If this fails, the throw did not
+		// fire and the rest of the test is a false pass.
+		expect(getSessionBudgetPct(sessionId)).toBe(0);
+
+		// O-002 assertion: the environment-profile injection downstream of the
+		// budget block is still present despite the throw. Pre-fix, the escaping
+		// throw skipped it entirely.
+		const hasEnvProfile = output.system.some(
+			(s) =>
+				s.includes('RUNTIME ENVIRONMENT') ||
+				s.includes('powershell-native') ||
+				s.includes('posix-native'),
+		);
+		expect(hasEnvProfile).toBe(true);
+
+		// And the budget warning itself is absent — the throw preceded it.
+		expect(output.system.some((s) => s.includes('[CONTEXT BUDGET:'))).toBe(
+			false,
+		);
+	});
+});

--- a/tests/unit/hooks/system-enhancer-context-budget-wiring.test.ts
+++ b/tests/unit/hooks/system-enhancer-context-budget-wiring.test.ts
@@ -23,7 +23,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PluginConfig } from '../../../src/config';
 import { createSystemEnhancerHook } from '../../../src/hooks/system-enhancer';
-import { resetSwarmState, swarmState } from '../../../src/state';
+import {
+	getSessionBudgetPct,
+	getSessionBudgetTokens,
+	resetSwarmState,
+	swarmState,
+} from '../../../src/state';
+
+/** The sessionID runHook() defaults to; the budget record is keyed by it. */
+const SESSION = 'test-session';
 
 const BUDGET_TOKENS = 100_000;
 /** chars = tokens * 3.5 */
@@ -137,13 +145,13 @@ describe('System Enhancer Hook - Context Budget Wiring', () => {
 	});
 
 	it('publishes the measured percentage to swarmState for downstream consumers', async () => {
-		// swarmState.lastBudgetPct drives the CONTEXT PRESSURE advisory in
+		// getSessionBudgetPct(SESSION) drives the CONTEXT PRESSURE advisory in
 		// src/index.ts and the compaction service tiers. While the budget check
 		// threw, it stayed at 0 and both of those were dormant.
-		expect(swarmState.lastBudgetPct).toBe(0);
+		expect(getSessionBudgetPct(SESSION)).toBe(0);
 		await runHook(configWithBudget(), WARNING_PROMPT);
-		expect(swarmState.lastBudgetPct).toBeGreaterThan(70);
-		expect(swarmState.lastBudgetPct).toBeLessThan(90);
+		expect(getSessionBudgetPct(SESSION)).toBeGreaterThan(70);
+		expect(getSessionBudgetPct(SESSION)).toBeLessThan(90);
 	});
 
 	it('measures the budget AFTER the rest of the system prompt is assembled', async () => {
@@ -195,6 +203,6 @@ describe('System Enhancer Hook - Context Budget Wiring', () => {
 		expect(
 			budgetBlockOf(await runHook(config, CRITICAL_PROMPT)),
 		).toBeUndefined();
-		expect(swarmState.lastBudgetPct).toBe(0);
+		expect(getSessionBudgetPct(SESSION)).toBe(0);
 	});
 });

--- a/tests/unit/hooks/system-enhancer-model-window-denominator.test.ts
+++ b/tests/unit/hooks/system-enhancer-model-window-denominator.test.ts
@@ -21,9 +21,15 @@ import type { PluginConfig } from '../../../src/config';
 import { createSystemEnhancerHook } from '../../../src/hooks/system-enhancer';
 import {
 	getLiveContextWindow,
+	getSessionBudgetPct,
+	getSessionBudgetTokens,
 	resetSwarmState,
 	swarmState,
 } from '../../../src/state';
+
+/** The sessionID runHook() defaults to; the budget record is keyed by it. */
+const SESSION = 'model-window-session';
+
 import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 /** `estimateTokens` is chars/3.5, so this yields ~`tokens` estimated tokens. */
@@ -153,8 +159,8 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 			const smallBlock = budgetBlockOf(smallSystem);
 			expect(smallBlock).toBeDefined();
 			expect(smallBlock).toContain('CRITICAL');
-			const smallPct = swarmState.lastBudgetPct;
-			expect(swarmState.lastBudgetTokens).toBe(128000);
+			const smallPct = getSessionBudgetPct(SESSION);
+			expect(getSessionBudgetTokens(SESSION)).toBe(128000);
 
 			resetSwarmState();
 
@@ -164,10 +170,10 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 			);
 			// Same prompt, ~8x the window: no warning at all.
 			expect(budgetBlockOf(hugeSystem)).toBeUndefined();
-			expect(swarmState.lastBudgetTokens).toBe(1_000_000);
+			expect(getSessionBudgetTokens(SESSION)).toBe(1_000_000);
 			// The percentage itself moved with the model, not just the verdict.
-			expect(swarmState.lastBudgetPct).toBeLessThan(smallPct / 5);
-			expect(swarmState.lastBudgetPct).toBeGreaterThan(0);
+			expect(getSessionBudgetPct(SESSION)).toBeLessThan(smallPct / 5);
+			expect(getSessionBudgetPct(SESSION)).toBeGreaterThan(0);
 		});
 
 		it(`${path}: a Copilot-capped entry uses the host's 200000, not the stale 128000 table`, async () => {
@@ -175,7 +181,7 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 			// PROVIDER_CAPS still says github-copilot === 128000. The live catalog
 			// says 200000 for this exact provider/model pair, and the live value
 			// wins outright — it is never min-capped against the stale table.
-			expect(swarmState.lastBudgetTokens).toBe(200000);
+			expect(getSessionBudgetTokens(SESSION)).toBe(200000);
 		});
 
 		it(`${path}: an explicit model_limits value beats the live window`, async () => {
@@ -184,7 +190,7 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 				HUGE_WINDOW_MODEL,
 			);
 			// The user asked for a smaller WORKING budget than the physical window.
-			expect(swarmState.lastBudgetTokens).toBe(60000);
+			expect(getSessionBudgetTokens(SESSION)).toBe(60000);
 		});
 
 		it(`${path}: a malformed limit.context falls back without NaN/Infinity`, async () => {
@@ -196,18 +202,18 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 				modelOf('green-s', 'greenpt', 0),
 				promptOf(1000),
 			);
-			expect(swarmState.lastBudgetTokens).toBe(128000);
-			expect(Number.isFinite(swarmState.lastBudgetPct)).toBe(true);
-			expect(Number.isNaN(swarmState.lastBudgetPct)).toBe(false);
-			expect(swarmState.lastBudgetPct).toBeGreaterThan(0);
+			expect(getSessionBudgetTokens(SESSION)).toBe(128000);
+			expect(Number.isFinite(getSessionBudgetPct(SESSION))).toBe(true);
+			expect(Number.isNaN(getSessionBudgetPct(SESSION))).toBe(false);
+			expect(getSessionBudgetPct(SESSION)).toBeGreaterThan(0);
 		});
 
 		it(`${path}: an absent model object still produces a finite budget`, async () => {
 			// The plugin .d.ts declares `model` as non-optional, but this hook runs
 			// on the host boundary and must not throw if it does not arrive.
 			await runHook(configWith({}, scoring), undefined, promptOf(1000));
-			expect(swarmState.lastBudgetTokens).toBe(128000);
-			expect(Number.isFinite(swarmState.lastBudgetPct)).toBe(true);
+			expect(getSessionBudgetTokens(SESSION)).toBe(128000);
+			expect(Number.isFinite(getSessionBudgetPct(SESSION))).toBe(true);
 		});
 	}
 
@@ -235,10 +241,10 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 		// `/swarm status` renders `est. X / Y tokens` from these two values. If
 		// only the pct is written, the estimate is reconstructed against a
 		// constant and contradicts the percentage printed beside it.
-		expect(swarmState.lastBudgetPct).toBe(0);
-		expect(swarmState.lastBudgetTokens).toBe(0);
+		expect(getSessionBudgetPct(SESSION)).toBe(0);
+		expect(getSessionBudgetTokens(SESSION)).toBe(0);
 		await runHook(configWith(), COPILOT_CLAUDE_MODEL, promptOf(150_000));
-		expect(swarmState.lastBudgetPct).toBeGreaterThan(0);
-		expect(swarmState.lastBudgetTokens).toBe(200000);
+		expect(getSessionBudgetPct(SESSION)).toBeGreaterThan(0);
+		expect(getSessionBudgetTokens(SESSION)).toBe(200000);
 	});
 });

--- a/tests/unit/services/compaction-metrics.test.ts
+++ b/tests/unit/services/compaction-metrics.test.ts
@@ -9,7 +9,11 @@ import {
 	resetCompactionState,
 } from '../../../src/services/compaction-service';
 import { getStatusData } from '../../../src/services/status-service';
-import { resetSwarmState, swarmState } from '../../../src/state';
+import {
+	resetSwarmState,
+	setSessionBudget,
+	swarmState,
+} from '../../../src/state';
 
 describe('compaction-metrics', () => {
 	const tempDir = path.join(os.tmpdir(), `swarm-compaction-test-${Date.now()}`);
@@ -40,7 +44,7 @@ describe('compaction-metrics', () => {
 
 	test('after observation tier fires, compactionCount increments and lastSnapshotAt is ISO string', async () => {
 		// Set budget above observation threshold (40%)
-		swarmState.lastBudgetPct = 45;
+		setSessionBudget('test-session', 45, 128000);
 
 		const hook = createCompactionService(
 			{
@@ -69,7 +73,7 @@ describe('compaction-metrics', () => {
 
 	test('getStatusData returns live compactionCount and lastSnapshotAt from getCompactionMetrics', async () => {
 		// Set budget above reflection threshold (60%)
-		swarmState.lastBudgetPct = 65;
+		setSessionBudget('test-session', 65, 128000);
 
 		const hook = createCompactionService(
 			{

--- a/tests/unit/services/status-context-denominator.test.ts
+++ b/tests/unit/services/status-context-denominator.test.ts
@@ -12,7 +12,7 @@
  * was rendered as "12.5% used (est. 5,000 / 40,000 tokens)", numbers that
  * contradict the percentage printed beside them.
  *
- * The fix pairs `swarmState.lastBudgetTokens` with `swarmState.lastBudgetPct`
+ * The fix pairs the denominator with the pct in one per-session record
  * at the two statements that write the pct, and surfaces it on `StatusData`.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -23,7 +23,11 @@ import {
 	getStatusData,
 	type StatusData,
 } from '../../../src/services/status-service';
-import { resetSwarmState, swarmState } from '../../../src/state';
+import {
+	resetSwarmState,
+	setSessionBudget,
+	swarmState,
+} from '../../../src/state';
 import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 function baseStatus(overrides: Partial<StatusData> = {}): StatusData {
@@ -119,9 +123,8 @@ describe('getStatusData — denominator is carried from swarmState', () => {
 		rmSync(root, { recursive: true, force: true });
 	});
 
-	test('surfaces lastBudgetTokens alongside lastBudgetPct', async () => {
-		swarmState.lastBudgetPct = 37.5;
-		swarmState.lastBudgetTokens = 200000;
+	test('surfaces the denominator alongside the pct', async () => {
+		setSessionBudget('s-display', 37.5, 200000);
 		const status = await getStatusData(root, {});
 		expect(status.contextBudgetPct).toBe(37.5);
 		expect(status.contextBudgetTokens).toBe(200000);

--- a/tests/unit/state/reset-swarm-state-preserving.test.ts
+++ b/tests/unit/state/reset-swarm-state-preserving.test.ts
@@ -3,8 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	getSessionBudgetPct,
 	resetSwarmState,
 	resetSwarmStatePreservingSingletons,
+	setSessionBudget,
 	startAgentSession,
 	swarmState,
 } from '../../../src/state';
@@ -175,12 +177,12 @@ describe('resetSwarmStatePreservingSingletons', () => {
 			expect(swarmState.agentSessions.size).toBe(0);
 		});
 
-		test('lastBudgetPct is reset to 0', () => {
-			swarmState.lastBudgetPct = 75;
+		test('the per-session budget record is cleared', () => {
+			setSessionBudget('s1', 75, 128000);
 
 			resetSwarmStatePreservingSingletons();
 
-			expect(swarmState.lastBudgetPct).toBe(0);
+			expect(getSessionBudgetPct('s1')).toBe(0);
 		});
 
 		test('opencodeClient is still preserved (not reset to null)', () => {


### PR DESCRIPTION
## Summary

> **Retargeted.** This PR originally fixed the workspace-root validator that made the
> context-budget feature inert. #2119 and #2129 landed that fix first — and #2129's
> `validateProjectDirectory` is stronger than what this PR had, because it also rejects
> drive roots and system locations. That part is dropped. What remains are two defects
> that *turning the budget check back on* made reachable, plus one accounting gap.

**1. The budget reading leaked across sessions.** `swarmState.lastBudgetPct` and its
denominator `lastBudgetTokens` were bare module-level scalars shared by every session in
the plugin process. Harmless only while the budget check threw on every call and left them
pinned at `0`. Now that it runs, the last session to transform overwrites them for
everyone:

- `compaction-service` is enabled by default (`config.compaction_service?.enabled !== false`)
  and evaluates after **every non-fast tool call of every agent**. A session reporting 85%
  fires the emergency tier inside an unrelated, small session — and because that service
  keys its *hysteresis* per session (`getSessionState(sessionId)`), the wrong session's
  state machine advances on another session's number.
- The `>= 50%` CONTEXT PRESSURE advisory (`src/index.ts`) is delivered to whichever session
  makes the next tool call.
- `/swarm status` could pair a percentage from one report with a denominator from another —
  precisely the mismatch `lastBudgetTokens` was added to prevent.

Replaced with one per-session record, `lastBudgetBySession`, keyed by `sessionID` and
FIFO-capped at 500 following the `setCriticalShownIds` precedent (AGENTS.md invariant 8).
The pct and its denominator are written together in a single `setSessionBudget` call, so
they cannot be paired across reports. Consumers that *act* on a session use
`getSessionBudgetPct` / `getSessionBudgetTokens`. `/swarm status`, which has no single
session in scope, uses `getDisplayBudget()` — documented display-only, returning the
most-pressured session's pct **and its own denominator** as a matched pair.

**2. A budget failure silently removed unrelated injections.** Neither budget block was
guarded, so a throw inside escaped to the hook-level catch at the bottom of the transform
and skipped every remaining statement in that branch — the pre-flight binary advisory, the
`coder`/`test_engineer` environment-profile injection, and the Path A unified-budget
finalize. Both blocks now carry a scoped `try/catch` with a debug-gated warning, matching
the optional injections that follow them.

**3. The budget warning was invisible to the budget it reports on.** Every other injection
is metered through `tryInject`, which accumulates `actualDemand`; the warning used a raw
`output.system.push`. Its tokens now count into `actualDemand`. It is still deliberately
*not* routed through `tryInject` — dropping an "out of budget" notice because you are over
budget is the wrong failure mode — but the ledger that sizes the knowledge injector's share
is no longer under-reported exactly when context is tightest.

### Deliberately not included

An earlier revision gated the report on `context_budget.tracked_agents` to save the
per-turn `.swarm` reads on subagent turns. Dropped after reading #2129: that branch now
computes the report for **every** agent on purpose, so `lastBudgetPct` stays fresh for
compaction on every tool call. Gating it would starve untracked sessions of measurements.

## Invariant audit

- 1 (plugin init): **not touched** — changes are inside the per-turn
  `experimental.chat.system.transform` handler and a `tool.execute.after` advisory, not the
  hook factory body or plugin init. No new init-path work, no new awaits before `server()`
  resolves.
- 2 (runtime portability): **touched** — `src/index.ts` is in the diff (import + the
  CONTEXT PRESSURE advisory read). No `bun:` imports, no `Bun.*` outside `bun-compat.ts`,
  plugin entry shape unchanged. `bun run build` OK; `node --input-type=module -e "await
  import('./dist/index.js')"` → `dist import OK`; `bundle-portability` 10/0;
  `bundle-plugin-shape` 2/0.
- 3 (subprocesses): **not touched** — no `spawn(`/`spawnSync(`/`bunSpawn(` in the diff.
- 4 (.swarm containment): **not touched** — no new `.swarm` write path. `formatBudgetWarning`'s
  existing `validateSwarmPath`-routed state write is unchanged.
- 5 (plan durability): **not touched**.
- 6 (test_runner safety): **not touched** — validation used per-file `bun test`.
- 7 (test writing): **touched** — added the new `state.ts` exports to
  `state-mock-transitive-stubs.ts`; a non-spreading `mock.module` of `state.ts` otherwise
  throws `Export named 'getSessionBudgetPct' not found` at *import* time and kills the whole
  file before any test runs. Updated six suites that seeded the old scalars. `check:test-file-cap`
  0 new / 0 ratchet; `check-test-clock` 0 new blocking; FR-011 tmpdir 0 new blocking.
- 8 (session state): **touched — this is the point of the PR.** Two bare module globals
  became one `Map` keyed by `sessionID`, FIFO-capped at `MAX_TRACKED_BUDGET_SESSIONS = 500`,
  cleared in `resetSwarmState`. Regression test in `compaction-service.test.ts`: "one session
  at emergency does not compact a different session".
- 9 (guardrails/retry): **not touched**.
- 10 (chat/system msg): **touched** — the budget warning's tokens are metered into
  `actualDemand`; the injected text, its `[FOR: architect]` tag, and the architect gate are
  unchanged. New `warn` calls are debug-gated, so no chat-visible noise.
- 11 (tool registration): **not touched** — `check-tool-registration.ts` run anyway: 116 tools coherent.
- 12 (release/cache): **touched** — `docs/releases/pending/per-session-context-budget-state.md`
  added. No hand-edit of `package.json#version`, `CHANGELOG.md`, or the release manifest.
  `dist/` not staged.

## Test plan

- [x] `bun run build` OK · `dist import OK` · `bundle-portability` 10/0 · `bundle-plugin-shape` 2/0
- [x] `bun run typecheck` clean · `bunx biome ci .` exit 0
- [x] Ratchets: `check:test-file-cap` 0/0 · `check-test-clock` 0 new · FR-011 tmpdir 0 new ·
      `check:gate-portability` · `check-bash-portability` · `check:events` ·
      `check:runtime-src-refs` · `generate-mock-allowlist.sh --check` all pass
- [x] Suites green: `compaction-service` 16 · `system-enhancer-context-budget-wiring` 8 ·
      `system-enhancer-model-window-denominator` 13 · `status-context-denominator` 7 ·
      `cleanup-drift` 2 · `close` 76 · `reset` 17 · `compaction-metrics` 3 ·
      `reset-swarm-state-preserving` 18
- [x] Blast-radius sweep over all 559 test files that load `state.ts` or any touched module
- [x] **Mutation check** — pointing `compaction-service` back at a cross-session aggregate
      (`getDisplayBudget()?.pct`) fails exactly the new isolation test and nothing else, so
      the test genuinely guards the fix rather than the wiring

## Pre-existing failures

Five files fail identically on clean `origin/main` (verified in a separate `git worktree` at
the same commit), so they are inherited, not introduced:

| file | origin/main | this branch |
| --- | --- | --- |
| `tests/unit/hooks/guardrails-config-file-logging.test.ts` | 2 pass / 29 fail | 2 pass / 29 fail |
| `src/hooks/delegation-gate.plan-fallback-security.test.ts` | 24 pass / 2 fail | 24 pass / 2 fail |
| `tests/integration/knowledge-real-host-boundary.test.ts` | 8 pass / 1 fail | 8 pass / 1 fail |
| `tests/unit/index-background-advisory-delivery.test.ts` | 0 pass / 1 fail | 0 pass / 1 fail |
| `tests/unit/tools/council-attempt-task.test.ts` | 5 pass / 1 fail | 5 pass / 1 fail |

`index-background-advisory-delivery` was checked with extra care because this PR touches
`src/index.ts`: its failure is on `[BACKGROUND COMPLETION`, an unrelated advisory, and with
an empty budget map the new read yields `0` exactly as the old global did.

Two further sweep failures (`phase-complete-auto-checkpoint`, `knowledge-injector-drift`)
pass in isolation and were load artifacts. None of these appear in
`scripts/ci/quarantined-tests*.txt`; they are Windows-dev-host environmental failures and
CI runs ubuntu/macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
