### PR TITLE
feat(repo-map): add zero-cost ask/orient action and upgrade context_pack

### DIFF
--- a/docs/releases/pending/1987-repo-map-ask-context-pack.md
+++ b/docs/releases/pending/1987-repo-map-ask-context-pack.md
@@ -1,0 +1,27 @@
+## What
+
+- New `repo_map action="ask"` for zero-LLM file localization: vocabulary expansion, IDF-weighted lexical seeding, and personalized PageRank over the file-level dependency graph.
+- `context_pack` gains `include_source` option to embed source text in spans (default false, fail-open on read errors).
+- `context_pack` no longer silently drops BFS-reached symbols without `exportRanges`; they now emit a file-level signature pointer with a note.
+- `key_files` and `package_boundaries` responses include `community` (inferred package boundary) and normalized `hubScore` (0-1).
+- All list-returning actions (`key_files`, `package_boundaries`, `dead_exports`, `context_pack`, `ask`) include `budget: { returned, dropped? }` for truncation visibility.
+
+## Why
+
+Agents need structural file localization without LLM calls, source text without opening every file individually, and visibility into how many results were truncated. Closes #1987.
+
+## Migration
+
+No breaking changes. All new fields are additive:
+- `ask` is a new action (existing actions unchanged).
+- `include_source` defaults to `false`; existing `context_pack` calls return identical shapes.
+- `budget`, `community`, `hubScore` are new fields on existing responses.
+- Internal-symbol fallback adds spans that were previously silently dropped.
+
+## Caveats
+
+- `ask` is orientation only — it ranks files by structural relevance but does not read or analyze file contents. Always read the located files before asserting anything about them.
+- `include_source` text is bounded to 80 lines per span, only applies to full-mode spans (not signature spans), and respects the token budget. Unreadable files fail open (span without text, with a note).
+- `hubScore` on `package_boundaries` uses `dependedOnBy.length` (boundary-level in-degree), not per-file in-degree.
+- `budget.dropped` is omitted on `dead_exports` where the total candidate count is not available without additional computation.
+- `ask` uses no stemming: "saved" will not match the export "saveGraph" via the stem "save". Query with the exact identifier for best results.

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -15,6 +15,7 @@
  * All existing imports of this module continue to work unchanged.
  */
 
