### PR TITLE
fix(pr-review): repair benign lane-output shape defects and record degraded coverage instead of aborting

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -947,7 +947,7 @@ build a minimal correct single-lane reproduction using the same workflow mode,
 lane identity, exact head, and canonical row. Before retrying, distinguish the
 three independent input layers: the header schema, data-row values, and tool
 argument shape. A correct header does not repair an invalid severity or lane
-value, and correct row data does not repair malformed dispatch JSON.
+value, and correct row data does not repair malformed dispatch JSON. Benign shape defects (evidence pipes, marker rows, verdict-row pipes) are auto-repaired and recorded as salvage — never a retry reason alone (contract and fidelity boundaries: `references/lane-output-recoverability.md`).
 
 Classify the incident from actual user-visible harm and the first failed
 predicate, not from the number of retries or the eventual result. A successful
@@ -1157,9 +1157,7 @@ pass the exact reviewed merge-base as `base_sha`, the exact live base branch
 tip/ref used to compute it as `base_ref`, and the same `pr_head_sha` to the
 writer. The writer runs bounded `git merge-base -- <base_ref> <pr_head_sha>` and
 rejects any claimed `base_sha` that is not the exact result. It accepts only an
-exact eleven-row v2 receipt: `MATCHED` rows are backed by completed,
-non-degraded, exact-head artifacts from lanes that declared and attested their
-families; `NOT_TRIGGERED` rows are provenance-free. Counts are recomputed and
+exact eleven-row v2 receipt backed by verifiable provenance (identity, ownership, digest, retained artifact); a coverage-QUALITY failure is disclosed on the receipt as `coverage_degradations` and the run proceeds, with synthesis disclosing degraded families (`references/lane-output-recoverability.md`). `NOT_TRIGGERED` rows are provenance-free. Counts are recomputed and
 must agree. It never uses keyword or path classification alone as absence
 evidence. Any head mismatch makes persistence fail. Historical unversioned and
 schema-v1 all-`MATCHED` receipts remain readable, but new writes are strict v2.

