### PR TITLE
fix(context): harden handoff model feedback

### DIFF
--- a/docs/releases/pending/context-budget-handoff-feedback-hardening.md
+++ b/docs/releases/pending/context-budget-handoff-feedback-hardening.md
@@ -1,0 +1,22 @@
+# Context budget handoff feedback hardening
+
+## What
+
+Live context-window state now preserves the host's trimmed model and provider
+spelling for case-sensitive `context_budget.model_limits` lookup and diagnostic
+reporting while comparing identities case-insensitively. A numeric live-window
+sample without model/provider identity can seed a new session, but cannot
+overwrite an existing exact binding. Production-wiring regressions now boot the
+real plugin and cover registered subagent defaults, primary UI authority, and
+incoming-model guardrail selection.
+
+## Why
+
+Lowercasing the stored host identity could miss a mixed-case user override and
+report a model name the host never supplied. An identity-less system-transform
+sample could also erase a valid model binding and make later message transforms
+relay a generic denominator under the wrong identity.
+
+## Migration
+
+No configuration changes are required.

--- a/src/state.ts
+++ b/src/state.ts
@@ -3287,23 +3287,34 @@ export function setLiveContextWindow(
 ): void {
 	if (!sessionID) return;
 	const map = swarmState.liveContextWindows;
-	const modelID = normalizeLiveContextIdentity(identity?.modelID);
-	const providerID = normalizeLiveContextIdentity(identity?.providerID);
+	// Preserve the host's spelling for case-sensitive model_limits lookup and
+	// diagnostics. Equality is normalized separately below so host casing drift
+	// does not make the same provider/model look like a handoff.
+	const modelID = trimLiveContextIdentity(identity?.modelID);
+	const providerID = trimLiveContextIdentity(identity?.providerID);
+	const hasIdentity = Boolean(modelID || providerID);
 	const existing = map.get(sessionID);
 	const hasUsableTokens =
 		typeof tokens === 'number' && Number.isFinite(tokens) && tokens >= 1;
 	if (!hasUsableTokens) {
-		if (!identity || (!modelID && !providerID)) return;
+		if (!hasIdentity) return;
 		if (
-			existing?.modelID === modelID &&
-			existing?.providerID === providerID &&
-			existing?.tokens !== undefined
+			existing &&
+			liveContextIdentityMatches(existing, { modelID, providerID }) &&
+			existing.tokens !== undefined
 		) {
 			return;
 		}
 		if (map.has(sessionID)) map.delete(sessionID);
 		map.set(sessionID, { modelID, providerID });
 		evictOldestLiveContextWindow(map, sessionID);
+		return;
+	}
+	// A numeric host sample without a usable identity is safe as an initial
+	// generic fallback, but it must not erase a prior exact binding. Otherwise a
+	// malformed system.transform turn can make messages.transform relay the new
+	// generic denominator as if it still belonged to the previous model.
+	if (!hasIdentity && existing && (existing.modelID || existing.providerID)) {
 		return;
 	}
 	if (map.has(sessionID)) map.delete(sessionID);
@@ -3328,12 +3339,7 @@ export function getLiveContextWindow(
 	if (!sessionID) return undefined;
 	const cached = swarmState.liveContextWindows.get(sessionID);
 	if (!cached) return undefined;
-	const modelID = normalizeLiveContextIdentity(identity?.modelID);
-	const providerID = normalizeLiveContextIdentity(identity?.providerID);
-	if (
-		identity &&
-		(cached.modelID !== modelID || cached.providerID !== providerID)
-	) {
+	if (identity && !liveContextIdentityMatches(cached, identity)) {
 		return undefined;
 	}
 	return cached.tokens;
@@ -3357,11 +3363,27 @@ function evictOldestLiveContextWindow(
 	if (oldest !== undefined && oldest !== sessionID) map.delete(oldest);
 }
 
-function normalizeLiveContextIdentity(
+function trimLiveContextIdentity(
 	value: string | undefined,
 ): string | undefined {
-	const normalized = value?.trim().toLowerCase();
-	return normalized ? normalized : undefined;
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function normalizeLiveContextIdentity(value: string | undefined): string {
+	return trimLiveContextIdentity(value)?.toLowerCase() ?? '';
+}
+
+function liveContextIdentityMatches(
+	left: { modelID?: string; providerID?: string },
+	right: { modelID?: string; providerID?: string },
+): boolean {
+	return (
+		normalizeLiveContextIdentity(left.modelID) ===
+			normalizeLiveContextIdentity(right.modelID) &&
+		normalizeLiveContextIdentity(left.providerID) ===
+			normalizeLiveContextIdentity(right.providerID)
+	);
 }
 
 /** Record this session's budget percentage and the denominator it was computed

--- a/tests/unit/config/agent-model.test.ts
+++ b/tests/unit/config/agent-model.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { getAgentConfigs } from '../../../src/agents';
 import {
 	parseAgentModel,
@@ -197,40 +195,5 @@ describe('parseAgentModel', () => {
 		'provider/model/',
 	])('rejects malformed input %j', (input) => {
 		expect(parseAgentModel(input)).toBeUndefined();
-	});
-});
-
-describe('agent-model production wiring', () => {
-	test('all exact-agent model-selection callers share the central resolver', () => {
-		const repositoryRoot = join(import.meta.dir, '..', '..', '..');
-		const indexSource = readFileSync(
-			join(repositoryRoot, 'src/index.ts'),
-			'utf8',
-		);
-		const contextSource = readFileSync(
-			join(repositoryRoot, 'src/hooks/context-budget.ts'),
-			'utf8',
-		);
-		const adversarialSource = readFileSync(
-			join(repositoryRoot, 'src/hooks/adversarial-detector.ts'),
-			'utf8',
-		);
-		const guardrailsTransformSource = readFileSync(
-			join(repositoryRoot, 'src/hooks/guardrails/messages-transform.ts'),
-			'utf8',
-		);
-
-		expect(indexSource).toContain("from './config/agent-model.js'");
-		expect(contextSource).toContain("from '../config/agent-model'");
-		expect(adversarialSource).toContain("from '../config/agent-model'");
-		expect(indexSource).toContain(
-			'resolveRuntimeAgentModel(config, agents, agentName)',
-		);
-		expect(guardrailsTransformSource).toContain(
-			'ctx.resolveAgentModel?.(targetAgent)',
-		);
-		expect(indexSource).not.toContain('function resolveDelegationModel');
-		expect(indexSource).not.toContain('function inferSwarmID');
-		expect(adversarialSource).not.toContain('Object.values(config.swarms)');
 	});
 });

--- a/tests/unit/hooks/context-budget-handoff-model-limit.test.ts
+++ b/tests/unit/hooks/context-budget-handoff-model-limit.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { getAgentConfigs } from '../../../src/agents';
+import { resolveRuntimeAgentModel } from '../../../src/config/agent-model';
 import { DEFAULT_MODELS } from '../../../src/config/constants';
 import type { PluginConfig } from '../../../src/config/schema';
 import { createContextBudgetHandler } from '../../../src/hooks/context-budget';
@@ -239,8 +241,19 @@ describe('context-budget target model handoff enforcement (#2122)', () => {
 	});
 
 	test('preserves assistant metadata for a primary target controlled by the UI', async () => {
-		const handler = createContextBudgetHandler(makeConfig(), () => undefined);
-		const output = budgetOutput('coder', 'session-primary');
+		const primaryConfig = makeConfig({
+			default_agent: 'architect',
+			agents: {
+				architect: { model: 'provider/model-small' },
+				coder: { model: 'provider/model-small' },
+			},
+		});
+		const registered = getAgentConfigs(primaryConfig);
+		expect(registered.architect.mode).toBe('primary');
+		const handler = createContextBudgetHandler(primaryConfig, (agentName) =>
+			resolveRuntimeAgentModel(primaryConfig, registered, agentName),
+		);
+		const output = budgetOutput('architect', 'session-primary');
 
 		await handler({}, output);
 

--- a/tests/unit/hooks/context-budget-plugin-wiring.test.ts
+++ b/tests/unit/hooks/context-budget-plugin-wiring.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Production wiring regressions for issue #2122.
+ *
+ * These tests boot the real plugin and invoke its composed
+ * `experimental.chat.messages.transform` chain. They therefore prove that
+ * `src/index.ts` passes the runtime agent-model resolver into context-budget;
+ * source-text assertions can pass when the matching text is dead or commented.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { DEFAULT_MODELS } from '../../../src/config/constants';
+import { resetSwarmState } from '../../../src/state';
+import {
+	bootKnowledgeHost,
+	createKnowledgeProject,
+} from '../../helpers/knowledge-real-host';
+import { safeRmRecursive } from '../../helpers/safe-test-dir';
+
+type Message = {
+	info: {
+		role: string;
+		agent?: string;
+		sessionID?: string;
+		modelID?: string;
+		providerID?: string;
+	};
+	parts: Array<{
+		type: string;
+		text?: string;
+		tool?: string;
+		state?: { status: string; output: string };
+	}>;
+};
+
+function handoffMessages(targetAgent: string, sessionID: string): Message[] {
+	return [
+		{
+			info: { role: 'user', agent: 'architect', sessionID },
+			parts: [{ type: 'text', text: 'start' }],
+		},
+		{
+			info: {
+				role: 'assistant',
+				modelID: 'model-large',
+				providerID: 'provider',
+				sessionID,
+			},
+			parts: [
+				{
+					type: 'tool',
+					tool: 'bash',
+					state: { status: 'completed', output: 'x'.repeat(6_000) },
+				},
+			],
+		},
+		{
+			info: { role: 'user', agent: 'architect', sessionID },
+			parts: [{ type: 'text', text: 'continue' }],
+		},
+		{
+			info: {
+				role: 'assistant',
+				modelID: 'model-large',
+				providerID: 'provider',
+				sessionID,
+			},
+			parts: [{ type: 'text', text: 'ready' }],
+		},
+		{
+			info: { role: 'user', agent: targetAgent, sessionID },
+			parts: [{ type: 'text', text: 'take over' }],
+		},
+	];
+}
+
+function allParts(messages: Message[]) {
+	return messages.flatMap((message) => message.parts ?? []);
+}
+
+const contextBudget = {
+	enabled: true,
+	warn_threshold: 0.65,
+	critical_threshold: 0.9,
+	enforce: true,
+	enforce_on_agent_switch: true,
+	prune_target: 0.7,
+	recent_window: 1,
+	preserve_last_n_turns: 1,
+	tool_output_mask_threshold: 50,
+	tracked_agents: ['architect', 'coder'],
+	model_limits: {
+		'provider/model-large': 10_000,
+		[DEFAULT_MODELS.coder]: 1_000,
+	},
+};
+
+describe('context-budget production agent-model wiring (#2122)', () => {
+	let directory = '';
+
+	beforeEach(() => {
+		resetSwarmState();
+		directory = createKnowledgeProject();
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		try {
+			safeRmRecursive(directory);
+		} catch {
+			// Background workers can retain Windows handles briefly; the temp root is
+			// OS-reclaimed and cleanup is not part of the behavioral assertion.
+		}
+	});
+
+	test('the real plugin resolves an unconfigured subagent factory default', async () => {
+		const plugin = await bootKnowledgeHost(directory, {
+			knowledge: { enabled: false },
+			default_agent: 'architect',
+			agents: { architect: { model: 'provider/model-large' } },
+			context_budget: contextBudget,
+		});
+		const messages = handoffMessages('coder', 'plugin-subagent-default');
+
+		await plugin.hooks['experimental.chat.messages.transform'](
+			{},
+			{ messages },
+		);
+
+		expect(
+			allParts(messages).some(
+				(part) =>
+					part.type === 'text' && part.text?.includes('[Tool output masked'),
+			),
+		).toBe(true);
+	});
+
+	test('the real plugin preserves UI metadata for a registered primary', async () => {
+		const plugin = await bootKnowledgeHost(directory, {
+			knowledge: { enabled: false },
+			default_agent: 'architect',
+			agents: {
+				architect: { model: DEFAULT_MODELS.coder },
+				coder: { model: DEFAULT_MODELS.coder },
+			},
+			context_budget: contextBudget,
+		});
+		const messages = handoffMessages('architect', 'plugin-primary-ui');
+
+		await plugin.hooks['experimental.chat.messages.transform'](
+			{},
+			{ messages },
+		);
+
+		expect(allParts(messages).some((part) => part.type === 'tool')).toBe(true);
+	});
+
+	test('the real guardrail chain receives the same incoming-model resolver', async () => {
+		const plugin = await bootKnowledgeHost(directory, {
+			knowledge: { enabled: false },
+			default_agent: 'architect',
+			agents: {
+				architect: { model: 'provider/gpt-4o' },
+				coder: { model: 'provider/gpt-4o-mini' },
+			},
+			context_budget: { enabled: false },
+		});
+		const messages: Message[] = [
+			{
+				info: { role: 'system', sessionID: 'plugin-guardrail-target' },
+				parts: [
+					{
+						type: 'text',
+						text: `System prompt
+<!-- BEHAVIORAL_GUIDANCE_START -->
+Rule for a high-capability model
+<!-- BEHAVIORAL_GUIDANCE_END -->`,
+					},
+				],
+			},
+			{
+				info: {
+					role: 'assistant',
+					modelID: 'gpt-4o',
+					providerID: 'provider',
+					sessionID: 'plugin-guardrail-target',
+				},
+				parts: [{ type: 'text', text: 'ready' }],
+			},
+			{
+				info: {
+					role: 'user',
+					agent: 'coder',
+					sessionID: 'plugin-guardrail-target',
+				},
+				parts: [{ type: 'text', text: 'take over' }],
+			},
+		];
+
+		await plugin.hooks['experimental.chat.messages.transform'](
+			{},
+			{ messages },
+		);
+
+		const text = allParts(messages)
+			.map((part) => part.text ?? '')
+			.join('\n');
+		expect(text).not.toContain('Rule for a high-capability model');
+		expect(text).toContain('[Enforcement: programmatic gates active]');
+	});
+});

--- a/tests/unit/hooks/system-enhancer-model-window-denominator.test.ts
+++ b/tests/unit/hooks/system-enhancer-model-window-denominator.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { PluginConfig } from '../../../src/config';
+import { resolveModelLimit } from '../../../src/hooks/model-limits';
 import { createSystemEnhancerHook } from '../../../src/hooks/system-enhancer';
 import {
 	getLiveContextModelIdentity,
@@ -266,6 +267,57 @@ describe('system-enhancer: budget denominator derives from model.limit.context',
 		expect(getLiveContextModelIdentity('model-window-session')).toEqual({
 			modelID: 'green-s',
 			providerID: 'greenpt',
+		});
+	});
+
+	it('preserves host identity casing while matching cache lookups case-insensitively', async () => {
+		await runHook(
+			configWith(),
+			modelOf('MiniMax-M3', 'MiniMax', 1_000_000),
+			promptOf(1000),
+		);
+
+		const identity = getLiveContextModelIdentity('model-window-session');
+		expect(identity).toEqual({
+			modelID: 'MiniMax-M3',
+			providerID: 'MiniMax',
+		});
+		expect(
+			getLiveContextWindow('model-window-session', {
+				modelID: 'minimax-m3',
+				providerID: 'minimax',
+			}),
+		).toBe(1_000_000);
+		expect(
+			resolveModelLimit(identity?.modelID, identity?.providerID, {
+				'MiniMax/MiniMax-M3': 1_000_000,
+			}),
+		).toBe(1_000_000);
+	});
+
+	it('does not let an identity-less window clobber an exact model binding', async () => {
+		await runHook(configWith(), HUGE_WINDOW_MODEL, promptOf(1000));
+		await runHook(configWith(), { limit: { context: 128000 } }, promptOf(1000));
+
+		expect(
+			getLiveContextWindow('model-window-session', {
+				modelID: HUGE_WINDOW_MODEL.id,
+				providerID: HUGE_WINDOW_MODEL.providerID,
+			}),
+		).toBe(1_000_000);
+		expect(getLiveContextModelIdentity('model-window-session')).toEqual({
+			modelID: HUGE_WINDOW_MODEL.id,
+			providerID: HUGE_WINDOW_MODEL.providerID,
+		});
+	});
+
+	it('retains an initial generic live window when no identity is available', async () => {
+		await runHook(configWith(), { limit: { context: 200000 } }, promptOf(1000));
+
+		expect(getLiveContextWindow('model-window-session')).toBe(200000);
+		expect(getLiveContextModelIdentity('model-window-session')).toEqual({
+			modelID: undefined,
+			providerID: undefined,
 		});
 	});
 


### PR DESCRIPTION
Follow-up to #2136 and #2122.

## Summary

- Preserve the host's trimmed model/provider spelling in live context-window state so mixed-case `context_budget.model_limits` keys and diagnostics remain exact, while identity comparisons stay case-insensitive.
- Prevent an identity-less numeric window sample from overwriting an existing exact session/model binding; initial generic samples remain supported.
- Replace source-text resolver assertions with real plugin initialization and composed-hook behavior coverage for registered subagent defaults, primary UI authority, and guardrail target selection.
- Port the independently reviewed feedback patch directly onto current `main` after #2136 merged while the feedback gates were running.

## Feedback closure

- `MI-INPUT-001`: fixed — mixed-case host identity no longer falls from a 1,000,000-token exact override to the 128,000-token fallback.
- `MI-PRIV-001`: fixed — diagnostic identity retains the spelling supplied by the host.
- `MI-UNC-001`: fixed — identity-less samples cannot clobber an exact cached binding.
- `TF-001`: fixed — primary/UI coverage now executes `getAgentConfigs` and `resolveRuntimeAgentModel` for an actual primary.
- `TF-002`: fixed — production wiring is exercised through the real default-export plugin and composed messages-transform chain.
- Historical #2136 comments were reverified against the merged implementation; no additional code changes were warranted.

## Invariant audit

- 1 (plugin init): not touched — production initialization code is unchanged; the new test boots the existing real plugin. Build, Node import, and `repro-704` pass (364.0/263.0/252.8 ms standalone).
- 2 (runtime portability): touched — `src/state.ts` remains dependency-free/pure; build and Node ESM import pass.
- 3 (subprocesses): not touched — no subprocess call or option changed.
- 4 (.swarm containment): not touched — no filesystem storage path changed.
- 5 (plan durability): not touched — no plan state or projection changed.
- 6 (test_runner safety): not touched — validation used bounded per-file shell tests only.
- 7 (test writing): touched — tests use `bun:test`, add no `mock.module`, use canonical temp helpers/cleanup, and all modified/new files remain below 500 lines; FR-006 and tmpdir gates pass with zero new violations.
- 8 (session state): touched — exact live-window bindings remain session-keyed and FIFO-bounded; the patch preserves identity fidelity and prevents identity-less clobbering. Exact, mixed-case, generic, and eviction paths are covered.
- 9 (guardrails/retry): touched — runtime behavior is unchanged; a new real-plugin test proves the incoming target-model resolver reaches guardrail trimming while primary policy authority remains separate.
- 10 (chat/system msg): touched — real composed messages-transform tests pass without changing message shape or rebind behavior.
- 11 (tool registration): not touched — no tool or agent map changed; 116-tool coherence passes.
- 12 (release/cache): touched — added `docs/releases/pending/context-budget-handoff-feedback-hardening.md`; no cache logic, generated version, changelog, or `dist/` artifact is committed.

## Test plan

- [x] 190 focused tests across 14 per-file-isolated files.
- [x] Renewed independent Stage-B reviewer and test-engineer approval on exact latest-main tree; test engineer reran 49/49 affected tests.
- [x] Renewed closeout reviewer and adversarial critic approval.
- [x] `bun run typecheck`; `bun run lint:ci` (3,238 files); `bun run build`; Node ESM import.
- [x] `node scripts/repro-704.mjs` standalone.
- [x] Tool registration, runtime-source references, event contract, gate portability, FR-006 test-file cap, canonical tmpdir, engineering-invariant, and test-clock gates.

## Migration

No migration required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

