### PR TITLE
fix: req_coverage preflight gate passes on file existence alone (never validates content) + hardcoded stale export version "4.5.0" (#1662)

### DIFF
--- a/docs/releases/pending/1662-req-coverage-content-validation.md
+++ b/docs/releases/pending/1662-req-coverage-content-validation.md
@@ -1,0 +1,20 @@
+# Preflight: req-coverage gate now validates report content; export version derived from package.json
+
+## What changed
+
+- `runRequirementCoverageCheck` in `src/services/preflight-service.ts` now reads and validates the req-coverage report's content instead of passing on file existence alone. Fails on: empty/whitespace file, unparseable JSON, schema-shape mismatch (zod schema pinning the writer's `success/phase/totalRequirements/coveredCount/missingCount/requirements` fields), `totalRequirements === 0`, and `missingCount > 0`. Passes only on a genuinely complete report and reports `coveredCount/totalRequirements`. Read bound is 500KB, matching `EVIDENCE_MAX_JSON_BYTES`.
+- `src/services/export-service.ts` derives the export payload `version` from `package.json` instead of the hardcoded stale `'4.5.0'`.
+- New regression suite `tests/unit/services/preflight-service-req-coverage.test.ts` (11 tests); `tests/unit/commands/export.test.ts` asserts version parity with `package.json`.
+
+## Why
+
+The gate previously treated `coverage.exists === true` as an unconditional pass while `checkRequirementCoverage` (`src/evidence/manager.ts`) is only an `fs.access` — so an empty, malformed, or incomplete report passed the preflight gate whenever the file merely existed (issue #1662). The export payload advertised version `4.5.0` while the package is at 7.x.
+
+## Migration steps
+
+None. Behavior change is fail-closed: preflight phases that previously passed with a garbage report will now fail with a precise message.
+
+## Known caveats
+
+- The status/schema guard validates the Entry-shaped req-coverage report only; no spec re-derivation or traceability scoring (explicitly out of scope in #1666-adjacent discussions; see issue #1662).
+- Reports larger than 500KB fail as oversized by design, mirroring the evidence manager's own bound.

--- a/src/services/export-service.ts
+++ b/src/services/export-service.ts
@@ -1,3 +1,8 @@
+// Bundled at build time from the plugin's own package.json — keeps the
+// exported `version` field in lockstep with releases instead of a stale
+// hardcoded literal (issue #1662: it had drifted to '4.5.0' three major
+// versions behind).
+import packageJson from '../../package.json' with { type: 'json' };
 import type { ExecutionProfile } from '../config/plan-schema';
 import { readSwarmFileAsync } from '../hooks/utils';
 import { loadPlanJsonOnly } from '../plan/manager';
@@ -24,7 +29,7 @@ export async function getExportData(directory: string): Promise<ExportData> {
 	const contextContent = await readSwarmFileAsync(directory, 'context.md');
 
 	return {
-		version: '4.5.0',
+		version: packageJson.version,
 		exported: new Date().toISOString(),
 		plan: planStructured || planContent, // structured Plan object if available, else markdown
 		context: contextContent,

--- a/src/services/preflight-service.ts
+++ b/src/services/preflight-service.ts
@@ -14,6 +14,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
 import { getDurableGateEvidenceStatusForTask } from '../evidence/gate-bridge.js';
 import {
 	checkRequirementCoverage,
@@ -719,6 +720,28 @@ async function runEvidenceCheck(dir: string): Promise<PreflightCheckResult> {
 }
 
 /**
+ * Schema for the req-coverage report written by the req_coverage tool
+ * (`src/tools/req-coverage.ts`) to `.swarm/evidence/req-coverage-phase-{N}.json`.
+ * Kept minimal and structural-only: it pins the writer's already-computed
+ * count fields so the gate fails on an unusable/incomplete report without
+ * re-deriving requirements from the effective spec (issue #1662: the gate
+ * previously passed on file existence alone and asserted nothing about
+ * content).
+ */
+const ReqCoverageReportSchema = z.object({
+	success: z.boolean(),
+	phase: z.number(),
+	totalRequirements: z.number(),
+	coveredCount: z.number(),
+	missingCount: z.number(),
+	requirements: z.array(z.unknown()),
+});
+
+/** Read cap for the report file — the writer's output is a small bounded
+ * JSON document; anything larger is treated as invalid rather than read. */
+const REQ_COVERAGE_MAX_JSON_BYTES = 500 * 1024; // 500KB, matches EVIDENCE_MAX_JSON_BYTES
+
+/**
  * Run requirement coverage check
  */
 async function runRequirementCoverageCheck(
@@ -742,21 +765,121 @@ async function runRequirementCoverageCheck(
 		// Check if coverage file exists for current phase
 		const coverage = await checkRequirementCoverage(currentPhase, dir);
 
-		if (coverage.exists) {
+		if (!coverage.exists) {
 			return {
 				type: 'req_coverage',
-				status: 'pass',
-				message: 'Requirement coverage report found',
+				status: 'fail',
+				message:
+					'Requirement coverage report missing but effective spec exists',
+				details: { expectedPath: coverage.path },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		// The report exists — validate its content. Existence alone proves
+		// nothing: an empty file, unparseable JSON, a wrong-shape document, or
+		// a report with uncovered/zero requirements must all fail the gate
+		// (#1662). The count fields are the writer's own output; they are
+		// read back here rather than re-derived from the effective spec.
+		let raw: string;
+		try {
+			const stat = await fs.promises.stat(coverage.path);
+			if (stat.size > REQ_COVERAGE_MAX_JSON_BYTES) {
+				return {
+					type: 'req_coverage',
+					status: 'fail',
+					message: `Requirement coverage report exceeds ${REQ_COVERAGE_MAX_JSON_BYTES} byte cap and cannot be validated`,
+					details: { path: coverage.path, sizeBytes: stat.size },
+					durationMs: Date.now() - startTime,
+				};
+			}
+			raw = await fs.promises.readFile(coverage.path, 'utf-8');
+		} catch (readError) {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message: `Requirement coverage report unreadable: ${
+					readError instanceof Error ? readError.message : String(readError)
+				}`,
 				details: { path: coverage.path },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		const trimmed = raw.trim();
+		if (trimmed.length === 0) {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message: 'Requirement coverage report is empty',
+				details: { path: coverage.path },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message: 'Requirement coverage report is not valid JSON',
+				details: { path: coverage.path },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		const report = ReqCoverageReportSchema.safeParse(parsed);
+		if (!report.success) {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message:
+					'Requirement coverage report does not match the expected report shape',
+				details: { path: coverage.path },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		const { totalRequirements, coveredCount, missingCount } = report.data;
+
+		if (totalRequirements === 0) {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message:
+					'Requirement coverage report contains no requirements (totalRequirements is 0) but effective spec exists',
+				details: { path: coverage.path, totalRequirements },
+				durationMs: Date.now() - startTime,
+			};
+		}
+
+		if (missingCount > 0) {
+			return {
+				type: 'req_coverage',
+				status: 'fail',
+				message: `Requirement coverage report has ${missingCount} uncovered requirement(s)`,
+				details: {
+					path: coverage.path,
+					totalRequirements,
+					coveredCount,
+					missingCount,
+				},
 				durationMs: Date.now() - startTime,
 			};
 		}
 
 		return {
 			type: 'req_coverage',
-			status: 'fail',
-			message: 'Requirement coverage report missing but effective spec exists',
-			details: { expectedPath: coverage.path },
+			status: 'pass',
+			message: `Requirement coverage report found: ${coveredCount}/${totalRequirements} requirement(s) covered`,
+			details: {
+				path: coverage.path,
+				totalRequirements,
+				coveredCount,
+				missingCount,
+			},
 			durationMs: Date.now() - startTime,
 		};
 	} catch (error) {

--- a/tests/unit/commands/export.test.ts
+++ b/tests/unit/commands/export.test.ts
@@ -3,6 +3,10 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+// Same bundler-resolved version the export service embeds (#1662) — asserting
+// against it keeps this test correct across future releases instead of
+// pinning a literal that drifts.
+import packageJson from '../../../package.json' with { type: 'json' };
 import { handleExportCommand } from '../../../src/commands/export';
 
 describe('handleExportCommand', () => {
@@ -51,7 +55,7 @@ Working on Phase 1
 
 		expect(result).toContain('## Swarm Export');
 		expect(result).toContain('```json');
-		expect(result).toContain('"version": "4.5.0"');
+		expect(result).toContain(`"version": "${packageJson.version}"`);
 		expect(result).toContain('"plan":');
 		expect(result).toContain('"context":');
 		expect(result).toContain('```');
@@ -147,10 +151,13 @@ Working on Phase 1
 		expect(result).toContain('```');
 	});
 
-	test('JSON has version field set to 4.5.0', async () => {
+	test('JSON version field matches the plugin package version', async () => {
 		const result = await handleExportCommand(tempDir, []);
 
-		expect(result).toContain('"version": "4.5.0"');
+		expect(result).toContain(`"version": "${packageJson.version}"`);
+		// Regression guard for #1662: the field was previously a hardcoded
+		// '4.5.0' literal that drifted from the real package version.
+		expect(packageJson.version).not.toBe('4.5.0');
 	});
 
 	test('JSON includes exported timestamp', async () => {

--- a/tests/unit/services/preflight-service-req-coverage.test.ts
+++ b/tests/unit/services/preflight-service-req-coverage.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { _internals } from '../../../src/services/preflight-service';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/**
+ * Regression tests for issue #1662: the req_coverage preflight gate used to
+ * pass on the mere existence of `.swarm/evidence/req-coverage-phase-{N}.json`
+ * and never validated the report's content. The gate must now fail on an
+ * empty, unparseable, wrong-shape, oversized, or incomplete
+ * (missingCount > 0 / totalRequirements === 0) report, and only pass on a
+ * genuinely complete report produced by the req_coverage tool.
+ */
+describe('Preflight Service req_coverage content validation', () => {
+	let testDir: string;
+	let evidenceDir: string;
+	let reportPath: string;
+
+	beforeEach(() => {
+		testDir = canonicalMkdtemp('preflight-req-coverage-');
+		fs.mkdirSync(path.join(testDir, '.swarm', 'evidence'), {
+			recursive: true,
+		});
+		// Effective spec present → the req_coverage gate is required.
+		fs.writeFileSync(
+			path.join(testDir, '.swarm', 'spec.md'),
+			'# Test Spec\n\nFR-001 MUST be covered by implementation evidence.\nFR-002 SHOULD be covered by documentation.\n',
+		);
+		evidenceDir = path.join(testDir, '.swarm', 'evidence');
+		reportPath = path.join(evidenceDir, 'req-coverage-phase-1.json');
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(testDir)) {
+			fs.rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	function writeReport(content: string): void {
+		fs.writeFileSync(reportPath, content);
+	}
+
+	test('fails on an empty report file (existence alone is not enough)', async () => {
+		writeReport('');
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.type).toBe('req_coverage');
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('empty');
+	});
+
+	test('fails on whitespace-only report file', async () => {
+		writeReport('   \n\t\n');
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('empty');
+	});
+
+	test('fails on unparseable (malformed JSON) report', async () => {
+		writeReport('{ not valid json !!!');
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('not valid JSON');
+	});
+
+	test('fails on a report that does not match the report shape', async () => {
+		writeReport(JSON.stringify({ unrelated: 'payload' }));
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('expected report shape');
+	});
+
+	test('fails on a report with missingCount > 0', async () => {
+		writeReport(
+			JSON.stringify({
+				success: true,
+				phase: 1,
+				totalRequirements: 2,
+				coveredCount: 0,
+				missingCount: 2,
+				requirements: [],
+			}),
+		);
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('uncovered requirement');
+		expect(result.message).toContain('2');
+		expect(result.details?.missingCount).toBe(2);
+	});
+
+	test('fails on a report with totalRequirements === 0 while a spec exists', async () => {
+		writeReport(
+			JSON.stringify({
+				success: true,
+				phase: 1,
+				totalRequirements: 0,
+				coveredCount: 0,
+				missingCount: 0,
+				requirements: [],
+			}),
+		);
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('totalRequirements is 0');
+	});
+
+	test('fails on a report exceeding the read cap', async () => {
+		writeReport(`${'a'.repeat(500 * 1024 + 1)}`);
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('cannot be validated');
+	});
+
+	test('passes on a genuinely complete, valid report', async () => {
+		writeReport(
+			JSON.stringify({
+				success: true,
+				phase: 1,
+				totalRequirements: 2,
+				coveredCount: 2,
+				missingCount: 0,
+				requirements: [
+					{
+						id: 'FR-001',
+						obligation: 'MUST',
+						text: 'be covered by implementation evidence.',
+						status: 'covered',
+						filesSearched: [],
+					},
+					{
+						id: 'FR-002',
+						obligation: 'SHOULD',
+						text: 'be covered by documentation.',
+						status: 'covered',
+						filesSearched: [],
+					},
+				],
+			}),
+		);
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.type).toBe('req_coverage');
+		expect(result.status).toBe('pass');
+		expect(result.message).toContain('2/2');
+		expect(result.details?.totalRequirements).toBe(2);
+		expect(result.details?.coveredCount).toBe(2);
+		expect(result.details?.missingCount).toBe(0);
+	});
+
+	test('still skips when no effective spec exists', async () => {
+		fs.rmSync(path.join(testDir, '.swarm', 'spec.md'));
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('skip');
+		expect(result.message).toContain('No effective spec found');
+	});
+
+	test('still fails when the report is missing but a spec exists', async () => {
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('missing but effective spec exists');
+	});
+
+	test('fails when only a different phase report exists', async () => {
+		writeReport(
+			JSON.stringify({
+				success: true,
+				phase: 2,
+				totalRequirements: 2,
+				coveredCount: 2,
+				missingCount: 0,
+				requirements: [],
+			}),
+		);
+		fs.renameSync(
+			reportPath,
+			path.join(evidenceDir, 'req-coverage-phase-2.json'),
+		);
+
+		const result = await _internals.runRequirementCoverageCheck(testDir, 1);
+
+		expect(result.status).toBe('fail');
+		expect(result.message).toContain('missing but effective spec exists');
+	});
+});


### PR DESCRIPTION
Closes #1662

## Summary
- `runRequirementCoverageCheck` now parses and validates the req-coverage report's **content** instead of passing on file existence alone: empty/whitespace, unparseable JSON, schema-shape mismatch (zod schema pinning the writer's `success/phase/totalRequirements/coveredCount/missingCount/requirements` fields), `totalRequirements === 0`, and `missingCount > 0` all fail; passes only on a genuinely complete report and reports `coveredCount/totalRequirements` in the message.
- `export-service.ts` derives the export `version` field from `package.json` instead of the hardcoded stale `'4.5.0'` (package now at 7.x).
- New regression suite `tests/unit/services/preflight-service-req-coverage.test.ts` (11 tests) covering all failure modes plus preserved skip/missing behaviors; `export.test.ts` pins version parity with `package.json`. Read bound capped at 500KB matching `EVIDENCE_MAX_JSON_BYTES`.

## Invariant audit
- 1 (plugin init): not touched - no changes to this invariant's surface in this diff
- 2 (runtime portability): not touched - no changes to this invariant's surface in this diff
- 3 (subprocesses): not touched - no changes to this invariant's surface in this diff
- 4 (.swarm containment): not touched - no changes to this invariant's surface in this diff
- 5 (plan durability): not touched - no changes to this invariant's surface in this diff
- 6 (test_runner safety): touched - preflight gates now enforce report-content validation — the req-coverage gate is part of the preflight/CI contract; evidence: new suite 11/11 green incl. skip/missing/oversize paths
- 7 (test writing): not touched - no changes to this invariant's surface in this diff
- 8 (session state): not touched - no changes to this invariant's surface in this diff
- 9 (guardrails/retry): not touched - no changes to this invariant's surface in this diff
- 10 (chat/system msg): not touched - no changes to this invariant's surface in this diff
- 11 (tool registration): not touched - no changes to this invariant's surface in this diff
- 12 (release/cache): touched - export payload version now derived from package.json instead of a stale literal; evidence: export.test.ts asserts version === packageJson.version

## Test plan
- `bun test tests/unit/services/preflight-service-req-coverage.test.ts` → 11 pass / 0 fail (re-verified post-rebase onto current main)
- `bun test tests/unit/commands/export.test.ts` → 8/8; `tests/unit/services/preflight-service.test.ts` → 37/37; `src/__tests__/req-coverage.test.ts` → 43/43; `tests/integration/phase-preflight-auto.test.ts` → 53/53
- `bunx tsc --noEmit` clean; `biome ci` clean on all four files; `bun run build` + dist ESM import check OK at fix time
- Falsifiability: pre-fix repro script showed empty/missingCount=2/malformed/totalReqs=0 reports all passed the gate; post-fix all fail with precise messages

---
🤖 This PR was opened by `auto-fix-easy` cron. The fix was attempted autonomously by the `auto-fix-issue` Hermes skill, pre-validated by a local reproduction tier and a pre-PR reviewer. Review carefully.