--- a/.opencode/skills/swarm-pr-review/references/lane-output-recoverability.md
+++ b/.opencode/skills/swarm-pr-review/references/lane-output-recoverability.md
@@ -1,0 +1,54 @@
+# Lane-output recoverability (repairs and recorded degradation)
+
+Supplement to the main `SKILL.md` (progressive disclosure per the issue #2131
+criterion-G ratchet). This file documents the recoverability contract added to
+keep substantively-correct but format-imperfect runs completable.
+
+## Parser-boundary repairs (recorded as salvage)
+
+Two benign shape defects are repaired automatically at the parser boundary and
+are never a reason to retry by themselves:
+
+- **`clean-evidence-pipe-tail-merge`** — literal unescaped pipes inside a
+  `[CLEAN]` row's evidence text (regex character classes like `,;|`, shell
+  snippets) are tail-merged into the evidence field instead of splitting the
+  row past the 4-field contract. Deterministic: evidence is the trailing field.
+- **`summary-row-dropped`** — pipe-bearing non-contract marker rows
+  (`[LANE_SUMMARY]`, `[NOTE]`, `[DONE]`, …) are dropped before parsing; they
+  were previously miscounted as malformed candidate rows that voided an
+  otherwise-valid clean attestation. Pipe-free lines are preserved (they may be
+  continuation fragments).
+
+Both repairs are recorded as salvage on the lane record. Lanes should still
+escape pipes as `\|` where practical, but the review no longer fails when they
+do not. The per-obligation CLEAN rules: a `[CLEAN]` conflicts with `[CANDIDATE]`
+rows only for the SAME lane; a valid CLEAN for a different lane in an unscoped
+parse is skipped, not an error; duplicates for the same lane still fail.
+
+## Verdict-row pipe tolerance and its fidelity boundary
+
+`[REVIEWED]` (10-field), `[CRITIC]` (6-field), and `[FEEDBACK-VERIFIED]`
+(4-field) rows tail-merge extra pipe separators into the trailing free-text
+field. Fidelity boundary: content-preserving when the extra pipes sit in the
+trailing field; a pipe in a mid-row prose field still authenticates (all
+machine-checked positions are untouched) but trailing prose fields may be
+re-arranged. A debug-gated warn fires on every applied merge; the raw lane
+emission is always retained verbatim in the lane-output store, so repairs are
+re-derivable.
+
+## Recorded coverage degradation (trigger evaluation)
+
+The trigger-eval writer accepts only an exact eleven-row v2 receipt whose
+`MATCHED` rows are backed by exact-head artifacts from lanes that declared
+ownership of their families through a verifiable provenance chain (identity,
+ownership, digest, retained artifact). A lane whose coverage QUALITY is
+imperfect — it ended `error`/`cancelled` after exhausting retries, or its
+artifact has no covered `[CANDIDATE]`/`[CLEAN]` row for the row's own family —
+no longer dead-ends the run: the writer records the failure on the durable
+receipt as a `coverage_degradations` entry (trigger id, source lane, reason,
+row-scoped so a consolidated lane's covered families are never misattributed)
+and proceeds. The tool result reports `coverage_degradation_count`; the
+synthesis phase MUST disclose every degraded family, with its recorded reason,
+in the final review report. Retries remain the first resort (COVERAGE GATE); a
+missing provenance chain still fails closed, and the reviewer/critic inventory
+skips exactly the receipt-disclosed dispatch tuples.

--- a/docs/releases/pending/pr-review-lane-contract-recoverability.md
+++ b/docs/releases/pending/pr-review-lane-contract-recoverability.md
@@ -1,0 +1,46 @@
+# PR review lane-contract recoverability — repairs instead of dead-ends
+
+A real `/swarm pr-review` run (MiniMax M3 orchestrator, v7.140.1) aborted and
+discarded 16 already-validated base-lane candidates after four substantively
+correct micro-lane outputs were all parser-rejected. Root causes were format
+perfection requirements no frontier model reliably meets, plus a persistence
+chain that turned any single lane defect into an unrecoverable workflow abort.
+
+## What changed for users
+
+- **Pipes in `[CLEAN]` evidence no longer break the row.** A literal `|` inside
+  evidence prose (regex text like `,;|`) is tail-merged into the evidence field
+  at the parser boundary and recorded as salvage. Escaping with `\|` still
+  works and is still preferred.
+- **Non-contract marker rows (`[LANE_SUMMARY]`, `[NOTE]`, `[DONE]`, …) are
+  dropped before parsing** instead of being miscounted as malformed candidate
+  rows that voided an otherwise-valid clean attestation.
+- **Consolidated lanes may mix `[CANDIDATE]` and per-family `[CLEAN]` rows.**
+  The CLEAN+candidate conflict is now scoped per lane/obligation (the #2131
+  prompt contract the parser previously contradicted), and a duplicate
+  attestation for a *different* owned lane is skipped instead of failing the
+  artifact.
+- **A degraded micro lane no longer aborts the whole review.** The trigger
+  evaluation still enforces the full provenance chain (identity, ownership,
+  exact head, retained artifact) but records coverage-quality failures
+  (`error`/`cancelled` status, degraded/truncated output, no covered row) on
+  the durable `trigger-eval.json` receipt as `coverage_degradations` entries
+  and proceeds. The tool result reports `coverage_degradation_count`; the
+  review report must disclose every degraded family.
+- **The initial base-dispatch BLOCKED error now names the six valid dimension
+  IDs** (`intent-architecture`, `correctness-state`, `tests-falsifiability`,
+  `security-trust`, `reliability-performance`, `compatibility-delivery`), so an
+  orchestrator can correct its next call without grepping plugin source.
+- **`[REVIEWED]`, `[CRITIC]`, and `[FEEDBACK-VERIFIED]` verdict rows tolerate
+  literal pipes** in their trailing free-text fields via the same deterministic
+  tail-merge. Fidelity boundary: content is preserved exactly when the extra
+  pipes sit in the trailing field; a pipe in a mid-row prose field still
+  authenticates (machine-checked positions are untouched) but trailing prose
+  fields may be re-arranged. The raw lane emission is always retained verbatim.
+
+## What did not change
+
+Provenance enforcement is intact: wrong lane, wrong mode, head mismatch,
+missing/foreign artifact, or ownership violations still fail closed, and
+retries (max 2) remain the first resort before the degraded path applies.
+Reviewer/critic substantive coverage gates are unchanged.

--- a/src/background/candidate-contract.ts
+++ b/src/background/candidate-contract.ts
@@ -261,7 +261,10 @@ function repairRedundantCleanConfidence(
  * pipe-bearing marker lines are dropped: a pipe-free line (even one starting
  * with a bracket token) is harmless prose today and may be a continuation
  * fragment, so it is preserved. Marker lines for the contract's own rows
- * ([CANDIDATE]/[CLEAN]) are never dropped.
+ * ([CANDIDATE]/[CLEAN]) are never dropped. The match is deliberately
+ * UPPERCASE-ONLY: the machine contract's markers are uppercase by convention
+ * ([LANE_SUMMARY], [NOTE], [DONE]), and a lowercase bracket token is likelier
+ * prose than a marker row.
  */
 const NON_CONTRACT_MARKER_LINE =
 	/^\[(?!(?:CANDIDATE|CLEAN)\])[A-Z][A-Z0-9_-]*\]/;

--- a/src/background/candidate-contract.ts
+++ b/src/background/candidate-contract.ts
@@ -153,7 +153,9 @@ export interface NormalizedCandidateArtifact {
 export type CandidateArtifactRepairKind =
 	| 'synthesized-header'
 	| 'terminal-protocol-fence'
-	| 'redundant-clean-confidence';
+	| 'redundant-clean-confidence'
+	| 'clean-evidence-pipe-tail-merge'
+	| 'summary-row-dropped';
 
 interface MarkdownFenceBlock {
 	openingLine: number;
@@ -244,6 +246,85 @@ function repairRedundantCleanConfidence(
 	let repaired = false;
 	const lines = text.split(/\r?\n/).map((line) => {
 		const result = repairRedundantCleanConfidenceLine(line, family);
+		repaired ||= result.repaired;
+		return result.line;
+	});
+	return { text: lines.join('\n'), repaired };
+}
+
+/**
+ * A lane's trailing self-summary or aside rows (``[LANE_SUMMARY]``, ``[NOTE]``,
+ * ``[DONE]``, …) carry a bracket marker token in their first pipe field. They
+ * are not part of the candidate contract, yet their pipe-delimited shape was
+ * previously misclassified as malformed short candidate rows, voiding an
+ * otherwise-valid CLEAN attestation via the zero-malformed-rows rule. Only
+ * pipe-bearing marker lines are dropped: a pipe-free line (even one starting
+ * with a bracket token) is harmless prose today and may be a continuation
+ * fragment, so it is preserved. Marker lines for the contract's own rows
+ * ([CANDIDATE]/[CLEAN]) are never dropped.
+ */
+const NON_CONTRACT_MARKER_LINE =
+	/^\[(?!(?:CANDIDATE|CLEAN)\])[A-Z][A-Z0-9_-]*\]/;
+
+function dropNonContractMarkerRows(text: string): {
+	text: string;
+	dropped: boolean;
+} {
+	const lines = text.split(/\r?\n/);
+	const kept = lines.filter((line) => {
+		if (!line.includes('|')) return true;
+		const firstField = splitPipeFields(line.trim())[0]?.trim() ?? '';
+		return !NON_CONTRACT_MARKER_LINE.test(firstField);
+	});
+	return {
+		text: kept.join('\n'),
+		dropped: kept.length !== lines.length,
+	};
+}
+
+/**
+ * Escape unescaped pipe separators beyond the CLEAN field count so free-text
+ * evidence containing literal pipes (regex character classes, `,;|`, shell
+ * snippets) re-merges into the trailing evidence field instead of splitting
+ * the row past `CLEAN_FIELD_COUNT`. Deterministic: evidence is the trailing
+ * field, so extra unescaped separators can only belong to it. Runs before the
+ * other line repairs so downstream repairs see canonical field counts.
+ */
+function repairCleanEvidencePipesLine(line: string): {
+	line: string;
+	repaired: boolean;
+} {
+	if (splitPipeFields(line)[0]?.trim() !== CLEAN_MARKER) {
+		return { line, repaired: false };
+	}
+	let separatorCount = 0;
+	let out = '';
+	for (let index = 0; index < line.length; index += 1) {
+		const char = line[index];
+		if (char === '\\' && line[index + 1] === '|') {
+			out += '\\|';
+			index += 1;
+			continue;
+		}
+		if (char === '|') {
+			separatorCount += 1;
+			out += separatorCount <= CLEAN_FIELD_COUNT - 1 ? '|' : '\\|';
+			continue;
+		}
+		out += char;
+	}
+	return separatorCount > CLEAN_FIELD_COUNT - 1
+		? { line: out, repaired: true }
+		: { line, repaired: false };
+}
+
+function repairCleanEvidencePipes(text: string): {
+	text: string;
+	repaired: boolean;
+} {
+	let repaired = false;
+	const lines = text.split(/\r?\n/).map((line) => {
+		const result = repairCleanEvidencePipesLine(line);
 		repaired ||= result.repaired;
 		return result.line;
 	});
@@ -350,14 +431,26 @@ export function normalizeCandidateArtifact(
 	fallbackFamily: RowFormatFamily,
 ): NormalizedCandidateArtifact {
 	const repairKinds: CandidateArtifactRepairKind[] = [];
-	const recoveredFence = recoverTerminalProtocolFence(rawText, fallbackFamily);
+	// Marker-row drop runs first (it is shape-only), then the pre-existing
+	// repairs in their historical order, then the pipe tail-merge LAST: the
+	// redundant-confidence repair must see a 5-field row before the tail-merge
+	// folds the trailing token into evidence, while the tail-merge is the final
+	// fallback for prose pipes that no earlier repair addresses.
+	const summaryDrop = dropNonContractMarkerRows(rawText);
+	if (summaryDrop.dropped) repairKinds.push('summary-row-dropped');
+	const recoveredFence = recoverTerminalProtocolFence(
+		summaryDrop.text,
+		fallbackFamily,
+	);
 	if (recoveredFence !== null) repairKinds.push('terminal-protocol-fence');
 	const cleanRepair = repairRedundantCleanConfidence(
-		recoveredFence ?? removeCandidateCodeFences(rawText),
+		recoveredFence ?? removeCandidateCodeFences(summaryDrop.text),
 		fallbackFamily,
 	);
 	if (cleanRepair.repaired) repairKinds.push('redundant-clean-confidence');
-	const text = cleanRepair.text;
+	const pipeRepair = repairCleanEvidencePipes(cleanRepair.text);
+	if (pipeRepair.repaired) repairKinds.push('clean-evidence-pipe-tail-merge');
+	const text = pipeRepair.text;
 	const header = selectCandidateHeader(text.split(/\r?\n/));
 	if (header?.markerBearing && header.family !== null) {
 		return { text, synthesizedHeader: false, repairKinds };
@@ -372,9 +465,10 @@ export function normalizeCandidateArtifact(
 	// be read. Honour the family it declared: if that disagrees with the expected
 	// family the artifact must still fail closed, but if it agrees there is
 	// nothing to protect and refusing would discard the lane's findings for no
-	// reason.
+	// reason. The declaration must be read from the PRE-strip source — the
+	// stripped text no longer contains the fenced header that declares it.
 	if (
-		declaredCanonicalFamilies(rawText).some(
+		declaredCanonicalFamilies(summaryDrop.text).some(
 			(family) => family !== fallbackFamily,
 		)
 	) {

--- a/src/background/candidate-parser.ts
+++ b/src/background/candidate-parser.ts
@@ -601,6 +601,26 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 			const cleanAnalysis = cleanFamily
 				? analyzeCleanFields(cleanFields, cleanFamily, cleanLane)
 				: undefined;
+			// A consolidated lane may emit one [CLEAN] attestation per owned lane.
+			// Scoped (expected-lane) callers never reach this branch for a sibling
+			// lane's row — the out-of-scope skip above already handled it — because
+			// analyzeCleanFields marks any non-expected lane invalid. This branch
+			// covers UNSCOPED parses (no expected_lane flags), where every lane's
+			// row validates: the artifact's singular attestation slot is already
+			// filled by a DIFFERENT lane's valid attestation, so the later row is
+			// skipped instead of failing the whole artifact. A duplicate
+			// attestation for the SAME lane still falls through and errors below.
+			if (
+				pendingClean !== undefined &&
+				cleanAnalysis?.valid === true &&
+				cleanAnalysis.lane !== null &&
+				cleanAnalysis.lane !==
+					(pendingClean.row_format_family === 'base_explorer'
+						? pendingClean.lane
+						: pendingClean.micro_lane)
+			) {
+				continue;
+			}
 			if (pendingClean !== undefined) {
 				cleanErrorCode = 'invalid-clean-attestation';
 				cleanErrorMessage =
@@ -900,14 +920,29 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 		}
 	}
 
-	if (pendingClean && candidates.length > 0) {
-		cleanErrorCode = 'conflicting-clean-attestation';
-		cleanErrorMessage = 'CLEAN attestation cannot appear with candidate rows';
-		parseErrorDetails.push({
-			row_index: headerIndex,
-			field: 'clean_attestation',
-			message: cleanErrorMessage,
-		});
+	// Per-obligation conflict (the #2131 prompt contract): a [CLEAN] attestation
+	// contradicts [CANDIDATE] rows only for the SAME lane. Candidates for other
+	// lanes of a consolidated artifact are legitimate siblings and must not void
+	// this lane's zero-findings attestation.
+	const pendingCleanLane = pendingClean
+		? pendingClean.row_format_family === 'base_explorer'
+			? pendingClean.lane
+			: pendingClean.micro_lane
+		: null;
+	if (pendingClean && pendingCleanLane !== null) {
+		const conflictingCandidate = candidates.find(
+			(candidate) =>
+				(candidate.lane ?? candidate.micro_lane) === pendingCleanLane,
+		);
+		if (conflictingCandidate) {
+			cleanErrorCode = 'conflicting-clean-attestation';
+			cleanErrorMessage = `CLEAN attestation cannot appear with candidate rows for the same lane (${pendingCleanLane})`;
+			parseErrorDetails.push({
+				row_index: headerIndex,
+				field: 'clean_attestation',
+				message: cleanErrorMessage,
+			});
+		}
 	}
 	if (
 		pendingClean &&
@@ -924,10 +959,11 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 		});
 	}
 
+	// `!cleanErrorCode` already encodes "no same-lane candidate conflict" (set
+	// above), so candidates for OTHER lanes of a consolidated artifact no longer
+	// suppress this lane's zero-findings attestation.
 	const cleanAttestation: CleanAttestationRecord | undefined =
-		pendingClean && !cleanErrorCode && candidates.length === 0
-			? pendingClean
-			: undefined;
+		pendingClean && !cleanErrorCode ? pendingClean : undefined;
 	if (cleanAttestation) {
 		formatFamiliesDetected.add(cleanAttestation.row_format_family);
 	}
@@ -936,7 +972,8 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 	// candidate rows: every candidate here was independently validated by
 	// analyzeCandidateFields. Discarding them made one malformed trailing row
 	// destroy an entire lane's findings. The attestation itself stays gated
-	// below on `!cleanErrorCode && candidates.length === 0`.
+	// above on `!cleanErrorCode`; the only candidate-related rejection is the
+	// per-obligation same-lane conflict, scoped per the #2131 prompt contract.
 	const acceptedCandidates = candidates;
 	const parseErrors = parseErrorDetails.length;
 

--- a/src/background/candidate-parser.ts
+++ b/src/background/candidate-parser.ts
@@ -613,7 +613,8 @@ function parseText(input: ArtifactInput, flags: ParseFlags): ParseResult {
 			if (
 				pendingClean !== undefined &&
 				cleanAnalysis?.valid === true &&
-				cleanAnalysis.lane !== null &&
+				// analyzeCleanFields marks a null lane invalid, so a valid
+				// analysis always carries one.
 				cleanAnalysis.lane !==
 					(pendingClean.row_format_family === 'base_explorer'
 						? pendingClean.lane

--- a/src/background/pr-review-trigger-contract.ts
+++ b/src/background/pr-review-trigger-contract.ts
@@ -364,6 +364,26 @@ const V2NotTriggeredRowSchema = z
 
 const V2RowSchema = z.union([V2MatchedRowSchema, V2NotTriggeredRowSchema]);
 
+/**
+ * Disclosure record for a MATCHED family whose cited micro lane could not
+ * produce a non-degraded, fully-covering artifact after retries. The run
+ * proceeds; the receipt — and therefore every consumer of it — can see exactly
+ * which families are degraded and why. Provenance (identity, ownership, exact
+ * head) is still enforced for these rows; only coverage QUALITY is relaxed.
+ */
+export const TriggerCoverageDegradationSchema = z
+	.object({
+		trigger_id: TriggerIdSchema,
+		source_batch_id: z.string().trim().min(1),
+		source_lane_id: z.string().trim().min(1),
+		reason: z.string().trim().min(1),
+	})
+	.strict();
+
+export type TriggerCoverageDegradation = z.infer<
+	typeof TriggerCoverageDegradationSchema
+>;
+
 const ReceiptEnvelopeSchema = z.object({
 	run_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/),
 	pr_head_sha: z
@@ -389,6 +409,7 @@ const V2ReceiptSchema = ReceiptEnvelopeSchema.extend({
 	not_triggered_count: z.number().int().min(0),
 	no_match_count: z.number().int().min(0),
 	rows: z.array(V2RowSchema),
+	coverage_degradations: z.array(TriggerCoverageDegradationSchema).default([]),
 }).strict();
 
 function assertCanonicalDefinitionFields(
@@ -428,6 +449,8 @@ export interface BuildPrReviewTriggerReceiptV2Args {
 	evaluated_at: string;
 	dispatched_micro_lane_count: number;
 	rows: unknown;
+	/** Receipt-level degradation disclosure; ledger rows stay untouched so the frozen-ledger digest is unaffected. */
+	coverage_degradations?: TriggerCoverageDegradation[];
 }
 
 function dispatchedMicroLaneCount(
@@ -480,6 +503,7 @@ export function buildPrReviewTriggerReceiptV2(
 		not_triggered_count: validated.notTriggeredIds.length,
 		no_match_count: 0,
 		rows,
+		coverage_degradations: input.coverage_degradations ?? [],
 	});
 }
 
@@ -524,6 +548,8 @@ export interface ParsedPrReviewTriggerReceipt {
 		PrReviewPersistedInputRow,
 		{ result: 'NOT_TRIGGERED' }
 	>[];
+	/** Empty for pre-v2.2 receipts. Present entries mean the family's cited lane is provenance-valid but coverage-degraded. */
+	coverageDegradations: TriggerCoverageDegradation[];
 }
 
 /**
@@ -549,6 +575,7 @@ export function prReviewTriggerLedgerDigest(
 function parsedReceipt(
 	schemaVersion: 0 | 1 | 2,
 	rows: PrReviewPersistedInputRow[],
+	coverageDegradations: TriggerCoverageDegradation[] = [],
 ): ParsedPrReviewTriggerReceipt {
 	return {
 		schemaVersion,
@@ -565,6 +592,7 @@ function parsedReceipt(
 				{ result: 'NOT_TRIGGERED' }
 			> => row.result === 'NOT_TRIGGERED',
 		),
+		coverageDegradations,
 	};
 }
 
@@ -604,7 +632,7 @@ export function parsePrReviewTriggerReceipt(
 				);
 			}
 		}
-		return parsedReceipt(2, validated.rows);
+		return parsedReceipt(2, validated.rows, receipt.coverage_degradations);
 	}
 
 	if (schemaVersion !== undefined && schemaVersion !== 1) {

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -5383,6 +5383,9 @@ export const _test_exports = {
 	// capped merge is content-preserving only when the extra pipes sit in the
 	// trailing (free-text) field.
 	pipeFieldsCapped,
+	// Exposed so the digest-stability test can hash the same canonical field
+	// view the critic-claim binding hashes.
+	reviewerVerdictRowDigest,
 	workflowGateStateRelativePath,
 	workflowGateStateLockRelativePath,
 	workflowCheckoutMutationLockRelativePath,
@@ -9275,7 +9278,12 @@ function readSettledFeedbackClassifications(
 			const loaded = ref ? readLaneOutput(directory, ref) : null;
 			if (!loaded) continue;
 			for (const line of loaded.artifact.text.split(/\r?\n/)) {
-				const fields = pipeFields(line);
+				// Same trailing-field pipe tolerance as feedbackArtifactCoversItems:
+				// the fourth field is free-text and may legitimately contain literal
+				// pipes. Parsing it raw here let coverage accept a row the settled
+				// read then skipped, blocking a verified no-change item (PR #2182
+				// review finding UIB-002).
+				const fields = pipeFieldsCapped(line, 4);
 				if (
 					fields[0] !== '[FEEDBACK-VERIFIED]' ||
 					fields.length !== 4 ||

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -5379,6 +5379,10 @@ export const _test_exports = {
 	extractCandidateIds,
 	parseCanonicalCandidateRows,
 	resolvePrReviewRowFamily,
+	// Exposed to pin the verdict-row pipe tolerance's fidelity boundary: the
+	// capped merge is content-preserving only when the extra pipes sit in the
+	// trailing (free-text) field.
+	pipeFieldsCapped,
 	workflowGateStateRelativePath,
 	workflowGateStateLockRelativePath,
 	workflowCheckoutMutationLockRelativePath,
@@ -6974,6 +6978,7 @@ function derivePrReviewCandidateInventory(
 			}
 		}
 	}
+	const degradedSourceKeys = new Set<string>();
 	if (state.prReviewTriggerEvalPath) {
 		const triggerPath = validateSwarmPath(
 			directory,
@@ -7005,6 +7010,16 @@ function derivePrReviewCandidateInventory(
 				workflowLane: row.trigger_id,
 			});
 		}
+		// Dispatch tuples whose micro lane was accepted with a recorded coverage
+		// degradation (write_pr_review_trigger_eval). If such a lane's retained
+		// artifact still cannot contribute a covered row, the family is skipped
+		// below — the degradation is already durably disclosed on the receipt —
+		// instead of re-creating the trigger-eval dead-end at the inventory.
+		for (const degradation of receipt.coverageDegradations) {
+			degradedSourceKeys.add(
+				`${degradation.source_batch_id}\0${degradation.source_lane_id}`,
+			);
+		}
 	}
 	const candidateIds: string[] = [];
 	// A consolidated lane can be the provenance source for several sources
@@ -7019,15 +7034,18 @@ function derivePrReviewCandidateInventory(
 		for (const record of findByBatchId(directory, source.batchId, {
 			parentSessionId: state.sessionID,
 		})) {
+			// Identity checks stay hard (lane, mode, exact head). Coverage-quality
+			// flags (status, degraded output) deliberately do NOT skip here: a
+			// micro lane that ended degraded after retries was already accepted by
+			// write_pr_review_trigger_eval with a recorded coverage degradation —
+			// re-blocking here would re-create the trigger-eval dead-end this
+			// inventory feeds. A degraded lane simply contributes whatever covered
+			// rows its retained artifact holds (possibly none).
 			if (
 				record.laneId !== source.laneId ||
 				record.mode !== source.mode ||
-				record.status !== 'completed' ||
 				record.workspace?.prHeadSha !== state.prHeadSha ||
-				record.workspace?.gitHead !== state.prHeadSha ||
-				record.result?.outputDegraded === true ||
-				record.result?.transcriptIncomplete === true ||
-				record.result?.truncated === true
+				record.workspace?.gitHead !== state.prHeadSha
 			)
 				continue;
 			const ref = record.result?.outputRef?.trim();
@@ -7078,6 +7096,12 @@ function derivePrReviewCandidateInventory(
 			}
 		}
 		if (source.mode === 'swarm-pr-review:micro' && !resolvedArtifact) {
+			if (degradedSourceKeys.has(`${source.batchId}\0${source.laneId}`)) {
+				// Accepted-with-disclosure at trigger-eval time: the receipt already
+				// records why this family's lane could not contribute. Skipping it
+				// here is the documented degraded path, not a silent waiver.
+				continue;
+			}
 			throw new Error(
 				`BLOCKED: PR_REVIEW mandatory micro-lane provenance is missing or invalid for ${source.workflowLane ?? source.laneId}`,
 			);
@@ -9032,7 +9056,7 @@ function parseReviewerVerdictFields(
 ): string[] | null {
 	const rows = text
 		.split(/\r?\n/)
-		.map(pipeFields)
+		.map((line) => pipeFieldsCapped(line, 10))
 		.filter((fields) => fields[0] === '[REVIEWED]' && fields[1] === itemId);
 	if (rows.length !== 1) return null;
 	const fields = rows[0];
@@ -9113,7 +9137,7 @@ function parseCriticVerdict(
 ): { status: string; severity: string } | null {
 	const rows = text
 		.split(/\r?\n/)
-		.map(pipeFields)
+		.map((line) => pipeFieldsCapped(line, 6))
 		.filter((fields) => fields[0] === '[CRITIC]' && fields[1] === itemId);
 	if (rows.length !== 1) return null;
 	const fields = rows[0];
@@ -9157,9 +9181,11 @@ function artifactHasExactPositiveVerdictRow(
 	itemId: string,
 	positiveVerdict: string,
 ): boolean {
+	// Same trailing-field pipe tolerance as feedbackArtifactCoversItems: the
+	// fourth field is free-text and may legitimately contain literal pipes.
 	const rows = text
 		.split(/\r?\n/)
-		.map(pipeFields)
+		.map((line) => pipeFieldsCapped(line, 4))
 		.filter((fields) => fields[0] === marker && fields[1] === itemId);
 	return (
 		rows.length === 1 &&
@@ -9172,6 +9198,33 @@ function artifactHasExactPositiveVerdictRow(
 function pipeFields(line: string): string[] {
 	if (!line.includes('|')) return [];
 	return line.split('|').map((field) => field.trim());
+}
+
+/**
+ * `pipeFields` capped at the row's canonical field count: separators beyond the
+ * expected count merge back into the trailing (free-text) field. Verdict rows
+ * ([REVIEWED], [CRITIC], [FEEDBACK-VERIFIED]) carry prose evidence in their
+ * last field, and prose containing literal pipes (regex text, `,;|`, shell
+ * snippets) otherwise splits the row past its strict field-count check and the
+ * whole verdict becomes unparseable. Deterministic: the enumerated leading
+ * fields are never merged.
+ */
+function pipeFieldsCapped(line: string, expectedFieldCount: number): string[] {
+	const fields = pipeFields(line);
+	if (fields.length <= expectedFieldCount) return fields;
+	const capped = [
+		...fields.slice(0, expectedFieldCount - 1),
+		fields.slice(expectedFieldCount - 1).join('|'),
+	];
+	// The enumerated leading fields are untouched, so machine-checked positions
+	// (classification, severity, file:line) stay correct. But the pipe may have
+	// originated in a NON-trailing prose field, in which case the trailing prose
+	// fields are re-arranged rather than preserved. Fidelity-safe only for
+	// trailing-field pipes; this warn (debug-gated) is the only trace.
+	warn(
+		`[pr-workflow-gate] verdict row pipe tail-merge applied (expected ${expectedFieldCount} fields, received ${fields.length}); leading machine fields preserved, trailing prose fields merged: ${line.slice(0, 120)}`,
+	);
+	return capped;
 }
 
 function feedbackArtifactCoversItems(
@@ -9189,7 +9242,7 @@ function feedbackArtifactCoversItems(
 	if (!loaded) return false;
 	const rows = loaded.artifact.text
 		.split(/\r?\n/)
-		.map(pipeFields)
+		.map((line) => pipeFieldsCapped(line, 4))
 		.filter((fields) => fields[0] === '[FEEDBACK-VERIFIED]');
 	if (rows.length !== itemIds.length) return false;
 	return itemIds.every((itemId) => {

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -1220,7 +1220,7 @@ export async function executeDispatchLanesAsync(
 								)
 							) {
 								throw new Error(
-									'BLOCKED: initial PR_REVIEW base dispatch requires exactly six lanes and max_concurrent: 6 at depth tier L (consolidated owned_workflow_lanes are allowed only at tiers S and M)',
+									`BLOCKED: initial PR_REVIEW base dispatch requires exactly six lanes and max_concurrent: 6 at depth tier L (consolidated owned_workflow_lanes are allowed only at tiers S and M); each lane owns exactly one dimension; valid dimensions: ${PR_REVIEW_BASE_DIMENSION_IDS.join(', ')}`,
 								);
 							}
 						} else if (
@@ -1231,7 +1231,7 @@ export async function executeDispatchLanesAsync(
 							parsed.data.max_concurrent !== parsed.data.lanes.length
 						) {
 							throw new Error(
-								`BLOCKED: initial PR_REVIEW base dispatch at depth tier ${depthTier} requires between ${PR_REVIEW_BASE_LANE_FLOORS[depthTier]} and ${PR_REVIEW_BASE_DIMENSION_IDS.length} lanes whose owned_workflow_lanes partition all six dimensions exactly once, with max_concurrent equal to the lane count`,
+								`BLOCKED: initial PR_REVIEW base dispatch at depth tier ${depthTier} requires between ${PR_REVIEW_BASE_LANE_FLOORS[depthTier]} and ${PR_REVIEW_BASE_DIMENSION_IDS.length} lanes whose owned_workflow_lanes partition all six dimensions exactly once, with max_concurrent equal to the lane count; valid dimensions: ${PR_REVIEW_BASE_DIMENSION_IDS.join(', ')}; a lane with one dimension may set workflow_lane to it and omit owned_workflow_lanes`,
 							);
 						}
 					}

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -1220,7 +1220,7 @@ export async function executeDispatchLanesAsync(
 								)
 							) {
 								throw new Error(
-									`BLOCKED: initial PR_REVIEW base dispatch requires exactly six lanes and max_concurrent: 6 at depth tier L (consolidated owned_workflow_lanes are allowed only at tiers S and M); each lane owns exactly one dimension; valid dimensions: ${PR_REVIEW_BASE_DIMENSION_IDS.join(', ')}`,
+									`BLOCKED: initial PR_REVIEW base dispatch requires exactly six lanes and max_concurrent: 6 at depth tier L (consolidated owned_workflow_lanes are allowed only at tiers S and M); each lane owns exactly one dimension and may set workflow_lane to it, omitting owned_workflow_lanes; valid dimensions: ${PR_REVIEW_BASE_DIMENSION_IDS.join(', ')}`,
 								);
 							}
 						} else if (

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -310,15 +310,15 @@ export async function executeWritePrReviewTriggerEval(
 		// families are each checked by their own citing row (ownership==matched-set
 		// is enforced below), so stamping a lane-wide uncovered list here would
 		// misattribute degradations to covered families on a consolidated lane —
-		// the exact shape that motivated this recoverability path.
-		const rowFamilyUncovered = recordOwnedLanes.includes(row.trigger_id)
-			? !prReviewDiscoveryArtifactCoversLane(
-					outputArtifact!.artifact.text,
-					row.trigger_id,
-					recordOwnedLanes,
-					record!.mode,
-				)
-			: true;
+		// the exact shape that motivated this recoverability path. The
+		// provenanceFailure gate above already guarantees the row's family is
+		// owned by the cited lane, so the ownership check is not repeated here.
+		const rowFamilyUncovered = !prReviewDiscoveryArtifactCoversLane(
+			outputArtifact!.artifact.text,
+			row.trigger_id,
+			recordOwnedLanes,
+			record!.mode,
+		);
 		if (rowFamilyUncovered) {
 			degradationReasons.push(
 				`no covered candidate or clean row for: ${row.trigger_id}`,

--- a/src/tools/write-pr-review-trigger-eval.ts
+++ b/src/tools/write-pr-review-trigger-eval.ts
@@ -7,6 +7,7 @@ import { findByBatchId } from '../background/pending-delegations.js';
 import {
 	buildPrReviewTriggerReceiptV2,
 	PrReviewWriterInputRowSchema,
+	type TriggerCoverageDegradation,
 	validatePrReviewInlineTriggerLedger,
 	validatePrReviewPersistedInputLedger,
 	validatePrReviewWriterInputLedger,
@@ -228,6 +229,7 @@ export async function executeWritePrReviewTriggerEval(
 	// overlap would let both artifacts legitimately back the same family,
 	// duplicating (or reintroducing stale) content for it downstream.
 	const citedLaneOwnership = new Map<string, string[]>();
+	const coverageDegradations: TriggerCoverageDegradation[] = [];
 	for (const row of validatedRows) {
 		if (row.result !== 'MATCHED') continue;
 		const records = findByBatchId(directory, row.source_batch_id!, {
@@ -249,15 +251,14 @@ export async function executeWritePrReviewTriggerEval(
 		const outputArtifact = outputRef
 			? readLaneOutput(directory, outputRef)
 			: null;
-		if (
+		// Provenance failures stay fail-closed: the cited lane must exist, be a
+		// micro lane that declared ownership of this family, and the retained
+		// artifact must be the exact, identity-checked output for this run's head.
+		// Without this chain any text could back a MATCHED row.
+		const provenanceFailure =
 			!record ||
 			record.mode !== 'swarm-pr-review:micro' ||
 			!recordOwnedLanes.includes(row.trigger_id) ||
-			record.status !== 'completed' ||
-			record.result?.outputDegraded === true ||
-			record.result?.transcriptIncomplete === true ||
-			record.result?.truncated === true ||
-			(record.result?.chars ?? 0) <= 0 ||
 			!record.result?.digest?.trim() ||
 			!record.result?.outputRef?.trim() ||
 			!outputArtifact ||
@@ -275,20 +276,61 @@ export async function executeWritePrReviewTriggerEval(
 			outputArtifact.artifact.revisionDigest !== currentRevisionDigest ||
 			outputArtifact.artifact.digest !== record.result?.digest ||
 			outputArtifact.artifact.chars !== record.result?.chars ||
-			!recordOwnedLanes.every((ownedFamily) =>
-				prReviewDiscoveryArtifactCoversLane(
-					outputArtifact.artifact.text,
-					ownedFamily,
-					recordOwnedLanes,
-					record.mode,
-				),
-			) ||
 			record.workspace?.prHeadSha !== parsed.data.pr_head_sha ||
-			record.workspace?.gitHead !== parsed.data.pr_head_sha
-		) {
+			record.workspace?.gitHead !== parsed.data.pr_head_sha;
+		if (provenanceFailure) {
 			return failure(
-				`MATCHED trigger ${row.trigger_id} does not reference a completed non-degraded micro-lane artifact`,
+				`MATCHED trigger ${row.trigger_id} does not reference a verifiable micro-lane provenance chain`,
 			);
+		}
+		// Coverage-quality failures are tolerated and DISCLOSED on the durable
+		// receipt instead of dead-ending the whole review (retries remain the
+		// first resort per the skill's COVERAGE GATE). A lane that completed but
+		// could not be parsed into covered rows, or that ended failed/cancelled
+		// after exhausting retries, still leaves its retained artifact as usable
+		// negative context — the synthesis phase must surface every entry
+		// recorded here in the final review report.
+		const degradationReasons: string[] = [];
+		if (record!.status !== 'completed') {
+			degradationReasons.push(`lane status ${record!.status}`);
+		}
+		if (record!.result?.outputDegraded === true) {
+			degradationReasons.push('output degraded');
+		}
+		if (record!.result?.transcriptIncomplete === true) {
+			degradationReasons.push('transcript incomplete');
+		}
+		if (record!.result?.truncated === true) {
+			degradationReasons.push('output truncated');
+		}
+		if ((record!.result?.chars ?? 0) <= 0) {
+			degradationReasons.push('empty output');
+		}
+		// Coverage is checked for THIS row's family only. The lane's other owned
+		// families are each checked by their own citing row (ownership==matched-set
+		// is enforced below), so stamping a lane-wide uncovered list here would
+		// misattribute degradations to covered families on a consolidated lane —
+		// the exact shape that motivated this recoverability path.
+		const rowFamilyUncovered = recordOwnedLanes.includes(row.trigger_id)
+			? !prReviewDiscoveryArtifactCoversLane(
+					outputArtifact!.artifact.text,
+					row.trigger_id,
+					recordOwnedLanes,
+					record!.mode,
+				)
+			: true;
+		if (rowFamilyUncovered) {
+			degradationReasons.push(
+				`no covered candidate or clean row for: ${row.trigger_id}`,
+			);
+		}
+		for (const reason of degradationReasons) {
+			coverageDegradations.push({
+				trigger_id: row.trigger_id,
+				source_batch_id: row.source_batch_id!,
+				source_lane_id: row.source_lane_id!,
+				reason,
+			});
 		}
 	}
 	const citedLaneEntries = [...citedLaneOwnership.entries()];
@@ -391,6 +433,7 @@ export async function executeWritePrReviewTriggerEval(
 		evaluated_at: new Date().toISOString(),
 		dispatched_micro_lane_count: dispatchedMicroLaneCount,
 		rows: validatedRows,
+		coverage_degradations: coverageDegradations,
 	});
 
 	const relativePath = path.join(
@@ -454,6 +497,13 @@ export async function executeWritePrReviewTriggerEval(
 			not_triggered_count: artifact.not_triggered_count,
 			no_match_count: artifact.no_match_count,
 			dispatched_micro_lane_count: dispatchedMicroLaneCount,
+			coverage_degradation_count: coverageDegradations.length,
+			...(coverageDegradations.length > 0
+				? {
+						coverage_degradations: coverageDegradations,
+						note: 'degraded families recorded on the receipt; disclose them in the final review report',
+					}
+				: {}),
 		},
 		null,
 		2,

--- a/tests/unit/background/candidate-contract-clean-repair.test.ts
+++ b/tests/unit/background/candidate-contract-clean-repair.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { normalizeCandidateArtifact } from '../../../src/background/candidate-contract';
+import {
+	type ArtifactInput,
+	type ParseFlags,
+	parseCandidates,
+} from '../../../src/background/candidate-parser';
+
+/**
+ * Lane-output recoverability repairs (PR-review deadlock fix).
+ *
+ * A real /swarm pr-review run (PR #2177, plugin v7.140.1) aborted after four
+ * substantively-correct micro-lane outputs were all parser-rejected:
+ * - a literal `|` inside [CLEAN] evidence (`validates against \`,;|\` injection
+ *   chars`) split the row past CLEAN_FIELD_COUNT;
+ * - a trailing `[LANE_SUMMARY] | k=v | k=v` line was misclassified as a
+ *   malformed short candidate row and voided the attestation via the
+ *   zero-malformed-rows rule.
+ *
+ * These tests pin the two normalize-boundary repairs and the per-lane CLEAN
+ * tolerance that let such artifacts parse as covered.
+ */
+
+const digest = createHash('sha256').update('clean-repair').digest('hex');
+const microHeader =
+	'[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+const capturedFamily = 'untrusted-input-boundaries';
+const ownedFamilies = [
+	'untrusted-input-boundaries',
+	'test-infrastructure',
+	'unclassified-risk',
+];
+
+function input(text: string, laneId = 'pr2177-micro'): ArtifactInput {
+	return {
+		output_ref: `L1:${'a'.repeat(64)}:${'b'.repeat(64)}:${digest}`,
+		batchId: 'micro-batch',
+		laneId,
+		agent: 'mega_explorer',
+		role: 'explorer',
+		digest,
+		text,
+		artifact_status: 'ok',
+		source: 'collect_lane_results',
+		produced_at: '2026-08-14T00:00:00.000Z',
+	};
+}
+
+function microFlags(
+	expectedMicroLane: string,
+	overrides: Record<string, unknown> = {},
+): ParseFlags {
+	return {
+		accept_partial: false,
+		accept_degraded: false,
+		degraded: false,
+		row_format_version: 1,
+		producer: 'swarm-pr-review',
+		expected_family: 'micro_lane',
+		expected_micro_lane: expectedMicroLane,
+		expected_micro_lanes: [
+			expectedMicroLane,
+			...ownedFamilies.filter((family) => family !== expectedMicroLane),
+		],
+		...overrides,
+	} as unknown as ParseFlags;
+}
+
+/** The exact captured artifact shape: preamble prose, three pipe-damaged
+ * per-family CLEAN rows (evidence cites `,;|`), and a trailing summary row. */
+const capturedArtifact = [
+	'Now let me verify the `_internals` export and test execution:',
+	microHeader,
+	'[CLEAN] | untrusted-input-boundaries | Stripping trailing parenthetical annotations from FILE directives via regex applied to user-provided args; the extractor validates against `,;|` injection chars before path use | Two locations in delegation-gate.ts modified identically; regex anchors to end-of-string preventing partial matches',
+	'[CLEAN] | test-infrastructure | New test file is 25 lines under the 500 cap, uses bun:test only, imports the _internals seam, zero mock.module usage | Test exercises the exact function added to _internals; no fixture drift or isolation leakage risks',
+	'[CLEAN] | unclassified-risk | Focused 32-line addition across 2 files with no new exports, schema changes, or subprocess modifications | Both duplication sites maintain identical strip logic; PR is a narrow fix with matched test coverage',
+	'[LANE_SUMMARY] | micro_lane=consolidated | candidates_emitted=0',
+].join('\n');
+
+describe('clean-evidence-pipe-tail-merge repair', () => {
+	test('repairs a [CLEAN] row whose evidence contains literal pipes', () => {
+		const damaged =
+			'[CLEAN] | some-lane | coverage scope text long enough | evidence mentioning `,;|` chars and a | b | c';
+		const normalized = normalizeCandidateArtifact(
+			`${microHeader}\n${damaged}`,
+			'micro_lane',
+		);
+		expect(normalized.repairKinds).toContain('clean-evidence-pipe-tail-merge');
+		const result = parseCandidates(
+			input(normalized.text),
+			microFlags('some-lane'),
+		);
+		expect(result.error_code).toBeUndefined();
+		expect(result.clean_attestation?.micro_lane).toBe('some-lane');
+		expect(result.clean_attestation?.evidence).toContain('`,;|`');
+		expect(result.clean_attestation?.evidence).toContain('a | b | c');
+		expect(result.diagnostics.malformed_rows).toBe(0);
+	});
+
+	test('leaves well-formed and non-CLEAN rows untouched', () => {
+		const fine = [
+			microHeader,
+			'[CLEAN] | some-lane | coverage scope text long enough | plain evidence text with no pipes at all',
+			'prose preamble line without pipes',
+		].join('\n');
+		const normalized = normalizeCandidateArtifact(fine, 'micro_lane');
+		expect(normalized.repairKinds).not.toContain(
+			'clean-evidence-pipe-tail-merge',
+		);
+		expect(normalized.repairKinds).not.toContain('summary-row-dropped');
+	});
+});
+
+describe('summary-row-dropped repair', () => {
+	test('drops [LANE_SUMMARY] rows before candidate parsing', () => {
+		const withSummary = [
+			microHeader,
+			'[CLEAN] | some-lane | coverage scope text long enough | plain evidence text describing coverage',
+			'[LANE_SUMMARY] | micro_lane=x | candidates_emitted=0',
+		].join('\n');
+		const normalized = normalizeCandidateArtifact(withSummary, 'micro_lane');
+		expect(normalized.repairKinds).toContain('summary-row-dropped');
+		expect(normalized.text).not.toContain('[LANE_SUMMARY]');
+		const result = parseCandidates(
+			input(normalized.text),
+			microFlags('some-lane'),
+		);
+		expect(result.clean_attestation?.micro_lane).toBe('some-lane');
+		expect(result.diagnostics.malformed_rows).toBe(0);
+	});
+
+	test('[NOTE]/[DONE]/[SUMMARY] marker rows are dropped like [LANE_SUMMARY]', () => {
+		// All non-contract bracket-marker rows share the [LANE_SUMMARY] failure
+		// shape: 2+ pipe fields after the header → "structurally short candidate
+		// row" → malformed → voids the CLEAN attestation. They are dropped, not
+		// parsed.
+		const artifact = [
+			microHeader,
+			'[CLEAN] | some-lane | coverage scope text long enough | plain evidence text describing coverage',
+			'[NOTE] | an aside | with two pipes',
+			'[DONE] | finished',
+			'[LANE_SUMMARY] | micro_lane=x | candidates_emitted=0',
+		].join('\n');
+		const normalized = normalizeCandidateArtifact(artifact, 'micro_lane');
+		expect(normalized.repairKinds).toContain('summary-row-dropped');
+		expect(normalized.text).not.toContain('[NOTE]');
+		expect(normalized.text).not.toContain('[DONE]');
+		expect(normalized.text).not.toContain('[LANE_SUMMARY]');
+		const result = parseCandidates(
+			input(normalized.text),
+			microFlags('some-lane'),
+		);
+		expect(result.clean_attestation?.micro_lane).toBe('some-lane');
+		expect(result.diagnostics.malformed_rows).toBe(0);
+	});
+});
+
+describe('captured consolidated micro artifact (PR #2177 run)', () => {
+	test('every owned family parses as covered after repairs', () => {
+		for (const family of ownedFamilies) {
+			const normalized = normalizeCandidateArtifact(
+				capturedArtifact,
+				'micro_lane',
+			);
+			expect(normalized.repairKinds).toContain(
+				'clean-evidence-pipe-tail-merge',
+			);
+			expect(normalized.repairKinds).toContain('summary-row-dropped');
+			const result = parseCandidates(
+				input(normalized.text),
+				microFlags(family),
+			);
+			expect(
+				result.error_code,
+				`family ${family} should parse cleanly`,
+			).toBeUndefined();
+			expect(
+				result.diagnostics.parse_errors,
+				`family ${family} should have zero parse errors`,
+			).toBe(0);
+			expect(
+				result.clean_attestation?.micro_lane,
+				`family ${family} should be attested clean`,
+			).toBe(family);
+		}
+	});
+
+	test('mixed artifact: CANDIDATE for one family + CLEAN for siblings does not conflict', () => {
+		const artifact = [
+			microHeader,
+			'[CANDIDATE] | c-1 | test-infrastructure | MEDIUM | coverage-gap | src/a.ts:1 | claim text here | invariant text | evidence text here | HIGH',
+			'[CLEAN] | untrusted-input-boundaries | coverage of input boundary normalization | concrete evidence describing boundary coverage here',
+		].join('\n');
+		const cleanLane = parseCandidates(
+			input(artifact),
+			microFlags('untrusted-input-boundaries'),
+		);
+		expect(cleanLane.error_code).toBeUndefined();
+		expect(cleanLane.clean_attestation?.micro_lane).toBe(
+			'untrusted-input-boundaries',
+		);
+		const candidateLane = parseCandidates(
+			input(artifact),
+			microFlags('test-infrastructure'),
+		);
+		expect(candidateLane.candidates).toHaveLength(1);
+		expect(candidateLane.clean_attestation).toBeUndefined();
+	});
+
+	test('unscoped parse: CLEAN rows for two different lanes both survive, no error', () => {
+		// No expected_lane flags (a manual parse_lane_candidates call). The first
+		// valid CLEAN fills the singular attestation slot; the second lane's valid
+		// CLEAN is skipped — not an "Only one CLEAN attestation" error.
+		const artifact = [
+			microHeader,
+			'[CLEAN] | lane-alpha | coverage scope text long enough | evidence for lane alpha here',
+			'[CLEAN] | lane-beta | coverage scope text long enough | evidence for lane beta here',
+		].join('\n');
+		const result = parseCandidates(
+			input(normalizeCandidateArtifact(artifact, 'micro_lane').text),
+			microFlags('lane-alpha', {
+				expected_micro_lane: undefined,
+				expected_micro_lanes: undefined,
+			}),
+		);
+		expect(result.error_code).toBeUndefined();
+		expect(result.diagnostics.malformed_rows).toBe(0);
+		expect(result.clean_attestation?.micro_lane).toBe('lane-alpha');
+	});
+
+	test('a pipe-free line starting with a bracket token is preserved', () => {
+		// Only pipe-bearing marker rows are dropped; a pipe-free [IMPORTANT] line
+		// is harmless prose today (single field, never a short candidate row) and
+		// may be a continuation fragment.
+		const artifact = [
+			microHeader,
+			'[CLEAN] | some-lane | coverage scope text long enough | plain evidence text describing coverage',
+			'[IMPORTANT] continuation prose without any pipes',
+		].join('\n');
+		const normalized = normalizeCandidateArtifact(artifact, 'micro_lane');
+		expect(normalized.repairKinds).not.toContain('summary-row-dropped');
+		expect(normalized.text).toContain('[IMPORTANT]');
+	});
+
+	test('duplicate CLEAN for the SAME lane is still rejected', () => {
+		const artifact = [
+			microHeader,
+			'[CLEAN] | some-lane | coverage scope text long enough | first evidence text here',
+			'[CLEAN] | some-lane | coverage scope text long enough | second evidence text here',
+		].join('\n');
+		const result = parseCandidates(
+			input(normalizeCandidateArtifact(artifact, 'micro_lane').text),
+			microFlags('some-lane'),
+		);
+		expect(result.diagnostics.parse_error_details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					field: 'clean_attestation',
+				}),
+			]),
+		);
+		expect(result.clean_attestation).toBeUndefined();
+	});
+
+	test('CLEAN alongside a CANDIDATE for the same lane still conflicts', () => {
+		const artifact = [
+			microHeader,
+			'[CANDIDATE] | c-1 | some-lane | MEDIUM | coverage-gap | src/a.ts:1 | claim text here | invariant text | evidence text here | HIGH',
+			'[CLEAN] | some-lane | coverage scope text long enough | contradictory clean evidence here',
+		].join('\n');
+		const result = parseCandidates(
+			input(normalizeCandidateArtifact(artifact, 'micro_lane').text),
+			microFlags('some-lane'),
+		);
+		expect(result.clean_attestation).toBeUndefined();
+		expect(result.diagnostics.parse_error_details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					field: 'clean_attestation',
+					message: expect.stringContaining('same lane'),
+				}),
+			]),
+		);
+	});
+});

--- a/tests/unit/background/candidate-contract-clean-repair.test.ts
+++ b/tests/unit/background/candidate-contract-clean-repair.test.ts
@@ -98,6 +98,31 @@ describe('clean-evidence-pipe-tail-merge repair', () => {
 		expect(result.diagnostics.malformed_rows).toBe(0);
 	});
 
+	test('backslash boundary: a pre-existing escaped pipe survives the tail-merge', () => {
+		// Input evidence containing an escaped pipe (single backslash before
+		// the pipe) ahead of later unescaped pipes must repair without losing
+		// the row. The parser-view evidence canonicalizes every pipe to a
+		// literal pipe with surrounding spacing preserved (ground-truthed
+		// against the parser); longer backslash runs collapse the same way,
+		// consistent with splitPipeFields escape handling.
+		const line =
+			'[CLEAN] | some-lane | coverage scope text long enough | alpha \\| beta | gamma | delta | epsilon';
+		const normalized = normalizeCandidateArtifact(
+			`${microHeader}
+${line}`,
+			'micro_lane',
+		);
+		expect(normalized.repairKinds).toContain('clean-evidence-pipe-tail-merge');
+		const result = parseCandidates(
+			input(normalized.text),
+			microFlags('some-lane'),
+		);
+		expect(result.error_code).toBeUndefined();
+		expect(result.clean_attestation?.evidence).toBe(
+			'alpha | beta | gamma | delta | epsilon',
+		);
+	});
+
 	test('leaves well-formed and non-CLEAN rows untouched', () => {
 		const fine = [
 			microHeader,

--- a/tests/unit/background/candidate-terminal-recovery.test.ts
+++ b/tests/unit/background/candidate-terminal-recovery.test.ts
@@ -132,6 +132,9 @@ describe('candidate artifact terminal protocol recovery', () => {
 			expect(result.error).toBeUndefined();
 			expect(result.clean_attestation?.lane).toBe('security-trust');
 			expect(result.clean_attestation?.evidence).toContain(EVIDENCE);
+			expect(
+				normalizeCandidateArtifact(salvaged, 'base_explorer').repairKinds,
+			).toContain('clean-evidence-pipe-tail-merge');
 		}
 		// Structurally broken rows stay rejected: evidence below the minimum
 		// length is not a pipe defect and must not be salvaged.

--- a/tests/unit/background/candidate-terminal-recovery.test.ts
+++ b/tests/unit/background/candidate-terminal-recovery.test.ts
@@ -115,14 +115,33 @@ describe('candidate artifact terminal protocol recovery', () => {
 		expect(parsed.error).toBeUndefined();
 		expect(parsed.clean_attestation?.lane).toBe('security-trust');
 
-		for (const rejected of [
+		// Recoverability contract change (PR-review deadlock fix): extra trailing
+		// pipe segments on a [CLEAN] row are tail-merged into the free-text
+		// evidence field instead of rejecting the row. Previously-shipped behavior
+		// rejected these shapes outright; the captured PR #2177 run showed
+		// frontier-model prose (regex chars like `,;|`) reliably trips them.
+		for (const salvaged of [
 			`${BASE_HEADER}\n[CLEAN] | security-trust | ${SCOPE} | ${EVIDENCE} | CERTAIN`,
 			`${BASE_HEADER}\n[CLEAN] | security-trust | ${SCOPE} | ${EVIDENCE} | HIGH | EXTRA`,
 		]) {
-			expect(
-				parseNormalized(rejected, 'base_explorer', 'security-trust').error,
-			).toBeDefined();
+			const result = parseNormalized(
+				salvaged,
+				'base_explorer',
+				'security-trust',
+			);
+			expect(result.error).toBeUndefined();
+			expect(result.clean_attestation?.lane).toBe('security-trust');
+			expect(result.clean_attestation?.evidence).toContain(EVIDENCE);
 		}
+		// Structurally broken rows stay rejected: evidence below the minimum
+		// length is not a pipe defect and must not be salvaged.
+		expect(
+			parseNormalized(
+				`${BASE_HEADER}\n[CLEAN] | security-trust | ${SCOPE} | too short`,
+				'base_explorer',
+				'security-trust',
+			).error,
+		).toBeDefined();
 	});
 
 	test('recovers the equivalent micro-lane terminal protocol', () => {

--- a/tests/unit/background/pr-review-trigger-contract.test.ts
+++ b/tests/unit/background/pr-review-trigger-contract.test.ts
@@ -283,6 +283,29 @@ describe('persisted PR-review trigger receipts', () => {
 		expect(() => parsePrReviewTriggerReceipt(rowWithUnknownField)).toThrow();
 	});
 
+	test('parses a pre-degradation v2 receipt lacking coverage_degradations', () => {
+		// Forward compatibility: receipts persisted before the recoverability
+		// change carry no coverage_degradations key; the strict v2 schema must
+		// default it to an empty array rather than reject the receipt.
+		const receipt = buildPrReviewTriggerReceiptV2({
+			run_id: 'run-coverage-omit',
+			pr_head_sha: 'a'.repeat(40),
+			base_ref: 'origin/main',
+			base_sha: 'b'.repeat(40),
+			evaluated_at: '2026-08-02T00:00:00.000Z',
+			dispatched_micro_lane_count: 4,
+			rows: persistedRows(),
+		});
+		const withoutDegradations = {
+			...receipt,
+			coverage_degradations: undefined,
+		} as Record<string, unknown>;
+		delete withoutDegradations.coverage_degradations;
+		const parsed = parsePrReviewTriggerReceipt(withoutDegradations);
+		expect(parsed.coverageDegradations).toEqual([]);
+		expect(parsed.matchedRows.length).toBe(receipt.matched_count);
+	});
+
 	test.each([
 		'scope',
 		'trigger_row',

--- a/tests/unit/hooks/pr-workflow-gate-degraded-inventory.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-degraded-inventory.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import { PR_REVIEW_TRIGGER_DEFINITIONS } from '../../../src/background/pr-review-trigger-contract.js';
+import {
+	activatePrWorkflow,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	markPrReviewTriggerEvaluationComplete,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+// End-to-end guard for the recorded-degradation path: a micro lane that ended
+// degraded after retries was accepted by write_pr_review_trigger_eval with a
+// coverage_degradations entry on the receipt. The reviewer/critic inventory
+// (derivePrReviewCandidateInventory) must skip that family instead of
+// re-creating the trigger-eval dead-end — while a family with NO record and NO
+// degradation entry still blocks.
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+const BASE_CANDIDATE_IDS = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_lane, index) => `C-${index}`,
+);
+
+async function recordDegradedMicroLane(family: string): Promise<void> {
+	const batchId = `micro-${family}`;
+	const laneId = `micro-lane-${family}`;
+	const correlationId = `${batchId}--${laneId}`;
+	const text =
+		'the lane produced no usable protocol rows before exhausting retries';
+	await recordPendingDelegation(tempDir, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `call-${correlationId}`,
+		normalizedAgent: 'explorer',
+		swarmPrefixedAgent: 'explorer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId,
+		laneId,
+		mode: 'swarm-pr-review:micro',
+		workflowLane: family,
+		workspace: {
+			directory: tempDir,
+			gitHead: HEAD_SHA,
+			dirtyHash: null,
+			prHeadSha: HEAD_SHA,
+			scope: `complete PR diff def456...${HEAD_SHA}`,
+		},
+	});
+	const stored = storeLaneOutput(tempDir, {
+		batchId,
+		laneId,
+		agent: 'explorer',
+		role: 'explorer',
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: 'swarm-pr-review:micro',
+		workflowLane: family,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: gateInternals.resolvePrWorkflowRevisionDigest(
+			tempDir,
+			HEAD_SHA,
+		),
+		scope: `complete PR diff def456...${HEAD_SHA}`,
+		source: 'collect_lane_results',
+		text,
+	});
+	await appendDelegationTransition(tempDir, correlationId, {
+		status: 'error',
+		result: {
+			text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			outputRef: stored.ref,
+		},
+	});
+}
+
+/** Writes a full v2 trigger receipt; `degradedFamilies` get coverage_degradations
+ * entries citing their (batch, lane) tuple. The receipt is hand-constructed to
+ * isolate the INVENTORY consumer: the trigger-eval provenance gate that would
+ * normally produce these degradations is exercised separately in
+ * tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts. */
+async function writeTriggerReceipt(degradedFamilies: string[]): Promise<void> {
+	const rows = PR_REVIEW_TRIGGER_DEFINITIONS.map((definition) => {
+		const batchId = `micro-${definition.id}`;
+		const laneId = `micro-lane-${definition.id}`;
+		return {
+			trigger_id: definition.id,
+			scope: definition.scope,
+			trigger_row: definition.trigger_row,
+			micro_lane: definition.micro_lane,
+			result: 'MATCHED' as const,
+			evidence: `fixture evidence for ${definition.id}`,
+			source_batch_id: batchId,
+			source_lane_id: laneId,
+		};
+	});
+	const coverage_degradations = degradedFamilies.map((family) => ({
+		trigger_id: family,
+		source_batch_id: `micro-${family}`,
+		source_lane_id: `micro-lane-${family}`,
+		reason: 'no covered candidate or clean row for the family',
+	}));
+	const triggerRelative = path.join(
+		'pr-review',
+		'test-run',
+		'trigger-eval.json',
+	);
+	const triggerAbsolute = path.join(tempDir, '.swarm', triggerRelative);
+	await fs.mkdir(path.dirname(triggerAbsolute), { recursive: true });
+	await fs.writeFile(
+		triggerAbsolute,
+		JSON.stringify({
+			schema_version: 2,
+			run_id: 'test-run',
+			pr_head_sha: HEAD_SHA,
+			base_ref: 'origin/main',
+			base_sha: 'def456',
+			evaluated_at: '2026-08-14T00:00:00.000Z',
+			dispatched_micro_lane_count: PR_REVIEW_TRIGGER_DEFINITIONS.length,
+			trigger_count: rows.length,
+			matched_count: rows.length,
+			not_triggered_count: 0,
+			no_match_count: 0,
+			rows,
+			coverage_degradations,
+		}),
+		'utf-8',
+	);
+	await markPrReviewTriggerEvaluationComplete(
+		tempDir,
+		SESSION_ID,
+		'test-run',
+		triggerRelative,
+	);
+}
+
+async function establishBaseAndMicroLanes(
+	degradedFamily?: string,
+): Promise<void> {
+	await activatePrWorkflow(tempDir, SESSION_ID, 'PR_REVIEW');
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(tempDir, SESSION_ID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: HEAD_SHA,
+	});
+	await persistBatch('base-all', 'swarm-pr-review:base', baseLanes);
+	for (const family of PR_REVIEW_REQUIRED_MICRO_LANE_IDS) {
+		if (family === degradedFamily) {
+			await recordDegradedMicroLane(family);
+			continue;
+		}
+		await persistBatch(
+			`micro-${family}`,
+			'swarm-pr-review:micro',
+			[{ laneId: `micro-lane-${family}`, workflowLane: family }],
+			{
+				textOverride: `[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence\n[CLEAN] | ${family} | exact reviewed diff | no finding after focused invariant review`,
+			},
+		);
+	}
+}
+
+describe('degraded micro lane does not block the reviewer inventory', () => {
+	test('reviewer dispatch proceeds when the receipt discloses the degradation', async () => {
+		const degradedFamily = PR_REVIEW_REQUIRED_MICRO_LANE_IDS[0];
+		await establishBaseAndMicroLanes(degradedFamily);
+		await writeTriggerReceipt([degradedFamily]);
+		await expect(
+			recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'reviewer',
+				[
+					{
+						laneId: 'review-all',
+						workflowLane: 'review-all',
+						reviewItemIds: BASE_CANDIDATE_IDS,
+					},
+				],
+				{ batchId: 'review-all', prHeadSha: HEAD_SHA },
+			),
+		).resolves.toBeDefined();
+	});
+
+	test('a missing micro lane with NO degradation entry still blocks', async () => {
+		// Same shape, but the receipt does not disclose the degraded family: the
+		// hard provenance requirement must still fail closed.
+		const degradedFamily = PR_REVIEW_REQUIRED_MICRO_LANE_IDS[0];
+		await establishBaseAndMicroLanes(degradedFamily);
+		await writeTriggerReceipt([]);
+		await expect(
+			recordPrReviewValidationBatch(
+				tempDir,
+				SESSION_ID,
+				'reviewer',
+				[
+					{
+						laneId: 'review-all',
+						workflowLane: 'review-all',
+						reviewItemIds: BASE_CANDIDATE_IDS,
+					},
+				],
+				{ batchId: 'review-all', prHeadSha: HEAD_SHA },
+			),
+		).rejects.toThrow('mandatory micro-lane provenance');
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-no-change-rebind.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-no-change-rebind.test.ts
@@ -151,7 +151,10 @@ async function persistLaneArtifact(
 
 /** Fabricate a fully settled PR_FEEDBACK gate for [FB-001] with the given
  * verification classification and a typed Stage A reproduction mapping. */
-async function settleFeedbackWorkflow(classification: string): Promise<void> {
+async function settleFeedbackWorkflow(
+	classification: string,
+	evidence = 'evidence text here',
+): Promise<void> {
 	await activatePrWorkflow(directory, SESSION_ID, 'PR_FEEDBACK');
 	await declarePrFeedbackInventory(directory, SESSION_ID, ['FB-001'], {
 		prHeadSha: HEAD_SHA,
@@ -167,7 +170,7 @@ async function settleFeedbackWorkflow(classification: string): Promise<void> {
 		'verify',
 		'swarm-pr-feedback:verification',
 		'reviewer',
-		`[FEEDBACK-VERIFIED] | FB-001 | ${classification} | evidence text here`,
+		`[FEEDBACK-VERIFIED] | FB-001 | ${classification} | ${evidence}`,
 	);
 	await recordPrFeedbackStageA(directory, SESSION_ID, REVISION, [
 		{ category: 'build', command: ['build'], durationMs: 1 },
@@ -259,6 +262,25 @@ describe('verified-no-change terminal (issue #2131 C1)', () => {
 			'utf-8',
 		);
 		expect(events).toContain('pr_feedback_verified_no_change');
+	});
+
+	test('pipe-bearing verification evidence still settles the zero-commit terminal (PR #2182 UIB-002)', async () => {
+		// The evidence field is free-text prose; a literal pipe in it previously
+		// passed coverage (capped splitter) but was skipped by the settled read
+		// (raw splitter), blocking a verified no-change item with an impossible
+		// remedy. Both readers must agree.
+		await settleFeedbackWorkflow(
+			'DISPROVED',
+			'no defect found; the guard checks the class `,;|` chars and a | b',
+		);
+		const status = await completePrWorkflow(
+			directory,
+			SESSION_ID,
+			'PR_FEEDBACK',
+			HEAD_SHA,
+		);
+		expect(status).toBe('verified-no-change');
+		expect(await readPrWorkflowGateState(directory, SESSION_ID)).toBeNull();
 	});
 
 	test.each([

--- a/tests/unit/hooks/pr-workflow-gate-verdict-pipe-tolerance.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-verdict-pipe-tolerance.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	assertPrReviewValidationSettled,
+	_test_exports as gateInternals,
+	recordPrReviewValidationBatch,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	establishReviewPrerequisites,
+	HEAD_SHA,
+	persistBatch,
+	SESSION_ID,
+	setupPrWorkflowGateFixtures,
+	teardownPrWorkflowGateFixtures,
+	tempDir,
+} from './pr-workflow-gate.test-fixtures.js';
+
+// Verdict-row pipe tolerance (PR-review deadlock fix). The strict verdict
+// parsers count pipe fields exactly ([REVIEWED]: 10, [CRITIC]: 6), so prose in
+// the trailing free-text fields that contains literal pipes — regex text,
+// `,;|`, shell snippets — previously made the whole verdict unparseable and
+// dead-ended the reviewer/critic phases exactly like the discovery phase.
+// pipeFieldsCapped tail-merges extra separators into the trailing field.
+
+beforeEach(setupPrWorkflowGateFixtures);
+afterEach(teardownPrWorkflowGateFixtures);
+
+describe('verdict row pipe tolerance', () => {
+	test('pipeFieldsCapped preserves all fields exactly when the pipe is trailing', () => {
+		// Fidelity-safe shape: extra pipes in the LAST (free-text) field merge
+		// back into it; every earlier field is byte-identical.
+		const row =
+			'[REVIEWED] | C-0 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale text | probe | reviewer notes mentioning `,;|` and a | b';
+		const capped = gateInternals.pipeFieldsCapped(row, 10);
+		expect(capped).toHaveLength(10);
+		expect(capped.slice(0, 9)).toEqual(
+			row
+				.split('|')
+				.map((f) => f.trim())
+				.slice(0, 9),
+		);
+		// Fields are pipe-split and trimmed before rejoining, so surrounding
+		// whitespace around an embedded pipe is normalized away — the pipe
+		// character and field content themselves are preserved.
+		expect(capped[9]).toBe('reviewer notes mentioning `,;|` and a|b');
+	});
+
+	test('pipeFieldsCapped preserves machine fields when the pipe is mid-row', () => {
+		// Documented boundary: a pipe in a NON-trailing prose field re-arranges
+		// the trailing prose fields, but the enumerated machine positions
+		// (id, classification, severity, file:line) are untouched.
+		const row =
+			'[REVIEWED] | C-0 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale mentioning `,;|` inline | probe | reviewer';
+		const capped = gateInternals.pipeFieldsCapped(row, 10);
+		expect(capped).toHaveLength(10);
+		expect(capped[1]).toBe('C-0');
+		expect(capped[2]).toBe('CONFIRMED');
+		expect(capped[4]).toBe('HIGH');
+		expect(capped[6]).toBe('file.ts:1');
+	});
+
+	test('a [REVIEWED] row with pipes in the rationale still authenticates', async () => {
+		await establishReviewPrerequisites();
+		const itemIds = ['C-0', 'C-1', 'C-2', 'C-3', 'C-4', 'C-5'];
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[
+				{
+					laneId: 'review-pipes',
+					workflowLane: 'review-pipes',
+					reviewItemIds: itemIds,
+				},
+			],
+			{ batchId: 'review-pipes', prHeadSha: HEAD_SHA },
+		);
+		// The pipe sits in a MID-row prose field (rationale). The tail-merge
+		// preserves every machine-checked position (classification, severity,
+		// file:line) so authentication succeeds, but trailing prose fields may be
+		// re-arranged — the documented fidelity boundary. The trailing-field case
+		// below pins the fidelity-safe shape.
+		const reviewerRows = itemIds
+			.map(
+				(id) =>
+					`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | regex text mentioning the class \`,;|\` inline | probe | reviewer`,
+			)
+			.join('\n');
+		await persistBatch(
+			'review-pipes',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'review-pipes', workflowLane: 'review-pipes' }],
+			{ textOverride: reviewerRows },
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+	});
+
+	test('a [CRITIC] row with pipes in its rationale still authenticates', async () => {
+		await establishReviewPrerequisites();
+		const itemIds = ['C-0', 'C-1', 'C-2', 'C-3', 'C-4', 'C-5'];
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'reviewer',
+			[
+				{
+					laneId: 'review-clean',
+					workflowLane: 'review-clean',
+					reviewItemIds: itemIds,
+				},
+			],
+			{ batchId: 'review-clean', prHeadSha: HEAD_SHA },
+		);
+		await persistBatch(
+			'review-clean',
+			'swarm-pr-review:reviewer',
+			[{ laneId: 'review-clean', workflowLane: 'review-clean' }],
+			{
+				textOverride: itemIds
+					.map(
+						(id) =>
+							`[REVIEWED] | ${id} | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer`,
+					)
+					.join('\n'),
+			},
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'reviewer'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+		await recordPrReviewValidationBatch(
+			tempDir,
+			SESSION_ID,
+			'critic',
+			[
+				{
+					laneId: 'critic-pipes',
+					workflowLane: 'critic-pipes',
+					reviewItemIds: itemIds,
+				},
+			],
+			{ batchId: 'critic-pipes', prHeadSha: HEAD_SHA },
+		);
+		const criticRows = itemIds
+			.map(
+				(id) =>
+					`[CRITIC] | ${id} | UPHELD | HIGH | the gate rejects \`,;|\` injection chars | required change spelled out`,
+			)
+			.join('\n');
+		await persistBatch(
+			'critic-pipes',
+			'swarm-pr-review:critic',
+			[{ laneId: 'critic-pipes', workflowLane: 'critic-pipes' }],
+			{ textOverride: criticRows },
+		);
+		await expect(
+			assertPrReviewValidationSettled(tempDir, SESSION_ID, 'critic'),
+		).resolves.toMatchObject({ mode: 'PR_REVIEW' });
+	});
+});

--- a/tests/unit/hooks/pr-workflow-gate-verdict-pipe-tolerance.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-verdict-pipe-tolerance.test.ts
@@ -44,6 +44,43 @@ describe('verdict row pipe tolerance', () => {
 		expect(capped[9]).toBe('reviewer notes mentioning `,;|` and a|b');
 	});
 
+	test('pipeFieldsCapped n=6 [CRITIC] identity: trailing-pipe merge preserves fields 0-4 exactly', () => {
+		const row =
+			'[CRITIC] | it-1 | UPHELD | HIGH | the gate rejects injection chars | final prose mentioning a | b';
+		const capped = gateInternals.pipeFieldsCapped(row, 6);
+		expect(capped).toHaveLength(6);
+		expect(capped.slice(0, 5)).toEqual(
+			row
+				.split('|')
+				.map((f) => f.trim())
+				.slice(0, 5),
+		);
+		expect(capped[5]).toBe('final prose mentioning a|b');
+	});
+
+	test('digest binds to the canonical capped view, stable across re-reads', () => {
+		const row =
+			'[REVIEWED] | C-0 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer notes mentioning a | b';
+		// reviewerVerdictRowDigest is what binds critic claims to reviewer rows;
+		// its input is the canonical capped field view, so repeated parses of the
+		// same retained artifact yield the identical digest (binding holds), and
+		// the digest demonstrably follows the canonical view rather than the raw
+		// split (a mid-row pipe re-arranges trailing prose; machine fields are
+		// unchanged).
+		const digestA = gateInternals.reviewerVerdictRowDigest(
+			gateInternals.pipeFieldsCapped(row, 10),
+		);
+		const digestB = gateInternals.reviewerVerdictRowDigest(
+			gateInternals.pipeFieldsCapped(row, 10),
+		);
+		expect(digestA).toBe(digestB);
+		expect(digestA).not.toBe(
+			gateInternals.reviewerVerdictRowDigest(
+				row.split('|').map((field) => field.trim()),
+			),
+		);
+	});
+
 	test('pipeFieldsCapped preserves machine fields when the pipe is mid-row', () => {
 		// Documented boundary: a pipe in a NON-trailing prose field re-arranges
 		// the trailing prose fields, but the enumerated machine positions

--- a/tests/unit/tools/dispatch-lanes-initial-dispatch-message.test.ts
+++ b/tests/unit/tools/dispatch-lanes-initial-dispatch-message.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import {
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	_internals as dispatchInternals,
+	executeDispatchLanesAsync,
+} from '../../../src/tools/dispatch-lanes.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+import { initializeGitRepository } from '../helpers/git-repository.js';
+
+// Split from dispatch-lanes-pr-workflow-gate.test.ts (FR-006: that file is over
+// the 500-line ratchet cap and must not grow). Discoverability fix for the
+// PR-review deadlock: the initial base-dispatch BLOCKED message must NAME the
+// six valid dimension IDs so an orchestrator can correct its next call without
+// grepping plugin source — the captured PR #2177 run burned ~8 rejected
+// dispatches on this.
+
+let directory = '';
+const originalGetSessionOps = dispatchInternals.getSessionOps;
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+const originalResolveRevision =
+	dispatchInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveRevisionAsync =
+	dispatchInternals.resolvePrWorkflowRevisionDigestAsync;
+const originalResolveMergeBase = dispatchInternals.resolveExactMergeBase;
+const originalResolveMergeBaseAsync =
+	dispatchInternals.resolveExactMergeBaseAsync;
+const originalResolveDiffStats = gateInternals.resolvePrReviewDiffStats;
+const originalResolveDiffStatsAsync =
+	gateInternals.resolvePrReviewDiffStatsAsync;
+
+beforeEach(async () => {
+	directory = canonicalMkdtemp('dispatch-message-');
+	await initializeGitRepository(directory);
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = () => 'abc123';
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+	gateInternals.resolvePrReviewDiffStats = () => ({
+		changedLines: 12,
+		changedFiles: 2,
+		hasSubmoduleChange: false,
+	});
+	gateInternals.resolvePrReviewDiffStatsAsync = async (...a) =>
+		gateInternals.resolvePrReviewDiffStats(...a);
+	dispatchInternals.resolvePrWorkflowRevisionDigest = () => 'revision-1';
+	dispatchInternals.resolvePrWorkflowRevisionDigestAsync = async (...a) =>
+		dispatchInternals.resolvePrWorkflowRevisionDigest(...a);
+	dispatchInternals.resolveExactMergeBase = () => 'def456';
+	dispatchInternals.resolveExactMergeBaseAsync = async (...a) =>
+		dispatchInternals.resolveExactMergeBase(...a);
+	dispatchInternals.getSessionOps = () => ({
+		create: mock(async () => ({ data: { id: 'lane-session' } })),
+		promptAsync: mock(async () => ({ data: undefined, error: undefined })),
+		delete: mock(async () => undefined),
+	});
+});
+
+afterEach(async () => {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	gateInternals.resolvePrReviewDiffStats = originalResolveDiffStats;
+	gateInternals.resolvePrReviewDiffStatsAsync = originalResolveDiffStatsAsync;
+	dispatchInternals.resolvePrWorkflowRevisionDigest = originalResolveRevision;
+	dispatchInternals.resolvePrWorkflowRevisionDigestAsync =
+		originalResolveRevisionAsync;
+	dispatchInternals.resolveExactMergeBase = originalResolveMergeBase;
+	dispatchInternals.resolveExactMergeBaseAsync = originalResolveMergeBaseAsync;
+	dispatchInternals.getSessionOps = originalGetSessionOps;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+describe('initial PR_REVIEW base dispatch BLOCKED message discoverability', () => {
+	test('tier-S partition rejection names all six valid dimension IDs', async () => {
+		const result = await executeDispatchLanesAsync(
+			{
+				mode: 'swarm-pr-review:base',
+				pr_head_sha: 'abc123',
+				base_sha: 'def456',
+				base_ref: 'origin/main',
+				max_concurrent: 2,
+				lanes: [
+					{
+						id: 'sweep-a',
+						agent: 'explorer',
+						prompt: 'Inspect sweep-a',
+						workflow_lane: PR_REVIEW_BASE_DIMENSION_IDS[0],
+						owned_workflow_lanes: [...PR_REVIEW_BASE_DIMENSION_IDS.slice(0, 3)],
+					},
+					{
+						id: 'sweep-b',
+						agent: 'explorer',
+						prompt: 'Inspect sweep-b',
+						workflow_lane: PR_REVIEW_BASE_DIMENSION_IDS[3],
+						owned_workflow_lanes: [...PR_REVIEW_BASE_DIMENSION_IDS.slice(3, 5)],
+					},
+				],
+			},
+			directory,
+			{ sessionID: 'message-session' },
+		);
+		expect(result.success).toBe(false);
+		expect(result.message).toContain(
+			'partition all six dimensions exactly once',
+		);
+		expect(result.message).toContain('valid dimensions:');
+		for (const dimensionId of PR_REVIEW_BASE_DIMENSION_IDS) {
+			expect(result.message).toContain(dimensionId);
+		}
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-micro-cycle.test.ts
@@ -378,7 +378,7 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 		expect(createdSessions).toBe(1);
 	});
 
-	test('uses an omitted-ledger retry artifact for final trigger provenance while rejecting the failed original', async () => {
+	test('uses an omitted-ledger retry artifact for final trigger provenance while disclosing the failed original', async () => {
 		await establishBaseCoverage();
 		const ledger = focusedRetryEvaluation();
 		await expect(
@@ -428,22 +428,11 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 					: row,
 			);
 
-		const rejected = JSON.parse(
-			await executeWritePrReviewTriggerEval(
-				{
-					run_id: 'micro-retry-failed-original',
-					pr_head_sha: HEAD_SHA,
-					base_ref: 'origin/main',
-					base_sha: PR_REVIEW_BASE_SHA,
-					rows: rowsFrom('micro-retry-original', 'micro-retry-original-lane'),
-				},
-				tempDir,
-				{ sessionID: SESSION_ID },
-			),
-		);
-		expect(rejected.success).toBe(false);
-		expect(rejected.message).toMatch(/completed|provenance|artifact/i);
-
+		// Recoverability contract change: citing the FAILED original lane would
+		// now succeed-with-disclosure (provenance intact, degradation recorded on
+		// the receipt — pinned in write-pr-review-trigger-eval-degraded.test.ts);
+		// the healthy retry tuple remains the preferred final provenance and
+		// produces an un-degraded receipt.
 		const accepted = JSON.parse(
 			await executeWritePrReviewTriggerEval(
 				{
@@ -458,6 +447,7 @@ describe('PR-review trigger-evaluation and micro-dispatch cycle', () => {
 			),
 		);
 		expect(accepted.success).toBe(true);
+		expect(accepted.coverage_degradation_count).toBe(0);
 		const finalState = await readPrWorkflowGateState(tempDir, SESSION_ID);
 		expect(finalState?.prReviewTriggerEvalPath).toBe(accepted.path);
 	});

--- a/tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts
@@ -1,0 +1,468 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { storeLaneOutput } from '../../../src/background/lane-output-store';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations';
+import {
+	activatePrWorkflow,
+	bindPrReviewBase,
+	bindPrReviewTriggerLedger,
+	enforcePrReviewBaseDimensions,
+	_test_exports as gateInternals,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+} from '../../../src/hooks/pr-workflow-gate';
+import {
+	executeWritePrReviewTriggerEval,
+	PR_REVIEW_TRIGGER_DEFINITIONS,
+	_internals as writerInternals,
+} from '../../../src/tools/write-pr-review-trigger-eval';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+// Split from write-pr-review-trigger-eval-provenance.test.ts (FR-006): the
+// recorded-degradation path. A MATCHED family whose cited micro lane is
+// provenance-valid but coverage-degraded (failed status, degraded output, or
+// no covered row) must no longer dead-end the whole review — the run proceeds
+// with the degradation disclosed on the durable receipt. Provenance failures
+// (wrong lane, wrong mode, wrong head) still fail closed.
+
+const tempDirs: string[] = [];
+const SESSION_ID = 'trigger-eval-degraded-session';
+const HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'review-revision';
+const REVIEW_SCOPE = `complete PR diff def456...${HEAD_SHA}`;
+const originalResolveCurrentGitHead = gateInternals.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	gateInternals.resolveCurrentGitHeadAsync;
+const originalResolveIsWorkingTreeClean =
+	gateInternals.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	gateInternals.resolveIsWorkingTreeCleanAsync;
+const originalGateRevisionDigest =
+	gateInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveRevisionDigest =
+	writerInternals.resolvePrWorkflowRevisionDigest;
+const originalResolveMergeBase = writerInternals.resolveMergeBase;
+const originalResolveDiffStats = gateInternals.resolvePrReviewDiffStats;
+const originalResolveDiffStatsAsync =
+	gateInternals.resolvePrReviewDiffStatsAsync;
+
+function tempRoot(): string {
+	const root = canonicalMkdtemp('trigger-eval-degraded-');
+	tempDirs.push(root);
+	return root;
+}
+
+function rows() {
+	return PR_REVIEW_TRIGGER_DEFINITIONS.map((definition, index) => ({
+		trigger_id: definition.id,
+		result: 'MATCHED' as const,
+		evidence: `mandatory review focus for ${definition.id}`,
+		source_batch_id: `micro-batch-${Math.floor(index / 8)}`,
+		source_lane_id: `lane-${index}`,
+	}));
+}
+
+async function recordLane(
+	root: string,
+	input: {
+		batchId: string;
+		laneId: string;
+		workflowLane: string;
+		mode: 'swarm-pr-review:base' | 'swarm-pr-review:micro';
+		status?: 'completed' | 'error' | 'cancelled';
+		emptyOutput?: boolean;
+		resultOverrides?: Record<string, unknown>;
+	},
+): Promise<void> {
+	const status = input.status ?? 'completed';
+	const correlationId = `${input.batchId}-${input.laneId}-session`;
+	const header =
+		input.mode === 'swarm-pr-review:base'
+			? '[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence'
+			: '[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+	const text = input.emptyOutput
+		? 'the lane produced no usable protocol rows at all'
+		: `${header}\n[CLEAN] | ${input.workflowLane} | exact reviewed diff | no candidate survived the focused review`;
+	await recordPendingDelegation(root, {
+		correlationId,
+		jobId: null,
+		subagentSessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		callID: `${input.batchId}-call`,
+		normalizedAgent: 'explorer',
+		swarmPrefixedAgent: 'explorer',
+		planTaskId: null,
+		evidenceTaskId: null,
+		batchId: input.batchId,
+		laneId: input.laneId,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		workspace: {
+			directory: root,
+			gitHead: HEAD_SHA,
+			dirtyHash: null,
+			prHeadSha: HEAD_SHA,
+			scope: REVIEW_SCOPE,
+		},
+	});
+	const stored = storeLaneOutput(root, {
+		batchId: input.batchId,
+		laneId: input.laneId,
+		agent: 'explorer',
+		role: 'explorer',
+		sessionId: correlationId,
+		parentSessionId: SESSION_ID,
+		mode: input.mode,
+		workflowLane: input.workflowLane,
+		prHeadSha: HEAD_SHA,
+		gitHead: HEAD_SHA,
+		revisionDigest: REVISION_DIGEST,
+		scope: REVIEW_SCOPE,
+		source: 'collect_lane_results',
+		text,
+	});
+	await appendDelegationTransition(root, correlationId, {
+		status,
+		result: {
+			text,
+			chars: stored.chars,
+			truncated: false,
+			digest: stored.digest,
+			outputRef: stored.ref,
+			...input.resultOverrides,
+		},
+	});
+}
+
+async function establishBoundReviewGate(
+	root: string,
+	options: { degradedMicroIndex?: number } = {},
+): Promise<void> {
+	gateInternals.resolveCurrentGitHead = () => HEAD_SHA;
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	gateInternals.resolvePrReviewDiffStats = () => ({
+		changedLines: 10,
+		changedFiles: 1,
+		hasSubmoduleChange: false,
+	});
+	writerInternals.resolvePrWorkflowRevisionDigest = () => REVISION_DIGEST;
+	writerInternals.resolveMergeBase = () => 'def456';
+	gateInternals.resolveCurrentGitHeadAsync = async (dir) =>
+		gateInternals.resolveCurrentGitHead(dir);
+	gateInternals.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		gateInternals.resolveIsWorkingTreeClean(dir);
+	gateInternals.resolvePrReviewDiffStatsAsync = async (dir, base, head) =>
+		gateInternals.resolvePrReviewDiffStats(dir, base, head);
+	await activatePrWorkflow(root, SESSION_ID, 'PR_REVIEW');
+	await bindPrReviewBase(root, SESSION_ID, {
+		prHeadSha: HEAD_SHA,
+		baseRef: 'origin/main',
+		baseSha: 'def456',
+	});
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(root, SESSION_ID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: HEAD_SHA,
+	});
+	for (const lane of baseLanes) {
+		await recordLane(root, {
+			batchId: 'base-all',
+			laneId: lane.laneId,
+			workflowLane: lane.workflowLane,
+			mode: 'swarm-pr-review:base',
+		});
+	}
+	await bindPrReviewTriggerLedger(
+		root,
+		SESSION_ID,
+		rows().map(({ trigger_id, result, evidence }) => ({
+			trigger_id,
+			result,
+			evidence,
+		})),
+	);
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		if (index === options.degradedMicroIndex) continue;
+		await recordLane(root, {
+			batchId: `micro-batch-${Math.floor(index / 8)}`,
+			laneId: `lane-${index}`,
+			workflowLane,
+			mode: 'swarm-pr-review:micro',
+		});
+	}
+}
+
+function receiptPath(root: string, runId: string): string {
+	// validateSwarmPath resolves every runtime artifact under <root>/.swarm/.
+	return join(root, '.swarm', 'pr-review', runId, 'trigger-eval.json');
+}
+
+function writeTriggerEval(root: string, runId: string) {
+	return executeWritePrReviewTriggerEval(
+		{
+			run_id: runId,
+			pr_head_sha: HEAD_SHA,
+			base_sha: 'def456',
+			base_ref: 'origin/main',
+			rows: rows(),
+		},
+		root,
+		{ sessionID: SESSION_ID },
+	);
+}
+
+afterEach(() => {
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	gateInternals.resolvePrWorkflowRevisionDigest = originalGateRevisionDigest;
+	writerInternals.resolvePrWorkflowRevisionDigest =
+		originalResolveRevisionDigest;
+	writerInternals.resolveMergeBase = originalResolveMergeBase;
+	gateInternals.resolvePrReviewDiffStats = originalResolveDiffStats;
+	gateInternals.resolvePrReviewDiffStatsAsync = originalResolveDiffStatsAsync;
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('write_pr_review_trigger_eval recorded degradation path', () => {
+	test('a failed micro lane no longer aborts: the receipt records the degradation', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root, { degradedMicroIndex: 2 });
+		// Lane 2 exhausted its retries and ended failed, but retained a valid,
+		// identity-checked artifact.
+		await recordLane(root, {
+			batchId: 'micro-batch-0',
+			laneId: 'lane-2',
+			workflowLane: PR_REVIEW_REQUIRED_MICRO_LANE_IDS[2],
+			mode: 'swarm-pr-review:micro',
+			status: 'error', // delegation-record terminal status for a lane that failed validation but retained its artifact
+		});
+		const result = JSON.parse(
+			await writeTriggerEval(root, 'review-degraded-1'),
+		);
+		expect(result.success).toBe(true);
+		expect(result.coverage_degradation_count).toBeGreaterThan(0);
+		const receiptFile = receiptPath(root, 'review-degraded-1');
+		expect(existsSync(receiptFile)).toBe(true);
+		const receipt = JSON.parse(readFileSync(receiptFile, 'utf-8'));
+		expect(Array.isArray(receipt.coverage_degradations)).toBe(true);
+		expect(receipt.coverage_degradations).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					trigger_id: PR_REVIEW_REQUIRED_MICRO_LANE_IDS[2],
+					reason: expect.stringContaining('lane status error'),
+				}),
+			]),
+		);
+	});
+
+	test('a degraded-output micro lane is disclosed, not fatal', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root, { degradedMicroIndex: 2 });
+		await recordLane(root, {
+			batchId: 'micro-batch-0',
+			laneId: 'lane-2',
+			workflowLane: PR_REVIEW_REQUIRED_MICRO_LANE_IDS[2],
+			mode: 'swarm-pr-review:micro',
+			resultOverrides: { outputDegraded: true },
+		});
+		const result = JSON.parse(
+			await writeTriggerEval(root, 'review-degraded-2'),
+		);
+		expect(result.success).toBe(true);
+		const receipt = JSON.parse(
+			readFileSync(receiptPath(root, 'review-degraded-2'), 'utf-8'),
+		);
+		expect(receipt.coverage_degradations).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: 'output degraded' }),
+			]),
+		);
+	});
+
+	test('a lane with no covered row is disclosed via the uncovered-family reason', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root, { degradedMicroIndex: 2 });
+		await recordLane(root, {
+			batchId: 'micro-batch-0',
+			laneId: 'lane-2',
+			workflowLane: PR_REVIEW_REQUIRED_MICRO_LANE_IDS[2],
+			mode: 'swarm-pr-review:micro',
+			emptyOutput: true,
+		});
+		const result = JSON.parse(
+			await writeTriggerEval(root, 'review-degraded-3'),
+		);
+		expect(result.success).toBe(true);
+		const receipt = JSON.parse(
+			readFileSync(receiptPath(root, 'review-degraded-3'), 'utf-8'),
+		);
+		expect(receipt.coverage_degradations).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					reason: expect.stringContaining('no covered candidate or clean row'),
+				}),
+			]),
+		);
+	});
+
+	test('a provenance failure still fails closed', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+		// Cite a lane tuple that was never dispatched at all.
+		const forged = rows();
+		forged[2] = {
+			...forged[2],
+			source_batch_id: 'never-dispatched-batch',
+			source_lane_id: 'ghost-lane',
+		};
+		const result = JSON.parse(
+			await executeWritePrReviewTriggerEval(
+				{
+					run_id: 'review-forged',
+					pr_head_sha: HEAD_SHA,
+					base_sha: 'def456',
+					base_ref: 'origin/main',
+					rows: forged,
+				},
+				root,
+				{ sessionID: SESSION_ID },
+			),
+		);
+		expect(result.success).toBe(false);
+		expect(result.message).toContain(
+			'does not reference a verifiable micro-lane provenance chain',
+		);
+	});
+
+	test('a healthy attestation writes no degradation entries', async () => {
+		const root = tempRoot();
+		await establishBoundReviewGate(root);
+		const result = JSON.parse(await writeTriggerEval(root, 'review-clean'));
+		expect(result.success).toBe(true);
+		expect(result.coverage_degradation_count).toBe(0);
+		const receipt = JSON.parse(
+			readFileSync(receiptPath(root, 'review-clean'), 'utf-8'),
+		);
+		expect(receipt.coverage_degradations).toEqual([]);
+	});
+
+	test('consolidated partial coverage stamps only the uncovered family', async () => {
+		// A consolidated lane owning families 0 and 1 whose artifact covers
+		// family 0 but not family 1: family 1's row gets the uncovered-family
+		// degradation, family 0's row gets NONE. Lane-wide stamping would
+		// misattribute the degradation to the covered family — the exact
+		// consolidated shape that motivated the recoverability path.
+		const root = tempRoot();
+		await establishBoundReviewGate(root, { degradedMicroIndex: 0 });
+		// Build the consolidated lane owning families 0 and 1 and point BOTH
+		// family rows at it (family 1's singleton record stays uncited — harmless).
+		const [family0, family1] = PR_REVIEW_REQUIRED_MICRO_LANE_IDS;
+		const consolidatedHeader =
+			'[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+		const text = `${consolidatedHeader}\n[CLEAN] | ${family0} | exact reviewed diff for family zero | no candidate survived the focused review`;
+		await recordPendingDelegation(root, {
+			correlationId: 'consol-session',
+			jobId: null,
+			subagentSessionId: 'consol-session',
+			parentSessionId: SESSION_ID,
+			callID: 'consol-call',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'micro-consol',
+			laneId: 'sweep-ab',
+			mode: 'swarm-pr-review:micro',
+			workflowLane: family0,
+			ownedWorkflowLanes: [family0, family1],
+			workspace: {
+				directory: root,
+				gitHead: HEAD_SHA,
+				dirtyHash: null,
+				prHeadSha: HEAD_SHA,
+				scope: REVIEW_SCOPE,
+			},
+		});
+		const stored = storeLaneOutput(root, {
+			batchId: 'micro-consol',
+			laneId: 'sweep-ab',
+			agent: 'explorer',
+			role: 'explorer',
+			sessionId: 'consol-session',
+			parentSessionId: SESSION_ID,
+			mode: 'swarm-pr-review:micro',
+			workflowLane: family0,
+			prHeadSha: HEAD_SHA,
+			gitHead: HEAD_SHA,
+			revisionDigest: REVISION_DIGEST,
+			scope: REVIEW_SCOPE,
+			source: 'collect_lane_results',
+			text,
+		});
+		await appendDelegationTransition(root, 'consol-session', {
+			status: 'completed',
+			result: {
+				text,
+				chars: stored.chars,
+				truncated: false,
+				digest: stored.digest,
+				outputRef: stored.ref,
+			},
+		});
+		const consolRows = rows();
+		consolRows[0] = {
+			...consolRows[0],
+			source_batch_id: 'micro-consol',
+			source_lane_id: 'sweep-ab',
+		};
+		consolRows[1] = {
+			...consolRows[1],
+			source_batch_id: 'micro-consol',
+			source_lane_id: 'sweep-ab',
+		};
+		const result = JSON.parse(
+			await executeWritePrReviewTriggerEval(
+				{
+					run_id: 'review-consol-partial',
+					pr_head_sha: HEAD_SHA,
+					base_sha: 'def456',
+					base_ref: 'origin/main',
+					rows: consolRows,
+				},
+				root,
+				{ sessionID: SESSION_ID },
+			),
+		);
+		expect(result.success).toBe(true);
+		const receipt = JSON.parse(
+			readFileSync(receiptPath(root, 'review-consol-partial'), 'utf-8'),
+		);
+		const uncoveredEntries = receipt.coverage_degradations.filter(
+			(entry: { reason: string }) =>
+				entry.reason.includes('no covered candidate or clean row'),
+		);
+		expect(uncoveredEntries).toEqual([
+			expect.objectContaining({
+				trigger_id: family1,
+				reason: `no covered candidate or clean row for: ${family1}`,
+			}),
+		]);
+	});
+});

--- a/tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts
@@ -451,6 +451,8 @@ describe('write_pr_review_trigger_eval recorded degradation path', () => {
 			),
 		);
 		expect(result.success).toBe(true);
+		// Exactly one degradation entry total: the uncovered family only.
+		expect(result.coverage_degradation_count).toBe(1);
 		const receipt = JSON.parse(
 			readFileSync(receiptPath(root, 'review-consol-partial'), 'utf-8'),
 		);

--- a/tests/unit/tools/write-pr-review-trigger-eval-provenance.test.ts
+++ b/tests/unit/tools/write-pr-review-trigger-eval-provenance.test.ts
@@ -323,7 +323,7 @@ describe('write_pr_review_trigger_eval provenance and ownership', () => {
 		);
 		expect(duplicateResult.success).toBe(false);
 		expect(duplicateResult.message).toContain(
-			'does not reference a completed non-degraded micro-lane artifact',
+			'does not reference a verifiable micro-lane provenance chain',
 		);
 	});
 
@@ -426,7 +426,7 @@ describe('write_pr_review_trigger_eval provenance and ownership', () => {
 		);
 		expect(result.success).toBe(false);
 		expect(result.message).toContain(
-			'does not reference a completed non-degraded micro-lane artifact',
+			'does not reference a verifiable micro-lane provenance chain',
 		);
 	});
 


### PR DESCRIPTION
Closes #2181

## Summary

`/swarm pr-review` dead-ended on format imperfections no frontier model reliably avoids, and turned any single micro-lane defect into an unrecoverable abort that discarded all completed work. A captured live run (PR #2177 review, plugin v7.140.1) lost 16 validated base-lane candidates this way after four substantively-correct micro-lane outputs were all parser-rejected.

What this PR changes (per the reporter's directive to relax the impossible format requirements while keeping provenance):

- **Pipes in `[CLEAN]` evidence are repaired, not rejected** (`src/background/candidate-contract.ts`). A literal `|` inside evidence prose (regex text like `` `,;|` ``) previously split the row past the 4-field contract and voided the attestation. The new `clean-evidence-pipe-tail-merge` repair re-merges the tail deterministically (evidence is the trailing field) and is recorded as salvage on the lane record. The `summary-row-dropped` repair removes pipe-bearing non-contract marker rows (`[LANE_SUMMARY]`, `[NOTE]`, `[DONE]`, …) that were miscounted as malformed candidate rows; pipe-free lines are preserved (possible continuation fragments). Repair order: marker-drop → fence recovery → redundant-confidence strip → tail-merge (the confidence strip must see 5-field rows first).
- **CLEAN conflicts are scoped per obligation** (`src/background/candidate-parser.ts`). The global "CLEAN cannot appear with candidate rows" rule now fires only for the SAME lane, matching the #2131 prompt contract the parser previously contradicted; a valid CLEAN for a different lane in an unscoped parse is skipped instead of failing the artifact. Duplicates for the same lane still error.
- **A degraded micro lane no longer aborts the review** (`src/tools/write-pr-review-trigger-eval.ts`, `src/background/pr-review-trigger-contract.ts`, `src/hooks/pr-workflow-gate.ts`). The MATCHED-row check is split: provenance failures (missing record, wrong mode, unowned family, head mismatch, artifact identity mismatch) still fail closed; coverage-quality failures (terminal error/cancelled status, degraded/truncated output, no covered row) are recorded on the durable `trigger-eval.json` receipt as `coverage_degradations` entries (row-scoped, so a consolidated lane's covered families are never misattributed) and the run proceeds. The reviewer/critic inventory skips exactly the receipt-disclosed tuples instead of re-blocking; the tool result reports `coverage_degradation_count`, and the skill mandates that synthesis disclose every degraded family. Receipts remain backward-compatible (`coverage_degradations` defaults to `[]`); the frozen-ledger digest and classification-drift checks are untouched.
- **Verdict rows tolerate pipes** (`src/hooks/pr-workflow-gate.ts`). `[REVIEWED]` (10-field), `[CRITIC]` (6-field), and `[FEEDBACK-VERIFIED]` (4-field) parsers tail-merge extra pipe separators into the trailing free-text field. Fidelity boundary (documented in the skill and release fragment): content-preserving for trailing-field pipes; a mid-row pipe still authenticates with all machine-checked positions intact, but trailing prose fields may be re-arranged. A debug-gated warn fires on every applied merge; the raw lane emission is always retained verbatim.
- **The initial base-dispatch BLOCKED error now names the six valid dimension IDs** (`src/tools/dispatch-lanes.ts`), so an orchestrator can correct its next call without grepping plugin source (the captured run burned ~8 dispatches on this).

The exact four-times-rejected artifact from the captured run is embedded in `tests/unit/background/candidate-contract-clean-repair.test.ts` and now parses as covered for all three owned families.

Known caveats (disclosed, deliberate): final-report disclosure of degraded families is a skill-level MUST with the receipt as durable backstop; verdict-row repair traces are debug-gated, not persisted (re-derivable from the retained raw artifact; salvage lane names on the delegation ledger are the durable signal).

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; `bun run build` + Node ESM import verified.
- 2 (runtime portability): not touched — no new imports; `node` ESM import of `dist/index.js` → `ESM_IMPORT_OK opencode-swarm`; bundle-portability/plugin-shape tests in blast radius pass.
- 3 (subprocesses): not touched — no spawn changes; grep of diff shows no new subprocess use.
- 4 (.swarm containment): touched — receipt writes go through the existing `validateSwarmPath` under `.swarm/pr-review/<run_id>/`; new tests write via the same paths. Evidence: `tests/unit/tools/write-pr-review-trigger-eval-degraded.test.ts` reads receipts only under `<root>/.swarm/`.
- 5 (plan durability): not touched — no plan/ledger changes.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — 4 new bun:test files (233/329/289/476 lines, all <500), no `mock.module` (DI via existing `_test_exports` seams, restored in `afterEach`), `realpathSync`-wrapped `mkdtempSync`, fixed timestamps (check-test-clock clean), falsifiability proven by mutation (disable pipe repair → 2 tests fail; break row-scoping → consolidated test fails; disable inventory skip → degraded-inventory test fails).
- 8 (session state): not touched — no new module-level state.
- 9 (guardrails/retry): touched — deliberate contract change: coverage-quality failures now record-and-proceed with durable disclosure; provenance remains fail-closed (verified by `write-pr-review-trigger-eval-degraded.test.ts` "a provenance failure still fails closed" and the inventory negative test). Retries remain the first resort per the skill.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched in registries — `check-tool-registration.ts`: "118 tools, coherent"; `bun run drift:check` clean (skill canonical is `.opencode`; `.claude`/`.agents` are adapters per `src/config/skill-mirrors.ts`).
- 12 (release/cache): touched — `docs/releases/pending/pr-review-lane-contract-recoverability.md` added; no version/CHANGELOG/manifest edits.

## Test plan

- New: `candidate-contract-clean-repair.test.ts` (10 tests incl. the captured artifact), `write-pr-review-trigger-eval-degraded.test.ts` (6), `pr-workflow-gate-degraded-inventory.test.ts` (2, end-to-end reviewer dispatch), `pr-workflow-gate-verdict-pipe-tolerance.test.ts` (4).
- Updated: `candidate-terminal-recovery.test.ts` (former rejected 5/6-field CLEAN shapes now asserted salvaged; short-evidence row still rejected), `write-pr-review-trigger-eval-provenance.test.ts` (message text; rejection behavior unchanged), `dispatch-lanes-pr-workflow-gate.test.ts` (asserts dimension IDs in BLOCKED message).
- Validation: `bun run typecheck`, `bun run lint:ci`, `bun run scripts/check-tool-registration.ts`, `check-mock-cleanup`, `check-invariants`, `check-cross-contamination` (0 new), `check-test-clock` (0 new), `check-test-file-cap`, `bun run drift:check` — all clean. `bun run test:unit:ci` scoped to changed + blast-radius files: all green. Security/adversarial/smoke tiers: 0 fail. Integration tier: failures proven pre-existing/environmental (identical on `origin/main` in this worktree; fresh worktree baseline).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

