### PR TITLE
fix(docs): align knowledge schema example with current category/status unions (#1611)

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -130,11 +130,11 @@ Every entry is a JSON line with these fields (see `src/hooks/knowledge-types.ts`
   "id": "lesson-abc123",
   "tier": "swarm",
   "lesson": "Prefer stream.Readable.from(generator) over async iterators for backpressure.",
-  "category": "pattern",
+  "category": "architecture",
   "tags": ["node", "streams"],
   "scope": "global",
   "confidence": 0.9,
-  "status": "active",
+  "status": "established",
   "confirmed_by": ["..."],
   "retrieval_outcomes": [],
   "phases_alive": 0,
@@ -284,12 +284,13 @@ from counters or inferred from cohort data. V2 is read first throughout cutover,
 and legacy access is restricted to the explicit imported pre-cutover trace set
 until that set drains to zero.
 
-Legacy sections mapped into the new schema:
+Legacy sections imported (each bullet's category is inferred from its text into a current
+`KnowledgeCategory` — see `inferCategoryFromText` in `src/hooks/knowledge-migrator.ts`):
 
-- `lessons-learned` → category `lesson`
-- `patterns` → category `pattern`
-- `sme-cache` → category `domain`
-- `decisions` → category `decision`
+- `lessons-learned`
+- `patterns`
+- `sme-cache`
+- `decisions`
 
 Entries that fail schema validation are dropped. Near-duplicates are collapsed via the dedup threshold.
 

--- a/docs/releases/pending/1611-knowledge-schema-docs-drift.md
+++ b/docs/releases/pending/1611-knowledge-schema-docs-drift.md
@@ -1,0 +1,19 @@
+# Docs: knowledge Entry Schema example aligned with current category/status unions
+
+## What changed
+
+- The Entry Schema example in `docs/knowledge.md` now uses category `"architecture"` and status `"established"` — both members of the current unions in `src/hooks/knowledge-types.ts` — instead of the stale `"pattern"` / `"active"` values that no longer exist.
+- The Migration section's stale legacy category mapping (lesson/pattern/domain/decision) and `docs/skills.md`'s stale 5-value category list are aligned with the current 10-member `KnowledgeCategory` union.
+- New drift-guard test `tests/unit/hooks/knowledge-docs-schema-example.test.ts` parses both unions from `knowledge-types.ts` (single source of truth) and validates the JSON example, doc-wide category literals (excluding immutable releases/archive), and the skills.md enumeration.
+
+## Why
+
+Generated agents copying the documented example would write entries with invalid category/status values (issue #1662's sibling docs drift, filed as #1611). The docs and the type unions had silently diverged.
+
+## Migration steps
+
+None. Docs and test files only; no runtime code touched.
+
+## Known caveats
+
+- Doc-wide `status` scanning is limited to knowledge.md's Entry Schema example — the sole knowledge-status example in current docs. Release notes and `docs/archive/` are immutable history and intentionally excluded.

--- a/docs/releases/pending/1611-knowledge-schema-docs-drift.md
+++ b/docs/releases/pending/1611-knowledge-schema-docs-drift.md
@@ -8,7 +8,7 @@
 
 ## Why
 
-Generated agents copying the documented example would write entries with invalid category/status values (issue #1662's sibling docs drift, filed as #1611). The docs and the type unions had silently diverged.
+Generated agents copying the documented example would write entries with invalid category/status values. The docs and the type unions had silently diverged; agents that copy the example produce entries with values that the schema rejects.
 
 ## Migration steps
 
@@ -16,4 +16,4 @@ None. Docs and test files only; no runtime code touched.
 
 ## Known caveats
 
-- Doc-wide `status` scanning is limited to knowledge.md's Entry Schema example — the sole knowledge-status example in current docs. Release notes and `docs/archive/` are immutable history and intentionally excluded.
+- Release notes and `docs/archive/` are immutable history and intentionally excluded from the doc-wide category/status literal sweep.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -39,7 +39,7 @@ Knowledge enters the system through four routes:
 
 Each entry carries:
 - **`lesson`** — the knowledge claim (15–280 chars, validated for safety)
-- **`category`** — `pattern`, `lesson`, `decision`, `domain`, `todo`
+- **`category`** — `process`, `architecture`, `tooling`, `security`, `testing`, `debugging`, `performance`, `integration`, `todo`, `other` (see [Entry Schema](knowledge.md#entry-schema))
 - **`confidence`** — 0.0–1.0, reflecting certainty
 - **`tier`** — `swarm` (project) or `hive` (cross-project)
 - **Optional v2 directives** — `triggers`, `required_actions`, `forbidden_actions`, `applies_to_agents`, `applies_to_tools`, `directive_priority`, source references

--- a/tests/unit/hooks/knowledge-docs-schema-example.test.ts
+++ b/tests/unit/hooks/knowledge-docs-schema-example.test.ts
@@ -62,10 +62,18 @@ function fencedBlocks(markdown: string): FencedBlock[] {
 	return blocks;
 }
 
-/** Walk current docs, skipping immutable release notes and archived docs. */
+/**
+ * Walk current docs, skipping immutable release notes and archived docs.
+ * Sorted for deterministic iteration order across platforms — `readdirSync`
+ * order is filesystem-dependent (NTFS / ext4 / APFS sort differently), and a
+ * non-deterministic order would leak into any future assertion that inspects
+ * non-empty offender contents.
+ */
 function currentDocsFiles(dir: string): string[] {
 	const out: string[] = [];
-	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+	for (const entry of fs
+		.readdirSync(dir, { withFileTypes: true })
+		.sort((a, b) => a.name.localeCompare(b.name))) {
 		const full = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
 			if (entry.name === 'releases' || entry.name === 'archive') continue;
@@ -91,9 +99,9 @@ describe('knowledge docs schema example — drift guard (#1611)', () => {
 		expect(statuses).toContain('established');
 	});
 
-	test('docs/knowledge.md Entry Schema example uses only valid category/status values', () => {
+	test('every docs/knowledge.md Entry Schema example uses only valid category/status values', () => {
 		const knowledge = readRepoFile('docs', 'knowledge.md');
-		const example = fencedBlocks(knowledge)
+		const examples = fencedBlocks(knowledge)
 			.filter((b) => b.language === 'json')
 			.map((b) => {
 				try {
@@ -102,20 +110,27 @@ describe('knowledge docs schema example — drift guard (#1611)', () => {
 					return null;
 				}
 			})
-			.find(
-				(parsed) =>
+			.filter(
+				(parsed): parsed is Record<string, unknown> =>
 					parsed !== null &&
 					'lesson' in parsed &&
 					'category' in parsed &&
 					'status' in parsed,
 			);
 
-		expect(example).toBeDefined();
-		expect(categories).toContain(example?.category);
-		expect(statuses).toContain(example?.status);
+		expect(examples.length).toBeGreaterThanOrEqual(1);
+		for (const example of examples) {
+			expect(categories).toContain(example.category);
+			expect(statuses).toContain(example.status);
+		}
 	});
 
-	test('no stale knowledge category literal appears in current docs', () => {
+	test('no stale knowledge category or status literal appears in current docs', () => {
+		// "status" is a generic JSON field reused by many subsystems (plan
+		// task status, full-auto lock status, etc.). Sweep it only when it
+		// sits in the same JSON object as a knowledge-shaped field — `lesson`
+		// is the unique marker of a knowledge entry — so we don't false-
+		// positive on unrelated domain statuses.
 		const offenders: string[] = [];
 		for (const file of currentDocsFiles(path.join(repoRoot, 'docs'))) {
 			const markdown = fs.readFileSync(file, 'utf-8');
@@ -125,21 +140,83 @@ describe('knowledge docs schema example — drift guard (#1611)', () => {
 					offenders.push(`${relative}: "category": "${match[1]}"`);
 				}
 			}
+			// Walk fenced JSON blocks; in each block that looks like a
+			// knowledge entry (has `lesson`), assert `status` is a union
+			// member.
+			for (const block of fencedBlocks(markdown)) {
+				if (block.language !== 'json') continue;
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(block.body);
+				} catch {
+					continue;
+				}
+				if (
+					parsed === null ||
+					typeof parsed !== 'object' ||
+					!('lesson' in parsed) ||
+					!('status' in parsed)
+				) {
+					continue;
+				}
+				const statusValue = (parsed as Record<string, unknown>).status;
+				if (typeof statusValue !== 'string') continue;
+				if (!statuses.includes(statusValue)) {
+					offenders.push(`${relative}: "status": "${statusValue}"`);
+				}
+			}
 		}
 		expect(offenders).toEqual([]);
 	});
 
-	test('docs/skills.md knowledge category enumeration matches the current union', () => {
+	test('docs/skills.md knowledge enumerations match the current unions', () => {
 		const skills = readRepoFile('docs', 'skills.md');
-		const bullet = skills
+		// Validate every enumeration-style bullet labelled with a backticked
+		// field name (`**\`fieldName\`**`) whose parsed value list must match
+		// a current union. Today only `**`category`**` exists; if a future
+		// contributor adds `**`status`**` (or any other knowledge union), the
+		// same set-equality check applies. The dispatcher is keyed on the
+		// field name so an unknown bullet is a passing no-op.
+		// `category` is the load-bearing bullet this drift guard was created
+		// to protect (#1611); its presence is asserted explicitly so that
+		// removing it fails the test loudly instead of vacuously matching.
+		// `status` is a forward hook — only required when a bullet exists.
+		const requiredBullets = ['category'] as const;
+		const expectedUnions: Record<string, string[]> = {
+			category: categories,
+			status: statuses,
+		};
+		const bullets = skills
 			.split(/\r?\n/)
-			.find((line) => line.includes('**`category`**'));
-		expect(bullet).toBeDefined();
-		// Only the value list after the label's em dash — the label itself
-		// (`category`) is backticked too and must not count as a value.
-		const listed = [
-			...(bullet?.split('—')[1]?.match(/`([a-z_]+)`/g) ?? []),
-		].map((m) => m.slice(1, -1));
-		expect(new Set(listed)).toEqual(new Set(categories));
+			.filter((line) => /\*\*`([a-z_]+)`\*\*/.test(line));
+
+		for (const required of requiredBullets) {
+			expect(bullets.some((l) => l.includes(`**\`${required}\`**`))).toBe(true);
+		}
+
+		const mismatches: string[] = [];
+		for (const bullet of bullets) {
+			const labelMatch = bullet.match(/\*\*`([a-z_]+)`\*\*/);
+			const field = labelMatch?.[1];
+			if (!field || !(field in expectedUnions)) continue;
+			const expected = expectedUnions[field];
+			// Only the value list after the label's em dash — the label
+			// itself (`category`) is backticked too and must not count as
+			// a value.
+			const listed = [
+				...(bullet.split('—')[1]?.match(/`([a-z_]+)`/g) ?? []),
+			].map((m) => m.slice(1, -1));
+			const listedSet = new Set(listed);
+			const expectedSet = new Set(expected);
+			if (
+				listedSet.size !== expectedSet.size ||
+				![...listedSet].every((v) => expectedSet.has(v))
+			) {
+				mismatches.push(
+					`**\`${field}\`** listed=[${[...listedSet].join(',')}] expected=[${[...expectedSet].join(',')}]`,
+				);
+			}
+		}
+		expect(mismatches).toEqual([]);
 	});
 });

--- a/tests/unit/hooks/knowledge-docs-schema-example.test.ts
+++ b/tests/unit/hooks/knowledge-docs-schema-example.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Docs drift guard for the knowledge Entry Schema example (issue #1611).
+ *
+ * `docs/knowledge.md` previously showed `category: "pattern"` and
+ * `status: "active"` — neither is a member of the current unions in
+ * `src/hooks/knowledge-types.ts`. Generated agents copy docs examples into
+ * real `knowledge_add` calls, so an invalid example produces invalid entries.
+ *
+ * The valid sets are parsed from the type-definitions source (the same file
+ * the docs cite) rather than hardcoded here, so a union change that forgets
+ * the docs fails this test instead of silently re-introducing drift.
+ */
+
+const repoRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'../../..',
+);
+
+function readRepoFile(...parts: string[]): string {
+	return fs.readFileSync(path.join(repoRoot, ...parts), 'utf-8');
+}
+
+/** String-literal members of the `KnowledgeCategory` union. */
+function parseKnowledgeCategories(source: string): string[] {
+	const union = source.match(/export type KnowledgeCategory =([\s\S]*?);/);
+	const members = union?.[1]?.match(/'([^']+)'/g) ?? [];
+	return members.map((m) => m.slice(1, -1));
+}
+
+/**
+ * String-literal members of the `status` union on `KnowledgeEntryBase`.
+ * Anchored to that interface so unrelated `status` fields (e.g.
+ * `CurationProposal.status: 'pending'`) are not swept in.
+ */
+function parseKnowledgeStatuses(source: string): string[] {
+	const base = source.match(
+		/export interface KnowledgeEntryBase extends ActionableDirectiveFields \{[\s\S]*?\n\}\n/,
+	);
+	const statusUnion = base?.[0]?.match(/\n\tstatus:([\s\S]*?)\n\tconfirmed_by/);
+	const members = statusUnion?.[1]?.match(/'([^']+)'/g) ?? [];
+	return members.map((m) => m.slice(1, -1));
+}
+
+interface FencedBlock {
+	language: string;
+	body: string;
+}
+
+function fencedBlocks(markdown: string): FencedBlock[] {
+	const blocks: FencedBlock[] = [];
+	const fence = /```(\w+)[^\n]*\n([\s\S]*?)```/g;
+	let match = fence.exec(markdown);
+	while (match !== null) {
+		blocks.push({ language: match[1], body: match[2] });
+		match = fence.exec(markdown);
+	}
+	return blocks;
+}
+
+/** Walk current docs, skipping immutable release notes and archived docs. */
+function currentDocsFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === 'releases' || entry.name === 'archive') continue;
+			out.push(...currentDocsFiles(full));
+		} else if (entry.name.endsWith('.md')) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+describe('knowledge docs schema example — drift guard (#1611)', () => {
+	const typesSource = readRepoFile('src', 'hooks', 'knowledge-types.ts');
+	const categories = parseKnowledgeCategories(typesSource);
+	const statuses = parseKnowledgeStatuses(typesSource);
+
+	// Parse-regression canaries: an empty/short list means the regex above
+	// silently stopped matching the source shape, not that the union shrank.
+	test('union parsers still find the current category and status members', () => {
+		expect(categories.length).toBeGreaterThanOrEqual(10);
+		expect(categories).toContain('architecture');
+		expect(statuses.length).toBeGreaterThanOrEqual(6);
+		expect(statuses).toContain('established');
+	});
+
+	test('docs/knowledge.md Entry Schema example uses only valid category/status values', () => {
+		const knowledge = readRepoFile('docs', 'knowledge.md');
+		const example = fencedBlocks(knowledge)
+			.filter((b) => b.language === 'json')
+			.map((b) => {
+				try {
+					return JSON.parse(b.body) as Record<string, unknown>;
+				} catch {
+					return null;
+				}
+			})
+			.find(
+				(parsed) =>
+					parsed !== null &&
+					'lesson' in parsed &&
+					'category' in parsed &&
+					'status' in parsed,
+			);
+
+		expect(example).toBeDefined();
+		expect(categories).toContain(example?.category);
+		expect(statuses).toContain(example?.status);
+	});
+
+	test('no stale knowledge category literal appears in current docs', () => {
+		const offenders: string[] = [];
+		for (const file of currentDocsFiles(path.join(repoRoot, 'docs'))) {
+			const markdown = fs.readFileSync(file, 'utf-8');
+			const relative = path.relative(repoRoot, file);
+			for (const match of markdown.matchAll(/"category"\s*:\s*"([^"]+)"/g)) {
+				if (!categories.includes(match[1])) {
+					offenders.push(`${relative}: "category": "${match[1]}"`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+
+	test('docs/skills.md knowledge category enumeration matches the current union', () => {
+		const skills = readRepoFile('docs', 'skills.md');
+		const bullet = skills
+			.split(/\r?\n/)
+			.find((line) => line.includes('**`category`**'));
+		expect(bullet).toBeDefined();
+		// Only the value list after the label's em dash — the label itself
+		// (`category`) is backticked too and must not count as a value.
+		const listed = [
+			...(bullet?.split('—')[1]?.match(/`([a-z_]+)`/g) ?? []),
+		].map((m) => m.slice(1, -1));
+		expect(new Set(listed)).toEqual(new Set(categories));
+	});
+});


### PR DESCRIPTION
Closes #1611

## Summary

- Entry Schema example in `docs/knowledge.md` used category `"pattern"` and status `"active"` — neither is a member of the current `KnowledgeCategory` union or the entry status union in `src/hooks/knowledge-types.ts` (generated agents copying the example would write invalid entries). Example now uses `"architecture"` / `"established"`.
- Swept adjacent drift per the issue's scope: the Migration section's stale legacy category mapping and `docs/skills.md`'s stale 5-value category list are aligned with the current 10-member union.
- Added a drift-guard test that parses both unions from `knowledge-types.ts` (single source of truth, no hardcoded copies) and validates the JSON example, doc-wide category literals (excluding immutable releases/archive), and the skills.md enumeration. No runtime code touched.

## Follow-up commit (addressed swarm-pr-review feedback)

A second commit (`abf21623`) closes 5 review findings and tightens test coverage:

- **Release fragment:** removed the incorrect attribution of this drift to issue #1662 (which is actually about req-coverage gate / export version, unrelated to knowledge schema docs). The release narrative is now accurate; `Known caveats` updated to reflect that the doc-wide status sweep is in effect.
- **Drift-guard test:**
  - `readdirSync` results are sorted for deterministic iteration across platforms (NTFS / ext4 / APFS sort differently).
  - The Entry Schema test now validates ALL knowledge-shaped JSON examples in `docs/knowledge.md`, not just the first match (`.find()` → `.filter()`).
  - Doc-wide `status` literal scan added, gated on a `lesson` discriminator so unrelated domain statuses (plan task status, full-auto lock status, etc.) don't false-positive.
  - The `docs/skills.md` enumeration test dispatches by field name (`category`, `status`) so future enumeration bullets are auto-validated, and asserts the load-bearing `**\`category\`**` bullet's presence explicitly so deletion fails loudly instead of vacuously matching.

## Invariant audit

- 1 (plugin init): not touched - no changes to this invariant's surface in this diff
- 2 (runtime portability): not touched - no changes to this invariant's surface in this diff
- 3 (subprocesses): not touched - no changes to this invariant's surface in this diff
- 4 (.swarm containment): not touched - no changes to this invariant's surface in this diff
- 5 (plan durability): not touched - no changes to this invariant's surface in this diff
- 6 (test_runner safety): not touched - no changes to this invariant's surface in this diff
- 7 (test writing): touched - new test file tests/unit/hooks/knowledge-docs-schema-example.test.ts added (214 lines, under 500-line FR-006 limit); parses unions from source rather than copying literals; no mock.module usage; deterministic iteration order
- 8 (session state): not touched - no changes to this invariant's surface in this diff
- 9 (guardrails/retry): not touched - no changes to this invariant's surface in this diff
- 10 (chat/system msg): not touched - no changes to this invariant's surface in this diff
- 11 (tool registration): not touched - no changes to this invariant's surface in this diff
- 12 (release/cache): touched - release fragment at docs/releases/pending/1611-knowledge-schema-docs-drift.md corrected; version files untouched

## Test plan

- `bun --smol test tests/unit/hooks/knowledge-docs-schema-example.test.ts` → 4 pass / 0 fail (verified at PR head `abf21623`)
- `bun --smol test tests/unit/scripts/drift-check.test.ts` (repo's own docs-claim drift detector) → 28 pass combined, 0 fail, no false positives
- Falsification suite (7 scenarios, all verified locally):
  - Revert category to `"pattern"` → tests 2 and 3 fail (toContain miss)
  - Revert status to `"active"` → tests 2 and 3 fail (toContain miss)
  - Revert skills.md category bullet → test 4 fails (set mismatch)
  - Add a SECOND stale JSON example → tests 2 and 3 fail (was previously silent)
  - Add a stale status literal in a second knowledge-shaped JSON → tests 2 and 3 fail (was previously silent)
  - Add a non-knowledge JSON with stale `"status": "active"` → ALL pass (no false positive; `lesson` discriminator holds)
  - Delete the `**\`category\`**` bullet from skills.md → test 4 fails (presence assertion holds)
- CI: all 23 checks green (drift, check-title, detect-paths, detect-release, integration, memory-recall-regression, package-check, php-validation, pr-standards, quality, rust-sandbox-runner, security, smoke × 3 OSes, unit × 6 shards, unit-passed)

---
🤖 This PR was opened by `auto-fix-easy` cron. The original fix was attempted autonomously by the `auto-fix-issue` Hermes skill, pre-validated by a local reproduction tier and a pre-PR reviewer. The follow-up commit was added to address feedback from a downstream swarm-pr-review (5 findings fixed, 1 LOW finding deliberately not changed per critic Kimi K3 confirmation).
