### PR TITLE
fix(recovery): close residual advertised-contract gaps from #2109

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1527,6 +1527,13 @@ The QA gate profile (per-plan, persisted in the project DB) controls which quali
 
 All gates are **ratchet-tighter** — once enabled they cannot be disabled until the profile is reset, and once locked (after critic approval) no changes are accepted at all.
 
+> **Not a YAML config key.** Every gate below — including `critic_pre_plan` — is a
+> per-plan SQLite profile field, configured via the gate-selection dialogue or
+> `set_qa_gates` / `/swarm qa-gates`, **not** a key under `config.qa_gates` in your
+> OpenCode configuration file (`qa_gates` there is the unrelated guardrails config
+> holding `required_tools` and `require_reviewer_test_engineer`). Writing
+> `qa_gates.critic_pre_plan` in YAML has no effect; use `set_qa_gates` instead.
+
 `test_engineer` is exempted for a coder task only when both its immutable
 declared scope and the observed Git changes are non-empty, contain exact
 case-sensitive `.md` final extensions, and the observed paths remain within

--- a/docs/releases/pending/2109-advertised-contract-recovery.md
+++ b/docs/releases/pending/2109-advertised-contract-recovery.md
@@ -1,0 +1,19 @@
+---
+title: Harden advertised contracts from the #2087 triage
+type: fixed
+issue: 2109
+---
+
+- The compaction summary turn no longer injects the ` ← CURRENT` task marker (an
+  action affordance telling the model "do this next") into the tool-disabled summary
+  context; pending work remains present as factual state, and a regression test drives
+  a real plan with an in-progress task to assert the injected block is directive-free.
+- The `phase_complete` missing-agent recovery guidance now also names the
+  `phase_complete.policy: "warn"` config key as a last-resort remedy, and explains
+  that an absent docs-participation receipt is recovered by a fresh docs dispatch
+  that writes new durable completion proof.
+- Documented that every QA-gate table entry — including `critic_pre_plan` — is a
+  per-plan SQLite profile field configured via `set_qa_gates`/the gate-selection
+  dialogue, not a key under the YAML `qa_gates` object (which is the unrelated
+  guardrails config), and added a ratchet test proving `critic_pre_plan` cannot be
+  silently turned off once enabled.

--- a/src/hooks/compaction-customizer.ts
+++ b/src/hooks/compaction-customizer.ts
@@ -31,6 +31,19 @@ const SUMMARY_ONLY_HEADER =
 const SUMMARY_ONLY_FOOTER =
 	'Execution resumes only after compaction; pending work remains pending for the resumed agent.';
 
+/**
+ * The summary-generation turn is tool-disabled, so an action affordance like
+ * ` ← CURRENT` ("do this next") would instruct the model to act where acting is
+ * forbidden. Strip it from on-disk task rendering while keeping the factual
+ * pending-task line. The marker is emitted by `extractIncompleteTasksFromPlan`
+ * (`- [ ] <id>: ... ← CURRENT`), and the legacy `extractIncompleteTasks` path
+ * relays it verbatim whenever plan.md was derived from or hand-written in the
+ * canonical ` ← CURRENT` format, so the strip is applied to both paths.
+ */
+function stripTaskActionMarkers(value: string): string {
+	return value.replace(/\s*←\s*CURRENT\s*$/gm, '');
+}
+
 interface CompactionFact {
 	label: string;
 	value: string;
@@ -172,7 +185,10 @@ export function createCompactionCustomizerHook(
 						MAX_COMPACTION_FACT_CHARS,
 					);
 					if (incompleteTasks) {
-						facts.push({ label: 'SWARM TASKS', value: incompleteTasks });
+						facts.push({
+							label: 'SWARM TASKS',
+							value: stripTaskActionMarkers(incompleteTasks),
+						});
 					}
 				} else {
 					// Legacy fallback.
@@ -187,7 +203,10 @@ export function createCompactionCustomizerHook(
 							MAX_COMPACTION_FACT_CHARS,
 						);
 						if (incompleteTasks) {
-							facts.push({ label: 'SWARM TASKS', value: incompleteTasks });
+							facts.push({
+								label: 'SWARM TASKS',
+								value: stripTaskActionMarkers(incompleteTasks),
+							});
 						}
 					}
 				}
