### PR TITLE
test(scripts): close PR #2110 review findings PRR-005/006/007

### DIFF
--- a/docs/releases/pending/fr-2069-review-followup.md
+++ b/docs/releases/pending/fr-2069-review-followup.md
@@ -1,0 +1,15 @@
+## Skill-assertion detector: close remaining PR #2110 review findings
+
+Follow-up to #2069 / PR #2110. Test-and-documentation only — no detector behavior changes.
+
+### What changed
+- PRR-005: New `check-skill-assertions-recall.test.ts` pins the FR-004 exact-line attribution recall boundary. A single-line assertion and a split-across-lines assertion, both genuinely broken against the same skill, are asserted in one fixture: the single-line form is reported, the multi-line form is not. The known false negative is now documented by a live test with a positive control rather than left implicit.
+- PRR-006: Closed three coverage gaps. The malformed-regex test asserted only `if (brokenAssertions.length > 0)`, so it passed vacuously when nothing was emitted — it now requires the finding. The `SKILL_ASSERTIONS_STRICT=1` hard-fail path had no test; it is now covered by `check-skill-assertions-strict-mode.test.ts`, which spawns the real CLI and asserts exit codes (0 advisory, 1 strict, 0 strict-but-clean). The attribution and self-exclusion fixtures asserted only that a phrase was NOT misreported; each now also asserts the genuinely broken assertion IS reported.
+- PRR-007: The regex and attribution fixtures cleaned up temp repos with `spawnSync('rm', ['-rf', d])`, which does not exist on Windows and leaked the directory on the Windows CI shards. Both now use `fs.rmSync`, matching the other fixtures.
+- Docs: The `checkAssertionsAgainstSkill` docblock still advertised a `// skill-assertion:` comment-attribution fallback that FR-004 removed. Corrected to describe exact-line chaining only, and to name the multi-line recall cost.
+
+### Why
+PR #2110's review left these open. The vacuous assertions were the load-bearing problem: a detector whose tests assert only negatives cannot distinguish "correctly filtered a false positive" from "stopped reporting anything," which is the failure mode #2069 was about.
+
+### Migration
+None. No production behavior changed.