+export { _internals as _askInternals, askGraph } from './repo-graph/ask';
 export type {
 	RepoGraphInputMetadata,
 	RepoGraphInputWalkOptions,
@@ -82,6 +83,9 @@ export {
 	saveIfDirty,
 } from './repo-graph/storage';
 export type {
+	AskHit,
+	AskOptions,
+	AskResult,
 	BlastRadiusResult,
 	BuildWorkspaceGraphOptions,
 	CallerReference,
@@ -115,6 +119,7 @@ export type {
 export {
 	createEmptyGraph,
 	GRAPH_SCHEMA_VERSION,
+	inferPackageBoundary,
 	isSchemaVersionAtLeast,
 	normalizeGraphPath,
 	REPO_GRAPH_FILENAME,

--- a/src/tools/repo-graph/ask.ts
+++ b/src/tools/repo-graph/ask.ts
@@ -60,15 +60,44 @@ function buildVocabulary(graph: RepoGraph): Set<string> {
 			.replace(/^.*[/\\]/, '')
 			.replace(/\.[^.]+$/, '');
 		vocab.add(baseName.toLowerCase());
+		// Add path segments so directory names are searchable (e.g. "agents", "hooks")
+		for (const seg of node.moduleName.split(/[/\\]/)) {
+			if (seg.length > 1) vocab.add(seg.toLowerCase());
+		}
 		for (const exp of node.exports) {
 			vocab.add(exp.toLowerCase());
 			for (const sub of splitCompound(exp)) vocab.add(sub.toLowerCase());
 		}
+	}
+	// Add ontology roles only when they'd score (nonzero IDF via substring match
+	// in moduleName/exports/imports). Roles with no overlap would produce
+	// misleading uniform-PageRank with empty matchedTerms.
+	const nodes = Object.values(graph.nodes);
+	const distinctRoles = new Set<string>();
+	for (const node of nodes) {
 		if (node.ontology) {
-			for (const role of node.ontology.roles) vocab.add(role.toLowerCase());
+			for (const role of node.ontology.roles)
+				distinctRoles.add(role.toLowerCase());
 		}
 	}
+	for (const r of distinctRoles) {
+		if (!vocab.has(r) && wouldScore(r, nodes)) vocab.add(r);
+	}
 	return vocab;
+}
+
+function wouldScore(term: string, nodes: GraphNode[]): boolean {
+	for (const node of nodes) {
+		const m = node.moduleName.toLowerCase();
+		if (
+			m.includes(term) ||
+			node.exports.some((e) => e.toLowerCase().includes(term)) ||
+			node.imports.some((i) => i.toLowerCase().includes(term))
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 function expandTerms(tokens: string[], vocab: Set<string>): string[] {

--- a/src/tools/repo-graph/ask.ts
+++ b/src/tools/repo-graph/ask.ts
@@ -1,0 +1,328 @@
+import { isAssetEdge } from './builder';
+import type {
+	AskHit,
+	AskOptions,
+	AskResult,
+	GraphNode,
+	RepoGraph,
+} from './types';
+import { inferPackageBoundary, normalizeGraphPath } from './types';
+
+const DEFAULT_TOP_N = 8;
+const MAX_TOP_N = 25;
+const ALPHA = 0.25;
+const MAX_ITERATIONS = 25;
+const CONVERGENCE_THRESHOLD = 1e-6;
+
+const FIELD_WEIGHTS = { moduleName: 3, exports: 2, imports: 1 } as const;
+const TEST_PATH_FACTOR = 0.35;
+const TEST_PATH_RE =
+	/(?:^|[/\\])(?:tests?|__tests?__|spec|__spec__|__mocks?__)[/\\]|\.(?:test|spec|stories)\./i;
+
+function tokenize(text: string): string[] {
+	const raw = text
+		.replace(/[^a-zA-Z0-9_]/g, ' ')
+		.split(/\s+/)
+		.filter((t) => t.length > 1);
+	const expanded: string[] = [];
+	for (const token of raw) {
+		expanded.push(token.toLowerCase());
+		for (const sub of splitCompound(token)) {
+			const lower = sub.toLowerCase();
+			if (lower !== token.toLowerCase()) expanded.push(lower);
+		}
+	}
+	return [...new Set(expanded)];
+}
+
+function splitCompound(token: string): string[] {
+	const parts: string[] = [];
+	// camelCase / PascalCase split
+	const camel = token.replace(/([a-z])([A-Z])/g, '$1 $2').split(/\s+/);
+	if (camel.length > 1) {
+		for (const p of camel) if (p.length > 1) parts.push(p);
+	}
+	// snake_case split
+	const snake = token.split('_');
+	if (snake.length > 1) {
+		for (const p of snake) if (p.length > 1) parts.push(p);
+	}
+	return parts;
+}
+
+function buildVocabulary(graph: RepoGraph): Set<string> {
+	const vocab = new Set<string>();
+	for (const node of Object.values(graph.nodes)) {
+		for (const sub of splitCompound(node.moduleName)) {
+			vocab.add(sub.toLowerCase());
+		}
+		const baseName = node.moduleName
+			.replace(/^.*[/\\]/, '')
+			.replace(/\.[^.]+$/, '');
+		vocab.add(baseName.toLowerCase());
+		for (const exp of node.exports) {
+			vocab.add(exp.toLowerCase());
+			for (const sub of splitCompound(exp)) vocab.add(sub.toLowerCase());
+		}
+		if (node.ontology) {
+			for (const role of node.ontology.roles) vocab.add(role.toLowerCase());
+		}
+	}
+	return vocab;
+}
+
+function expandTerms(tokens: string[], vocab: Set<string>): string[] {
+	const expanded = new Set<string>();
+	for (const token of tokens) {
+		if (vocab.has(token)) expanded.add(token);
+		for (const sub of splitCompound(token)) {
+			const lower = sub.toLowerCase();
+			if (vocab.has(lower)) expanded.add(lower);
+		}
+	}
+	return [...expanded].sort();
+}
+
+function computeIDF(term: string, nodes: GraphNode[]): number {
+	let docFreq = 0;
+	const lower = term.toLowerCase();
+	for (const node of nodes) {
+		const moduleLower = node.moduleName.toLowerCase();
+		const baseName = moduleLower
+			.replace(/^.*[/\\]/, '')
+			.replace(/\.[^.]+$/, '');
+		if (
+			moduleLower.includes(lower) ||
+			baseName === lower ||
+			node.exports.some((e) => e.toLowerCase().includes(lower)) ||
+			node.imports.some((i) => i.toLowerCase().includes(lower))
+		) {
+			docFreq++;
+		}
+	}
+	if (docFreq === 0) return 0;
+	return Math.log((nodes.length + 1) / (docFreq + 1)) + 1;
+}
+
+function lexicalScore(
+	node: GraphNode,
+	terms: string[],
+	idfMap: Map<string, number>,
+): { score: number; matchedTerms: string[] } {
+	let score = 0;
+	const matched: string[] = [];
+	const moduleLower = node.moduleName.toLowerCase();
+	const baseName = moduleLower.replace(/^.*[/\\]/, '').replace(/\.[^.]+$/, '');
+
+	for (const term of terms) {
+		const idf = idfMap.get(term) ?? 0;
+		if (idf === 0) continue;
+		let termScore = 0;
+
+		if (moduleLower.includes(term) || baseName === term) {
+			termScore += FIELD_WEIGHTS.moduleName * idf;
+		}
+		if (node.exports.some((e) => e.toLowerCase().includes(term))) {
+			termScore += FIELD_WEIGHTS.exports * idf;
+		}
+		if (node.imports.some((i) => i.toLowerCase().includes(term))) {
+			termScore += FIELD_WEIGHTS.imports * idf;
+		}
+
+		if (termScore > 0) {
+			score += termScore;
+			matched.push(term);
+		}
+	}
+
+	if (TEST_PATH_RE.test(node.moduleName)) {
+		score *= TEST_PATH_FACTOR;
+	}
+
+	return { score, matchedTerms: matched };
+}
+
+function buildUndirectedAdjacency(
+	graph: RepoGraph,
+	nodeKeys: string[],
+): Map<string, Set<string>> {
+	const adj = new Map<string, Set<string>>();
+	for (const key of nodeKeys) adj.set(key, new Set());
+	for (const edge of graph.edges) {
+		if (isAssetEdge(edge)) continue;
+		const s = normalizeGraphPath(edge.source);
+		const t = normalizeGraphPath(edge.target);
+		if (adj.has(s) && adj.has(t)) {
+			adj.get(s)!.add(t);
+			adj.get(t)!.add(s);
+		}
+	}
+	return adj;
+}
+
+function personalizedPageRank(
+	adj: Map<string, Set<string>>,
+	restart: Map<string, number>,
+	nodeKeys: string[],
+): Map<string, number> {
+	const n = nodeKeys.length;
+	if (n === 0) return new Map();
+
+	let scores = new Map<string, number>();
+	for (const key of nodeKeys) scores.set(key, restart.get(key) ?? 0);
+
+	for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
+		const next = new Map<string, number>();
+		for (const key of nodeKeys) next.set(key, 0);
+
+		let danglingMass = 0;
+		for (const key of nodeKeys) {
+			const neighbors = adj.get(key);
+			if (!neighbors || neighbors.size === 0) {
+				danglingMass += scores.get(key) ?? 0;
+			} else {
+				const share = (scores.get(key) ?? 0) / neighbors.size;
+				for (const neighbor of neighbors) {
+					next.set(neighbor, (next.get(neighbor) ?? 0) + share);
+				}
+			}
+		}
+
+		const danglingShare = danglingMass / n;
+
+		// ALPHA = walk weight (graph re-rank); (1-ALPHA) = restart weight (lexical seed)
+		let l1Delta = 0;
+		for (const key of nodeKeys) {
+			const damped =
+				(1 - ALPHA) * (restart.get(key) ?? 0) +
+				ALPHA * ((next.get(key) ?? 0) + danglingShare);
+			l1Delta += Math.abs(damped - (scores.get(key) ?? 0));
+			next.set(key, damped);
+		}
+
+		scores = next;
+		if (l1Delta < CONVERGENCE_THRESHOLD) break;
+	}
+
+	return scores;
+}
+
+export function askGraph(
+	graph: RepoGraph,
+	question: string,
+	options: AskOptions = {},
+): AskResult {
+	const topN = Math.min(options.topN ?? DEFAULT_TOP_N, MAX_TOP_N);
+	const nodes = Object.values(graph.nodes);
+	const nodeKeys = Object.keys(graph.nodes).sort();
+
+	if (!question.trim() || nodes.length === 0) {
+		return {
+			hits: [],
+			expandedTerms: [],
+			budget: { requested: topN, returned: 0, dropped: 0 },
+		};
+	}
+
+	const vocab = buildVocabulary(graph);
+	const rawTokens = tokenize(question);
+	const expandedTerms = expandTerms(rawTokens, vocab);
+
+	if (expandedTerms.length === 0) {
+		return {
+			hits: [],
+			expandedTerms: [],
+			budget: { requested: topN, returned: 0, dropped: 0 },
+		};
+	}
+
+	// Compute IDF for each expanded term
+	const idfMap = new Map<string, number>();
+	for (const term of expandedTerms) {
+		idfMap.set(term, computeIDF(term, nodes));
+	}
+
+	// Compute lexical scores for each node
+	const lexScores = new Map<
+		string,
+		{ score: number; matchedTerms: string[] }
+	>();
+	let totalLexScore = 0;
+	for (const key of nodeKeys) {
+		const node = graph.nodes[key];
+		const result = lexicalScore(node, expandedTerms, idfMap);
+		lexScores.set(key, result);
+		totalLexScore += result.score;
+	}
+
+	// Build restart vector (normalized lexical scores)
+	const restart = new Map<string, number>();
+	if (totalLexScore > 0) {
+		for (const key of nodeKeys) {
+			restart.set(key, (lexScores.get(key)?.score ?? 0) / totalLexScore);
+		}
+	} else {
+		const uniform = 1 / nodeKeys.length;
+		for (const key of nodeKeys) restart.set(key, uniform);
+	}
+
+	// Build adjacency and run PageRank
+	const adj = buildUndirectedAdjacency(graph, nodeKeys);
+	const prScores = personalizedPageRank(adj, restart, nodeKeys);
+
+	// Rank and build hits
+	const scored: { key: string; score: number; matchedTerms: string[] }[] = [];
+	for (const key of nodeKeys) {
+		const pr = prScores.get(key) ?? 0;
+		const lex = lexScores.get(key);
+		if (pr > 0 || (lex && lex.score > 0)) {
+			scored.push({
+				key,
+				score: Math.round(pr * 1e6) / 1e6,
+				matchedTerms: lex?.matchedTerms ?? [],
+			});
+		}
+	}
+
+	scored.sort((a, b) => {
+		if (b.score !== a.score) return b.score - a.score;
+		return a.key.localeCompare(b.key);
+	});
+
+	const total = scored.length;
+	const topHits = scored.slice(0, topN);
+
+	const hits: AskHit[] = topHits.map(({ key, score, matchedTerms }) => {
+		const node = graph.nodes[key];
+		return {
+			file: node.moduleName,
+			score,
+			matchedTerms,
+			topExports: node.exports.slice(0, 5),
+			role: node.ontology?.roles[0] ?? 'source_module',
+			community:
+				node.ontology?.packageBoundary ?? inferPackageBoundary(node.moduleName),
+		};
+	});
+
+	return {
+		hits,
+		expandedTerms,
+		budget: {
+			requested: topN,
+			returned: hits.length,
+			dropped: Math.max(0, total - topN),
+		},
+	};
+}
+
+export const _internals = {
+	tokenize,
+	splitCompound,
+	expandTerms,
+	buildVocabulary,
+	computeIDF,
+	lexicalScore,
+	personalizedPageRank,
+	buildUndirectedAdjacency,
+};

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
 	containsControlChars,
@@ -695,7 +696,12 @@ export function getContextPack(
 	graph: RepoGraph,
 	file: string,
 	symbol: string,
-	options: { maxDepth?: number; maxTokens?: number } = {},
+	options: {
+		maxDepth?: number;
+		maxTokens?: number;
+		includeSource?: boolean;
+		directory?: string;
+	} = {},
 ): ContextPackResult {
 	if (!isSchemaVersionAtLeast(graph.schema_version, '1.2.0')) {
 		return {
@@ -789,11 +795,27 @@ export function getContextPack(
 	const TOKENS_PER_SIGNATURE = 10;
 
 	// Build spans from exportRanges, attaching depth for ordering.
+	// Internal-symbol fallback: when a BFS-reached symbol has no exportRanges
+	// entry, emit a file-level signature pointer instead of silently dropping it.
 	const spansWithDepth: { span: ContextPackSpan; depth: number }[] = [];
 	for (const { file: symFile, symbol: sym, depth: d } of reached) {
 		const node = graph.nodes[symFile];
 		const range = node?.exportRanges?.[sym];
-		if (!range) continue;
+
+		if (!range) {
+			spansWithDepth.push({
+				span: {
+					file: symFile,
+					symbol: sym,
+					startLine: 1,
+					endLine: 1,
+					mode: 'signature',
+					note: 'internal symbol — span unavailable',
+				},
+				depth: d,
+			});
+			continue;
+		}
 
 		const mode: 'full' | 'signature' =
 			d === 0 ? 'full' : d < maxDepth ? 'full' : 'signature';
@@ -823,13 +845,17 @@ export function getContextPack(
 		return a.span.symbol.localeCompare(b.span.symbol);
 	});
 
+	const includeSource = options.includeSource ?? false;
+	const directory = options.directory ?? graph.workspaceRoot;
+	const MAX_SOURCE_LINES = 80;
+
 	// Apply token budget; keep at least the target span if present.
 	let estimatedTokens = 0;
 	const finalSpans: ContextPackSpan[] = [];
 	let truncated = false;
 
 	for (const { span } of spansWithDepth) {
-		const spanTokens =
+		let spanTokens =
 			span.mode === 'full'
 				? (span.endLine - span.startLine + 1) * TOKENS_PER_LINE
 				: TOKENS_PER_SIGNATURE;
@@ -839,17 +865,51 @@ export function getContextPack(
 			break;
 		}
 
+		if (includeSource && !span.note && span.mode === 'full') {
+			const absPath = path.isAbsolute(span.file)
+				? span.file
+				: path.resolve(directory, span.file);
+			const resolved = path.resolve(absPath);
+			const resolvedDir = path.resolve(directory);
+			if (
+				resolved.startsWith(resolvedDir + path.sep) ||
+				resolved === resolvedDir
+			) {
+				try {
+					const content = fs.readFileSync(resolved, 'utf-8');
+					const lines = content.split('\n');
+					const start = Math.max(0, span.startLine - 1);
+					const end = Math.min(
+						lines.length,
+						span.startLine - 1 + MAX_SOURCE_LINES,
+						span.endLine,
+					);
+					const slice = lines.slice(start, end);
+					span.text = slice.join('\n');
+					spanTokens = slice.length * TOKENS_PER_LINE;
+				} catch {
+					span.note = 'source read failed';
+				}
+			}
+		}
+
 		finalSpans.push(span);
 		estimatedTokens += spanTokens;
 	}
 
-	return {
+	const result: ContextPackResult = {
 		schemaSupported: true,
 		target: { file: targetFile, symbol },
 		spans: finalSpans,
 		truncated,
 		estimatedTokens,
 	};
+
+	if (includeSource) {
+		result.sourceIncluded = true;
+	}
+
+	return result;
 }
 
 function collectExternallyUsedSymbols(

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -323,6 +323,8 @@ export interface ContextPackSpan {
 	startLine: number;
 	endLine: number;
 	mode: 'full' | 'signature';
+	text?: string;
+	note?: string;
 }
 
 /**
@@ -342,6 +344,27 @@ export interface ContextPackResult {
 	estimatedTokens: number;
 	/** Optional human-readable note about scope or limitations. */
 	note?: string;
+	/** Whether source text was embedded in spans (only present when include_source was requested). */
+	sourceIncluded?: boolean;
+}
+
+export interface AskHit {
+	file: string;
+	score: number;
+	matchedTerms: string[];
+	topExports: string[];
+	role: string;
+	community: string;
+}
+
+export interface AskOptions {
+	topN?: number;
+}
+
+export interface AskResult {
+	hits: AskHit[];
+	expandedTerms: string[];
+	budget: { requested: number; returned: number; dropped: number };
 }
 
 /**

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/path-security';
 import { createSwarmTool } from './create-tool';
 import {
+	askGraph,
 	buildOntologyPreflightPacket,
 	buildWorkspaceGraphAsync,
 	type FreshnessOptions,
@@ -25,6 +26,7 @@ import {
 	getLocalizationContext,
 	getPackageBoundaries,
 	getSymbolConsumers,
+	inferPackageBoundary,
 	isGraphWideInputPath,
 	loadGraph,
 	normalizeGraphPath,
@@ -69,12 +71,14 @@ const VALID_ACTIONS = [
 	'dead_exports',
 	'context_pack',
 	'graph_health',
+	'ask',
 ] as const;
 
 type RepoMapAction = (typeof VALID_ACTIONS)[number];
 
 const MAX_FILE_PATH_LENGTH = 500;
 const MAX_SYMBOL_LENGTH = 256;
+const MAX_QUESTION_LENGTH = 500;
 const REPO_GRAPH_DISABLED_NOTICE =
 	'Repository graph is disabled by configuration (repo_graph.enabled=false).';
 
@@ -92,6 +96,8 @@ interface RepoMapArgs {
 	symbol?: string;
 	top_n?: number;
 	max_depth?: number;
+	question?: string;
+	include_source?: boolean;
 }
 
 function validateFile(p: string): string | null {
@@ -117,6 +123,15 @@ function validateSymbol(s: string): string | null {
 		return `symbol exceeds maximum length of ${MAX_SYMBOL_LENGTH}`;
 	}
 	if (containsControlChars(s)) return 'symbol contains control characters';
+	return null;
+}
+
+function validateQuestion(q: string): string | null {
+	if (!q || q.trim().length === 0) return 'question is empty';
+	if (q.length > MAX_QUESTION_LENGTH) {
+		return `question exceeds maximum length of ${MAX_QUESTION_LENGTH}`;
+	}
+	if (containsControlChars(q)) return 'question contains control characters';
 	return null;
 }
 
@@ -220,8 +235,9 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		'"preflight_packet" (bounded ontology packet for planning), ' +
 		'"callers" (files that reference an exported symbol, call-site granularity; needs file+symbol), ' +
 		'"dead_exports" (advisory: exported symbols with no detected in-repo reference; results are review candidates, not delete directives), ' +
-		'"context_pack" (token-budgeted slice of source spans for a target symbol — definition + transitive callers/callees; advisory/conservative; needs file+symbol; uses max_depth for traversal depth, top_n for span cap), ' +
-		'"graph_health" (freshness and bounded extraction diagnostics; no file required). ' +
+		'"context_pack" (token-budgeted slice of source spans for a target symbol — definition + transitive callers/callees; advisory/conservative; needs file+symbol; uses max_depth for traversal depth, top_n for span cap; set include_source=true to embed source text in spans), ' +
+		'"graph_health" (freshness and bounded extraction diagnostics; no file required), ' +
+		'"ask" (zero-LLM file localization: pass a natural-language question to rank files by relevance via vocabulary expansion + IDF + PageRank; orientation only — read the located files before asserting anything about them). ' +
 		'Use this before refactoring shared modules to avoid breaking unseen consumers. ' +
 		'Note: "callers"/"dead_exports"/"context_pack" use conservative regex analysis (TS/JS/Python) and cannot see ' +
 		'dynamic dispatch or namespace/barrel re-export usage; "dead_exports" results are review candidates, not delete directives.',
@@ -241,9 +257,10 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				'dead_exports',
 				'context_pack',
 				'graph_health',
+				'ask',
 			])
 			.describe(
-				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports" | "context_pack" | "graph_health"',
+				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports" | "context_pack" | "graph_health" | "ask"',
 			),
 		file: z
 			.string()
@@ -280,6 +297,18 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			.optional()
 			.describe(
 				'For action="blast_radius": max BFS depth (default 3). For action="context_pack": traversal depth (default 2).',
+			),
+		question: z
+			.string()
+			.optional()
+			.describe(
+				'Natural-language question for action="ask". Orientation only — read the located files before asserting anything about them.',
+			),
+		include_source: z
+			.boolean()
+			.optional()
+			.describe(
+				'For action="context_pack": embed source text in spans (default false).',
 			),
 	},
 	async execute(
@@ -406,17 +435,29 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		if (action === 'key_files') {
 			const topN = a.top_n ?? 10;
 			const nodes = getKeyFiles(graph, topN);
-			const reverseCounts = nodes.map((n) => ({
+			const totalFiles = Object.keys(graph.nodes).length;
+			const inDegrees = nodes.map(
+				(n) => getImporters(graph, n.moduleName).length,
+			);
+			const maxInDegree = Math.max(1, ...inDegrees);
+			const reverseCounts = nodes.map((n, i) => ({
 				file: n.moduleName,
 				language: n.language,
 				exports: n.exports.length,
 				roles: n.ontology?.roles ?? [],
 				findings: n.ontology?.findings.length ?? 0,
-				inDegree: getImporters(graph, n.moduleName).length,
+				inDegree: inDegrees[i],
+				hubScore: Math.round((inDegrees[i] / maxInDegree) * 1e4) / 1e4,
+				community:
+					n.ontology?.packageBoundary ?? inferPackageBoundary(n.moduleName),
 			}));
 			return ok(action, {
 				count: reverseCounts.length,
 				files: reverseCounts,
+				budget: {
+					returned: reverseCounts.length,
+					dropped: Math.max(0, totalFiles - reverseCounts.length),
+				},
 				...freshness,
 			});
 		}
@@ -424,16 +465,39 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		if (action === 'package_boundaries') {
 			const topN = a.top_n ?? 10;
 			const boundaries = getPackageBoundaries(graph, topN);
+			const maxDepOnBy = Math.max(
+				1,
+				...boundaries.map((b) => b.dependedOnBy.length),
+			);
+			const enriched = boundaries.map((b) => ({
+				...b,
+				hubScore: Math.round((b.dependedOnBy.length / maxDepOnBy) * 1e4) / 1e4,
+				community: b.name,
+			}));
+			const totalBoundaries = new Set(
+				Object.values(graph.nodes).map(
+					(n) =>
+						n.ontology?.packageBoundary ?? inferPackageBoundary(n.moduleName),
+				),
+			).size;
 			return ok(action, {
-				count: boundaries.length,
-				boundaries,
+				count: enriched.length,
+				boundaries: enriched,
+				budget: {
+					returned: enriched.length,
+					dropped: Math.max(0, totalBoundaries - enriched.length),
+				},
 				...freshness,
 			});
 		}
 
 		if (action === 'dead_exports') {
 			const result = getDeadExports(graph, { maxCandidates: a.top_n ?? 100 });
-			return ok(action, { ...result, ...freshness });
+			return ok(action, {
+				...result,
+				budget: { returned: result.candidates.length },
+				...freshness,
+			});
 		}
 
 		if (action === 'preflight_packet') {
@@ -451,6 +515,15 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				}),
 				...freshness,
 			});
+		}
+
+		if (action === 'ask') {
+			if (!a.question) return err(action, 'ask requires `question`');
+			const qErr = validateQuestion(a.question);
+			if (qErr) return err(action, `invalid question: ${qErr}`);
+			const topN = Math.min(a.top_n ?? 8, 25);
+			const result = askGraph(graph, a.question, { topN });
+			return ok(action, { ...result, ...freshness });
 		}
 
 		// Remaining actions need a file or files list.
@@ -526,6 +599,8 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			const raw = getContextPack(graph, target, a.symbol, {
 				maxDepth: a.max_depth ?? 2,
 				maxTokens: 4000,
+				includeSource: a.include_source ?? false,
+				directory,
 			});
 			// Normalize absolute paths to workspace-relative (Phase 4 SME caveat).
 			// If the input is already relative (e.g. from a pre-1.2.0 graph fallback
@@ -556,9 +631,14 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				spans: cappedSpans,
 				truncated,
 				estimatedTokens: raw.estimatedTokens,
+				budget: {
+					returned: cappedSpans.length,
+					dropped: Math.max(0, normalizedSpans.length - cappedSpans.length),
+				},
 				...freshness,
 				schemaSupported: raw.schemaSupported,
 				...(raw.note ? { note: raw.note } : {}),
+				...(raw.sourceIncluded ? { sourceIncluded: true } : {}),
 			});
 		}
 

--- a/tests/unit/tools/repo-graph-ask-integration.test.ts
+++ b/tests/unit/tools/repo-graph-ask-integration.test.ts
@@ -1,0 +1,132 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { askGraph, type RepoGraph } from '../../../src/tools/repo-graph';
+import { buildWorkspaceGraphAsync } from '../../../src/tools/repo-graph/builder';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tempDir: string;
+let graph: RepoGraph;
+
+beforeAll(async () => {
+	tempDir = canonicalMkdtemp('ask-integ-');
+
+	const src = path.join(tempDir, 'src');
+	fs.mkdirSync(src, { recursive: true });
+
+	fs.writeFileSync(
+		path.join(src, 'types.ts'),
+		[
+			'export interface Config { name: string; }',
+			'export interface Result { ok: boolean; }',
+			'export type Status = "idle" | "running";',
+		].join('\n'),
+	);
+
+	fs.writeFileSync(
+		path.join(src, 'storage.ts'),
+		[
+			"import { Config } from './types';",
+			'export function saveConfig(c: Config) { return JSON.stringify(c); }',
+			'export function loadConfig(s: string): Config { return JSON.parse(s); }',
+		].join('\n'),
+	);
+
+	fs.writeFileSync(
+		path.join(src, 'cache.ts'),
+		[
+			"import { Config } from './types';",
+			'const _cache = new Map<string, Config>();',
+			'export function getCached(key: string) { return _cache.get(key); }',
+			'export function setCached(key: string, v: Config) { _cache.set(key, v); }',
+		].join('\n'),
+	);
+
+	fs.writeFileSync(
+		path.join(src, 'builder.ts'),
+		[
+			"import { saveConfig } from './storage';",
+			"import { Config } from './types';",
+			'export function buildConfig(name: string): Config { return { name }; }',
+			'export function persistConfig(name: string) { return saveConfig(buildConfig(name)); }',
+		].join('\n'),
+	);
+
+	fs.writeFileSync(
+		path.join(src, 'validator.ts'),
+		[
+			"import { Result } from './types';",
+			'export function validate(input: string): Result { return { ok: input.length > 0 }; }',
+		].join('\n'),
+	);
+
+	graph = await buildWorkspaceGraphAsync(tempDir, { walkBudgetMs: 10000 });
+}, 30000);
+
+afterEach(() => {});
+
+// Clean up after all tests
+afterAll(() => {
+	if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('askGraph integration with real graph', () => {
+	test('graph has expected nodes', () => {
+		const moduleNames = Object.values(graph.nodes).map((n) => n.moduleName);
+		expect(moduleNames.length).toBeGreaterThanOrEqual(5);
+	});
+
+	test('discriminates: "cache" ranks cache.ts first', () => {
+		const result = askGraph(graph, 'cache');
+		expect(result.hits.length).toBeGreaterThan(0);
+		expect(result.hits[0].file).toContain('cache');
+	});
+
+	test('discriminates: "validate" ranks validator.ts first', () => {
+		const result = askGraph(graph, 'validate');
+		expect(result.hits.length).toBeGreaterThan(0);
+		expect(result.hits[0].file).toContain('validator');
+	});
+
+	test('discriminates: "storage" ranks storage.ts in top 2', () => {
+		const result = askGraph(graph, 'storage saveConfig');
+		const top2 = result.hits.slice(0, 2).map((h) => h.file);
+		expect(top2.some((f) => f.includes('storage'))).toBe(true);
+	});
+
+	test('types.ts does not dominate unrelated queries', () => {
+		const cacheResult = askGraph(graph, 'cache getCached');
+		const builderResult = askGraph(graph, 'persistConfig builder');
+		expect(cacheResult.hits[0].file).not.toContain('types');
+		expect(builderResult.hits[0].file).not.toContain('types');
+	});
+
+	test('budget counts are coherent', () => {
+		const result = askGraph(graph, 'config', { topN: 2 });
+		expect(result.budget.requested).toBe(2);
+		expect(result.budget.returned).toBeLessThanOrEqual(2);
+		expect(result.budget.returned + result.budget.dropped).toBeLessThanOrEqual(
+			Object.keys(graph.nodes).length,
+		);
+	});
+
+	test('expandedTerms reflect real vocabulary', () => {
+		const result = askGraph(graph, 'buildConfig persistConfig');
+		expect(result.expandedTerms.length).toBeGreaterThan(0);
+	});
+
+	test('hits include community from real ontology', () => {
+		const result = askGraph(graph, 'storage');
+		for (const hit of result.hits) {
+			expect(typeof hit.community).toBe('string');
+			expect(hit.community.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/tests/unit/tools/repo-graph-ask.test.ts
+++ b/tests/unit/tools/repo-graph-ask.test.ts
@@ -210,9 +210,9 @@ describe('askGraph', () => {
 		const testIdx = result.hits.findIndex(
 			(h) => h.file === 'tests/storage.test.ts',
 		);
-		if (testIdx >= 0) {
-			expect(storageIdx).toBeLessThan(testIdx);
-		}
+		expect(storageIdx).toBeGreaterThanOrEqual(0);
+		expect(testIdx).toBeGreaterThanOrEqual(0);
+		expect(storageIdx).toBeLessThan(testIdx);
 	});
 
 	test('empty question returns empty hits', () => {
@@ -230,9 +230,8 @@ describe('askGraph', () => {
 		const result = askGraph(graph, 'types graph node', { topN: 2 });
 		expect(result.budget.requested).toBe(2);
 		expect(result.budget.returned).toBeLessThanOrEqual(2);
-		if (result.budget.returned === 2) {
-			expect(result.budget.dropped).toBeGreaterThanOrEqual(0);
-		}
+		expect(result.budget.returned).toBeGreaterThan(0);
+		expect(result.budget.dropped).toBeGreaterThan(0);
 	});
 
 	test('top_n is clamped to 25', () => {
@@ -252,6 +251,30 @@ describe('askGraph', () => {
 	test('expandedTerms populated', () => {
 		const result = askGraph(graph, 'saveGraph builder');
 		expect(result.expandedTerms.length).toBeGreaterThan(0);
+	});
+
+	test('path segments are searchable (directory names enter vocab)', () => {
+		const dirGraph = makeGraph([
+			{
+				key: '/workspace/src/agents/runner.ts',
+				moduleName: 'src/agents/runner.ts',
+				exports: ['start', 'stop'],
+				roles: ['agent'],
+			},
+			{
+				key: '/workspace/src/utils/math.ts',
+				moduleName: 'src/utils/math.ts',
+				exports: ['sum'],
+			},
+		]);
+		// Plural query matches path segment directly
+		const plural = askGraph(dirGraph, 'agents');
+		expect(plural.hits.length).toBeGreaterThan(0);
+		expect(plural.hits[0].file).toBe('src/agents/runner.ts');
+		// Singular role "agent" also matches via substring in moduleName
+		const singular = askGraph(dirGraph, 'agent');
+		expect(singular.hits.length).toBeGreaterThan(0);
+		expect(singular.hits[0].file).toBe('src/agents/runner.ts');
 	});
 
 	test('asset edges excluded from adjacency', () => {

--- a/tests/unit/tools/repo-graph-ask.test.ts
+++ b/tests/unit/tools/repo-graph-ask.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	_askInternals,
+	askGraph,
+	type RepoGraph,
+} from '../../../src/tools/repo-graph';
+
+const {
+	tokenize,
+	splitCompound,
+	expandTerms,
+	buildVocabulary,
+	personalizedPageRank,
+	buildUndirectedAdjacency,
+} = _askInternals;
+
+function makeGraph(
+	nodeSpecs: {
+		key: string;
+		moduleName: string;
+		exports?: string[];
+		imports?: string[];
+		roles?: string[];
+		boundary?: string;
+	}[],
+	edges: { source: string; target: string }[] = [],
+): RepoGraph {
+	const nodes: Record<string, any> = {};
+	for (const spec of nodeSpecs) {
+		nodes[spec.key] = {
+			filePath: spec.key,
+			moduleName: spec.moduleName,
+			exports: spec.exports ?? [],
+			imports: spec.imports ?? [],
+			language: 'typescript',
+			mtime: '2024-01-01T00:00:00Z',
+			ontology: {
+				roles: spec.roles ?? ['source_module'],
+				routes: [],
+				dataOperations: [],
+				findings: [],
+				security: [],
+				conventions: [],
+				packageBoundary: spec.boundary,
+			},
+		};
+	}
+	return {
+		schema_version: '1.4.0',
+		workspaceRoot: '/workspace',
+		nodes,
+		edges: edges.map((e) => ({
+			source: e.source,
+			target: e.target,
+			importSpecifier: './target',
+			importType: 'static' as const,
+		})),
+		metadata: {
+			generatedAt: '2024-01-01T00:00:00Z',
+			generator: 'test',
+			nodeCount: nodeSpecs.length,
+			edgeCount: edges.length,
+		},
+	};
+}
+
+describe('tokenize', () => {
+	test('splits and lowercases', () => {
+		const tokens = tokenize('Where is the GraphBuilder stored');
+		expect(tokens).toContain('where');
+		expect(tokens).toContain('graph');
+		expect(tokens).toContain('builder');
+		expect(tokens).toContain('graphbuilder');
+		expect(tokens).toContain('stored');
+	});
+
+	test('splits snake_case', () => {
+		const tokens = tokenize('find_user_by_id');
+		expect(tokens).toContain('find');
+		expect(tokens).toContain('user');
+	});
+});
+
+describe('splitCompound', () => {
+	test('camelCase', () => {
+		expect(splitCompound('getKeyFiles')).toContain('get');
+		expect(splitCompound('getKeyFiles')).toContain('Key');
+		expect(splitCompound('getKeyFiles')).toContain('Files');
+	});
+
+	test('snake_case', () => {
+		expect(splitCompound('get_key_files')).toContain('get');
+		expect(splitCompound('get_key_files')).toContain('key');
+		expect(splitCompound('get_key_files')).toContain('files');
+	});
+});
+
+describe('expandTerms', () => {
+	test('filters to vocabulary', () => {
+		const vocab = new Set(['storage', 'graph', 'builder', 'cache']);
+		const result = expandTerms(['storage', 'nosuch', 'graph'], vocab);
+		expect(result).toContain('storage');
+		expect(result).toContain('graph');
+		expect(result).not.toContain('nosuch');
+	});
+});
+
+describe('personalizedPageRank', () => {
+	test('converges on a small graph', () => {
+		const keys = ['a', 'b', 'c'];
+		const adj = new Map<string, Set<string>>([
+			['a', new Set(['b'])],
+			['b', new Set(['a', 'c'])],
+			['c', new Set(['b'])],
+		]);
+		const restart = new Map([
+			['a', 1],
+			['b', 0],
+			['c', 0],
+		]);
+		const scores = personalizedPageRank(adj, restart, keys);
+		expect(scores.get('a')!).toBeGreaterThan(scores.get('c')!);
+	});
+});
+
+describe('askGraph', () => {
+	const graph = makeGraph(
+		[
+			{
+				key: '/workspace/src/storage.ts',
+				moduleName: 'src/storage.ts',
+				exports: ['saveGraph', 'loadGraph'],
+				imports: ['./types'],
+				boundary: 'src/tools/repo-graph',
+			},
+			{
+				key: '/workspace/src/builder.ts',
+				moduleName: 'src/builder.ts',
+				exports: ['buildWorkspaceGraph', 'isAssetEdge'],
+				imports: ['./storage', './types'],
+				boundary: 'src/tools/repo-graph',
+			},
+			{
+				key: '/workspace/src/types.ts',
+				moduleName: 'src/types.ts',
+				exports: ['RepoGraph', 'GraphNode', 'GraphEdge'],
+				imports: [],
+				boundary: 'src/tools/repo-graph',
+			},
+			{
+				key: '/workspace/src/cache.ts',
+				moduleName: 'src/cache.ts',
+				exports: ['getCachedGraph', 'setCachedGraph'],
+				imports: ['./types'],
+				boundary: 'src/tools/repo-graph',
+			},
+			{
+				key: '/workspace/tests/storage.test.ts',
+				moduleName: 'tests/storage.test.ts',
+				exports: [],
+				imports: ['../src/storage'],
+				roles: ['test_file'],
+			},
+		],
+		[
+			{
+				source: '/workspace/src/builder.ts',
+				target: '/workspace/src/storage.ts',
+			},
+			{
+				source: '/workspace/src/builder.ts',
+				target: '/workspace/src/types.ts',
+			},
+			{
+				source: '/workspace/src/storage.ts',
+				target: '/workspace/src/types.ts',
+			},
+			{ source: '/workspace/src/cache.ts', target: '/workspace/src/types.ts' },
+			{
+				source: '/workspace/tests/storage.test.ts',
+				target: '/workspace/src/storage.ts',
+			},
+		],
+	);
+
+	test('determinism: same graph same output', () => {
+		const a = askGraph(graph, 'where is the graph saved atomically');
+		const b = askGraph(graph, 'where is the graph saved atomically');
+		expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+	});
+
+	test('ranks storage.ts in top 3 for save question', () => {
+		const result = askGraph(graph, 'where is the graph saved');
+		expect(result.hits.length).toBeGreaterThan(0);
+		const top3 = result.hits.slice(0, 3).map((h) => h.file);
+		expect(top3).toContain('src/storage.ts');
+	});
+
+	test('rare term outranks common term (IDF)', () => {
+		const result = askGraph(graph, 'isAssetEdge');
+		expect(result.hits.length).toBeGreaterThan(0);
+		expect(result.hits[0].file).toBe('src/builder.ts');
+	});
+
+	test('test files are de-ranked', () => {
+		const result = askGraph(graph, 'storage');
+		const storageIdx = result.hits.findIndex(
+			(h) => h.file === 'src/storage.ts',
+		);
+		const testIdx = result.hits.findIndex(
+			(h) => h.file === 'tests/storage.test.ts',
+		);
+		if (testIdx >= 0) {
+			expect(storageIdx).toBeLessThan(testIdx);
+		}
+	});
+
+	test('empty question returns empty hits', () => {
+		const result = askGraph(graph, '');
+		expect(result.hits).toEqual([]);
+		expect(result.budget.returned).toBe(0);
+	});
+
+	test('no-match question returns empty hits', () => {
+		const result = askGraph(graph, 'xyzzy frobnicator');
+		expect(result.hits).toEqual([]);
+	});
+
+	test('budget counts are correct', () => {
+		const result = askGraph(graph, 'types graph node', { topN: 2 });
+		expect(result.budget.requested).toBe(2);
+		expect(result.budget.returned).toBeLessThanOrEqual(2);
+		if (result.budget.returned === 2) {
+			expect(result.budget.dropped).toBeGreaterThanOrEqual(0);
+		}
+	});
+
+	test('top_n is clamped to 25', () => {
+		const result = askGraph(graph, 'graph', { topN: 100 });
+		expect(result.budget.requested).toBe(25);
+	});
+
+	test('hits include community and role', () => {
+		const result = askGraph(graph, 'storage');
+		for (const hit of result.hits) {
+			expect(typeof hit.community).toBe('string');
+			expect(typeof hit.role).toBe('string');
+			expect(hit.community.length).toBeGreaterThan(0);
+		}
+	});
+
+	test('expandedTerms populated', () => {
+		const result = askGraph(graph, 'saveGraph builder');
+		expect(result.expandedTerms.length).toBeGreaterThan(0);
+	});
+
+	test('asset edges excluded from adjacency', () => {
+		const assetGraph = makeGraph(
+			[
+				{
+					key: '/workspace/src/app.ts',
+					moduleName: 'src/app.ts',
+					exports: ['App'],
+				},
+				{
+					key: '/workspace/src/data.json',
+					moduleName: 'src/data.json',
+					exports: [],
+				},
+			],
+			[{ source: '/workspace/src/app.ts', target: '/workspace/src/data.json' }],
+		);
+		(assetGraph.edges[0] as any).targetKind = 'asset';
+		const keys = Object.keys(assetGraph.nodes).sort();
+		const adj = buildUndirectedAdjacency(assetGraph, keys);
+		expect(adj.get('/workspace/src/app.ts')!.size).toBe(0);
+	});
+});

--- a/tests/unit/tools/repo-graph-context-pack-source.test.ts
+++ b/tests/unit/tools/repo-graph-context-pack-source.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	getContextPack,
+	normalizeGraphPath,
+	type RepoGraph,
+} from '../../../src/tools/repo-graph';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = canonicalMkdtemp('cp-src-');
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function makeGraph(opts: {
+	files: {
+		moduleName: string;
+		exports: string[];
+		exportRanges?: Record<string, { startLine: number; endLine: number }>;
+	}[];
+	symbolEdges?: {
+		fromFile: string;
+		fromSymbol: string;
+		toFile: string;
+		toSymbol: string;
+	}[];
+}): RepoGraph {
+	const nodes: Record<string, any> = {};
+	for (const f of opts.files) {
+		const absPath = normalizeGraphPath(path.resolve(tempDir, f.moduleName));
+		nodes[absPath] = {
+			filePath: absPath,
+			moduleName: f.moduleName,
+			exports: f.exports,
+			exportRanges: f.exportRanges,
+			imports: [],
+			language: 'typescript',
+			mtime: '2024-01-01T00:00:00Z',
+		};
+	}
+	const symbolEdges = (opts.symbolEdges ?? []).map((e) => ({
+		...e,
+		fromFile: normalizeGraphPath(path.resolve(tempDir, e.fromFile)),
+		toFile: normalizeGraphPath(path.resolve(tempDir, e.toFile)),
+	}));
+	return {
+		schema_version: '1.4.0',
+		workspaceRoot: tempDir,
+		nodes,
+		edges: [],
+		metadata: {
+			generatedAt: '2024-01-01T00:00:00Z',
+			generator: 'test',
+			nodeCount: opts.files.length,
+			edgeCount: 0,
+		},
+		symbolEdges,
+	};
+}
+
+describe('getContextPack include_source', () => {
+	test('default false: spans have no text field', () => {
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/util.ts',
+					exports: ['add'],
+					exportRanges: { add: { startLine: 1, endLine: 3 } },
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/util.ts', 'add');
+		expect(result.spans.length).toBeGreaterThan(0);
+		expect(result.spans[0].text).toBeUndefined();
+		expect(result.sourceIncluded).toBeUndefined();
+	});
+
+	test('include_source embeds text from file', () => {
+		const filePath = path.join(tempDir, 'src', 'util.ts');
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		fs.writeFileSync(
+			filePath,
+			'export function add(a: number, b: number) {\n  return a + b;\n}\n',
+		);
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/util.ts',
+					exports: ['add'],
+					exportRanges: { add: { startLine: 1, endLine: 3 } },
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/util.ts', 'add', {
+			includeSource: true,
+			directory: tempDir,
+		});
+		expect(result.sourceIncluded).toBe(true);
+		expect(result.spans[0].text).toContain('function add');
+	});
+
+	test('fail-open on unreadable file', () => {
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/missing.ts',
+					exports: ['gone'],
+					exportRanges: { gone: { startLine: 1, endLine: 1 } },
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/missing.ts', 'gone', {
+			includeSource: true,
+			directory: tempDir,
+		});
+		expect(result.spans[0].text).toBeUndefined();
+		expect(result.spans[0].note).toBe('source read failed');
+	});
+
+	test('source text bounded to 80 lines', () => {
+		const filePath = path.join(tempDir, 'src', 'big.ts');
+		fs.mkdirSync(path.dirname(filePath), { recursive: true });
+		const lines = Array.from({ length: 200 }, (_, i) => `// line ${i + 1}`);
+		fs.writeFileSync(filePath, lines.join('\n'));
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/big.ts',
+					exports: ['big'],
+					exportRanges: { big: { startLine: 1, endLine: 200 } },
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/big.ts', 'big', {
+			includeSource: true,
+			directory: tempDir,
+		});
+		const textLines = result.spans[0].text?.split('\n') ?? [];
+		expect(textLines.length).toBeLessThanOrEqual(80);
+	});
+});
+
+describe('getContextPack internal-symbol fallback', () => {
+	test('non-exported symbol gets signature pointer', () => {
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/util.ts',
+					exports: ['add'],
+					exportRanges: { add: { startLine: 1, endLine: 3 } },
+				},
+				{
+					moduleName: 'src/helper.ts',
+					exports: ['helper'],
+					exportRanges: {},
+				},
+			],
+			symbolEdges: [
+				{
+					fromFile: 'src/util.ts',
+					fromSymbol: 'add',
+					toFile: 'src/helper.ts',
+					toSymbol: 'internalFn',
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/util.ts', 'add', {
+			maxDepth: 2,
+		});
+		const internal = result.spans.find((s) => s.symbol === 'internalFn');
+		expect(internal).toBeDefined();
+		expect(internal!.mode).toBe('signature');
+		expect(internal!.startLine).toBe(1);
+		expect(internal!.note).toBe('internal symbol — span unavailable');
+	});
+
+	test('exported symbol still gets full span', () => {
+		const graph = makeGraph({
+			files: [
+				{
+					moduleName: 'src/util.ts',
+					exports: ['add'],
+					exportRanges: { add: { startLine: 1, endLine: 5 } },
+				},
+			],
+		});
+		const result = getContextPack(graph, 'src/util.ts', 'add');
+		expect(result.spans[0].mode).toBe('full');
+		expect(result.spans[0].note).toBeUndefined();
+		expect(result.spans[0].startLine).toBe(1);
+		expect(result.spans[0].endLine).toBe(5);
+	});
+});

--- a/tests/unit/tools/repo-map-ask.test.ts
+++ b/tests/unit/tools/repo-map-ask.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { repo_map } from '../../../src/tools/repo-map';
+
+let tmp: string;
+
+function call(args: Record<string, unknown>): Promise<string> {
+	type Executable = {
+		execute: (
+			args: Record<string, unknown>,
+			ctx: { directory: string },
+		) => Promise<string>;
+	};
+	return (repo_map as unknown as Executable).execute(args, { directory: tmp });
+}
+
+beforeEach(() => {
+	tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-map-ask-'));
+	const src = path.join(tmp, 'src');
+	fs.mkdirSync(src, { recursive: true });
+	fs.writeFileSync(
+		path.join(src, 'util.ts'),
+		[
+			'export function add(a: number, b: number) { return a + b; }',
+			"import { helper } from './helper';",
+		].join('\n'),
+	);
+	fs.writeFileSync(
+		path.join(src, 'helper.ts'),
+		'export function helper() { return 1; }',
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('repo_map: ask', () => {
+	it('requires question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('requires `question`');
+	});
+
+	it('rejects control-char question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'hello\x00world' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('control characters');
+	});
+
+	it('returns hits after build', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'add util' });
+		const r = JSON.parse(out) as {
+			success: boolean;
+			hits: Array<{ file: string; score: number }>;
+			budget: { requested: number; returned: number; dropped: number };
+		};
+		expect(r.success).toBe(true);
+		expect(r.hits.length).toBeGreaterThan(0);
+		expect(r.budget.returned).toBeGreaterThan(0);
+	});
+
+	it('rejects whitespace-only question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: '   \t  ' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('question is empty');
+	});
+
+	it('rejects question exceeding max length', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'x'.repeat(501) });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('exceeds maximum length');
+	});
+
+	it('accepts question at exactly the max length boundary', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'x'.repeat(500) });
+		const r = JSON.parse(out) as { success: boolean };
+		expect(r.success).toBe(true);
+	});
+});

--- a/tests/unit/tools/repo-map-ask.test.ts
+++ b/tests/unit/tools/repo-map-ask.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { repo_map } from '../../../src/tools/repo-map';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 let tmp: string;
 
@@ -17,7 +17,7 @@ function call(args: Record<string, unknown>): Promise<string> {
 }
 
 beforeEach(() => {
-	tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-map-ask-'));
+	tmp = canonicalMkdtemp('repo-map-ask-');
 	const src = path.join(tmp, 'src');
 	fs.mkdirSync(src, { recursive: true });
 	fs.writeFileSync(

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -454,60 +454,6 @@ describe('repo_map: validation', () => {
 	});
 });
 
-describe('repo_map: ask', () => {
-	it('requires question', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask' });
-		const r = JSON.parse(out) as { success: boolean; error: string };
-		expect(r.success).toBe(false);
-		expect(r.error).toContain('requires `question`');
-	});
-
-	it('rejects control-char question', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask', question: 'hello\x00world' });
-		const r = JSON.parse(out) as { success: boolean; error: string };
-		expect(r.success).toBe(false);
-		expect(r.error).toContain('control characters');
-	});
-
-	it('returns hits after build', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask', question: 'add util' });
-		const r = JSON.parse(out) as {
-			success: boolean;
-			hits: Array<{ file: string; score: number }>;
-			budget: { requested: number; returned: number; dropped: number };
-		};
-		expect(r.success).toBe(true);
-		expect(r.hits.length).toBeGreaterThan(0);
-		expect(r.budget.returned).toBeGreaterThan(0);
-	});
-
-	it('rejects whitespace-only question', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask', question: '   \t  ' });
-		const r = JSON.parse(out) as { success: boolean; error: string };
-		expect(r.success).toBe(false);
-		expect(r.error).toContain('question is empty');
-	});
-
-	it('rejects question exceeding max length', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask', question: 'x'.repeat(501) });
-		const r = JSON.parse(out) as { success: boolean; error: string };
-		expect(r.success).toBe(false);
-		expect(r.error).toContain('exceeds maximum length');
-	});
-
-	it('accepts question at exactly the max length boundary', async () => {
-		await call({ action: 'build' });
-		const out = await call({ action: 'ask', question: 'x'.repeat(500) });
-		const r = JSON.parse(out) as { success: boolean };
-		expect(r.success).toBe(true);
-	});
-});
-
 describe('repo_map: callers / dead_exports', () => {
 	it('callers reports files that reference an exported symbol', async () => {
 		await call({ action: 'build' });

--- a/tests/unit/tools/repo-map.test.ts
+++ b/tests/unit/tools/repo-map.test.ts
@@ -454,6 +454,60 @@ describe('repo_map: validation', () => {
 	});
 });
 
+describe('repo_map: ask', () => {
+	it('requires question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('requires `question`');
+	});
+
+	it('rejects control-char question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'hello\x00world' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('control characters');
+	});
+
+	it('returns hits after build', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'add util' });
+		const r = JSON.parse(out) as {
+			success: boolean;
+			hits: Array<{ file: string; score: number }>;
+			budget: { requested: number; returned: number; dropped: number };
+		};
+		expect(r.success).toBe(true);
+		expect(r.hits.length).toBeGreaterThan(0);
+		expect(r.budget.returned).toBeGreaterThan(0);
+	});
+
+	it('rejects whitespace-only question', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: '   \t  ' });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('question is empty');
+	});
+
+	it('rejects question exceeding max length', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'x'.repeat(501) });
+		const r = JSON.parse(out) as { success: boolean; error: string };
+		expect(r.success).toBe(false);
+		expect(r.error).toContain('exceeds maximum length');
+	});
+
+	it('accepts question at exactly the max length boundary', async () => {
+		await call({ action: 'build' });
+		const out = await call({ action: 'ask', question: 'x'.repeat(500) });
+		const r = JSON.parse(out) as { success: boolean };
+		expect(r.success).toBe(true);
+	});
+});
+
 describe('repo_map: callers / dead_exports', () => {
 	it('callers reports files that reference an exported symbol', async () => {
 		await call({ action: 'build' });


### PR DESCRIPTION
Closes #1987

## Summary

- New `repo_map action="ask"` for zero-LLM file localization: vocabulary expansion, IDF-weighted lexical seeding, personalized PageRank over the file-level dependency graph, ranked file output with matched terms and budget metadata.
- `context_pack` gains `include_source` option to embed source text in spans (default false, 80-line cap, fail-open on read errors), and no longer silently drops BFS-reached symbols without `exportRanges` â€” they now emit a file-level signature pointer with a note.
- `key_files` and `package_boundaries` responses include `community` (inferred package boundary) and normalized `hubScore` (0-1).
- All list-returning actions (`key_files`, `package_boundaries`, `dead_exports`, `context_pack`, `ask`) include `budget: { returned, dropped? }` for truncation visibility.
- Input validation: `question` arg validated with 500-char cap and control-char rejection, matching existing `validateFile`/`validateSymbol` patterns.
- PageRank dangling-node optimization: O(n) per iteration via scalar mass accumulation (was O(dangling x n)).
- Score rounding before sort for cross-build determinism.

## Invariant audit

- 1 (plugin init): not touched - no changes to plugin initialization or manifest loading
- 2 (runtime portability): not touched - no `bun:` imports in production code, no `Bun.*` calls
- 3 (subprocesses): not touched - no subprocess spawn calls added
- 4 (.swarm containment): not touched - no `.swarm/` writes or `process.cwd()` in tools
- 5 (plan durability): not touched - no plan schema or ledger changes
- 6 (test_runner safety): not touched - no `test_runner` tool usage
- 7 (test writing): touched - 3 new test files (31 tests total) using `bun:test`, `_internals` DI seams, no `mock.module`, `mkdtempSync` with `realpathSync`, all under 500-line cap
- 8 (session state): not touched - no session-scoped or global state changes
- 9 (guardrails/retry): not touched - no guardrail or retry logic changes
- 10 (chat/system msg): not touched - no message shape changes
- 11 (tool registration): touched - `ask` added to `VALID_ACTIONS`, zod `.enum()`, tool description, `RepoMapArgs` interface; `askGraph` + types barrel-exported; `inferPackageBoundary` added to value re-exports; `scripts/check-tool-registration.ts`: 116 tools, coherent
- 12 (release/cache): not touched - release fragment added at `docs/releases/pending/1987-repo-map-ask-context-pack.md`; no manual version/CHANGELOG edits

## Test plan

- [x] `bun run typecheck`: clean
- [x] `bun run lint:ci`: clean (biome 2.3.14)
- [x] `bun run scripts/check-tool-registration.ts`: 116 tools, coherent
- [x] `bash scripts/check-invariants.sh`: pass
- [x] `bash scripts/check-cross-contamination.sh`: pass (pre-existing warnings, non-blocking)
- [x] `bun test tests/unit/tools/repo-graph*.test.ts tests/unit/tools/repo-map.test.ts`: 454 pass, 0 fail
- [x] `bash scripts/check-test-file-cap.sh`: clean
- [x] `bash .opencode/skills/issue-tracer/scripts/scan-deferred.sh`: clean
- [x] `bun run build && node --input-type=module -e "await import('./dist/index.js')"`: dist import OK
- [x] Independent critic review: all 3 blockers resolved (B1: tests exist, B2: question validation added, B3: dangling-node O(n) optimization)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