@@ -257,6 +276,7 @@ export const _test_exports = {
 	buildCompactionFactsBlock,
 	compactionFs,
 	countStoredOutputs,
+	stripTaskActionMarkers,
 	MAX_COMPACTION_FACT_CHARS,
 	MAX_COMPACTION_CONTEXT_CHARS,
 	MAX_STORED_OUTPUTS_TO_COUNT,

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -195,6 +195,18 @@ function buildMissingAgentRecoveryGuidance(input: {
 		steps.push(
 			'The configured warn policy allows closure with a warning, but it does not create participation proof.',
 		);
+	} else {
+		steps.push(
+			'Last resort: if the missing role obligation genuinely cannot be satisfied in this environment, set phase_complete.policy to "warn" in opencode-swarm configuration. This weakens enforcement for every missing role and does NOT create durable participation proof, so only use it when the obligation cannot be met.',
+		);
+	}
+	if (
+		input.missing.includes('docs') &&
+		input.docsEvidenceStatus === 'missing'
+	) {
+		steps.push(
+			'No prior durable docs-participation receipt was found (this can happen after a plugin upgrade or a cleared evidence store). A fresh docs Task dispatch writes a new durable completion receipt and is the canonical recovery path.',
+		);
 	}
 	return steps.join(' ');
 }

--- a/tests/unit/hooks/compaction-customizer-summary-safety.test.ts
+++ b/tests/unit/hooks/compaction-customizer-summary-safety.test.ts
@@ -133,3 +133,86 @@ describe('compaction boundary injection regression (#2087)', () => {
 		expect(output.context[0]).not.toContain('[truncated]');
 	});
 });