--- a/scripts/check-skill-assertions.ts
+++ b/scripts/check-skill-assertions.ts
@@ -409,12 +409,19 @@ function extractAssertions(
 /**
  * Check assertions in a test file against the current content of a skill file.
  *
- * Scoping rule: only check an assertion if it is (a) chained off the variable
- * that was assigned from a readFileSync call that loaded THIS skill file, or
- * (b) explicitly attributed to the skill via a comment like `// skill-assertion:`.
+ * Scoping rule (FR-004, issue #2069): check an assertion only when the
+ * assertion's OWN line chains off a variable that was assigned from a
+ * readFileSync call loading THIS skill file. Proximity is never sufficient —
+ * neither the former ±2-line window nor the former `// skill-assertion:`
+ * comment fallback is honored; both were removed because they mis-attributed
+ * assertions and produced 68 false positives on a single PR.
  *
  * This prevents false positives when a test file mentions the skill slug in an
  * import/require but also has unrelated toContain/toMatch assertions.
+ *
+ * Known cost: an assertion split across lines (`expect(v)` on one line,
+ * `.toContain(...)` on the next) is not attributed and so is not reported.
+ * That trade-off is pinned by tests/unit/scripts/check-skill-assertions-recall.test.ts.
  */
 function checkAssertionsAgainstSkill(
 	testFile: string,

--- a/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-attribution.test.ts
@@ -48,7 +48,9 @@ function writeFile(root: string, relPath: string, content: string): void {
 
 afterEach(() => {
 	const d = tempDirs.pop();
-	if (d) spawnSync('rm', ['-rf', d], { stdio: 'ignore' });
+	// PRR-007: fs.rmSync, not `rm -rf` — the latter does not exist on Windows,
+	// so the temp repo would leak on the Windows CI shards.
+	if (d) fs.rmSync(d, { recursive: true, force: true });
 });
 
 describe('SC-005: precise target attribution', () => {
@@ -107,12 +109,9 @@ describe('two-vars', () => {
 `,
 		);
 
-		// Modify the skill so the detector runs
-		writeFile(
-			repo,
-			'.opencode/skills/test/SKILL.md',
-			'# TEST\n\nskill content updated\n',
-		);
+		// Modify the skill so the detector runs, removing 'skill content' so the
+		// assertion that DOES target the skill genuinely breaks.
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
 
 		const result = await checkSkillAssertions(repo);
 		expect(result.changedSkillFiles).toContain(
@@ -124,6 +123,16 @@ describe('two-vars', () => {
 			(b) => b.phrase === 'architect-only phrase',
 		);
 		expect(promptPhraseBroken).toBeUndefined();
+
+		// PRR-006 positive control: the assertion that genuinely targets the skill
+		// MUST be reported. Without this, the negative assertion above would also
+		// pass if the detector silently stopped emitting anything at all.
+		const skillPhraseBroken = result.brokenAssertions.find(
+			(b) => b.phrase === 'skill content',
+		);
+		expect(skillPhraseBroken).toBeDefined();
+		expect(skillPhraseBroken!.assertionKind).toBe('toContain');
+		expect(skillPhraseBroken!.skillFile).toBe('.opencode/skills/test/SKILL.md');
 	});
 });
 

--- a/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-regex.test.ts
@@ -49,7 +49,9 @@ function writeFile(root: string, relPath: string, content: string): void {
 
 afterEach(() => {
 	const d = tempDirs.pop();
-	if (d) spawnSync('rm', ['-rf', d], { stdio: 'ignore' });
+	// PRR-007: fs.rmSync, not `rm -rf` — the latter does not exist on Windows,
+	// so the temp repo would leak on the Windows CI shards.
+	if (d) fs.rmSync(d, { recursive: true, force: true });
 });
 
 describe('SC-002 / SC-003 / FR-002: regex semantic matching', () => {
@@ -199,11 +201,14 @@ describe('regex', () => {
 		expect(result.changedSkillFiles).toContain(
 			'.opencode/skills/test/SKILL.md',
 		);
-		// FR-002 malformed: detector must not crash; if a finding is emitted,
-		// its assertionKind must be 'malformed-regex'
-		expect(result).toBeDefined();
-		if (result.brokenAssertions.length > 0) {
-			expect(result.brokenAssertions[0]!.assertionKind).toBe('malformed-regex');
-		}
+		// FR-002 malformed: the detector must not crash, AND it must actually
+		// emit the finding. PRR-006: the previous form guarded this behind
+		// `if (brokenAssertions.length > 0)`, so it passed vacuously if the
+		// detector silently dropped malformed regexes instead of reporting them.
+		expect(result.brokenAssertions).toHaveLength(1);
+		expect(result.brokenAssertions[0]!.assertionKind).toBe('malformed-regex');
+		expect(result.brokenAssertions[0]!.skillFile).toBe(
+			'.opencode/skills/test/SKILL.md',
+		);
 	});
 });

--- a/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-false-positive-self-exclusion.test.ts
@@ -84,6 +84,29 @@ describe('self', () => {
 });
 `,
 		);
+		// PRR-006 positive control: an equivalent fixture OUTSIDE
+		// tests/unit/scripts/, whose assertion genuinely breaks. This proves the
+		// exclusion above is specific to the detector's own directory rather
+		// than the detector having stopped reporting anything at all.
+		mkdirSyncLocal(repo, 'tests/unit/agents/');
+		writeFile(
+			repo,
+			'tests/unit/agents/outside-detector-dir.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('outside', () => {
+  test('real phrase', () => {
+    expect(content).toContain('real content');
+  });
+});
+`,
+		);
 		// Create a real skill file that the detector will look at
 		mkdirSyncLocal(repo, '.opencode/skills/test/');
 		writeFile(
@@ -103,12 +126,9 @@ describe('self', () => {
 			timeout: GIT_TIMEOUT_MS,
 		});
 
-		// Modify the skill so the detector runs
-		writeFile(
-			repo,
-			'.opencode/skills/test/SKILL.md',
-			'# TEST\n\nreal content updated\n',
-		);
+		// Modify the skill so the detector runs, removing 'real content' so the
+		// out-of-directory assertion genuinely breaks.
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
 
 		const result = await checkSkillAssertions(repo);
 		// The fixture phrase from tests/unit/scripts/detector-self.test.ts
@@ -118,6 +138,14 @@ describe('self', () => {
 			(b) => b.phrase === fixturePhrase,
 		);
 		expect(brokenFixturePhrase).toBeUndefined();
+
+		// PRR-006 positive control: the identical-shape assertion living outside
+		// tests/unit/scripts/ MUST be reported.
+		const outsideBroken = result.brokenAssertions.find(
+			(b) => b.phrase === 'real content',
+		);
+		expect(outsideBroken).toBeDefined();
+		expect(outsideBroken!.testFile).toContain('outside-detector-dir.test.ts');
 	});
 
 	test('phrases inside string-literal regions of test files are NOT reported', async () => {
@@ -160,12 +188,9 @@ describe('lit', () => {
 			timeout: GIT_TIMEOUT_MS,
 		});
 
-		// Modify the skill so the detector runs
-		writeFile(
-			repo,
-			'.opencode/skills/test/SKILL.md',
-			'# TEST\n\nreal content updated\n',
-		);
+		// Modify the skill so the detector runs, removing 'real content' so the
+		// genuine assertion in the same file breaks.
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
 
 		const result = await checkSkillAssertions(repo);
 		// 'fixture-only-phrase' is inside a string literal in the test file
@@ -174,6 +199,16 @@ describe('lit', () => {
 			(b) => b.phrase === 'fixture-only-phrase',
 		);
 		expect(fixtureOnlyPhrase).toBeUndefined();
+
+		// PRR-006 positive control: the REAL assertion in that same file — one
+		// line below the string literal — MUST still be reported, proving the
+		// string-literal filter is scoped to the literal and not swallowing the
+		// whole file.
+		const realBroken = result.brokenAssertions.find(
+			(b) => b.phrase === 'real content',
+		);
+		expect(realBroken).toBeDefined();
+		expect(realBroken!.assertionKind).toBe('toContain');
 	});
 });
 

--- a/tests/unit/scripts/check-skill-assertions-recall.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-recall.test.ts
@@ -1,0 +1,163 @@
+/**
+ * PRR-005 — recall boundary of FR-004 exact-line attribution.
+ *
+ * FR-004 (issue #2069) deliberately narrowed attribution: an assertion counts
+ * against a skill ONLY when the assertion's own line chains off a confirmed
+ * skill variable. The previous ±2-line proximity window, plus a
+ * `// skill-assertion:` comment fallback, were both removed because proximity
+ * mis-attributed assertions and produced 68 false positives on a single PR.
+ *
+ * The cost of that trade is a real recall loss: an assertion split across two
+ * lines is no longer attributed, because the line carrying `.toContain(...)`
+ * does not itself contain `expect(<skillVar>)`.
+ *
+ * These tests PIN that trade-off rather than assert it is desirable. Both
+ * assertions below are genuinely broken against the skill; only the
+ * single-line one is reported. If recall is ever restored, the multi-line
+ * expectation here is the one to update — deliberately, with its own review —
+ * and reopening proximity-based attribution must not reintroduce #2069.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { checkSkillAssertions } from '../../../scripts/check-skill-assertions';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const GIT_TIMEOUT_MS = 15_000;
+const tempDirs: string[] = [];
+
+function runGit(args: string[], cwd: string): void {
+	spawnSync('git', args, { cwd, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+}
+
+function makeGitRepo(): string {
+	const root = canonicalMkdtemp('recall-');
+	runGit(['init', '-q'], root);
+	runGit(['config', 'user.email', 'test@test.com'], root);
+	runGit(['config', 'user.name', 'Test'], root);
+	fs.writeFileSync(path.join(root, 'README.md'), 'initial\n', 'utf-8');
+	runGit(['add', 'README.md'], root);
+	runGit(['commit', '-q', '-m', 'initial'], root);
+	tempDirs.push(root);
+	return root;
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+afterEach(() => {
+	const d = tempDirs.pop();
+	if (d) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('PRR-005: FR-004 exact-line attribution recall boundary', () => {
+	test('single-line assertion is reported; the equivalent multi-line assertion is not', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nsingle-line-phrase and multi-line-phrase\n',
+		);
+
+		// Both assertions target the same confirmed skill variable and both
+		// phrases are removed from the skill below, so both are genuinely
+		// broken. They differ ONLY in line layout.
+		writeFile(
+			repo,
+			'tests/unit/agents/recall.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('recall', () => {
+  test('single line', () => {
+    expect(content).toContain('single-line-phrase');
+  });
+  test('split across lines', () => {
+    expect(content)
+      .toContain('multi-line-phrase');
+  });
+});
+`,
+		);
+		runGit(['add', '.'], repo);
+		runGit(['commit', '-q', '-m', 'add skill and test'], repo);
+
+		// Remove BOTH phrases — both assertions are now broken in fact.
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
+
+		const result = await checkSkillAssertions(repo);
+		expect(result.changedSkillFiles).toContain(
+			'.opencode/skills/test/SKILL.md',
+		);
+
+		// Control: the single-line form IS attributed and reported.
+		const singleLine = result.brokenAssertions.find(
+			(b) => b.phrase === 'single-line-phrase',
+		);
+		expect(singleLine).toBeDefined();
+		expect(singleLine!.assertionKind).toBe('toContain');
+
+		// PRR-005: the multi-line form is NOT reported — a known false negative,
+		// not an accident of this fixture. The control above proves the detector
+		// ran against this very file and was capable of reporting.
+		const multiLine = result.brokenAssertions.find(
+			(b) => b.phrase === 'multi-line-phrase',
+		);
+		expect(multiLine).toBeUndefined();
+	});
+
+	test('a `// skill-assertion:` comment does not restore attribution', async () => {
+		const repo = makeGitRepo();
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\ncommented-phrase\n',
+		);
+
+		// The detector's docblock previously advertised a `// skill-assertion:`
+		// comment fallback. FR-004 removed it; this pins that it is really gone,
+		// so the docblock and the code cannot silently disagree again.
+		writeFile(
+			repo,
+			'tests/unit/agents/commented.test.ts',
+			`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+const other = 'unrelated string';
+describe('commented', () => {
+  test('comment-attributed', () => {
+    // skill-assertion: .opencode/skills/test/SKILL.md
+    expect(other).toContain('commented-phrase');
+  });
+});
+`,
+		);
+		runGit(['add', '.'], repo);
+		runGit(['commit', '-q', '-m', 'add skill and test'], repo);
+
+		writeFile(repo, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
+
+		const result = await checkSkillAssertions(repo);
+		// The assertion chains off `other`, not the skill variable. The comment
+		// does not re-attribute it, so nothing is reported for this phrase.
+		const commented = result.brokenAssertions.find(
+			(b) => b.phrase === 'commented-phrase',
+		);
+		expect(commented).toBeUndefined();
+	});
+});

--- a/tests/unit/scripts/check-skill-assertions-strict-mode.test.ts
+++ b/tests/unit/scripts/check-skill-assertions-strict-mode.test.ts
@@ -1,0 +1,151 @@
+/**
+ * PRR-006 — coverage for the SKILL_ASSERTIONS_STRICT=1 hard-fail path.
+ *
+ * FR-006 made skill-assertion findings advisory: the CLI reports them and
+ * exits 0, so a broken assertion never blocks a merge on its own.
+ * SKILL_ASSERTIONS_STRICT=1 is the documented opt-in that turns the same
+ * findings into `process.exit(1)`. That branch had no test.
+ *
+ * Why a subprocess: the branch under test IS `process.exit(1)`. Calling it
+ * in-process would kill the bun test runner mid-suite, and stubbing
+ * process.exit would let execution fall through past the call site — a false
+ * pass, and a mock.module isolation hazard (AGENTS.md invariant 7). Spawning
+ * the real CLI and asserting on its exit code tests the actual behavior with
+ * no mocks.
+ *
+ * The detector resolves REPO_ROOT from its own file location, so the script is
+ * copied into the fixture repo. It imports only node builtins, which is what
+ * makes that copy safe; if it ever gains a repo-relative import, this test
+ * will fail loudly at spawn rather than silently analyzing the wrong tree.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const GIT_TIMEOUT_MS = 15_000;
+const CLI_TIMEOUT_MS = 60_000;
+const DETECTOR_SRC = path.resolve(
+	import.meta.dirname,
+	'../../../scripts/check-skill-assertions.ts',
+);
+const tempDirs: string[] = [];
+
+function runGit(args: string[], cwd: string): void {
+	spawnSync('git', args, { cwd, stdio: 'ignore', timeout: GIT_TIMEOUT_MS });
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+	const full = path.join(root, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+/**
+ * Build a repo containing a copy of the detector plus one genuinely broken
+ * skill assertion, so the CLI reaches the exit-code branch under test.
+ */
+function makeRepoWithBrokenAssertion(): string {
+	const root = canonicalMkdtemp('strict-');
+	tempDirs.push(root);
+	runGit(['init', '-q'], root);
+	runGit(['config', 'user.email', 'test@test.com'], root);
+	runGit(['config', 'user.name', 'Test'], root);
+
+	writeFile(
+		root,
+		'scripts/check-skill-assertions.ts',
+		fs.readFileSync(DETECTOR_SRC, 'utf-8'),
+	);
+	writeFile(
+		root,
+		'.opencode/skills/test/SKILL.md',
+		'# TEST\n\nstrict-phrase\n',
+	);
+	writeFile(
+		root,
+		'tests/unit/agents/strict.test.ts',
+		`
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(
+  join(process.cwd(), '.opencode/skills/test/SKILL.md'),
+  'utf-8',
+);
+describe('strict', () => {
+  test('phrase', () => {
+    expect(content).toContain('strict-phrase');
+  });
+});
+`,
+	);
+	runGit(['add', '.'], root);
+	runGit(['commit', '-q', '-m', 'initial'], root);
+
+	// Remove the phrase so the assertion is broken against the changed skill.
+	writeFile(root, '.opencode/skills/test/SKILL.md', '# TEST\n\nreplaced\n');
+	return root;
+}
+
+function runDetectorCli(
+	repo: string,
+	env: Record<string, string>,
+): { status: number | null; stdout: string } {
+	const result = spawnSync(
+		process.execPath,
+		[path.join(repo, 'scripts/check-skill-assertions.ts')],
+		{
+			cwd: repo,
+			encoding: 'utf-8',
+			timeout: CLI_TIMEOUT_MS,
+			env: { ...process.env, ...env },
+		},
+	);
+	return {
+		status: result.status,
+		stdout: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+	};
+}
+
+afterEach(() => {
+	const d = tempDirs.pop();
+	if (d) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe('PRR-006: SKILL_ASSERTIONS_STRICT hard-fail path', () => {
+	test('default (advisory) exits 0 even though a broken assertion is found', () => {
+		const repo = makeRepoWithBrokenAssertion();
+		const { status, stdout } = runDetectorCli(repo, {
+			SKILL_ASSERTIONS_STRICT: '',
+		});
+		// Control: the run must actually FIND the broken assertion, otherwise
+		// exit 0 would prove nothing about the advisory default.
+		expect(stdout).toContain('broken assertion');
+		expect(status).toBe(0);
+	});
+
+	test('SKILL_ASSERTIONS_STRICT=1 exits 1 on the same repo', () => {
+		const repo = makeRepoWithBrokenAssertion();
+		const { status, stdout } = runDetectorCli(repo, {
+			SKILL_ASSERTIONS_STRICT: '1',
+		});
+		expect(stdout).toContain('broken assertion');
+		expect(status).toBe(1);
+	});
+
+	test('SKILL_ASSERTIONS_STRICT=1 still exits 0 when nothing is broken', () => {
+		const repo = makeRepoWithBrokenAssertion();
+		// Restore the phrase so the assertion holds again.
+		writeFile(
+			repo,
+			'.opencode/skills/test/SKILL.md',
+			'# TEST\n\nstrict-phrase restored\n',
+		);
+		const { status } = runDetectorCli(repo, { SKILL_ASSERTIONS_STRICT: '1' });
+		// Strict mode escalates real findings; it must not fail a clean run.
+		expect(status).toBe(0);
+	});
+});


### PR DESCRIPTION
Follow-up to #2069 / #2110, closing the three review findings that PR left open. Test-and-documentation only — **no detector behavior changes**.

## Summary

**PRR-007 — Windows temp-dir leak (MEDIUM).** `check-skill-assertions-false-positive-{regex,attribution}.test.ts` cleaned up temp repos with `spawnSync('rm', ['-rf', d])`. `rm` does not exist on Windows, so the fixture repo leaked on every Windows shard. Both now use `fs.rmSync`, matching the negation and self-exclusion fixtures.

**PRR-006 — three coverage gaps (LOW).**
- *Vacuous malformed-regex assertion.* The test asserted only inside `if (result.brokenAssertions.length > 0)`, so it passed even if the detector emitted nothing. Verified empirically that `/foo[/` produces exactly one `malformed-regex` finding, and pinned that.
- *Untested strict path.* `SKILL_ASSERTIONS_STRICT=1` → `process.exit(1)` had no coverage. New `check-skill-assertions-strict-mode.test.ts` spawns the real CLI and asserts exit codes: `0` advisory, `1` strict, `0` strict-but-clean. It runs as a subprocess deliberately — a real `process.exit` would kill the bun runner mid-suite, and a stubbed one would let execution fall through past the call site (false pass, plus an invariant-7 mock hazard). The detector resolves `REPO_ROOT` from its own location and imports only node builtins, so the fixture copies the script into the temp repo.
- *Negative-only assertions.* The attribution and self-exclusion fixtures asserted only that a phrase was *not* misreported. Each now also asserts the genuinely broken assertion **is** reported. This matters for this detector specifically: tested only on negatives, "correctly filtered a false positive" and "stopped reporting anything at all" are indistinguishable — and the second is the failure mode #2069 was about.

**PRR-005 — FR-004 recall boundary (MEDIUM).** New `check-skill-assertions-recall.test.ts` pins the trade-off. One fixture carries a single-line assertion and a split-across-lines assertion, **both genuinely broken against the same skill**; the single-line form is reported, the multi-line form is not.

I pinned this rather than restoring recall, deliberately. FR-004 removed the ±2-line window on purpose to kill #2069's 68 false positives; re-widening attribution — even by paren-balancing rather than proximity — reopens exactly the surface that PR closed, on a detector whose false-positive history is why the issue existed. It also has an unbounded blast radius: every multi-line skill assertion in the repo becomes newly detectable, and sizing that is its own investigation. If recall should be restored, that deserves its own issue and review; the multi-line expectation here is the line to change.

**Unlisted fix.** `checkAssertionsAgainstSkill`'s docblock still advertised a `// skill-assertion:` comment-attribution fallback that FR-004 deleted — it documented a mechanism that no longer exists. Corrected to describe exact-line chaining only and to name the multi-line cost. A test also pins that the comment form really does not re-attribute, so code and docs cannot silently diverge again.

## Invariant audit

- 1 (plugin init): not touched — no changes to src/index.ts or plugin registration
- 2 (runtime portability): not touched — no bundle config, package exports, or bun: import changes
- 3 (subprocesses): not touched — the detector's git subprocess handling is unchanged; the new strict-mode test spawns via `spawnSync` with an explicit `timeout` and no shell
- 4 (.swarm containment): not touched — no writes outside temp fixture repos created via `canonicalMkdtemp`
- 5 (plan durability): not touched — no plan ledger or projection changes
- 6 (test_runner safety): not touched — tests invoked by explicit file path, no broad scopes
- 7 (test writing): **touched** — two new test files, Tier 0 zero-mock (real temp git repos, no `mock.module`), `canonicalMkdtemp` + `fs.rmSync` throughout; all touched files under the FR-006 500-line cap
- 8 (session state): not touched — no session-scoped state changes
- 9 (guardrails/retry): not touched
- 10 (chat/system msg): not touched
- 11 (tool registration): not touched — no tool additions/removals/modifications
- 12 (release/cache): **touched** — release note fragment at `docs/releases/pending/fr-2069-review-followup.md`; version files untouched (release-please owns them)

## Test plan

- [x] All 13 `quality` gates run locally: pass. The two diff-scoped ones (`check-test-tmpdir.sh`, `check-test-file-cap.ts`) were re-run after commit, since they read the committed diff rather than the working tree.
- [x] `check-skill-assertions*` suite: 36 pass / 0 fail, both per-file and co-run. Was 31 — the 5 new tests are 2 recall + 3 strict-mode.
- [x] Blast radius: the directory-scanning tests over `tests/unit/scripts/` (`check-test-file-cap-pure`, `check-mock-allowlist-ratchet`, `check-invariants`, `check-event-contract`) all pass with two new files added to that tree.
- [x] Largest touched test file is 443 lines, under the FR-006 cap; `check-test-file-cap` reports 0 new-file and 0 ratchet violations.
- [x] Each new assertion was verified to be discriminating, not just passing: the malformed-regex and recall expectations were confirmed empirically against the real detector before being pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
