### PR TITLE
fix(hooks): strip trailing parenthetical remarks from FILE directives to prevent SCOPE_CONFLICT

### DIFF
--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -1751,7 +1751,9 @@ function extractTaskFileDirectives(args: Record<string, unknown>): {
 		for (const line of field.split(/\r?\n/)) {
 			if (!/^\s*FILE\s*:/i.test(line)) continue;
 			present = true;
-			const value = line.replace(/^\s*FILE\s*:\s*/i, '').trim();
+			let value = line.replace(/^\s*FILE\s*:\s*/i, '').trim();
+			// Strip trailing parenthetical annotations like " (test file)"
+			value = value.replace(/\s+\([^)]+\)$/, '').trim();
 			if (!value || /[,;|]/.test(value)) return { present: true, files: null };
 			files.add(value);
 		}
@@ -2259,6 +2261,7 @@ export const _internals = {
 	resolveEvidenceTaskId,
 	resolveDelegatedPlanTaskId,
 	describeCoderScopeFailure,
+	extractTaskFileDirectives,
 	parsePerTaskVerdicts,
 	buildParallelExecutionGuidance,
 	loadPlanJsonOnly,
@@ -4659,7 +4662,9 @@ export function createDelegationGateHook(
 				const fileDirPattern = /^FILE:\s*(.+)$/gm;
 				const declaredFiles: string[] = [];
 				for (const match of text.matchAll(fileDirPattern)) {
-					const filePath = match[1].trim();
+					let filePath = match[1].trim();
+					// Strip trailing parenthetical annotations like " (test file)"
+					filePath = filePath.replace(/\s+\([^)]+\)$/, '').trim();
 					if (filePath.length > 0 && !declaredFiles.includes(filePath)) {
 						declaredFiles.push(filePath);
 					}

--- a/tests/unit/hooks/delegation-gate.extract-file-directives.test.ts
+++ b/tests/unit/hooks/delegation-gate.extract-file-directives.test.ts
@@ -1,0 +1,25 @@
+import { expect, test, describe } from 'bun:test';
+import { _internals } from '../../../src/hooks/delegation-gate';
+
+describe('extractTaskFileDirectives', () => {
+	test('extracts exact path', () => {
+		const args = { prompt: 'FILE: src/foo.ts' };
+		const result = _internals.extractTaskFileDirectives(args);
+		expect(result.present).toBe(true);
+		expect(result.files).toEqual(['src/foo.ts']);
+	});
+
+	test('strips trailing parenthetical annotations (issue)', () => {
+		const args = { prompt: 'FILE: tests/unit/connection_limit_test.cpp (or another appropriately named test file in tests/unit/)' };
+		const result = _internals.extractTaskFileDirectives(args);
+		expect(result.present).toBe(true);
+		expect(result.files).toEqual(['tests/unit/connection_limit_test.cpp']);
+	});
+
+	test('ignores parentheticals in the middle of paths if that were to happen, but strips at the end', () => {
+		const args = { prompt: 'FILE: src/weird (dir)/file.ts (some comment)' };
+		const result = _internals.extractTaskFileDirectives(args);
+		expect(result.present).toBe(true);
+		expect(result.files).toEqual(['src/weird (dir)/file.ts']);
+	});
+});


### PR DESCRIPTION
Fixes #2176.

## Summary
Modifies `extractTaskFileDirectives` to strictly strip trailing parenthetical remarks from `FILE:` directive values when extracting file paths. Also applies this fix to the telemetry observable parser inside `messagesTransform` to maintain consistency across the codebase.

## Invariant audit
- `FILE:` paths are correctly matched against `declare_scope`.
- `TASK:` and `ACCEPTANCE:` parsers were verified to be structurally immune to trailing annotations.

## Test plan
Added regression tests to `tests/unit/hooks/delegation-gate.extract-file-directives.test.ts`. Verified the whole `tests/unit/hooks` suite passes with no edge cases impacted.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

