### PR TITLE
fix(compaction): close residual feedback gaps from #2154 review

### DIFF
--- a/docs/releases/pending/2109-advertised-contract-recovery.md
+++ b/docs/releases/pending/2109-advertised-contract-recovery.md
@@ -17,3 +17,12 @@ issue: 2109
   dialogue, not a key under the YAML `qa_gates` object (which is the unrelated
   guardrails config), and added a ratchet test proving `critic_pre_plan` cannot be
   silently turned off once enabled.
+- Fixed a residual contract gap: the compaction hook now extracts the full task list
+  before stripping end-of-line ` ← CURRENT` markers, eliminating partial-marker
+  truncation; previously the marker could be cut mid-token when the list exceeded the
+  extraction budget.
+- Fixed ordering in missing-agent recovery guidance: the easy-fix dispatch hint now
+  appears before the last-resort warn-policy suggestion; a test asserts the ordering
+  invariant.
+- Added test coverage for the warn-policy recovery path and hardened both test suites
+  against ambient user config leakage via `XDG_CONFIG_HOME` isolation.

--- a/src/hooks/compaction-customizer.ts
+++ b/src/hooks/compaction-customizer.ts
@@ -24,6 +24,12 @@ const COMPACTION_FACTS_OPEN = '<swarm_compaction_facts>';
 const COMPACTION_FACTS_CLOSE = '</swarm_compaction_facts>';
 const MAX_COMPACTION_FACT_CHARS = 2_000;
 const MAX_COMPACTION_CONTEXT_CHARS = 8_000;
+// Budget passed to task extractors before stripping action markers. Using
+// Number.MAX_SAFE_INTEGER means the extractor never truncates, so the
+// ← CURRENT marker is always complete when stripTaskActionMarkers runs.
+// truncateFact in buildCompactionFactsBlock then bounds the result to
+// MAX_COMPACTION_FACT_CHARS. This eliminates all partial-marker truncation.
+const TASK_EXTRACT_PRE_STRIP_CHARS = Number.MAX_SAFE_INTEGER;
 const MAX_STORED_OUTPUTS_TO_COUNT = 256;
 const TRUNCATION_MARKER = '\n[truncated]';
 const SUMMARY_ONLY_HEADER =
@@ -39,9 +45,17 @@ const SUMMARY_ONLY_FOOTER =
  * (`- [ ] <id>: ... ← CURRENT`), and the legacy `extractIncompleteTasks` path
  * relays it verbatim whenever plan.md was derived from or hand-written in the
  * canonical ` ← CURRENT` format, so the strip is applied to both paths.