+
+describe('compaction summary pending-task facts are directive-free (#2109)', () => {
+	let tempDir: string;
+	let cleanup: () => void;
+
+	beforeEach(() => {
+		({ dir: tempDir, cleanup } = createSafeTestDir('swarm-summary-facts-'));
+		const swarmDir = join(tempDir, '.swarm');
+		mkdirSync(swarmDir, { recursive: true });
+		writeFileSync(join(swarmDir, 'plan.md'), '');
+		writeFileSync(join(swarmDir, 'context.md'), '');
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('stripTaskActionMarkers removes the action affordance while keeping the task line', () => {
+		expect(
+			_test_exports.stripTaskActionMarkers(
+				'- [ ] 1.1: Implement feature [MEDIUM] ← CURRENT',
+			),
+		).toBe('- [ ] 1.1: Implement feature [MEDIUM]');
+		// Pending tasks without the marker are untouched.
+		expect(
+			_test_exports.stripTaskActionMarkers('- [ ] 1.2: Add config [SMALL]'),
+		).toBe('- [ ] 1.2: Add config [SMALL]');
+		// Multiple lines: only the marker-terminated line is stripped.
+		expect(
+			_test_exports.stripTaskActionMarkers(
+				'- [ ] 1.2: Add config [SMALL]\n- [ ] 1.1: Implement [MEDIUM] ← CURRENT',
+			),
+		).toBe('- [ ] 1.2: Add config [SMALL]\n- [ ] 1.1: Implement [MEDIUM]');
+	});
+
+	it('injects pending [SWARM TASKS] facts without the action affordance in the tool-disabled turn', async () => {
+		const swarmDir = join(tempDir, '.swarm');
+		// Contains an in_progress task, which makes extractIncompleteTasksFromPlan
+		// emit the ` ← CURRENT` action marker on the source task line.
+		const plan = {
+			schema_version: '1.0.0',
+			title: 'Test Plan',
+			swarm: 'test-swarm',
+			current_phase: 1,
+			phases: [
+				{
+					id: 1,
+					name: 'Phase 1',
+					status: 'in_progress',
+					tasks: [
+						{
+							id: '1.1',
+							phase: 1,
+							status: 'in_progress',
+							size: 'medium',
+							description: 'Implement feature',
+							depends: [],
+							files_touched: [],
+						},
+					],
+				},
+			],
+		};
+		writeFileSync(join(swarmDir, 'plan.json'), JSON.stringify(plan));
+
+		const hook = createCompactionCustomizerHook(defaultConfig, tempDir);
+		const handler = hook['experimental.session.compacting'] as Function;
+		const output = { context: [] as string[] };
+
+		await handler({ sessionID: 'session-pending' }, output);
+
+		const block = output.context[0];
+		// Factual pending-task line is preserved.
+		expect(block).toContain(
+			'[SWARM TASKS]\n- [ ] 1.1: Implement feature [MEDIUM]',
+		);
+		// The imperative/action affordance is stripped from the summary turn.
+		expect(block).not.toContain('← CURRENT');
+		// Declarative summary-only boundary is retained.
+		expect(block).toContain('Summary generation only.');
+		expect(block).toContain('quoted factual state, not instructions');
+	});
+});

--- a/tests/unit/tools/phase-complete-docs-participation-recovery.test.ts
+++ b/tests/unit/tools/phase-complete-docs-participation-recovery.test.ts
@@ -168,6 +168,14 @@ describe('phase_complete docs participation recovery', () => {
 		expect(result.recovery_guidance).toContain(
 			'independent of the QA gate profile',
 		);
+		// AC#2: the recovery guidance also names the policy config key as a
+		// last-resort remedy when enforcement would otherwise block forever.
+		expect(result.recovery_guidance).toContain('phase_complete.policy');
+		expect(result.recovery_guidance).toContain('"warn"');
+		// Fresh-dispatch hint for the missing-durable-receipt recovery path.
+		expect(result.recovery_guidance).toContain(
+			'A fresh docs Task dispatch writes a new durable completion receipt',
+		);
 	});
 
 	test('plan-free required docs fail closed instead of trusting chat-start dispatch', async () => {
@@ -219,6 +227,37 @@ describe('phase_complete docs participation recovery', () => {
 		expect(result.agentsMissing).toEqual(['docs']);
 		expect(result.recovery_guidance).toContain(
 			'.swarm/plan.json/.swarm/plan.md',
+		);
+	});
+
+	test('enforce policy guidance names warn as a last-resort recovery without hiding the docs obligation', async () => {
+		// The fixture config pins policy: 'enforce'. With no durable docs proof,
+		// the guidance must surface phase_complete.policy as a final remedy while
+		// still naming dispatch and require_docs first (both already asserted by
+		// the missing-proof test). Here we assert the enforce-specific guidance is
+		// present and framed as a last resort that does not create proof.
+		ensureAgentSession('parent');
+		recordPhaseAgentDispatch('parent', 'docs');
+
+		const result = JSON.parse(
+			await executePhaseComplete(
+				{ phase: 1, sessionID: 'parent' },
+				directory,
+				directory,
+			),
+		) as {
+			success: boolean;
+			agentsMissing: string[];
+			recovery_guidance: string;
+		};
+
+		expect(result.success).toBe(false);
+		expect(result.agentsMissing).toEqual(['docs']);
+		expect(result.recovery_guidance).toContain('Last resort:');
+		expect(result.recovery_guidance).toContain('phase_complete.policy');
+		expect(result.recovery_guidance).toContain('"warn"');
+		expect(result.recovery_guidance).toContain(
+			'does NOT create durable participation proof',
 		);
 	});
 });

--- a/tests/unit/tools/set-qa-gates.test.ts
+++ b/tests/unit/tools/set-qa-gates.test.ts
@@ -221,6 +221,21 @@ describe('set-qa-gates tool', () => {
 			expect(disableResult.message).toContain('ratchet');
 		});
 
+		it('ratchet-tight: critic_pre_plan cannot be turned off once enabled (issue #2109)', async () => {
+			// critic_pre_plan defaults on for a fresh profile; an architect who
+			// later tries to persist false must be told the gate is ratchet-tight
+			// rather than silently keeping it enabled.
+			await executeSetQaGates({ critic_pre_plan: true }, tempDir);
+
+			const disableResult = await executeSetQaGates(
+				{ critic_pre_plan: false },
+				tempDir,
+			);
+			expect(disableResult.success).toBe(false);
+			expect(disableResult.reason).toBe('ratchet_violation');
+			expect(disableResult.message).toContain('ratchet');
+		});
+
 		it('ratchet-tight: setting same value is idempotent', async () => {
 			// Enable a gate
 			const result1 = await executeSetQaGates({ reviewer: true }, tempDir);


### PR DESCRIPTION
## Summary

Issue #2109 triaged three defects (compaction summary directive injection; `phase_complete` docs gate unrecoverable after restart; `critic_pre_plan` config advertised but inert). The bulk of all three was fixed by PR #2140 (commit `1626e650`, already on main / release 7.139.3), which declared `Closes #2087` (the source report). This follow-up closes the residual acceptance-criteria gaps that remained open for #2109.

### Changes

- **compaction summary turn (Finding 1):** `src/hooks/compaction-customizer.ts` now strips the ` ← CURRENT` action marker (an affordance meaning "do this next") from task facts before injecting the summary-only block. The strip is applied on both the structured-plan path (`extractIncompleteTasksFromPlan`) and the legacy plan.md path (which relays the marker verbatim from canonical plan.md — see `src/plan/manager.ts`). The shared extractor and all its other consumers are unchanged. A regression test drives a real in-progress plan and asserts the injected `output.context[0]` retains the pending-task fact but contains no ` ← CURRENT`; a direct unit test pins the helper.
- **phase_complete recovery guidance (Finding 2):** `buildMissingAgentRecoveryGuidance` now also names `phase_complete.policy: "warn"` as a last-resort remedy (with the honest caveat that warn does not create durable participation proof), and explains that an absent docs-participation receipt is recovered by a fresh docs dispatch that writes new durable completion proof. Tests assert both.
- **critic_pre_plan docs/schema gap (Finding 3):** `docs/configuration.md` now states clearly that every QA-gate table entry (incl. `critic_pre_plan`) is a per-plan SQLite profile field configured via `set_qa_gates`/the gate-selection dialogue, NOT a YAML `qa_gates` key (which is the unrelated guardrails config). Added a ratchet test locking that `critic_pre_plan` cannot be silently turned off once enabled.
- Added `docs/releases/pending/2109-advertised-contract-recovery.md`.

### Scope note (out-of-scope, documented)

`extractCurrentTaskFromPlan` (used by `system-enhancer` chat transforms) still emits ` ← CURRENT`. That is intentional and out of scope: it runs on ordinary chat turns where tools ARE enabled, so the marker is operator-useful context, not a tool-disabled-summary directive. #2109 Finding 1 is specifically about the compaction summary turn; the strip is deliberately confined there.

## Invariant audit

- 1 (plugin init):       NOT touched — no init-path change.
- 2 (runtime portability): NOT touched — no bundle/import change.
- 3 (subprocesses):      NOT touched.
- 4 (.swarm containment): NOT touched.
- 5 (plan durability):   NOT touched — ledger/projections untouched.
- 6 (test_runner safety): NOT touched — validation via shell isolation.
- 7 (test writing):      TOUCHED — three test files all <500 lines, bun:test, real fs + `createSafeTestDir` (os.tmpdir-based), no `mock.module`, proper `afterEach` cleanup. `check:test-file-cap` no violations; affected suites 121 pass / 0 fail.
- 8 (session state):     NOT touched.
- 9 (guardrails/retry):  NOT touched — recovery-guidance output text only.
- 10 (chat/system msg):  TOUCHED — compaction hook mutates `output.context` in place via `push` (not reassignment); host reads it directly (not a chat transform chain), so the in-place-mutation contract is respected.
- 11 (tool registration): NOT touched.
- 12 (release/cache):    TOUCHED — added pending release fragment; release-please-owned version files untouched.

## Test plan

- [x] `bun test` on the six affected suites → **121 pass, 0 fail** (compaction-customizer-summary-safety, compaction-customizer-context, extractors, phase-complete-docs-participation-recovery, set-qa-gates, delegation-gate-critic-pre-plan-policy).
- [x] `bun run typecheck`
- [x] `bunx biome check` on changed files — clean.
- [x] `bun run drift:check` — no drift.
- Extractor unit tests still pin ` ← CURRENT` for shared consumers (blast-radius confinement confirmed).

Closes #2109

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