+ *
+ * Callers must pass TASK_EXTRACT_PRE_STRIP_CHARS to the extractor so the full
+ * marker always fits before this function runs. `(?:\.\.\.)?` is defense-in-depth
+ * for hand-authored plan.md lines that end with `← CURRENT...` — the programmatic
+ * extractor never appends `...` when TASK_EXTRACT_PRE_STRIP_CHARS is MAX_SAFE_INTEGER.
+ *
+ * Uses `[^\S\r\n]*` (horizontal whitespace only) to avoid O(n²) regex backtracking
+ * across line boundaries that `\s*` would cause on large inputs.
  */
 function stripTaskActionMarkers(value: string): string {
-	return value.replace(/\s*←\s*CURRENT\s*$/gm, '');
+	return value.replace(/[^\S\r\n]*←[^\S\r\n]*CURRENT[^\S\r\n]*(?:\.\.\.)?[^\S\r\n]*$/gm, '');
 }
 
 interface CompactionFact {
@@ -135,10 +149,16 @@ function buildCompactionFactsBlock(facts: CompactionFact[]): string {
 		const sectionPrefix = `\n[${fact.label}]\n`;
 		if (remaining <= sectionPrefix.length) break;
 
-		const escaped = escapeCompactionBoundary(fact.value);
 		const valueBudget = Math.min(
 			MAX_COMPACTION_FACT_CHARS,
 			remaining - sectionPrefix.length,
+		);
+		// Slice before escape: escapeCompactionBoundary is O(n) but its regex
+		// can scan large strings when fact.value is unbounded. The escape is
+		// length-preserving, so slicing to valueBudget + TRUNCATION_MARKER.length
+		// gives truncateFact enough room to append the marker correctly.
+		const escaped = escapeCompactionBoundary(
+			fact.value.slice(0, valueBudget + TRUNCATION_MARKER.length),
 		);
 		const boundedValue = truncateFact(escaped, valueBudget);
 		sections.push(`${sectionPrefix}${boundedValue}`);
@@ -182,7 +202,7 @@ export function createCompactionCustomizerHook(
 					}
 					const incompleteTasks = extractIncompleteTasksFromPlan(
 						plan,
-						MAX_COMPACTION_FACT_CHARS,
+						TASK_EXTRACT_PRE_STRIP_CHARS,
 					);
 					if (incompleteTasks) {
 						facts.push({
@@ -200,7 +220,7 @@ export function createCompactionCustomizerHook(
 						}
 						const incompleteTasks = extractIncompleteTasks(
 							planContent,
-							MAX_COMPACTION_FACT_CHARS,
+							TASK_EXTRACT_PRE_STRIP_CHARS,
 						);
 						if (incompleteTasks) {
 							facts.push({

--- a/src/hooks/compaction-customizer.ts
+++ b/src/hooks/compaction-customizer.ts
@@ -55,7 +55,10 @@ const SUMMARY_ONLY_FOOTER =
  * across line boundaries that `\s*` would cause on large inputs.
  */
 function stripTaskActionMarkers(value: string): string {
-	return value.replace(/[^\S\r\n]*←[^\S\r\n]*CURRENT[^\S\r\n]*(?:\.\.\.)?[^\S\r\n]*$/gm, '');
+	return value.replace(
+		/[^\S\r\n]*←[^\S\r\n]*CURRENT[^\S\r\n]*(?:\.\.\.)?[^\S\r\n]*$/gm,
+		'',
+	);
 }
 
 interface CompactionFact {

--- a/src/tools/phase-complete.ts
+++ b/src/tools/phase-complete.ts
@@ -191,6 +191,14 @@ function buildMissingAgentRecoveryGuidance(input: {
 			'The docs-participation projection needs operator repair or archival before a re-dispatch can persist new proof.',
 		);
 	}
+	if (
+		input.missing.includes('docs') &&
+		input.docsEvidenceStatus === 'missing'
+	) {
+		steps.push(
+			'No prior durable docs-participation receipt was found (this can happen after a plugin upgrade or a cleared evidence store). A fresh docs Task dispatch writes a new durable completion receipt and is the canonical recovery path.',
+		);
+	}
 	if (input.policy === 'warn') {
 		steps.push(
 			'The configured warn policy allows closure with a warning, but it does not create participation proof.',
@@ -198,14 +206,6 @@ function buildMissingAgentRecoveryGuidance(input: {
 	} else {
 		steps.push(
 			'Last resort: if the missing role obligation genuinely cannot be satisfied in this environment, set phase_complete.policy to "warn" in opencode-swarm configuration. This weakens enforcement for every missing role and does NOT create durable participation proof, so only use it when the obligation cannot be met.',
-		);
-	}
-	if (
-		input.missing.includes('docs') &&
-		input.docsEvidenceStatus === 'missing'
-	) {
-		steps.push(
-			'No prior durable docs-participation receipt was found (this can happen after a plugin upgrade or a cleared evidence store). A fresh docs Task dispatch writes a new durable completion receipt and is the canonical recovery path.',
 		);
 	}
 	return steps.join(' ');

--- a/tests/unit/hooks/compaction-customizer-summary-safety.test.ts
+++ b/tests/unit/hooks/compaction-customizer-summary-safety.test.ts
@@ -166,6 +166,13 @@ describe('compaction summary pending-task facts are directive-free (#2109)', () 
 				'- [ ] 1.2: Add config [SMALL]\n- [ ] 1.1: Implement [MEDIUM] ← CURRENT',
 			),
 		).toBe('- [ ] 1.2: Add config [SMALL]\n- [ ] 1.1: Implement [MEDIUM]');
+		// Extractor truncation suffix appended after the marker is also stripped
+		// (occurs when the task list is truncated at exactly the ← CURRENT boundary).
+		expect(
+			_test_exports.stripTaskActionMarkers(
+				'- [ ] 1.1: Implement feature [MEDIUM] ← CURRENT...',
+			),
+		).toBe('- [ ] 1.1: Implement feature [MEDIUM]');
 	});
 
 	it('injects pending [SWARM TASKS] facts without the action affordance in the tool-disabled turn', async () => {

--- a/tests/unit/tools/phase-complete-docs-participation-recovery.test.ts
+++ b/tests/unit/tools/phase-complete-docs-participation-recovery.test.ts
@@ -90,9 +90,14 @@ function writeFixture(directory: string): Plan {
 describe('phase_complete docs participation recovery', () => {
 	let directory: string;
 	let cleanup: () => void;
+	let savedXdgConfigHome: string | undefined;
 
 	beforeEach(() => {
 		({ dir: directory, cleanup } = createSafeTestDir('phase-complete-docs-'));
+		// Prevent the user's global opencode config from being merged into the
+		// fixture — same rationale as the warn-policy describe block below.
+		savedXdgConfigHome = process.env.XDG_CONFIG_HOME;
+		process.env.XDG_CONFIG_HOME = directory;
 		writeFixture(directory);
 		resetSwarmState();
 		resetPhaseParticipationForTests();
@@ -101,6 +106,11 @@ describe('phase_complete docs participation recovery', () => {
 	afterEach(() => {
 		resetSwarmState();
 		resetPhaseParticipationForTests();
+		if (savedXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = savedXdgConfigHome;
+		}
 		cleanup();
 	});
 
@@ -259,5 +269,117 @@ describe('phase_complete docs participation recovery', () => {
 		expect(result.recovery_guidance).toContain(
 			'does NOT create durable participation proof',
 		);
+		// Ordering: easy-fix dispatch hint must precede the nuclear last-resort option.
+		const docsIdx = result.recovery_guidance.indexOf('canonical recovery path');
+		const lastResortIdx = result.recovery_guidance.indexOf('Last resort:');
+		expect(docsIdx).toBeGreaterThan(-1);
+		expect(lastResortIdx).toBeGreaterThan(-1);
+		expect(docsIdx).toBeLessThan(lastResortIdx);
+	});
+});
+
+describe('phase_complete warn-policy recovery guidance', () => {
+	let directory: string;
+	let cleanup: () => void;
+	let savedXdgConfigHome: string | undefined;
+
+	beforeEach(() => {
+		({ dir: directory, cleanup } = createSafeTestDir('phase-complete-warn-'));
+		// Prevent the user's global opencode config from being merged into the
+		// fixture: loadPluginConfig reads XDG_CONFIG_HOME/opencode/CONFIG_FILENAME
+		// as the "user" layer and deep-merges it with the project config. Pointing
+		// XDG_CONFIG_HOME at the (freshly created, otherwise-empty) temp dir
+		// makes that lookup a no-op.
+		savedXdgConfigHome = process.env.XDG_CONFIG_HOME;
+		process.env.XDG_CONFIG_HOME = directory;
+		const swarmDir = path.join(directory, '.swarm');
+		fs.mkdirSync(path.join(directory, '.opencode'), { recursive: true });
+		fs.mkdirSync(swarmDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, '.opencode', 'opencode-swarm.json'),
+			JSON.stringify({
+				phase_complete: {
+					enabled: true,
+					required_agents: ['coder'],
+					require_docs: false,
+					policy: 'warn',
+				},
+				knowledge: { enabled: false },
+				curator: { enabled: false },
+				skill_improver: { enabled: false },
+			}),
+		);
+		const plan = {
+			schema_version: '1.0.0',
+			title: 'Warn Policy Test',
+			swarm: 'test',
+			current_phase: 1,
+			phases: [{ id: 1, name: 'Phase 1', status: 'in_progress', tasks: [] }],
+		};
+		fs.writeFileSync(
+			path.join(swarmDir, 'plan.json'),
+			JSON.stringify(plan, null, 2),
+		);
+		const retroDir = path.join(swarmDir, 'evidence', 'retro-1');
+		fs.mkdirSync(retroDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(retroDir, 'evidence.json'),
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: 'retro-1',
+				created_at: FIXED_EVIDENCE_TIMESTAMP,
+				updated_at: FIXED_EVIDENCE_TIMESTAMP,
+				entries: [
+					{
+						task_id: 'retro-1',
+						type: 'retrospective',
+						timestamp: FIXED_EVIDENCE_TIMESTAMP,
+						agent: 'architect',
+						verdict: 'pass',
+						summary: 'Phase reviewed.',
+						phase_number: 1,
+						total_tool_calls: 1,
+						coder_revisions: 0,
+						reviewer_rejections: 0,
+						test_failures: 0,
+						security_findings: 0,
+						integration_issues: 0,
+						task_count: 1,
+						task_complexity: 'simple',
+						top_rejection_reasons: [],
+						lessons_learned: [],
+					},
+				],
+			}),
+		);
+		resetSwarmState();
+		resetPhaseParticipationForTests();
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		resetPhaseParticipationForTests();
+		if (savedXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = savedXdgConfigHome;
+		}
+		cleanup();
+	});
+
+	test('warn policy names warn-allows-closure in recovery_guidance', async () => {
+		ensureAgentSession('parent');
+		// coder is required but not dispatched — warn policy allows success with a warning
+
+		const result = JSON.parse(
+			await executePhaseComplete(
+				{ phase: 1, sessionID: 'parent' },
+				directory,
+				directory,
+			),
+		) as { success: boolean; recovery_guidance: string };
+
+		expect(result.success).toBe(true);
+		expect(result.recovery_guidance).toContain('warn policy allows closure');
 	});
 });


### PR DESCRIPTION
## Summary

Feedback follow-up for [#2154](https://github.com/ZaxbyHub/opencode-swarm/pull/2154) (now merged into `main`). Closes the three confirmed findings from the swarm-pr-review session on 2026-08-13.

### F-004 — Strip-before-bound (compaction hook)

`extractIncompleteTasksFromPlan` / `extractIncompleteTasks` previously received `MAX_COMPACTION_FACT_CHARS` (2 000) as their extraction budget. When the task list exceeded that budget the `← CURRENT` marker was truncated mid-token, leaving a partial literal that `stripTaskActionMarkers` could not strip. Fix: pass `Number.MAX_SAFE_INTEGER` so the extractor never truncates; `truncateFact` in `buildCompactionFactsBlock` then bounds the output to 2 000 chars.

### Regex hardening (critic Finding 1 from this session)

The `Number.MAX_SAFE_INTEGER` change exposed two latent O(n²) paths:

- `stripTaskActionMarkers`: switched `/\s*←\s*CURRENT\s*$/gm` → `/[^\S\r\n]*←[^\S\r\n]*CURRENT[^\S\r\n]*(?:\.\.\.)?[^\S\r\n]*$/gm` — horizontal-whitespace-only prevents cross-line backtracking while preserving identical strip semantics and the `(?:\.\.\.)?` defense-in-depth arm.
- `escapeCompactionBoundary`: now receives `fact.value.slice(0, valueBudget + TRUNCATION_MARKER.length)` rather than the raw unbounded value, bounding the O(n) scan to at most ~2 012 chars.

### F-003 — Ordering in missing-agent recovery guidance

`buildMissingAgentRecoveryGuidance` in `phase-complete.ts`: docs-dispatch hint (easy fix) now precedes the warn-policy suggestion (last resort). A new ordering assertion in the test suite enforces this.

### Test hardening (F-002)

- `XDG_CONFIG_HOME` isolation added to the first describe block in `phase-complete-docs-participation-recovery.test.ts` (was present only in the second block), preventing ambient user config from leaking into fixtures.
- New `phase_complete warn-policy recovery guidance` describe block covers the warn-allows-closure path end-to-end.

## Invariant audit

- **Never defer work**: all extraction and strip paths are synchronous and awaited in-band. `TASK_EXTRACT_PRE_STRIP_CHARS` is consumed at both extractor call sites (`compaction-customizer.ts:208`, `226`); `stripTaskActionMarkers` runs immediately on the returned string before `buildCompactionFactsBlock` receives it. No fire-and-forget introduced.
- **Never ship unwired code**: `TASK_EXTRACT_PRE_STRIP_CHARS` is module-private and consumed at both call sites (lines 208, 226) — no dead export. The updated regex in `stripTaskActionMarkers` is exercised by the new test case at `compaction-customizer-summary-safety.test.ts:169–175`. The docs-dispatch ordering change is tested by the `docsIdx < lastResortIdx` assertion at `phase-complete-docs-participation-recovery.test.ts:277`. The new warn-policy describe block and XDG isolation are both active test code with assertions, not scaffolding stubs.

## Test plan

- [x] `git diff --check` clean
- [x] `bun run typecheck` passes (0 errors)
- [x] `bun run lint:ci` passes (format + lint, 3 288 files)
- [x] `bun test tests/unit/hooks/compaction-customizer-summary-safety.test.ts` — 15/15 pass
- [x] `bun test tests/unit/tools/phase-complete-docs-participation-recovery.test.ts` — 6/6 pass
- [x] Stage B: fresh reviewer + test-engineer approved (prior session)
- [x] Closeout: fresh reviewer APPROVED, critic APPROVE-WITH-FIXES (critic fixes now applied)

References: #2109, #2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
