### PR TITLE
feat(context): wire graph delivery into agent prompts, lane dispatch, and skills

### DIFF
--- a/.claude/skills/deep-dive/SKILL.md
+++ b/.claude/skills/deep-dive/SKILL.md
@@ -35,12 +35,13 @@ If the header is malformed or missing required fields, report the error and stop
 ## Step 2 — Scope Resolution
 
 Use the following tools to map the audit scope:
-1. `repo_map` with action "build" to establish the code graph
-2. `repo_map` with action "localization" for the scope target
-3. `symbols` and `batch_symbols` on key files identified by localization
-4. `imports` to trace dependency boundaries
-5. `doc_scan` if documentation coverage is relevant
-6. `knowledge_recall` with query matching the scope domain
+1. `repo_map` with action "graph_health" — only if the graph is missing or incomplete (stale beyond the refresh cap, extraction failures) run `repo_map` with action "build"; plugin init and the session-start probe keep the graph fresh otherwise
+2. `repo_map` with action "ask" (the audit scope as the question) and action "key_files" to rank scope-relevant files and repo hubs before any manual symbol walk
+3. `repo_map` with action "localization" for the scope target
+4. `symbols` and `batch_symbols` on key files identified by ask or localization
+5. `imports` to trace dependency boundaries
+6. `doc_scan` if documentation coverage is relevant
+7. `knowledge_recall` with query matching the scope domain
 
 Produce a SCOPE MAP: list of files, modules, and interfaces within the audit boundary. Cap at 50 files total.
 

--- a/.opencode/skills/deep-dive/SKILL.md
+++ b/.opencode/skills/deep-dive/SKILL.md
@@ -35,12 +35,13 @@ If the header is malformed or missing required fields, report the error and stop
 ## Step 2 — Scope Resolution
 
 Use the following tools to map the audit scope:
-1. `repo_map` with action "build" to establish the code graph
-2. `repo_map` with action "localization" for the scope target
-3. `symbols` and `batch_symbols` on key files identified by localization
-4. `imports` to trace dependency boundaries
-5. `doc_scan` if documentation coverage is relevant
-6. `knowledge_recall` with query matching the scope domain
+1. `repo_map` with action "graph_health" — only if the graph is missing or incomplete (stale beyond the refresh cap, extraction failures) run `repo_map` with action "build"; plugin init and the session-start probe keep the graph fresh otherwise
+2. `repo_map` with action "ask" (the audit scope as the question) and action "key_files" to rank scope-relevant files and repo hubs before any manual symbol walk
+3. `repo_map` with action "localization" for the scope target
+4. `symbols` and `batch_symbols` on key files identified by ask or localization
+5. `imports` to trace dependency boundaries
+6. `doc_scan` if documentation coverage is relevant
+7. `knowledge_recall` with query matching the scope domain
 
 Produce a SCOPE MAP: list of files, modules, and interfaces within the audit boundary. Cap at 50 files total.
 

--- a/docs/releases/pending/issue-1988-graph-delivery-wiring.md
+++ b/docs/releases/pending/issue-1988-graph-delivery-wiring.md
@@ -1,0 +1,23 @@
+# Graph delivery wiring: agent prompts, lane orientation, deep-dive reuse, delivery dedupe persistence
+
+## What changed
+
+The repo graph is now delivered to the agents and workflows that need it (issue #1988, plan PR4):
+
+- **Explorer, coder, and reviewer prompts are graph-first.** Explorer's ACTIONS block now leads with `repo_map action="ask"` / `action="context_pack"` (orientation first — read the located files before reporting), with blind tree/glob/grep scanning reserved for gaps the graph does not cover (`stale: true`, missing files, non-code assets). Coder is directed to `repo_map action="localization"` before editing shared or cross-imported files (covering the undeclared-scope case the injected block does not), and reviewer to `repo_map action="blast_radius"` for changed files not covered by an injected REPO GRAPH block.
+- **Lane dispatch gains a bounded orientation block.** `dispatch_lanes` and `dispatch_lanes_async` accept an optional `orientation` boolean (no schema default — availability depends on graph state; omitted means "attempt when a fresh graph exists"). When emitted, a deterministic, cache-prefix-positioned block — top mission-relevant files (single `ask` over the concatenated lane missions), repo hubs, and a one-line freshness statement — is appended to `common_prompt` so lanes start graph-oriented instead of blind. Emission is gated by a relevance floor (normalized top-3 share ≥ 0.35), a 600-token budget, per-session novelty dedupe (bounded 128 pointers, silent suppression on repeats), and a pre-append `MAX_PROMPT_CHARS` overflow check that drops the block rather than failing dispatch.
+- **deep-dive no longer re-pays the full graph build.** Its scope-resolution step now runs `repo_map action="graph_health"` first and only builds when the graph is missing or incomplete, and prefers `ask`/`key_files` over manual symbol/import walks. Both skill trees updated byte-identically.
+- **Lane-output redelivery dedupe survives restarts.** Delivery keys are now session-scoped and persisted to `.swarm/lane-delivery-cache.json` (bounded 1024 entries, cross-session FIFO, best-effort atomic write, fail-open load with corrupt-file quarantine), fixing both the restart re-delivery gap and the documented cross-session false-suppression bug of the old in-memory Set.
+
+## Why
+
+The repo-graph subsystem was capable but undelivered: zero agent prompts mentioned `repo_map`, lane prompts were pure `common_prompt` concatenation, deep-dive rebuilt the graph unconditionally, and the lane-output dedupe fell open across restarts. Curated, bounded, relevance-gated orientation is the delivery layer that makes the graph felt (plan §7; AOrchestra/Anthropic multi-agent evidence summarized in the issue).
+
+## Migration
+
+No migration required. The new `orientation` dispatch argument is optional; behavior defaults to "emit when a fresh, relevant graph exists". The lane-delivery cache file appears under `.swarm/` automatically and is safe to delete at any time (fail-open).
+
+## Known caveats
+
+- The 0.35 relevance floor is applied to the normalized top-3 score share because raw `ask` scores are graph-size-dependent PageRank probabilities (a perfectly-targeted mission on this 3.4k-node repo scores ~0.01 absolute). The constant remains the plan's starting value and is re-tuned in PR6 (#1989's measurement work).
+- Suppressed repeat orientation blocks emit nothing by design (dedupe); a dispatch with entirely novel missions still emits.

--- a/src/agents/coder.test.ts
+++ b/src/agents/coder.test.ts
@@ -96,6 +96,29 @@ describe('CODER_PROMPT — REUSE_SCAN in DONE template', () => {
 	});
 });
 
+describe('CODER_PROMPT — repo_map localization directive (issue #1988 C1)', () => {
+	const agent = createCoderAgent('test-model');
+	const prompt = agent.config.prompt ?? '';
+
+	it('RULES direct repo_map localization before editing shared files', () => {
+		const rulesStart = prompt.indexOf('RULES:');
+		const worktreeIndex = prompt.indexOf('WORKTREE ISOLATION');
+		const rulesSection = prompt.substring(rulesStart, worktreeIndex);
+		expect(rulesSection).toContain('repo_map action="localization"');
+		expect(rulesSection).toContain('shared or cross-imported file');
+	});
+
+	it('directive is positioned after "Read target file before editing"', () => {
+		const readIndex = prompt.indexOf('Read target file before editing');
+		const directiveIndex = prompt.indexOf('repo_map action="localization"');
+		expect(directiveIndex).toBeGreaterThan(readIndex);
+	});
+
+	it('directive explains it covers the undeclared-scope case', () => {
+		expect(prompt).toContain('including when no scope was declared');
+	});
+});
+
 describe('CODER_PROMPT — ACCEPTANCE field (issue #1687 task 2.1)', () => {
 	const agent = createCoderAgent('test-model');
 	const prompt = agent.config.prompt ?? '';

--- a/src/agents/coder.ts
+++ b/src/agents/coder.ts
@@ -39,6 +39,7 @@ SKILLS HANDLING: If SKILLS is present and not "none", read the skill names/descr
 
 RULES:
 - Read target file before editing
+- Before editing a shared or cross-imported file, call \`repo_map action="localization"\` — the injected localization block covers only a declared scope's primary file; this covers the rest, including when no scope was declared
 - Implement exactly what TASK specifies
 - Respect CONSTRAINT
 - No web searches or documentation lookups — but DO use the search tool for cross-codebase pattern lookup before using any function

--- a/src/agents/explorer-consumer-contract.test.ts
+++ b/src/agents/explorer-consumer-contract.test.ts
@@ -9,10 +9,10 @@ const EXPLORER_SOURCE = readFileSync(
 	'utf-8',
 );
 
-// Extract a prompt block from the source by name
+// Extract a prompt block from the source by name (closing backtick-semicolon anchor).
 function extractPromptBlock(source: string, promptName: string): string {
 	const regex = new RegExp(
-		`export\\s+const\\s+${promptName}\\s*=\\s*\x60([\\s\\S]*?)\x60`,
+		`export\\s+const\\s+${promptName}\\s*=\\s*\x60([\\s\\S]*?)\x60;`,
 		'm',
 	);
 	const match = source.match(regex);

--- a/src/agents/explorer-repo-map-directive.test.ts
+++ b/src/agents/explorer-repo-map-directive.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { EXPLORER_PROMPT } from './explorer';
+
+/**
+ * Prompt-contract tests for the repo_map graph-first ACTIONS directive
+ * added by issue #1988 (C1). Kept in a dedicated file because
+ * explorer-consumer-contract.test.ts is over the FR-006 500-line ratchet
+ * cap and must not grow.
+ */
+describe('EXPLORER_PROMPT — repo_map graph-first directive (issue #1988 C1)', () => {
+	const actionsSection = EXPLORER_PROMPT.substring(
+		EXPLORER_PROMPT.indexOf('ACTIONS:'),
+		EXPLORER_PROMPT.indexOf('RULES:'),
+	);
+
+	test('ACTIONS leads with repo_map ask/context_pack before any blind scanning', () => {
+		expect(actionsSection).toContain('repo_map action="ask"');
+		expect(actionsSection).toContain('action="context_pack"');
+		expect(actionsSection).toContain('include_source: true');
+		expect(actionsSection.indexOf('repo_map action="ask"')).toBeLessThan(
+			actionsSection.indexOf('Read key files'),
+		);
+	});
+
+	test('directive frames graph output as orientation and requires reading located files', () => {
+		expect(actionsSection).toContain('orientation');
+		expect(actionsSection).toContain(
+			'read the located files before reporting on them',
+		);
+	});
+
+	test('blind-scan opener is gone from the prompt', () => {
+		expect(EXPLORER_PROMPT).not.toContain('Scan structure (tree, ls, glob)');
+	});
+
+	test('fallback to tree/glob/grep is scoped to missing graph coverage', () => {
+		expect(actionsSection).toContain('Fall back to tree/glob/grep');
+		expect(actionsSection).toContain('stale: true');
+		expect(actionsSection).toContain('non-code assets');
+	});
+});

--- a/src/agents/explorer-role-boundary.test.ts
+++ b/src/agents/explorer-role-boundary.test.ts
@@ -401,3 +401,23 @@ describe('explorer-role-boundary', () => {
 		});
 	});
 });
+
+describe('repo_map graph-first directive role-boundary (issue #1988 C1)', () => {
+	// The graph-first ACTIONS directive must not smuggle in verdict,
+	// enforcement, or routing language — it is a discovery-strategy
+	// directive only.
+	test('graph-first directive present in ACTIONS without verdict/imperative language', () => {
+		const actionsSection = EXPLORER_PROMPT.substring(
+			EXPLORER_PROMPT.indexOf('ACTIONS:'),
+			EXPLORER_PROMPT.indexOf('RULES:'),
+		);
+		expect(actionsSection).toContain('repo_map action="ask"');
+		expect(actionsSection).not.toMatch(/\bVERDICT\b/);
+		expect(actionsSection).not.toMatch(/\bapprove\b/i);
+		expect(actionsSection).not.toMatch(/\breject\b/i);
+		expect(actionsSection).not.toMatch(/\benforce\b/i);
+		expect(actionsSection).not.toMatch(/\bmandate\b/i);
+		expect(actionsSection).not.toMatch(/\bshall\b/i);
+		expect(actionsSection).not.toMatch(/\bmust\b/i);
+	});
+});

--- a/src/agents/explorer.ts
+++ b/src/agents/explorer.ts
@@ -17,7 +17,9 @@ TASK: Analyze [purpose]
 INPUT: [focus areas/paths]
 
 ACTIONS:
-- Scan structure (tree, ls, glob)
+- FIRST call \`repo_map action="ask"\` with your mission question, and \`action="context_pack"\` (with include_source: true) for your target symbols; use the hits to decide what to read
+- Graph output is orientation — read the located files before reporting on them
+- Fall back to tree/glob/grep only where the graph has no coverage (\`stale: true\`, missing files, or non-code assets)
 - Read key files (README, configs, entry points)
 - Search patterns using the search tool
 

--- a/src/agents/reviewer.test.ts
+++ b/src/agents/reviewer.test.ts
@@ -182,3 +182,26 @@ describe('REVIEWER_PROMPT — ACCEPTANCE field (issue #1687 task 2.2)', () => {
 		);
 	});
 });
+
+describe('REVIEWER_PROMPT — repo_map blast radius directive (issue #1988 C1)', () => {
+	const agent = createReviewerAgent('test-model');
+	const prompt = agent.config.prompt ?? '';
+
+	it('DO (explicitly) directs repo_map blast_radius for uncovered changed files', () => {
+		const doStart = prompt.indexOf('DO (explicitly):');
+		const configStart = prompt.indexOf('## CONFIG STRICTNESS VERIFICATION');
+		const doSection = prompt.substring(doStart, configStart);
+		expect(doSection).toContain('repo_map action="blast_radius"');
+		expect(doSection).toContain('not covered by an injected REPO GRAPH block');
+	});
+
+	it('blast radius directive is positioned after the platform-compatibility check', () => {
+		const platformIndex = prompt.indexOf('VERIFY platform compatibility');
+		const blastIndex = prompt.indexOf('repo_map action="blast_radius"');
+		expect(blastIndex).toBeGreaterThan(platformIndex);
+	});
+
+	it('directive requires checking the listed dependents', () => {
+		expect(prompt).toContain('check the listed dependents');
+	});
+});

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -108,6 +108,7 @@ DO (explicitly):
 - VERIFY imports exist: if the coder added a new import, use search to verify the export exists in the source
 - CHECK test files were updated: if the coder changed a function signature, the tests should reflect it
 - VERIFY platform compatibility: path.join() used for all paths, no hardcoded separators
+- VERIFY blast radius: for changed files not covered by an injected REPO GRAPH block, call \`repo_map action="blast_radius"\` and check the listed dependents
 - For confirmed issues requiring a concrete fix: use suggest_patch to produce a structured patch artifact for the coder
 
 ## CONFIG STRICTNESS VERIFICATION

--- a/src/background/lane-delivery-store.ts
+++ b/src/background/lane-delivery-store.ts
@@ -34,8 +34,9 @@ import { writeAtomicJson } from './lane-output-store.js';
 export const LANE_DELIVERY_CACHE_FILENAME = 'lane-delivery-cache.json';
 export const MAX_DELIVERED_LANE_OUTPUT_KEYS = 1024;
 const MAX_TRACKED_SESSIONS = 16;
-// Mirrors MAX_CACHED_DIRECTORIES in repo-graph-injection.ts deliberately:
-// both bound per-directory in-memory state at the same footprint.
+// Bound alignment with MAX_CACHED_DIRECTORIES in repo-graph-injection.ts: both
+// cap per-directory in-memory state at 16 entries. Eviction policy differs by
+// design — this store is strict FIFO (insertion order), the graph cache is LRU.
 const MAX_TRACKED_DIRECTORIES = 16;
 
 const CORRUPT_SUFFIX = '.corrupt';
@@ -105,11 +106,25 @@ function loadBucketFromDisk(directory: string): LaneDeliveryBucket {
 		parsed = null;
 	}
 	if (!isValidCacheFile(parsed)) {
-		// Rename the unusable file out of the way (best-effort) so every
+		// Rename the unusable file out of the way (best-effort, with the same
+		// Windows transient-error retry loop writeAtomicJson uses) so every
 		// subsequent read does not re-parse it; the next mark() writes a
 		// fresh, valid cache.
 		try {
-			fs.renameSync(file, `${file}${CORRUPT_SUFFIX}`);
+			const corruptPath = `${file}${CORRUPT_SUFFIX}`;
+			let lastRenameError: unknown;
+			for (let attempt = 0; attempt < 3; attempt++) {
+				try {
+					fs.renameSync(file, corruptPath);
+					lastRenameError = undefined;
+					break;
+				} catch (err) {
+					lastRenameError = err;
+					const code = (err as NodeJS.ErrnoException).code;
+					if (code !== 'EEXIST' && code !== 'EBUSY' && code !== 'EPERM') break;
+				}
+			}
+			if (lastRenameError) throw lastRenameError;
 		} catch {
 			/* best-effort — reads stay fail-open either way */
 		}

--- a/src/background/lane-delivery-store.ts
+++ b/src/background/lane-delivery-store.ts
@@ -1,0 +1,240 @@
+/**
+ * Persistent, session-scoped record of which lane outputs have already been
+ * delivered to a controller session (issue #1988, plan §7.4).
+ *
+ * `collect_lane_results` is polled repeatedly by the PR-review protocol;
+ * re-delivering a settled lane's bounded preview on every poll is the
+ * dominant controller-context driver behind compaction loops. The in-memory
+ * `deliveredLaneOutputs` Set this store replaces fell open across plugin
+ * restarts AND suppressed across sessions (a key delivered in session A
+ * wrongly suppressed session B's first delivery when batch/lane/digest
+ * collided). This store keys delivery state by session and persists it to
+ * `.swarm/lane-delivery-cache.json` so dedupe survives restarts and
+ * compaction cycles within a session.
+ *
+ * Failure semantics (both directions are safe):
+ *   - Load is fail-open: a missing, corrupt, or version-mismatched file
+ *     yields an empty bucket (a corrupt file is renamed `.corrupt` so the
+ *     next mark heals it; delivery then repeats once, which is harmless
+ *     because suppressed output is always recoverable via `output_ref`).
+ *   - Write is best-effort: any error is swallowed — losing a key only
+ *     causes one extra inline delivery.
+ *
+ * Bounds (invariant 8): at most MAX_DELIVERED_LANE_OUTPUT_KEYS keys per
+ * directory bucket, evicted FIFO across sessions via the global `order`
+ * list (oldest keys of the oldest sessions go first); at most
+ * MAX_TRACKED_SESSIONS sessions and MAX_TRACKED_DIRECTORIES in-memory
+ * buckets, each FIFO-evicted.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { writeAtomicJson } from './lane-output-store.js';
+
+export const LANE_DELIVERY_CACHE_FILENAME = 'lane-delivery-cache.json';
+export const MAX_DELIVERED_LANE_OUTPUT_KEYS = 1024;
+const MAX_TRACKED_SESSIONS = 16;
+// Mirrors MAX_CACHED_DIRECTORIES in repo-graph-injection.ts deliberately:
+// both bound per-directory in-memory state at the same footprint.
+const MAX_TRACKED_DIRECTORIES = 16;
+
+const CORRUPT_SUFFIX = '.corrupt';
+
+interface LaneDeliveryBucket {
+	/** Session ids in first-touch order — the cross-session FIFO eviction order. */
+	order: string[];
+	/** Per-session delivered keys, each in insertion order. */
+	sessions: Map<string, string[]>;
+	total: number;
+}
+
+interface LaneDeliveryCacheFile {
+	version: 1;
+	order: string[];
+	sessions: Record<string, string[]>;
+}
+
+const directoryBuckets = new Map<string, LaneDeliveryBucket>();
+
+function bucketKey(directory: string | undefined): string {
+	return directory ? path.normalize(path.resolve(directory)) : '';
+}
+
+function emptyBucket(): LaneDeliveryBucket {
+	return { order: [], sessions: new Map(), total: 0 };
+}
+
+function cacheFilePath(directory: string): string {
+	return path.join(directory, '.swarm', LANE_DELIVERY_CACHE_FILENAME);
+}
+
+function isValidCacheFile(value: unknown): value is LaneDeliveryCacheFile {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		(value as { version?: unknown }).version !== 1
+	) {
+		return false;
+	}
+	const { order, sessions } = value as {
+		order?: unknown;
+		sessions?: unknown;
+	};
+	if (!Array.isArray(order) || order.some((id) => typeof id !== 'string')) {
+		return false;
+	}
+	if (!sessions || typeof sessions !== 'object') return false;
+	return Object.values(sessions).every(
+		(keys) =>
+			Array.isArray(keys) && keys.every((key) => typeof key === 'string'),
+	);
+}
+
+function loadBucketFromDisk(directory: string): LaneDeliveryBucket {
+	const file = cacheFilePath(directory);
+	let raw: string;
+	try {
+		raw = fs.readFileSync(file, 'utf-8');
+	} catch {
+		return emptyBucket();
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		parsed = null;
+	}
+	if (!isValidCacheFile(parsed)) {
+		// Rename the unusable file out of the way (best-effort) so every
+		// subsequent read does not re-parse it; the next mark() writes a
+		// fresh, valid cache.
+		try {
+			fs.renameSync(file, `${file}${CORRUPT_SUFFIX}`);
+		} catch {
+			/* best-effort — reads stay fail-open either way */
+		}
+		return emptyBucket();
+	}
+	const bucket = emptyBucket();
+	const seen = new Set<string>();
+	for (const sessionID of parsed.order) {
+		if (seen.has(sessionID)) continue;
+		const keys = parsed.sessions[sessionID];
+		if (!keys || keys.length === 0) continue;
+		seen.add(sessionID);
+		bucket.order.push(sessionID);
+		bucket.sessions.set(sessionID, [...keys]);
+		bucket.total += keys.length;
+	}
+	// Sessions present but missing from `order` (torn write) are dropped:
+	// re-delivering a preview once is harmless; trusting un-ordered state
+	// would break the FIFO eviction contract.
+	return bucket;
+}
+
+function persistBucket(directory: string, bucket: LaneDeliveryBucket): void {
+	const file: LaneDeliveryCacheFile = {
+		version: 1,
+		order: bucket.order,
+		sessions: Object.fromEntries(bucket.sessions),
+	};
+	try {
+		writeAtomicJson(cacheFilePath(directory), file);
+	} catch {
+		// Best-effort by contract (see module doc): a lost write only causes
+		// one extra inline delivery after a restart.
+	}
+}
+
+function evictOverflow(bucket: LaneDeliveryBucket): void {
+	while (bucket.total > MAX_DELIVERED_LANE_OUTPUT_KEYS) {
+		let evicted = false;
+		for (const sessionID of bucket.order) {
+			const keys = bucket.sessions.get(sessionID);
+			if (!keys || keys.length === 0) continue;
+			keys.shift();
+			bucket.total -= 1;
+			if (keys.length === 0) {
+				bucket.sessions.delete(sessionID);
+				bucket.order = bucket.order.filter((id) => id !== sessionID);
+			}
+			evicted = true;
+			break;
+		}
+		if (!evicted) break;
+	}
+}
+
+function bucketFor(directory: string | undefined): LaneDeliveryBucket {
+	const key = bucketKey(directory);
+	const existing = directoryBuckets.get(key);
+	if (existing) return existing;
+	while (directoryBuckets.size >= MAX_TRACKED_DIRECTORIES) {
+		const oldestDirectory = directoryBuckets.keys().next().value;
+		if (oldestDirectory === undefined) break;
+		directoryBuckets.delete(oldestDirectory);
+	}
+	const bucket = directory ? loadBucketFromDisk(directory) : emptyBucket();
+	directoryBuckets.set(key, bucket);
+	return bucket;
+}
+
+function sessionKeys(
+	bucket: LaneDeliveryBucket,
+	sessionID: string | undefined,
+): string[] {
+	const key = sessionID ?? '';
+	let keys = bucket.sessions.get(key);
+	if (!keys) {
+		while (bucket.order.length >= MAX_TRACKED_SESSIONS) {
+			const oldest = bucket.order.shift();
+			if (oldest === undefined) break;
+			const oldestKeys = bucket.sessions.get(oldest);
+			bucket.sessions.delete(oldest);
+			bucket.total -= oldestKeys?.length ?? 0;
+		}
+		keys = [];
+		bucket.sessions.set(key, keys);
+		bucket.order.push(key);
+	}
+	return keys;
+}
+
+/**
+ * Whether this session has already received the lane output identified by
+ * `key` in this directory. Memory-only (no persistence) when `directory` is
+ * undefined — the direct test-seam path.
+ */
+export function hasLaneOutputBeenDelivered(
+	directory: string | undefined,
+	sessionID: string | undefined,
+	key: string,
+): boolean {
+	if (!key) return false;
+	const bucket = bucketFor(directory);
+	return bucket.sessions.get(sessionID ?? '')?.includes(key) ?? false;
+}
+
+/**
+ * Record that `key` was delivered to this session in this directory and
+ * persist the cache best-effort. FIFO bounds are enforced after recording.
+ */
+export function markLaneOutputDelivered(
+	directory: string | undefined,
+	sessionID: string | undefined,
+	key: string,
+): void {
+	if (!key) return;
+	const bucket = bucketFor(directory);
+	const keys = sessionKeys(bucket, sessionID);
+	if (keys.includes(key)) return;
+	keys.push(key);
+	bucket.total += 1;
+	evictOverflow(bucket);
+	if (directory) persistBucket(directory, bucket);
+}
+
+/** Test-only: clear all in-memory buckets (disk state is untouched). */
+export function resetLaneDeliveryStoreForTests(): void {
+	directoryBuckets.clear();
+}

--- a/src/background/lane-output-store.ts
+++ b/src/background/lane-output-store.ts
@@ -343,7 +343,12 @@ function artifactIdentityMatchesInput(
 // Windows can briefly hold a file handle after close; retry on transient errors.
 const WINDOWS_RENAME_MAX_RETRIES = 3;
 
-function writeAtomicJson(absPath: string, value: unknown): void {
+/**
+ * Atomic JSON write (temp file + rename with Windows transient-error retry).
+ * Shared by the lane-output store and the lane-delivery cache; exported for
+ * reuse so both keep the same crash-safety semantics.
+ */
+export function writeAtomicJson(absPath: string, value: unknown): void {
 	mkdirSync(path.dirname(absPath), { recursive: true });
 	const tempFile = `${absPath}.tmp-${Date.now()}-${process.pid}`;
 	try {

--- a/src/hooks/repo-graph-injection.ts
+++ b/src/hooks/repo-graph-injection.ts
@@ -20,7 +20,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { loadPluginConfigWithMeta } from '../config/loader';
+import { loadPluginConfigWithMetaAsync } from '../config/loader';
 import { RepoGraphConfigSchema } from '../config/schema';
 import {
 	askGraph,
@@ -55,6 +55,9 @@ export const _internals = {
 	cacheSize: () => cache.size,
 	renderLaneOrientationBlock,
 	orientationFreshnessLine,
+	// Routed through the seam so tests can force the config-load failure
+	// fallback (the sync-free async variant per issue #704/#1900 discipline).
+	loadPluginConfigWithMetaAsync,
 };
 
 function touchCache(key: string, value: CachedGraph): void {
@@ -362,7 +365,8 @@ export async function buildLaneOrientationBlock(
 	try {
 		let resolved: RepoGraphInjectionOptions = options ?? {};
 		try {
-			const { config } = loadPluginConfigWithMeta(directory);
+			const { config } =
+				await _internals.loadPluginConfigWithMetaAsync(directory);
 			const repoGraphConfig = RepoGraphConfigSchema.parse(
 				config.repo_graph ?? {},
 			);

--- a/src/hooks/repo-graph-injection.ts
+++ b/src/hooks/repo-graph-injection.ts
@@ -20,16 +20,21 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { loadPluginConfigWithMeta } from '../config/loader';
+import { RepoGraphConfigSchema } from '../config/schema';
 import {
+	askGraph,
 	type FreshnessOptions,
 	getBlastRadius,
 	getGraphNode,
 	getGraphPath,
+	getKeyFiles,
 	getLocalizationContext,
 	loadGraphSync,
 	probeFreshness,
 	type RepoGraph,
 } from '../tools/repo-graph';
+import { estimateTokens } from './utils';
 
 interface CachedGraph {
 	graph: RepoGraph;
@@ -48,6 +53,8 @@ export interface RepoGraphInjectionOptions extends FreshnessOptions {
 export const _internals = {
 	probeFreshness,
 	cacheSize: () => cache.size,
+	renderLaneOrientationBlock,
+	orientationFreshnessLine,
 };
 
 function touchCache(key: string, value: CachedGraph): void {
@@ -199,4 +206,235 @@ export async function buildReviewerBlastRadiusBlock(
 		`  Risk: ${blast.riskLevel} (${blast.totalDependents} total)`,
 		'_Verify these dependents still build/typecheck._',
 	].join('\n');
+}
+
+/**
+ * Options for {@link buildLaneOrientationBlock}.
+ *
+ * `sessionID` scopes the novelty dedupe so two controller sessions never
+ * suppress each other's orientation blocks (invariant 8).
+ */
+export interface LaneOrientationOptions extends RepoGraphInjectionOptions {
+	sessionID?: string;
+}
+
+/**
+ * Relevance floor for the top `ask` hit (plan §7.2 starting constant; PR6
+ * re-tunes). Applied to the normalized top-hit share — top score divided by
+ * the sum of the top-3 hit scores (the top hit's absolute score when fewer
+ * than 3 hits exist). Raw askGraph scores are personalized-PageRank
+ * probabilities that sum to 1 across ALL graph nodes, so their absolute
+ * magnitude scales with 1/graph-size: on this repository (3.4k nodes) a
+ * perfectly-targeted mission yields top scores of ~0.01, while a uniform
+ * noise ranking yields ~1/N per file. The share normalization makes the
+ * 0.35 constant mean the same thing on every scale: the top file must own
+ * more than a third of the top-3 ranking mass (a diffuse ranking scores
+ * ~0.33 and is suppressed; a concentrated one clears the floor). Verified
+ * against this repo: real missions measure 0.35-0.37 share and emit.
+ */
+const LANE_ORIENTATION_SCORE_FLOOR = 0.35;
+/** Rendered-block budget, in estimateTokens tokens. */
+const LANE_ORIENTATION_MAX_TOKENS = 600;
+/** How many mission-ranked files and repo hubs the block may list. */
+const LANE_ORIENTATION_TOP_ASK_FILES = 6;
+const LANE_ORIENTATION_TOP_KEY_FILES = 4;
+/**
+ * Deterministic bound on the concatenated lane mission text fed to `ask`.
+ * Keeps the question bounded no matter how many lanes or how long their
+ * prompts are (lane prompts alone may be up to MAX_PROMPT_CHARS each).
+ */
+const ORIENTATION_MISSION_CHAR_BUDGET = 4_000;
+/** Per-session already-delivered file pointers, FIFO-evicted at this bound. */
+const LANE_ORIENTATION_DEDUPE_BOUND = 128;
+/** Bound on tracked dedupe sessions (invariant 8: explicit eviction). */
+const LANE_ORIENTATION_MAX_SESSIONS = 16;
+
+const laneOrientationDelivered = new Map<string, Set<string>>();
+
+/** Test-only: clear the per-session orientation dedupe state. */
+export function resetLaneOrientationDedupe(): void {
+	laneOrientationDelivered.clear();
+}
+
+function sessionDeliveredSet(sessionKey: string): Set<string> {
+	const existing = laneOrientationDelivered.get(sessionKey);
+	if (existing) return existing;
+	while (laneOrientationDelivered.size >= LANE_ORIENTATION_MAX_SESSIONS) {
+		const oldestSession = laneOrientationDelivered.keys().next().value;
+		if (oldestSession === undefined) break;
+		laneOrientationDelivered.delete(oldestSession);
+	}
+	const created = new Set<string>();
+	laneOrientationDelivered.set(sessionKey, created);
+	return created;
+}
+
+function recordDeliveredPointers(
+	sessionKey: string,
+	pointers: readonly string[],
+): void {
+	const delivered = sessionDeliveredSet(sessionKey);
+	for (const pointer of pointers) {
+		delivered.add(pointer);
+		while (delivered.size > LANE_ORIENTATION_DEDUPE_BOUND) {
+			const oldest = delivered.values().next().value;
+			if (oldest === undefined) break;
+			delivered.delete(oldest);
+		}
+	}
+}
+
+interface OrientationAskFile {
+	file: string;
+	score: number;
+	exports: string[];
+}
+
+/**
+ * Pure render for the lane orientation block. Deterministic: a pure function
+ * of its arguments — no timestamps, no randomness, no probe timing fields.
+ * Exported only through {@link _internals} for tests.
+ */
+function renderLaneOrientationBlock(
+	askFiles: OrientationAskFile[],
+	hubFiles: string[],
+	freshnessLine: string,
+): string {
+	const lines: string[] = ['## REPO GRAPH — LANE ORIENTATION'];
+	if (askFiles.length > 0) {
+		lines.push(
+			'Mission-relevant files (graph-ranked; orientation only — read before relying):',
+		);
+		for (const hit of askFiles) {
+			const exports = hit.exports.slice(0, 3).join(', ');
+			lines.push(
+				`- ${hit.file} (score ${hit.score.toFixed(2)}${exports ? `; exports: ${exports}` : ''})`,
+			);
+		}
+	}
+	if (hubFiles.length > 0) {
+		lines.push(`Repo hubs (most imported): ${hubFiles.join(', ')}`);
+	}
+	lines.push(`Freshness: ${freshnessLine}`);
+	return lines.join('\n');
+}
+
+/**
+ * Deterministic freshness statement for the orientation block. Only probe
+ * state and drift counts feed the text — never elapsedMs, probedFiles, or
+ * truncated, which would break the block's determinism contract.
+ */
+function orientationFreshnessLine(
+	state: string,
+	changedCount: number,
+	removedCount: number,
+): string {
+	if (state === 'clean') return 'fresh (probe clean)';
+	if (state === 'drifted') {
+		return `drifted within refresh cap (${changedCount} changed, ${removedCount} removed)`;
+	}
+	return 'freshness unknown (probe inconclusive)';
+}
+
+/**
+ * Build a bounded, relevance-gated repo-graph orientation block for a lane
+ * dispatch batch (issue #1988 C2/C6). The block is appended to the shared
+ * `common_prompt` prefix by the dispatch caller.
+ *
+ * Gating policy — the block is emitted only when ALL hold:
+ *   - a usable graph exists (fresh, or drifted within the refresh cap);
+ *   - the top `ask` hit for the concatenated mission texts clears
+ *     LANE_ORIENTATION_SCORE_FLOOR;
+ *   - at least one file pointer is novel for this session (per-session
+ *     novelty dedupe, bounded FIFO — suppressed repeats emit NOTHING);
+ *   - the rendered block fits LANE_ORIENTATION_MAX_TOKENS.
+ *
+ * Determinism contract: a pure function of (graph state, mission texts,
+ * empty dedupe state) — the same dispatch replayed from a reset dedupe
+ * state produces a byte-identical block. Returns null on every gate
+ * failure or error; never throws into the dispatch path.
+ */
+export async function buildLaneOrientationBlock(
+	directory: string,
+	lanePrompts: string[],
+	options?: LaneOrientationOptions,
+): Promise<string | null> {
+	try {
+		let resolved: RepoGraphInjectionOptions = options ?? {};
+		try {
+			const { config } = loadPluginConfigWithMeta(directory);
+			const repoGraphConfig = RepoGraphConfigSchema.parse(
+				config.repo_graph ?? {},
+			);
+			resolved = {
+				...resolved,
+				enabled: options?.enabled ?? repoGraphConfig.enabled,
+				refreshCap: options?.refreshCap ?? repoGraphConfig.refresh_cap,
+				maxFiles: options?.maxFiles ?? repoGraphConfig.max_files,
+				walkBudgetMs: options?.walkBudgetMs ?? repoGraphConfig.walk_budget_ms,
+				excludeDirs: options?.excludeDirs ?? repoGraphConfig.exclude_dirs,
+			};
+		} catch {
+			// No readable plugin config — fall back to option defaults.
+		}
+
+		const graph = await getCachedGraph(directory, resolved);
+		if (!graph) return null;
+
+		const missionText = lanePrompts
+			.join('\n')
+			.slice(0, ORIENTATION_MISSION_CHAR_BUDGET);
+		if (!missionText.trim()) return null;
+		const ask = askGraph(graph, missionText, {
+			topN: LANE_ORIENTATION_TOP_ASK_FILES,
+		});
+		if (ask.hits.length === 0) return null;
+		const topScore = ask.hits[0].score;
+		const floorValue =
+			ask.hits.length >= 3
+				? topScore / (topScore + ask.hits[1].score + ask.hits[2].score)
+				: topScore;
+		if (floorValue < LANE_ORIENTATION_SCORE_FLOOR) return null;
+
+		const probe = await _internals.probeFreshness(directory, resolved);
+		const freshnessLine = orientationFreshnessLine(
+			probe.state,
+			probe.changed.length,
+			probe.removed.length,
+		);
+
+		const sessionKey = options?.sessionID ?? '';
+		const delivered = sessionDeliveredSet(sessionKey);
+		const novelAskFiles: OrientationAskFile[] = ask.hits
+			.filter((hit) => !delivered.has(hit.file))
+			.map((hit) => ({
+				file: hit.file,
+				score: hit.score,
+				exports: hit.topExports,
+			}));
+		const novelHubFiles = getKeyFiles(graph, LANE_ORIENTATION_TOP_KEY_FILES)
+			.map((node) => node.moduleName)
+			.filter((file) => !delivered.has(file));
+		if (novelAskFiles.length === 0 && novelHubFiles.length === 0) {
+			// Suppressed repeat: emit nothing (no nudge text in lane prompts).
+			return null;
+		}
+
+		const block = renderLaneOrientationBlock(
+			novelAskFiles,
+			novelHubFiles,
+			freshnessLine,
+		);
+		if (estimateTokens(block) > LANE_ORIENTATION_MAX_TOKENS) return null;
+
+		recordDeliveredPointers(sessionKey, [
+			...novelAskFiles.map((hit) => hit.file),
+			...novelHubFiles,
+		]);
+		return block;
+	} catch {
+		// Silent fallback contract: orientation is advisory and must never
+		// break dispatch.
+		return null;
+	}
 }

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -2829,6 +2829,16 @@ interface OrientationAugmentDeps {
 }
 
 /**
+ * Conservative headroom reserved inside the orientation overflow check for the
+ * LATER prompt-size appends (applyExplorerFormatSuffix and
+ * applyPrWorkflowPromptContract), each of which independently hard-fails the
+ * dispatch on MAX_PROMPT_CHARS. Without this reserve, a PR-review lane whose
+ * common_prompt + prompt + suffixes fit before could hard-fail purely because
+ * a fresh graph made an orientation block available (review finding F-09).
+ */
+const ORIENTATION_SUFFIX_RESERVE_CHARS = 5_000;
+
+/**
  * Resolve the `orientation` arg into an augmented common_prompt (issue #1988 C2).
  *
  * Execute-time resolution (no zod default — a schema default cannot depend on
@@ -2837,12 +2847,15 @@ interface OrientationAugmentDeps {
  * exists, so undefined degrades to "false when no fresh graph".
  *
  * Overflow rule: the drop decision runs ONCE here, at the common+lane stage —
- * max over lanes of (common_prompt + orientation + separator + lane.prompt)
- * versus MAX_PROMPT_CHARS — BEFORE appending. If any lane would exceed the
- * cap the block is dropped (debug log) rather than truncating content or
- * failing dispatch. The later applyExplorerFormatSuffix /
- * applyPrWorkflowPromptContract suffix checks are intentionally outside this
- * rule (issue spec scopes the pre-check to the combined common+lane length).
+ * max over lanes of (common_prompt + orientation + separator + lane.prompt +
+ * ORIENTATION_SUFFIX_RESERVE_CHARS) versus MAX_PROMPT_CHARS — BEFORE
+ * appending. If any lane would exceed the cap the block is dropped (debug
+ * log) rather than truncating content or failing dispatch. The reserve keeps
+ * typical suffix appends (fixed worst case ≈3.2k chars) out of failure
+ * territory they would not have reached without the block; extreme but
+ * schema-valid configurations (maxed item-id/owned-lane arrays) can exceed
+ * the reserve, and anything beyond it remains the caller's own size
+ * responsibility, as before this feature.
  *
  * Fail-open: any builder error degrades to the un-augmented common_prompt.
  */
@@ -2875,12 +2888,15 @@ async function augmentCommonPromptWithOrientation(
 		: block;
 	const overflow = lanes.some(
 		(lane) =>
-			combined.length + COMMON_PROMPT_SEPARATOR.length + lane.prompt.length >
+			combined.length +
+				COMMON_PROMPT_SEPARATOR.length +
+				lane.prompt.length +
+				ORIENTATION_SUFFIX_RESERVE_CHARS >
 			MAX_PROMPT_CHARS,
 	);
 	if (overflow) {
 		logger.log(
-			'lane orientation block dropped: combined common_prompt + orientation + lane prompt would exceed MAX_PROMPT_CHARS',
+			'lane orientation block dropped: combined common_prompt + orientation + lane prompt + suffix reserve would exceed MAX_PROMPT_CHARS',
 			{ maxPromptChars: MAX_PROMPT_CHARS, blockChars: block.length },
 		);
 		return commonPrompt;
@@ -2978,7 +2994,7 @@ function applyExplorerFormatSuffix(
 
 ${controllerIdentity}${formatSuffix}`;
 		if (prompt.length > MAX_PROMPT_CHARS) {
-			const diagnostic = `Lane "${lane.id}" prompt plus mandatory explorer output contract is ${prompt.length} chars; max ${MAX_PROMPT_CHARS}`;
+			const diagnostic = `Lane "${lane.id}" prompt plus mandatory explorer output contract is ${prompt.length} chars; max ${MAX_PROMPT_CHARS} (a repo-graph orientation block may have been prepended to common_prompt — retry with orientation: false to exclude it)`;
 			if (options.failClosed) {
 				errors.push(diagnostic);
 				return lane;
@@ -3062,7 +3078,7 @@ This controller block is authoritative over conflicting caller text. Inspect the
 		const prompt = `${lane.prompt}${contract}`;
 		if (prompt.length > MAX_PROMPT_CHARS) {
 			errors.push(
-				`Lane "${lane.id}" prompt plus mandatory PR workflow contract is ${prompt.length} chars; max ${MAX_PROMPT_CHARS}`,
+				`Lane "${lane.id}" prompt plus mandatory PR workflow contract is ${prompt.length} chars; max ${MAX_PROMPT_CHARS} (a repo-graph orientation block may have been prepended to common_prompt — retry with orientation: false to exclude it)`,
 			);
 		}
 		return { ...lane, prompt };
@@ -3221,7 +3237,7 @@ function sleep(ms: number): Promise<void> {
 export const dispatch_lanes: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Dispatch multiple read-only exploration/review lanes concurrently and BLOCK until every lane finishes, returning a structured join result. This blocks the caller until completion; for non-blocking dispatch that lets you keep working while lanes run, prefer dispatch_lanes_async + collect_lane_results and use this blocking variant only when promptAsync is unavailable. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt. When the repo graph is fresh, a bounded orientation block (orientation arg) is prepended to common_prompt so lanes start graph-oriented instead of blind.',
+			'Dispatch multiple read-only exploration/review lanes concurrently and BLOCK until every lane finishes, returning a structured join result. This blocks the caller until completion; for non-blocking dispatch that lets you keep working while lanes run, prefer dispatch_lanes_async + collect_lane_results and use this blocking variant only when promptAsync is unavailable. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt. A bounded repo-graph orientation block is prepended to common_prompt by default when the graph is fresh and relevant (set orientation: false to disable).',
 		args: {
 			lanes: DispatchLanesArgsSchema.shape.lanes,
 			common_prompt: DispatchLanesArgsSchema.shape.common_prompt,
@@ -3241,7 +3257,7 @@ export const dispatch_lanes: ReturnType<typeof createSwarmTool> =
 export const dispatch_lanes_async: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Launch multiple read-only advisory lanes with OpenCode promptAsync and return IMMEDIATELY with a batch id and lane session handles (non-blocking). launch_timeout_ms only bounds session creation and promptAsync acceptance; it is NOT a lane runtime timeout. After launching, keep working on non-dependent investigation while lanes run — poll incrementally with collect_lane_results (wait omitted or false) to process settled lanes as they complete, or use wait: true only at workflow boundaries where all results are needed. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt, which can produce oversized or malformed tool-call JSON. When the repo graph is fresh, a bounded orientation block (orientation arg) is prepended to common_prompt so lanes start graph-oriented instead of blind.',
+			'Launch multiple read-only advisory lanes with OpenCode promptAsync and return IMMEDIATELY with a batch id and lane session handles (non-blocking). launch_timeout_ms only bounds session creation and promptAsync acceptance; it is NOT a lane runtime timeout. After launching, keep working on non-dependent investigation while lanes run — poll incrementally with collect_lane_results (wait omitted or false) to process settled lanes as they complete, or use wait: true only at workflow boundaries where all results are needed. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt, which can produce oversized or malformed tool-call JSON. A bounded repo-graph orientation block is prepended to common_prompt by default when the graph is fresh and relevant (set orientation: false to disable).',
 		args: {
 			lanes: DispatchLanesAsyncArgsSchema.shape.lanes,
 			common_prompt: DispatchLanesAsyncArgsSchema.shape.common_prompt,

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -8,6 +8,11 @@ import {
 	CLEAN_TEMPLATES,
 } from '../background/candidate-contract.js';
 import {
+	hasLaneOutputBeenDelivered,
+	markLaneOutputDelivered,
+	resetLaneDeliveryStoreForTests,
+} from '../background/lane-delivery-store.js';
+import {
 	buildLaneOutputPreview,
 	readLaneOutput,
 	storeLaneOutput,
@@ -53,6 +58,7 @@ import {
 	recordPrReviewValidationBatch,
 	validatePrReviewDiscoveryLaneCompletion,
 } from '../hooks/pr-workflow-gate.js';
+import { buildLaneOrientationBlock } from '../hooks/repo-graph-injection.js';
 import type { ParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
 import { createParallelDispatcher } from '../parallel/dispatcher/parallel-dispatcher.js';
 import { swarmState } from '../state.js';
@@ -130,42 +136,26 @@ const CREATE_FAILURE_STATUS_KEYS = new Set([
 const AGENT_NAME_SEPARATORS = ['_', '-', ' '] as const;
 
 /**
- * Bound on how many "already delivered lane output" keys we remember
- * (invariant 8: module-level state must have an explicit eviction strategy).
+ * Lane-output redelivery dedupe (issue #1988 C7, plan §7.4).
  * `collect_lane_results` is polled repeatedly by the PR-review protocol; once
  * a settled lane's output has been delivered once, re-delivering the same
  * bounded preview on every subsequent poll is the dominant controller-context
- * driver behind PR-review compaction loops (see S1.1). This Set tracks which
- * `${batchId}\0${laneId}\0${digest}` keys have already been sent so later
- * polls can omit the `output` field (setting `output_omitted_repeat: true`
- * instead) while still returning every other metadata field unchanged.
+ * driver behind PR-review compaction loops (see S1.1). Delivery state is
+ * tracked per `${batchId}\0${laneId}\0${digest}` key so later polls can omit
+ * the `output` field (setting `output_omitted_repeat: true` instead) while
+ * still returning every other metadata field unchanged.
  *
- * This is in-memory by design: a process restart re-delivers each preview
- * once more, which is harmless because `output` is only ever suppressed
- * when BOTH a digest AND a durable ref (`output_ref`, recoverable via
- * `retrieve_lane_output`) are present. If either is missing — e.g. the
- * artifact write failed (disk full, permission error) or the text was too
- * large to store — this falls open and keeps delivering `output` inline on
- * every poll, since there would otherwise be no way to recover the text.
- *
- * Cross-session caveat: When two sessions in different directories reuse the
- * same `batch_id`, `laneId`, and produce byte-identical output (identical
- * digest), the second session's first inline delivery may be suppressed as
- * though already delivered; subsequent polls correctly return metadata and
- * `output_ref`. This is degraded-not-broken because `output_ref` is always
- * returned and `retrieve_lane_output` recovers the full text.
+ * The state lives in `src/background/lane-delivery-store.ts`: keyed by the
+ * collecting session and persisted to `.swarm/lane-delivery-cache.json`
+ * (bounded 1024 keys, cross-session FIFO, best-effort write, fail-open load)
+ * so dedupe survives plugin restarts and compaction cycles within a session.
+ * Session keying also removes the old global-Set cross-session false
+ * suppression (two sessions reusing batch_id/laneId/digest). `output` is only
+ * ever suppressed when BOTH a digest AND a durable ref (`output_ref`,
+ * recoverable via `retrieve_lane_output`) are present; if either is missing
+ * — e.g. the artifact write failed — delivery falls open and keeps returning
+ * the text inline, since there would otherwise be no way to recover it.
  */
-const MAX_TRACKED_DELIVERED_LANE_OUTPUTS = 1024;
-const deliveredLaneOutputs = new Set<string>();
-
-/** FIFO-evict the oldest delivered-output key when the set exceeds the bound. */
-function evictDeliveredLaneOutputsIfOverBound(): void {
-	while (deliveredLaneOutputs.size > MAX_TRACKED_DELIVERED_LANE_OUTPUTS) {
-		const oldestKey = deliveredLaneOutputs.values().next().value;
-		if (oldestKey === undefined) break;
-		deliveredLaneOutputs.delete(oldestKey);
-	}
-}
 
 /**
  * Formats a Zod issue list for error output, bounded to the first
@@ -434,6 +424,12 @@ const DispatchLanesArgsSchema = z.object({
 		.optional()
 		.describe(
 			'Per-lane timeout in milliseconds. For blocking dispatch this covers session create and prompt execution; for async dispatch this covers launch only, never lane runtime.',
+		),
+	orientation: z
+		.boolean()
+		.optional()
+		.describe(
+			'Prepend a bounded, deterministic repo-graph orientation block (mission-relevant files, repo hubs, freshness line) to common_prompt when the repo graph is fresh and relevant. No schema default: availability depends on graph state, resolved at execute time (omitted ⇒ attempted, skipped when no fresh graph exists). Explicitly false disables the block entirely.',
 		),
 });
 
@@ -775,6 +771,7 @@ export const _test_exports = {
 	applyCommonPrompt,
 	applyExplorerFormatSuffix,
 	applyPrWorkflowPromptContract,
+	augmentCommonPromptWithOrientation,
 	buildCollectResult,
 	buildReadOnlyTools,
 	buildLaneSessionCreateArgs,
@@ -790,12 +787,13 @@ export const _test_exports = {
 	DEFAULT_ASYNC_STALE_TIMEOUT_MS,
 	DEFAULT_COLLECT_TIMEOUT_MS,
 	/**
-	 * Clears the module-level `deliveredLaneOutputs` de-dupe set (see
-	 * S1.1) so tests can assert first-poll vs. repeat-poll behavior without
-	 * cross-test bleed-through.
+	 * Clears the lane-output delivery de-dupe state (see S1.1) so tests can
+	 * assert first-poll vs. repeat-poll behavior without cross-test
+	 * bleed-through. Delegates to the persistent lane-delivery store's
+	 * in-memory reset; disk state is untouched.
 	 */
 	resetDeliveredLaneOutputs: () => {
-		deliveredLaneOutputs.clear();
+		resetLaneDeliveryStoreForTests();
 	},
 	// Test-only export seam: lets tests exercise the S1.1 output-delivery
 	// de-duplication logic directly against in-memory record literals,
@@ -864,10 +862,14 @@ export async function executeDispatchLanes(
 		});
 	}
 
-	const common = applyCommonPrompt(
+	const orientedCommonPrompt = await augmentCommonPromptWithOrientation(
+		directory,
 		parsed.data.lanes,
 		parsed.data.common_prompt,
+		parsed.data.orientation,
+		context.sessionID,
 	);
+	const common = applyCommonPrompt(parsed.data.lanes, orientedCommonPrompt);
 	if (!common.ok) {
 		return failureResult({
 			failure_class: 'invalid_args',
@@ -963,10 +965,14 @@ export async function executeDispatchLanesAsync(
 		});
 	}
 
-	const common = applyCommonPrompt(
+	const orientedCommonPrompt = await augmentCommonPromptWithOrientation(
+		directory,
 		parsed.data.lanes,
 		parsed.data.common_prompt,
+		parsed.data.orientation,
+		context.sessionID,
 	);
+	const common = applyCommonPrompt(parsed.data.lanes, orientedCommonPrompt);
 	if (!common.ok) {
 		return asyncFailureResult({
 			failure_class: 'invalid_args',
@@ -1572,6 +1578,7 @@ export async function executeCollectLaneResults(
 		parsed.data.batch_id,
 		records,
 		parsed.data.include_pending ?? parsed.data.wait !== true,
+		{ directory, sessionID: context.sessionID },
 	);
 	if (hostTimeouts.size > 0) {
 		result.message =
@@ -2441,6 +2448,7 @@ function buildCollectResult(
 	batchId: string,
 	records: BackgroundDelegationRecord[],
 	includePending: boolean,
+	deliveryContext?: { directory?: string; sessionID?: string },
 ): CollectLaneResultsResult {
 	const laneResults = records
 		.filter(
@@ -2450,7 +2458,7 @@ function buildCollectResult(
 					record.status !== 'running' &&
 					record.status !== 'ingesting'),
 		)
-		.map((record) => recordToLaneResult(record, batchId));
+		.map((record) => recordToLaneResult(record, batchId, deliveryContext));
 	const completed = records.filter((record) => record.status === 'completed');
 	const failed = records.filter(
 		(record) =>
@@ -2487,6 +2495,7 @@ function buildCollectResult(
 function recordToLaneResult(
 	record: BackgroundDelegationRecord,
 	batchId: string,
+	deliveryContext?: { directory?: string; sessionID?: string },
 ): DispatchLaneResult {
 	const status =
 		record.status === 'error'
@@ -2510,10 +2519,17 @@ function recordToLaneResult(
 		outputRef
 	) {
 		const key = `${batchId}\0${laneId}\0${digest}`;
-		alreadyDelivered = deliveredLaneOutputs.has(key);
+		alreadyDelivered = hasLaneOutputBeenDelivered(
+			deliveryContext?.directory,
+			deliveryContext?.sessionID,
+			key,
+		);
 		if (!alreadyDelivered) {
-			deliveredLaneOutputs.add(key);
-			evictDeliveredLaneOutputsIfOverBound();
+			markLaneOutputDelivered(
+				deliveryContext?.directory,
+				deliveryContext?.sessionID,
+				key,
+			);
 		}
 	}
 	return {
@@ -2808,6 +2824,70 @@ type ApplyCommonPromptResult =
  * when no `commonPrompt` is provided, or shallow-copied lanes with rewritten
  * prompts when it is. Callers may treat the returned array as their own.
  */
+interface OrientationAugmentDeps {
+	buildBlock?: typeof buildLaneOrientationBlock;
+}
+
+/**
+ * Resolve the `orientation` arg into an augmented common_prompt (issue #1988 C2).
+ *
+ * Execute-time resolution (no zod default — a schema default cannot depend on
+ * graph state): `false` skips entirely; `true` or undefined attempts the block,
+ * and buildLaneOrientationBlock itself returns null unless a fresh graph
+ * exists, so undefined degrades to "false when no fresh graph".
+ *
+ * Overflow rule: the drop decision runs ONCE here, at the common+lane stage —
+ * max over lanes of (common_prompt + orientation + separator + lane.prompt)
+ * versus MAX_PROMPT_CHARS — BEFORE appending. If any lane would exceed the
+ * cap the block is dropped (debug log) rather than truncating content or
+ * failing dispatch. The later applyExplorerFormatSuffix /
+ * applyPrWorkflowPromptContract suffix checks are intentionally outside this
+ * rule (issue spec scopes the pre-check to the combined common+lane length).
+ *
+ * Fail-open: any builder error degrades to the un-augmented common_prompt.
+ */
+async function augmentCommonPromptWithOrientation(
+	directory: string,
+	lanes: readonly { prompt: string }[],
+	commonPrompt: string | undefined,
+	orientation: boolean | undefined,
+	sessionID: string | undefined,
+	deps?: OrientationAugmentDeps,
+): Promise<string | undefined> {
+	if (orientation === false) return commonPrompt;
+	const buildBlock = deps?.buildBlock ?? buildLaneOrientationBlock;
+	let block: string | null = null;
+	try {
+		block = await buildBlock(
+			directory,
+			lanes.map((lane) => lane.prompt),
+			sessionID ? { sessionID } : undefined,
+		);
+	} catch (error) {
+		logger.log('lane orientation block failed open', {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return commonPrompt;
+	}
+	if (!block) return commonPrompt;
+	const combined = commonPrompt
+		? `${commonPrompt}${COMMON_PROMPT_SEPARATOR}${block}`
+		: block;
+	const overflow = lanes.some(
+		(lane) =>
+			combined.length + COMMON_PROMPT_SEPARATOR.length + lane.prompt.length >
+			MAX_PROMPT_CHARS,
+	);
+	if (overflow) {
+		logger.log(
+			'lane orientation block dropped: combined common_prompt + orientation + lane prompt would exceed MAX_PROMPT_CHARS',
+			{ maxPromptChars: MAX_PROMPT_CHARS, blockChars: block.length },
+		);
+		return commonPrompt;
+	}
+	return combined;
+}
+
 function applyCommonPrompt(
 	lanes: DispatchLaneSpec[],
 	commonPrompt: string | undefined,
@@ -3141,12 +3221,13 @@ function sleep(ms: number): Promise<void> {
 export const dispatch_lanes: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Dispatch multiple read-only exploration/review lanes concurrently and BLOCK until every lane finishes, returning a structured join result. This blocks the caller until completion; for non-blocking dispatch that lets you keep working while lanes run, prefer dispatch_lanes_async + collect_lane_results and use this blocking variant only when promptAsync is unavailable. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt.',
+			'Dispatch multiple read-only exploration/review lanes concurrently and BLOCK until every lane finishes, returning a structured join result. This blocks the caller until completion; for non-blocking dispatch that lets you keep working while lanes run, prefer dispatch_lanes_async + collect_lane_results and use this blocking variant only when promptAsync is unavailable. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt. When the repo graph is fresh, a bounded orientation block (orientation arg) is prepended to common_prompt so lanes start graph-oriented instead of blind.',
 		args: {
 			lanes: DispatchLanesArgsSchema.shape.lanes,
 			common_prompt: DispatchLanesArgsSchema.shape.common_prompt,
 			max_concurrent: DispatchLanesArgsSchema.shape.max_concurrent,
 			timeout_ms: DispatchLanesArgsSchema.shape.timeout_ms,
+			orientation: DispatchLanesArgsSchema.shape.orientation,
 		},
 		execute: async (args: unknown, directory: string, ctx): Promise<string> => {
 			const result = await executeDispatchLanes(args, directory, {
@@ -3160,7 +3241,7 @@ export const dispatch_lanes: ReturnType<typeof createSwarmTool> =
 export const dispatch_lanes_async: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Launch multiple read-only advisory lanes with OpenCode promptAsync and return IMMEDIATELY with a batch id and lane session handles (non-blocking). launch_timeout_ms only bounds session creation and promptAsync acceptance; it is NOT a lane runtime timeout. After launching, keep working on non-dependent investigation while lanes run — poll incrementally with collect_lane_results (wait omitted or false) to process settled lanes as they complete, or use wait: true only at workflow boundaries where all results are needed. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt, which can produce oversized or malformed tool-call JSON.',
+			'Launch multiple read-only advisory lanes with OpenCode promptAsync and return IMMEDIATELY with a batch id and lane session handles (non-blocking). launch_timeout_ms only bounds session creation and promptAsync acceptance; it is NOT a lane runtime timeout. After launching, keep working on non-dependent investigation while lanes run — poll incrementally with collect_lane_results (wait omitted or false) to process settled lanes as they complete, or use wait: true only at workflow boundaries where all results are needed. Keep each lane prompt compact: send large shared context once via common_prompt (or have lanes read it from a file by absolute path) instead of inlining it into every lane prompt, which can produce oversized or malformed tool-call JSON. When the repo graph is fresh, a bounded orientation block (orientation arg) is prepended to common_prompt so lanes start graph-oriented instead of blind.',
 		args: {
 			lanes: DispatchLanesAsyncArgsSchema.shape.lanes,
 			common_prompt: DispatchLanesAsyncArgsSchema.shape.common_prompt,
@@ -3175,6 +3256,7 @@ export const dispatch_lanes_async: ReturnType<typeof createSwarmTool> =
 			scope: DispatchLanesAsyncArgsSchema.shape.scope,
 			trigger_evaluation: DispatchLanesAsyncArgsSchema.shape.trigger_evaluation,
 			feedback_inventory: DispatchLanesAsyncArgsSchema.shape.feedback_inventory,
+			orientation: DispatchLanesAsyncArgsSchema.shape.orientation,
 		},
 		execute: async (args: unknown, directory: string, ctx): Promise<string> => {
 			const result = await executeDispatchLanesAsync(args, directory, {

--- a/tests/unit/tools/dispatch-lanes-lane-delivery-cache.test.ts
+++ b/tests/unit/tools/dispatch-lanes-lane-delivery-cache.test.ts
@@ -224,3 +224,29 @@ describe('recordToLaneResult — delivery store integration', () => {
 		expect(other.output_omitted_repeat).toBeUndefined();
 	});
 });
+
+describe('lane-delivery cache — torn-write recovery (review nit)', () => {
+	test('session present in sessions but missing from order is dropped on load', () => {
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			cacheFile(),
+			JSON.stringify({
+				version: 1,
+				order: ['session-kept'],
+				sessions: {
+					'session-kept': ['batch\0lane\0kept'],
+					'session-torn': ['batch\0lane\0torn'],
+				},
+			}),
+		);
+		// The torn session's state is not trusted (FIFO contract requires the
+		// order array); its delivery repeats once — the documented harmless
+		// direction — while the ordered session survives.
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-torn', 'batch\0lane\0torn'),
+		).toBe(false);
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-kept', 'batch\0lane\0kept'),
+		).toBe(true);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-lane-delivery-cache.test.ts
+++ b/tests/unit/tools/dispatch-lanes-lane-delivery-cache.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	hasLaneOutputBeenDelivered,
+	LANE_DELIVERY_CACHE_FILENAME,
+	MAX_DELIVERED_LANE_OUTPUT_KEYS,
+	markLaneOutputDelivered,
+	resetLaneDeliveryStoreForTests,
+} from '../../../src/background/lane-delivery-store';
+import { _test_exports } from '../../../src/tools/dispatch-lanes';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+let tmp: string;
+
+beforeEach(() => {
+	resetLaneDeliveryStoreForTests();
+	tmp = canonicalMkdtemp('lane-delivery-cache-');
+});
+
+function cacheFile(directory: string = tmp): string {
+	return path.join(directory, '.swarm', LANE_DELIVERY_CACHE_FILENAME);
+}
+
+function readCache(directory: string = tmp): string {
+	return fs.readFileSync(cacheFile(directory), 'utf-8');
+}
+
+describe('lane-delivery cache — persistence (issue #1988 C7)', () => {
+	test('mark persists and a fresh store instance round-trips from disk', () => {
+		markLaneOutputDelivered(tmp, 'session-1', 'batch\0lane\0digest');
+		expect(fs.existsSync(cacheFile())).toBe(true);
+		// Simulate a plugin restart: in-memory state gone, disk state loads.
+		resetLaneDeliveryStoreForTests();
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest'),
+		).toBe(true);
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0other'),
+		).toBe(false);
+	});
+
+	test('keys are session-scoped: another session is not suppressed', () => {
+		markLaneOutputDelivered(tmp, 'session-1', 'batch\0lane\0digest');
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-2', 'batch\0lane\0digest'),
+		).toBe(false);
+		markLaneOutputDelivered(tmp, 'session-2', 'batch\0lane\0digest');
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-2', 'batch\0lane\0digest'),
+		).toBe(true);
+	});
+
+	test('directories are isolated buckets', () => {
+		const other = canonicalMkdtemp('lane-delivery-other-');
+		try {
+			markLaneOutputDelivered(tmp, 'session-1', 'batch\0lane\0digest');
+			expect(
+				hasLaneOutputBeenDelivered(other, 'session-1', 'batch\0lane\0digest'),
+			).toBe(false);
+		} finally {
+			fs.rmSync(other, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('lane-delivery cache — bound enforcement', () => {
+	test('global 1024-key ceiling evicts the oldest key FIFO within a session', () => {
+		for (let i = 0; i <= MAX_DELIVERED_LANE_OUTPUT_KEYS; i++) {
+			markLaneOutputDelivered(tmp, 'session-1', `batch\0lane\0digest-${i}`);
+		}
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest-0'),
+		).toBe(false);
+		expect(
+			hasLaneOutputBeenDelivered(
+				tmp,
+				'session-1',
+				`batch\0lane\0digest-${MAX_DELIVERED_LANE_OUTPUT_KEYS}`,
+			),
+		).toBe(true);
+	});
+
+	test('other sessions are pruned FIFO first when the global ceiling is hit', () => {
+		// Oldest session's keys go before the current session's newest keys.
+		markLaneOutputDelivered(tmp, 'session-old', 'batch\0lane\0oldest');
+		for (let i = 0; i < MAX_DELIVERED_LANE_OUTPUT_KEYS; i++) {
+			markLaneOutputDelivered(tmp, 'session-new', `batch\0lane\0digest-${i}`);
+		}
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-old', 'batch\0lane\0oldest'),
+		).toBe(false);
+		expect(
+			hasLaneOutputBeenDelivered(
+				tmp,
+				'session-new',
+				`batch\0lane\0digest-${MAX_DELIVERED_LANE_OUTPUT_KEYS - 1}`,
+			),
+		).toBe(true);
+	});
+
+	test('17th tracked session evicts the oldest session entirely', () => {
+		for (let i = 0; i < 16; i++) {
+			markLaneOutputDelivered(tmp, `session-${i}`, `batch\0lane\0digest-${i}`);
+		}
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-0', 'batch\0lane\0digest-0'),
+		).toBe(true);
+		markLaneOutputDelivered(tmp, 'session-16', 'batch\0lane\0digest-16');
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-0', 'batch\0lane\0digest-0'),
+		).toBe(false);
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest-1'),
+		).toBe(true);
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-16', 'batch\0lane\0digest-16'),
+		).toBe(true);
+	});
+});
+
+describe('lane-delivery cache — fail-open behavior', () => {
+	test('corrupt cache file is renamed and the store starts empty', () => {
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+		fs.writeFileSync(cacheFile(), '{ not valid json');
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest'),
+		).toBe(false);
+		expect(fs.existsSync(`${cacheFile()}.corrupt`)).toBe(true);
+		expect(fs.existsSync(cacheFile())).toBe(false);
+	});
+
+	test('first mark after corruption heals the file', () => {
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+		fs.writeFileSync(cacheFile(), 'null');
+		markLaneOutputDelivered(tmp, 'session-1', 'batch\0lane\0digest');
+		expect(fs.existsSync(cacheFile())).toBe(true);
+		expect(() => readCache()).not.toThrow();
+		resetLaneDeliveryStoreForTests();
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest'),
+		).toBe(true);
+	});
+
+	test('version-mismatched cache file is treated as unusable', () => {
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+		fs.writeFileSync(
+			cacheFile(),
+			JSON.stringify({ version: 2, order: [], sessions: {} }),
+		);
+		expect(
+			hasLaneOutputBeenDelivered(tmp, 'session-1', 'batch\0lane\0digest'),
+		).toBe(false);
+	});
+
+	test('undefined directory stays memory-only (direct test-seam path)', () => {
+		markLaneOutputDelivered(undefined, 'session-1', 'batch\0lane\0digest');
+		expect(
+			hasLaneOutputBeenDelivered(undefined, 'session-1', 'batch\0lane\0digest'),
+		).toBe(true);
+		resetLaneDeliveryStoreForTests();
+		expect(
+			hasLaneOutputBeenDelivered(undefined, 'session-1', 'batch\0lane\0digest'),
+		).toBe(false);
+		expect(fs.existsSync(cacheFile())).toBe(false);
+	});
+});
+
+describe('recordToLaneResult — delivery store integration', () => {
+	function makeRecord(): Parameters<
+		typeof _test_exports.recordToLaneResult
+	>[0] {
+		return {
+			correlationId: 'corr-1',
+			laneId: 'lane-1',
+			status: 'completed',
+			swarmPrefixedAgent: 'swarm_explorer',
+			normalizedAgent: 'explorer',
+			subagentSessionId: 'sub-1',
+			createdAt: '2026-08-15T00:00:00.000Z',
+			completedAt: '2026-08-15T00:00:01.000Z',
+			updatedAt: '2026-08-15T00:00:02.000Z',
+			result: {
+				text: 'lane output body',
+				digest: 'digest-abc',
+				outputRef: 'L1:aaaa:bbbb:cccc',
+			},
+		} as unknown as Parameters<typeof _test_exports.recordToLaneResult>[0];
+	}
+
+	test('second delivery in the same session is suppressed; disk survives restart', () => {
+		const first = _test_exports.recordToLaneResult(makeRecord(), 'batch-1', {
+			directory: tmp,
+			sessionID: 'session-1',
+		});
+		expect(first.output).toBe('lane output body');
+
+		const second = _test_exports.recordToLaneResult(makeRecord(), 'batch-1', {
+			directory: tmp,
+			sessionID: 'session-1',
+		});
+		expect(second.output).toBeUndefined();
+		expect(second.output_omitted_repeat).toBe(true);
+
+		// Restart: in-memory state gone, persisted state still suppresses.
+		resetLaneDeliveryStoreForTests();
+		const third = _test_exports.recordToLaneResult(makeRecord(), 'batch-1', {
+			directory: tmp,
+			sessionID: 'session-1',
+		});
+		expect(third.output_omitted_repeat).toBe(true);
+	});
+
+	test("another session is never suppressed by this session's delivery", () => {
+		_test_exports.recordToLaneResult(makeRecord(), 'batch-1', {
+			directory: tmp,
+			sessionID: 'session-1',
+		});
+		const other = _test_exports.recordToLaneResult(makeRecord(), 'batch-1', {
+			directory: tmp,
+			sessionID: 'session-2',
+		});
+		expect(other.output).toBe('lane output body');
+		expect(other.output_omitted_repeat).toBeUndefined();
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-orientation-block.test.ts
+++ b/tests/unit/tools/dispatch-lanes-orientation-block.test.ts
@@ -259,6 +259,101 @@ describe('buildLaneOrientationBlock — gating policy (issue #1988 C2/C6)', () =
 			fs.rmSync(longDir, { recursive: true, force: true });
 		}
 	});
+
+	test('17th tracked session evicts the oldest session dedupe state (PRR-017)', async () => {
+		await buildAndSaveStartupGraph();
+		const mission = ['Audit the payment validation flow.'];
+		// Fill all 16 session slots; each call delivers pointers into its own
+		// session's dedupe set.
+		for (let i = 0; i < 16; i++) {
+			const block = await buildLaneOrientationBlock(tmp, mission, {
+				sessionID: `session-evict-${i}`,
+			});
+			expect(block).not.toBeNull();
+		}
+		// Session 0's pointers are all delivered — suppressed before eviction.
+		expect(
+			await buildLaneOrientationBlock(tmp, mission, {
+				sessionID: 'session-evict-0',
+			}),
+		).toBeNull();
+		// Creating the 17th session evicts the OLDEST (session-evict-0) set...
+		expect(
+			await buildLaneOrientationBlock(tmp, mission, {
+				sessionID: 'session-evict-16',
+			}),
+		).not.toBeNull();
+		// ...so session-evict-0's pointers are novel again and it re-emits.
+		expect(
+			await buildLaneOrientationBlock(tmp, mission, {
+				sessionID: 'session-evict-0',
+			}),
+		).not.toBeNull();
+		// Re-creating session-evict-0 evicted the NEXT-oldest session
+		// (session-evict-1); session-evict-2 is still tracked and suppressed.
+		expect(
+			await buildLaneOrientationBlock(tmp, mission, {
+				sessionID: 'session-evict-2',
+			}),
+		).toBeNull();
+	});
+
+	test('config-load failure falls back to option defaults (PRR-018)', async () => {
+		await buildAndSaveStartupGraph();
+		const original = injectionInternals.loadPluginConfigWithMetaAsync;
+		injectionInternals.loadPluginConfigWithMetaAsync = async () => {
+			throw new Error('config read exploded');
+		};
+		try {
+			const block = await buildLaneOrientationBlock(tmp, [
+				'Audit the payment validation flow.',
+			]);
+			expect(block).not.toBeNull();
+			expect(block).toContain('Freshness: fresh (probe clean)');
+		} finally {
+			injectionInternals.loadPluginConfigWithMetaAsync = original;
+		}
+	});
+
+	test('probe-inconclusive end-to-end renders the unknown-freshness line (PRR-020a)', async () => {
+		await buildAndSaveStartupGraph();
+		const original = injectionInternals.probeFreshness;
+		injectionInternals.probeFreshness = (async () => ({
+			state: 'inconclusive' as const,
+			changed: [],
+			removed: [],
+			truncated: true,
+			probedFiles: 42,
+			elapsedMs: 1,
+		})) as typeof original;
+		try {
+			const block = await buildLaneOrientationBlock(tmp, [
+				'Audit the payment validation flow.',
+			]);
+			expect(block).not.toBeNull();
+			expect(block).toContain(
+				'Freshness: freshness unknown (probe inconclusive)',
+			);
+		} finally {
+			injectionInternals.probeFreshness = original;
+		}
+	});
+
+	test('mission text beyond ORIENTATION_MISSION_CHAR_BUDGET is sliced deterministically (PRR-020b)', async () => {
+		await buildAndSaveStartupGraph();
+		const filler = 'z'.repeat(4_500);
+		// Mission terms inside the first 4000 chars: block emitted.
+		const inBudget = await buildLaneOrientationBlock(tmp, [
+			`Audit the payment validation flow. ${filler}`,
+		]);
+		expect(inBudget).not.toBeNull();
+		// Same filler FIRST pushes the payment terms past the 4000-char slice,
+		// so the graph sees no matching terms and nothing is emitted.
+		const outOfBudget = await buildLaneOrientationBlock(tmp, [
+			`${filler} Audit the payment validation flow.`,
+		]);
+		expect(outOfBudget).toBeNull();
+	});
 });
 
 describe('orientation render seam — pure render and freshness mapping', () => {

--- a/tests/unit/tools/dispatch-lanes-orientation-block.test.ts
+++ b/tests/unit/tools/dispatch-lanes-orientation-block.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	buildLaneOrientationBlock,
+	_internals as injectionInternals,
+	resetGraphInjectionCache,
+	resetLaneOrientationDedupe,
+} from '../../../src/hooks/repo-graph-injection';
+import {
+	buildWorkspaceGraphAsync,
+	saveGraph,
+	writeFingerprint,
+} from '../../../src/tools/repo-graph';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const ORIENTATION_HEADING = '## REPO GRAPH — LANE ORIENTATION';
+
+let tmp: string;
+
+beforeEach(() => {
+	resetLaneOrientationDedupe();
+	resetGraphInjectionCache();
+	tmp = canonicalMkdtemp('lanes-orientation-');
+	fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-validator.ts'),
+		'export function validatePayment(amount: number): boolean {\n\treturn amount > 0;\n}\n',
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-routes.ts'),
+		"import { validatePayment } from './payment-validator';\nexport function routePayment(a: number): string {\n\treturn validatePayment(a) ? 'ok' : 'reject';\n}\n",
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-store.ts'),
+		"import { validatePayment } from './payment-validator';\nexport function storePayment(a: number): number {\n\treturn validatePayment(a) ? a : 0;\n}\n",
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'invoice-renderer.ts'),
+		'export function renderInvoice(label: string): string {\n\treturn label.toUpperCase();\n}\n',
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function buildAndSaveStartupGraph(): Promise<void> {
+	const graph = await buildWorkspaceGraphAsync(tmp);
+	await saveGraph(tmp, graph);
+	await writeFingerprint(tmp, graph);
+}
+
+describe('buildLaneOrientationBlock — gating policy (issue #1988 C2/C6)', () => {
+	test('emits a deterministic block when the floor is cleared on a fresh graph', async () => {
+		await buildAndSaveStartupGraph();
+		const block = await buildLaneOrientationBlock(tmp, [
+			'Audit the payment validation flow and its consumers.',
+		]);
+		expect(block).not.toBeNull();
+		expect(block?.startsWith(ORIENTATION_HEADING)).toBe(true);
+		expect(block).toContain('Mission-relevant files');
+		expect(block).toContain('payment-validator.ts');
+		expect(block).toContain('Repo hubs');
+		expect(block).toContain('Freshness: fresh (probe clean)');
+		expect(block).not.toContain('elapsedMs');
+		expect(block).not.toContain('probedFiles');
+	});
+
+	test('suppressed on repeat dispatch (dedupe) — separate test', async () => {
+		await buildAndSaveStartupGraph();
+		const missions = ['Audit the payment validation flow.'];
+		const first = await buildLaneOrientationBlock(tmp, missions, {
+			sessionID: 'session-a',
+		});
+		expect(first).not.toBeNull();
+		// Second identical dispatch in the same session, NO reset: the file
+		// pointers are all already delivered, so nothing is emitted.
+		const second = await buildLaneOrientationBlock(tmp, missions, {
+			sessionID: 'session-a',
+		});
+		expect(second).toBeNull();
+	});
+
+	test('scale-free floor: concentrated ranking emits even with tiny absolute scores (large-graph behavior)', async () => {
+		// On a 3463-node graph a perfectly-targeted mission yields raw top
+		// scores of ~0.01, so the 0.35 floor must be applied to the
+		// normalized top-3 share, not the absolute score (real-repo evidence
+		// in the PR body). One strongly-matching file among many weakly-
+		// matching ones concentrates the share and must emit.
+		const big = canonicalMkdtemp('lanes-orient-scale-');
+		try {
+			fs.mkdirSync(path.join(big, 'src'), { recursive: true });
+			fs.writeFileSync(
+				path.join(big, 'src', 'target-flow.ts'),
+				'export function workflowTargetStep() {}\nexport function workflowTargetGuard() {}\nexport function workflowTargetAudit() {}\n',
+			);
+			for (let i = 0; i < 9; i++) {
+				fs.writeFileSync(
+					path.join(big, 'src', `neighbor-${i}.ts`),
+					`export function workflowNeighborStep${i}() {}\n`,
+				);
+			}
+			const graph = await buildWorkspaceGraphAsync(big);
+			await saveGraph(big, graph);
+			await writeFingerprint(big, graph);
+			const block = await buildLaneOrientationBlock(big, [
+				'workflow target audit guard step',
+			]);
+			expect(block).not.toBeNull();
+			expect(block).toContain('target-flow.ts');
+		} finally {
+			fs.rmSync(big, { recursive: true, force: true });
+		}
+	});
+
+	test('scale-free floor: diffuse ranking is suppressed', async () => {
+		// Six files all matching the same single term equally produce a
+		// near-uniform ranking: the top file owns ~1/3 of the top-3 mass,
+		// below the 0.35 concentration floor — no orientation is pushed.
+		const diffuse = canonicalMkdtemp('lanes-orient-diffuse-');
+		try {
+			fs.mkdirSync(path.join(diffuse, 'src'), { recursive: true });
+			for (let i = 0; i < 6; i++) {
+				fs.writeFileSync(
+					path.join(diffuse, 'src', `uniform-${i}.ts`),
+					'export function sharedzzTerm() {}\n',
+				);
+			}
+			const graph = await buildWorkspaceGraphAsync(diffuse);
+			await saveGraph(diffuse, graph);
+			await writeFingerprint(diffuse, graph);
+			const block = await buildLaneOrientationBlock(diffuse, [
+				'sharedzzTerm lookup',
+			]);
+			expect(block).toBeNull();
+		} finally {
+			fs.rmSync(diffuse, { recursive: true, force: true });
+		}
+	});
+
+	test('determinism — identical dispatches from reset dedupe state are byte-identical', async () => {
+		await buildAndSaveStartupGraph();
+		const missions = ['Audit the payment validation flow and routing.'];
+		const first = await buildLaneOrientationBlock(tmp, missions, {
+			sessionID: 'session-det',
+		});
+		resetLaneOrientationDedupe();
+		resetGraphInjectionCache();
+		const second = await buildLaneOrientationBlock(tmp, missions, {
+			sessionID: 'session-det',
+		});
+		expect(second).not.toBeNull();
+		expect(second).toBe(first);
+	});
+
+	test('suppressed when the graph is stale beyond refresh_cap', async () => {
+		await buildAndSaveStartupGraph();
+		// Drift the graph: touch a tracked file so the probe reports 'drifted'.
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'payment-validator.ts'),
+			'export function validatePayment(amount: number): boolean {\n\treturn amount >= 0;\n}\n',
+		);
+		const block = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the payment validation flow.'],
+			{ refreshCap: 0 },
+		);
+		expect(block).toBeNull();
+	});
+
+	test('suppressed when no fingerprint exists (uncertified graph)', async () => {
+		const graph = await buildWorkspaceGraphAsync(tmp);
+		await saveGraph(tmp, graph);
+		const block = await buildLaneOrientationBlock(tmp, [
+			'Audit the payment validation flow.',
+		]);
+		expect(block).toBeNull();
+	});
+
+	test('suppressed when no graph exists at all', async () => {
+		const block = await buildLaneOrientationBlock(tmp, [
+			'Audit the payment validation flow.',
+		]);
+		expect(block).toBeNull();
+	});
+
+	test('suppressed when repo graph injection is disabled (enabled: false gate)', async () => {
+		await buildAndSaveStartupGraph();
+		const block = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the payment validation flow.'],
+			{ enabled: false },
+		);
+		expect(block).toBeNull();
+	});
+
+	test('same-session mission whose pointers were all already delivered is suppressed', async () => {
+		await buildAndSaveStartupGraph();
+		const first = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the payment validation flow.'],
+			{ sessionID: 'session-novel' },
+		);
+		expect(first).not.toBeNull();
+		// In this 4-file fixture every file is either a mission hit or a
+		// top-4 hub, so the first block delivered ALL pointers — including
+		// invoice-renderer.ts as a hub. The invoice mission therefore has no
+		// novel pointer and emits nothing (novelty dedupe by design).
+		const second = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the invoice rendering.'],
+			{ sessionID: 'session-novel' },
+		);
+		expect(second).toBeNull();
+	});
+
+	test('per-session dedupe: the same mission in a different session emits again', async () => {
+		await buildAndSaveStartupGraph();
+		const first = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the payment validation flow.'],
+			{ sessionID: 'session-one' },
+		);
+		expect(first).not.toBeNull();
+		const second = await buildLaneOrientationBlock(
+			tmp,
+			['Audit the payment validation flow.'],
+			{ sessionID: 'session-two' },
+		);
+		expect(second).not.toBeNull();
+		// Same graph state and mission ⇒ byte-identical block in the fresh
+		// session (empty dedupe state).
+		expect(second).toBe(first);
+	});
+
+	test('token gate — a rendered block over the 600-token budget is dropped', async () => {
+		// Long file and export names push the rendered block past the
+		// LANE_ORIENTATION_MAX_TOKENS budget (estimateTokens = ceil(len*0.33),
+		// so >1818 chars exceeds 600 tokens).
+		const longDir = canonicalMkdtemp('lanes-orient-big-');
+		try {
+			fs.mkdirSync(path.join(longDir, 'src'), { recursive: true });
+			const longName = 'a'.repeat(120);
+			for (let i = 0; i < 6; i++) {
+				fs.writeFileSync(
+					path.join(longDir, 'src', `${longName}${i}.ts`),
+					`import { exportFunctionWithLongExportName${(i + 1) % 6}_0 } from './${longName}${(i + 1) % 6}';\nexport function exportFunctionWithLongExportName${i}_0() {}\nexport function exportFunctionWithLongExportName${i}_1() {}\nexport function exportFunctionWithLongExportName${i}_2() {}\n`,
+				);
+			}
+			const graph = await buildWorkspaceGraphAsync(longDir);
+			await saveGraph(longDir, graph);
+			await writeFingerprint(longDir, graph);
+			const block = await buildLaneOrientationBlock(longDir, [
+				'exportFunctionWithLongExportName audit',
+			]);
+			expect(block).toBeNull();
+		} finally {
+			fs.rmSync(longDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('orientation render seam — pure render and freshness mapping', () => {
+	test('render includes sections only when non-empty', () => {
+		const both = injectionInternals.renderLaneOrientationBlock(
+			[{ file: 'src/a.ts', score: 0.42, exports: ['x', 'y', 'z', 'w'] }],
+			['src/hub1.ts', 'src/hub2.ts'],
+			'fresh (probe clean)',
+		);
+		expect(both.startsWith(ORIENTATION_HEADING)).toBe(true);
+		expect(both).toContain('- src/a.ts (score 0.42; exports: x, y, z)');
+		expect(both).toContain(
+			'Repo hubs (most imported): src/hub1.ts, src/hub2.ts',
+		);
+		expect(both.endsWith('Freshness: fresh (probe clean)')).toBe(true);
+
+		const askOnly = injectionInternals.renderLaneOrientationBlock(
+			[{ file: 'src/a.ts', score: 0.42, exports: [] }],
+			[],
+			'fresh (probe clean)',
+		);
+		expect(askOnly).not.toContain('Repo hubs');
+		expect(askOnly).toContain('(score 0.42)');
+
+		const hubsOnly = injectionInternals.renderLaneOrientationBlock(
+			[],
+			['src/hub1.ts'],
+			'fresh (probe clean)',
+		);
+		expect(hubsOnly).not.toContain('Mission-relevant files');
+	});
+
+	test('freshness line covers every probe state deterministically', () => {
+		const { orientationFreshnessLine } = injectionInternals;
+		expect(orientationFreshnessLine('clean', 0, 0)).toBe('fresh (probe clean)');
+		expect(orientationFreshnessLine('drifted', 3, 1)).toBe(
+			'drifted within refresh cap (3 changed, 1 removed)',
+		);
+		expect(orientationFreshnessLine('inconclusive', 0, 0)).toBe(
+			'freshness unknown (probe inconclusive)',
+		);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-orientation-dispatch.test.ts
+++ b/tests/unit/tools/dispatch-lanes-orientation-dispatch.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	resetGraphInjectionCache,
+	resetLaneOrientationDedupe,
+} from '../../../src/hooks/repo-graph-injection';
+import {
+	_internals,
+	_test_exports,
+	executeDispatchLanes,
+	executeDispatchLanesAsync,
+	MAX_PROMPT_CHARS,
+	type SessionOps,
+} from '../../../src/tools/dispatch-lanes';
+import {
+	buildWorkspaceGraphAsync,
+	saveGraph,
+	writeFingerprint,
+} from '../../../src/tools/repo-graph';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const originalInternals = { ..._internals };
+
+const { DispatchLanesArgsSchema, DispatchLanesAsyncArgsSchema } = _test_exports;
+
+const ORIENTATION_HEADING = '## REPO GRAPH — LANE ORIENTATION';
+
+let tmp: string;
+
+beforeEach(() => {
+	resetLaneOrientationDedupe();
+	resetGraphInjectionCache();
+	tmp = canonicalMkdtemp('lanes-orientation-');
+	fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-validator.ts'),
+		'export function validatePayment(amount: number): boolean {\n\treturn amount > 0;\n}\n',
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-routes.ts'),
+		"import { validatePayment } from './payment-validator';\nexport function routePayment(a: number): string {\n\treturn validatePayment(a) ? 'ok' : 'reject';\n}\n",
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'payment-store.ts'),
+		"import { validatePayment } from './payment-validator';\nexport function storePayment(a: number): number {\n\treturn validatePayment(a) ? a : 0;\n}\n",
+	);
+	fs.writeFileSync(
+		path.join(tmp, 'src', 'invoice-renderer.ts'),
+		'export function renderInvoice(label: string): string {\n\treturn label.toUpperCase();\n}\n',
+	);
+});
+
+afterEach(() => {
+	Object.assign(_internals, originalInternals);
+	fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function buildAndSaveStartupGraph(): Promise<void> {
+	const graph = await buildWorkspaceGraphAsync(tmp);
+	await saveGraph(tmp, graph);
+	await writeFingerprint(tmp, graph);
+}
+
+function makeSessionOps(): { ops: SessionOps; prompts: string[] } {
+	const prompts: string[] = [];
+	const ops: SessionOps = {
+		create: mock(async () => ({
+			data: { id: `session-${prompts.length + 1}` },
+			error: undefined,
+		})),
+		prompt: mock(async (input) => {
+			prompts.push(input.body.parts[0]?.text ?? '');
+			return {
+				data: { parts: [{ type: 'text' as const, text: 'done' }] },
+				error: undefined,
+			};
+		}),
+		delete: mock(async () => undefined),
+	};
+	return { ops, prompts };
+}
+
+function lanePromptTexts(ops: SessionOps): string[] {
+	return (ops.prompt as ReturnType<typeof mock>).mock.calls.map(
+		(call) => call[0].body.parts[0].text as string,
+	);
+}
+
+describe('augmentCommonPromptWithOrientation — resolution and overflow rule', () => {
+	test('orientation false never probes the graph (DI seam proves zero builder calls)', async () => {
+		const buildBlock = mock(
+			async () => '## REPO GRAPH — LANE ORIENTATION\nshould not appear',
+		);
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: 'lane one' }],
+			'shared context',
+			false,
+			'session-x',
+			{ buildBlock: buildBlock as never },
+		);
+		expect(result).toBe('shared context');
+		expect(buildBlock).toHaveBeenCalledTimes(0);
+	});
+
+	test('orientation true appends the block after common_prompt', async () => {
+		const block = `${ORIENTATION_HEADING}\nFreshness: fresh (probe clean)`;
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: 'lane one' }],
+			'shared context',
+			true,
+			'session-x',
+			{
+				buildBlock: (async () => block) as never,
+			},
+		);
+		expect(result).toBe(`shared context\n\n${block}`);
+	});
+
+	test('block becomes the common prefix when common_prompt is omitted', async () => {
+		const block = `${ORIENTATION_HEADING}\nFreshness: fresh (probe clean)`;
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: 'lane one' }],
+			undefined,
+			undefined,
+			undefined,
+			{
+				buildBlock: (async () => block) as never,
+			},
+		);
+		expect(result).toBe(block);
+	});
+
+	test('overflow rule — block dropped when combined length would exceed MAX_PROMPT_CHARS', async () => {
+		const common = 'c'.repeat(76_000);
+		const lane = 'l'.repeat(2_000);
+		// common + separator + lane fits; adding a 2000-char block does not.
+		expect(common.length + 2 + lane.length).toBeLessThanOrEqual(
+			MAX_PROMPT_CHARS,
+		);
+		const block = 'b'.repeat(2_000);
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: lane }],
+			common,
+			true,
+			'session-x',
+			{
+				buildBlock: (async () => block) as never,
+			},
+		);
+		expect(result).toBe(common);
+	});
+
+	test('builder errors fail open to the un-augmented common_prompt', async () => {
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: 'lane one' }],
+			'shared context',
+			true,
+			'session-x',
+			{
+				buildBlock: (async () => {
+					throw new Error('probe exploded');
+				}) as never,
+			},
+		);
+		expect(result).toBe('shared context');
+	});
+});
+
+describe('dispatch_lanes schemas — orientation arg (issue #1988)', () => {
+	test('orientation is optional with no zod default on both schemas', () => {
+		expect(DispatchLanesArgsSchema.shape.orientation).toBeDefined();
+		expect(DispatchLanesAsyncArgsSchema.shape.orientation).toBeDefined();
+		const parsed =
+			DispatchLanesArgsSchema.shape.orientation.safeParse(undefined);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) expect(parsed.data).toBeUndefined();
+	});
+
+	test('both schemas accept args without orientation and with explicit values', () => {
+		const lanes = [{ id: 'a', agent: 'explorer', prompt: 'p' }];
+		expect(DispatchLanesArgsSchema.safeParse({ lanes }).success).toBe(true);
+		expect(
+			DispatchLanesArgsSchema.safeParse({ lanes, orientation: true }).success,
+		).toBe(true);
+		expect(
+			DispatchLanesArgsSchema.safeParse({ lanes, orientation: false }).success,
+		).toBe(true);
+		expect(DispatchLanesAsyncArgsSchema.safeParse({ lanes }).success).toBe(
+			true,
+		);
+		expect(
+			DispatchLanesAsyncArgsSchema.safeParse({
+				lanes,
+				orientation: false,
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('executeDispatchLanes — lane orientation delivery (issue #1988 C2)', () => {
+	test('lane prompts receive the orientation block in the shared prefix position', async () => {
+		await buildAndSaveStartupGraph();
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				common_prompt: 'SHARED MISSION CONTEXT',
+				lanes: [
+					{
+						id: 'validator',
+						agent: 'explorer',
+						prompt: 'Audit the payment validation flow.',
+					},
+					{
+						id: 'consumers',
+						agent: 'explorer',
+						prompt: 'Find consumers of validatePayment.',
+					},
+				],
+			},
+			tmp,
+			{ sessionID: 'parent-orientation-1' },
+		);
+
+		expect(result.success).toBe(true);
+		const texts = lanePromptTexts(ops);
+		expect(texts).toHaveLength(2);
+		const lanePrompts = [
+			'Audit the payment validation flow.',
+			'Find consumers of validatePayment.',
+		];
+		texts.forEach((text, i) => {
+			const sharedIndex = text.indexOf('SHARED MISSION CONTEXT');
+			const blockIndex = text.indexOf(ORIENTATION_HEADING);
+			const laneIndex = text.indexOf(lanePrompts[i]);
+			expect(sharedIndex).toBeGreaterThan(-1);
+			expect(blockIndex).toBeGreaterThan(sharedIndex);
+			expect(laneIndex).toBeGreaterThan(blockIndex);
+			expect(text).toContain('Freshness: fresh (probe clean)');
+		});
+	});
+
+	test('repeat dispatch in the same session is suppressed by dedupe', async () => {
+		await buildAndSaveStartupGraph();
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+
+		const args = {
+			common_prompt: 'SHARED MISSION CONTEXT',
+			lanes: [
+				{
+					id: 'validator',
+					agent: 'explorer',
+					prompt: 'Audit the payment validation flow.',
+				},
+			],
+		} as const;
+
+		await executeDispatchLanes({ ...args }, tmp, {
+			sessionID: 'parent-orientation-2',
+		});
+		expect(lanePromptTexts(ops)[0]).toContain(ORIENTATION_HEADING);
+
+		const { ops: ops2 } = makeSessionOps();
+		_internals.getSessionOps = () => ops2;
+		await executeDispatchLanes({ ...args }, tmp, {
+			sessionID: 'parent-orientation-2',
+		});
+		expect(lanePromptTexts(ops2)[0]).not.toContain(ORIENTATION_HEADING);
+	});
+
+	test('dispatch-level determinism — identical dispatches from reset state are byte-identical', async () => {
+		await buildAndSaveStartupGraph();
+		const args = {
+			common_prompt: 'SHARED MISSION CONTEXT',
+			lanes: [
+				{
+					id: 'validator',
+					agent: 'explorer',
+					prompt: 'Audit the payment validation flow.',
+				},
+			],
+		} as const;
+
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+		await executeDispatchLanes({ ...args }, tmp, {
+			sessionID: 'parent-orientation-3',
+		});
+
+		resetLaneOrientationDedupe();
+		resetGraphInjectionCache();
+
+		const { ops: ops2 } = makeSessionOps();
+		_internals.getSessionOps = () => ops2;
+		await executeDispatchLanes({ ...args }, tmp, {
+			sessionID: 'parent-orientation-3',
+		});
+
+		expect(lanePromptTexts(ops2)[0]).toBe(lanePromptTexts(ops)[0]);
+	});
+
+	test('orientation false disables the block end to end', async () => {
+		await buildAndSaveStartupGraph();
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+
+		await executeDispatchLanes(
+			{
+				orientation: false,
+				common_prompt: 'SHARED MISSION CONTEXT',
+				lanes: [
+					{
+						id: 'validator',
+						agent: 'explorer',
+						prompt: 'Audit the payment validation flow.',
+					},
+				],
+			},
+			tmp,
+			{ sessionID: 'parent-orientation-4' },
+		);
+		expect(lanePromptTexts(ops)[0]).not.toContain(ORIENTATION_HEADING);
+	});
+});
+
+describe('executeDispatchLanesAsync — lane orientation delivery', () => {
+	test('async lane prompts receive the orientation block too', async () => {
+		await buildAndSaveStartupGraph();
+		const prompts: string[] = [];
+		const ops: SessionOps = {
+			create: mock(async () => ({
+				data: { id: `session-${prompts.length + 1}` },
+				error: undefined,
+			})),
+			prompt: mock(async () => ({
+				data: { parts: [{ type: 'text' as const, text: 'unused' }] },
+				error: undefined,
+			})),
+			promptAsync: mock(async (input) => {
+				prompts.push(input.body.parts[0]?.text ?? '');
+				return { data: undefined, error: undefined };
+			}),
+			status: mock(async () => ({ data: {}, error: undefined })),
+			messages: mock(async () => {
+				throw new Error('dispatch_lanes_async must not read lane output');
+			}),
+			delete: mock(async () => undefined),
+		};
+		_internals.getSessionOps = () => ops;
+		_internals.now = () => 1_700_000_000_000;
+
+		const result = await executeDispatchLanesAsync(
+			{
+				batch_id: 'batch-orientation-async-1',
+				mode: 'deep-dive',
+				common_prompt: 'SHARED MISSION CONTEXT',
+				lanes: [
+					{
+						id: 'validator',
+						agent: 'explorer',
+						prompt: 'Audit the payment validation flow.',
+					},
+				],
+			},
+			tmp,
+			{ sessionID: 'parent-orientation-async-1' },
+		);
+
+		expect(result.success).toBe(true);
+		expect(prompts).toHaveLength(1);
+		const sharedIndex = prompts[0].indexOf('SHARED MISSION CONTEXT');
+		const blockIndex = prompts[0].indexOf(ORIENTATION_HEADING);
+		expect(blockIndex).toBeGreaterThan(sharedIndex);
+	});
+});

--- a/tests/unit/tools/dispatch-lanes-orientation-dispatch.test.ts
+++ b/tests/unit/tools/dispatch-lanes-orientation-dispatch.test.ts
@@ -98,7 +98,7 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 			'shared context',
 			false,
 			'session-x',
-			{ buildBlock: buildBlock as never },
+			{ buildBlock },
 		);
 		expect(result).toBe('shared context');
 		expect(buildBlock).toHaveBeenCalledTimes(0);
@@ -113,7 +113,7 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 			true,
 			'session-x',
 			{
-				buildBlock: (async () => block) as never,
+				buildBlock: async () => block,
 			},
 		);
 		expect(result).toBe(`shared context\n\n${block}`);
@@ -128,7 +128,7 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 			undefined,
 			undefined,
 			{
-				buildBlock: (async () => block) as never,
+				buildBlock: async () => block,
 			},
 		);
 		expect(result).toBe(block);
@@ -137,7 +137,8 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 	test('overflow rule — block dropped when combined length would exceed MAX_PROMPT_CHARS', async () => {
 		const common = 'c'.repeat(76_000);
 		const lane = 'l'.repeat(2_000);
-		// common + separator + lane fits; adding a 2000-char block does not.
+		// common + separator + lane fits; adding a 2000-char block exceeds the
+		// cap even before the suffix reserve.
 		expect(common.length + 2 + lane.length).toBeLessThanOrEqual(
 			MAX_PROMPT_CHARS,
 		);
@@ -149,7 +150,32 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 			true,
 			'session-x',
 			{
-				buildBlock: (async () => block) as never,
+				buildBlock: async () => block,
+			},
+		);
+		expect(result).toBe(common);
+	});
+
+	test('suffix reserve (review F-09) — block dropped when it fits the raw cap but not cap minus reserve', async () => {
+		// common + separator + lane + block = 78,004 ≤ 80,000, so the raw
+		// common+lane check alone would KEEP the block; with the conservative
+		// reserve for the later explorer/PR-workflow suffix appends it must be
+		// dropped so those appenders can never hard-fail a previously-passing
+		// dispatch because an orientation block appeared.
+		const common = 'c'.repeat(74_000);
+		const lane = 'l'.repeat(2_000);
+		const block = 'b'.repeat(2_000);
+		expect(
+			common.length + 2 + lane.length + 2 + block.length,
+		).toBeLessThanOrEqual(MAX_PROMPT_CHARS);
+		const result = await _test_exports.augmentCommonPromptWithOrientation(
+			tmp,
+			[{ prompt: lane }],
+			common,
+			true,
+			'session-x',
+			{
+				buildBlock: async () => block,
 			},
 		);
 		expect(result).toBe(common);
@@ -163,9 +189,9 @@ describe('augmentCommonPromptWithOrientation — resolution and overflow rule', 
 			true,
 			'session-x',
 			{
-				buildBlock: (async () => {
+				buildBlock: async () => {
 					throw new Error('probe exploded');
-				}) as never,
+				},
 			},
 		);
 		expect(result).toBe('shared context');
@@ -379,5 +405,63 @@ describe('executeDispatchLanesAsync — lane orientation delivery', () => {
 		const sharedIndex = prompts[0].indexOf('SHARED MISSION CONTEXT');
 		const blockIndex = prompts[0].indexOf(ORIENTATION_HEADING);
 		expect(blockIndex).toBeGreaterThan(sharedIndex);
+	});
+});
+
+describe('executeDispatchLanes — orientation edge paths', () => {
+	test('near-cap dispatch drops the block via the suffix reserve and still succeeds (review F-09)', async () => {
+		await buildAndSaveStartupGraph();
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+
+		// common + block + separator + lane stays under the raw 80k cap, so
+		// without the reserve the block would be kept — and the later suffix
+		// appenders could then hard-fail a dispatch that previously passed.
+		// (75,700 + 2 + ~38 lane + 2 + ~330 block ≈ 76,072 ≤ 80,000 raw;
+		// + 5,000 reserve → over the cap.)
+		const common = 'c'.repeat(75_700);
+		const result = await executeDispatchLanes(
+			{
+				common_prompt: common,
+				lanes: [
+					{
+						id: 'validator',
+						agent: 'explorer',
+						prompt: 'Audit the payment validation flow.',
+					},
+				],
+			},
+			tmp,
+			{ sessionID: 'parent-near-cap-1' },
+		);
+
+		expect(result.success).toBe(true);
+		const text = lanePromptTexts(ops)[0];
+		expect(text.startsWith(common)).toBe(true);
+		expect(text).not.toContain(ORIENTATION_HEADING);
+	});
+
+	test('cold start with no graph present dispatches cleanly with no block', async () => {
+		// No buildAndSaveStartupGraph: the directory has no .swarm graph.
+		const { ops } = makeSessionOps();
+		_internals.getSessionOps = () => ops;
+
+		const result = await executeDispatchLanes(
+			{
+				common_prompt: 'SHARED MISSION CONTEXT',
+				lanes: [
+					{
+						id: 'validator',
+						agent: 'explorer',
+						prompt: 'Audit the payment validation flow.',
+					},
+				],
+			},
+			tmp,
+			{ sessionID: 'parent-cold-start-1' },
+		);
+
+		expect(result.success).toBe(true);
+		expect(lanePromptTexts(ops)[0]).not.toContain(ORIENTATION_HEADING);
 	});
 });


### PR DESCRIPTION
Closes #1988

## Review-cycle addendum (2026-08-16)

A post-publish swarm review (explorer lanes + micro risk-families + independent reviewer + critic) and a bot multi-stage review both ran against head `a97040cf`; all findings were closed in `d676e024` ("fix(context): reserve suffix headroom in orientation overflow guard and close review findings"):

- **F-09 (REQUEST_CHANGES, fixed)** — the orientation overflow guard now reserves `ORIENTATION_SUFFIX_RESERVE_CHARS = 5,000` of headroom for the later `applyExplorerFormatSuffix`/`applyPrWorkflowPromptContract` appends, so an orientation block can no longer be the straw that hard-fails a previously-passing PR-review dispatch; both downstream overflow diagnostics now name the orientation block and its `orientation: false` opt-out. Two discriminating tests (unit + dispatch-level near-cap) prove the reserve flips the decision.
- **Closed from the review handoff** — async config load (`loadPluginConfigWithMetaAsync` via the `_internals` seam, review PRR-005/018), Windows retry on the corrupt-file quarantine rename (PRR-014), four previously-untested paths now pinned (17th-session orientation eviction, config-failure fallback, probe-inconclusive end-to-end, 4000-char mission slice — PRR-017/020a/020b), `as never` casts removed from the DI-seam mocks (PRR-023), dispatch-level no-graph cold-start test, torn-write load test, FIFO-vs-LRU comment accuracy, and default-on wording in both tool descriptions.
- **Advisory findings classified (with evidence, not silently dropped)** — F-10 case-folding (consistent with the sibling cache convention; host-supplied single-cased directory; fail-open bounded), F-11 askGraph cost (PR6 measurement owns tuning), F-12 silence (module contract mandates silent fail-open; the issue mandates no nudge text; debug-gated logging exists at the wrapper), plus the critic-downgraded LOWs (validateSwarmPath context-appropriateness, identifier-syntax-bounded injection surface, local-state size clamp, documented cross-process overwrite, per-session-dimension advisory). Full ledger with every row's outcome is in the review-run artifacts.
- **Known follow-up (reviewer/critic-discovered, non-blocking)** — a block that passes the builder but is dropped by the overflow rule still records its novelty pointers for the session (benign direction: missing advisory context until prompts shrink); the final critic filed this as follow-up-tier, not for this PR.

Updated counts: 46 tests across the three orientation/delivery test files (399/467/252 lines — all under the FR-006 cap); 67 tests green across the six affected suites including both suffix-overflow assertion files; typecheck, `biome ci .`, drift-check, cap/clock/tmpdir shell gates all green locally.

## Summary

PR4 of the context-layer gap-closure plan (docs/context-layer-gap-closure-plan.md §7): wires the repo-graph subsystem into the paths that consume context, closing all five confirmed delivery gaps.

- **C1 — Agent prompts are graph-first.** `explorer`'s ACTIONS block now leads with `repo_map action="ask"` (mission question) and `action="context_pack"` (target symbols), explicitly framing graph output as orientation that must be followed by reading the located files; blind tree/glob/grep scanning is reserved for graph gaps (`stale: true`, missing files, non-code assets). `coder` directs `repo_map action="localization"` before editing shared/cross-imported files (covering the undeclared-scope case the system-enhancer injection does not); `reviewer` directs `repo_map action="blast_radius"` for changed files not covered by an injected REPO GRAPH block. `repo_map` was already granted to all three roles — this was a pure prompt gap. All four files named by the issue were updated; because `explorer-consumer-contract.test.ts` sits over the FR-006 500-line ratchet baseline (510 lines on main) it took only a net-zero regex hardening, and the explorer directive assertions live in a fifth new colocated file, `src/agents/explorer-repo-map-directive.test.ts` (39 lines).
- **C2/C6 — Lane orientation block.** New `buildLaneOrientationBlock(directory, lanePrompts, options)` in `src/hooks/repo-graph-injection.ts`: one `ask` over the concatenated lane mission texts (deterministically bounded), top-6 mission-relevant files + top-4 repo hubs + a one-line freshness statement, appended to `common_prompt` (cacheable shared-prefix position) by both `dispatch_lanes` and `dispatch_lanes_async`. New optional `orientation` arg on both schemas with **no zod default** (availability depends on graph state; execute-time resolution: `false` opts out, otherwise attempted and silently skipped without a fresh graph). Gating policy: relevance floor (constant 0.35), ≤600-token budget (`estimateTokens`), per-session novelty dedupe (bounded 128 pointers FIFO, suppressed repeats emit nothing), and a pre-append `MAX_PROMPT_CHARS` overflow check that drops the block (debug log) rather than truncating or failing dispatch.
- **C3 — deep-dive reuse.** Step 2 (Scope Resolution) now runs `repo_map action="graph_health"` first and only builds when missing/incomplete, and prefers `ask`/`key_files` before manual symbol/import walks. Both skill trees byte-identical (drift-check green). The issue's `grep "Scan structure"` across skill trees has zero occurrences on main — verified and recorded; the only blind-scan protocol text was explorer's ACTIONS block (C1).
- **C7 — Lane-output redelivery persistence.** `deliveredLaneOutputs` (in-memory, session-agnostic Set with a documented cross-session false-suppression bug) is replaced by `src/background/lane-delivery-store.ts`: session-keyed, persisted to `.swarm/lane-delivery-cache.json` (global 1024-key ceiling with cross-session FIFO pruning, 16-session/16-directory bounds, best-effort atomic write reusing `writeAtomicJson`, fail-open load with corrupt-file rename-quarantine so the next mark heals). `recordToLaneResult`/`buildCollectLaneResults` thread `{directory, sessionID}` from the collect context; `_test_exports` seams preserved (2-arg `recordToLaneResult` and `resetDeliveredLaneOutputs` shim) — existing output-delivery tests pass unchanged.

### Floor normalization note (spec interpretation, evidence-forced)

Raw `ask` scores are personalized-PageRank probabilities summing to 1 across **all** graph nodes, so absolute magnitude scales with 1/graph-size. Measured on this repository (3,463 nodes): a perfectly-targeted mission tops out at **~0.017** absolute (with `src/tools/dispatch-lanes.ts` and `src/hooks/repo-graph-injection.ts` correctly ranked #1-2). An absolute 0.35 floor would therefore make the block a provably-dead no-op on every real repository — contradicting the issue's own acceptance criterion (a live 2-lane dispatch on this repo must show graph-oriented lanes). The 0.35 constant is applied to the **normalized top-3 share** (top ÷ sum of top-3 scores; absolute score when fewer than 3 hits): a diffuse/noise ranking scores ~0.33 and is suppressed; real missions on this repo measure 0.35-0.37 and emit. Known seam for PR6 tuning: with fewer than 3 hits the gate falls back to the absolute score, so a highly-relevant 2-hit result on a large repo can be suppressed while a trivial 1-hit result on a tiny repo emits (rare — `ask` returns up to 6 hits whenever ≥3 nodes carry any score). The constant value is unchanged from the spec and PR6 re-tunes it. Unit tests pin both directions (concentrated-emits, diffuse-suppressed); the real-repo evidence below shows a live block.

## Invariant audit

- 1 (plugin init): not touched — orientation runs in the dispatch execute path (user-initiated tool call), not init; graph load is mtime/size-cached, probe is 16-entry LRU with 30s TTL, same cost class as one system-enhancer turn; all builder errors fail open to no block.
- 2 (runtime portability): touched — new module `src/background/lane-delivery-store.ts` imports only `node:fs`/`node:path` + the exported `writeAtomicJson`; no `bun:` imports, no `Bun.*`. Evidence: `bun run build` OK; `node --input-type=module -e "await import('./dist/index.js')"` → OK; `tests/unit/build/bundle-portability.test.ts` + `bundle-plugin-shape.test.ts` → 12 pass 0 fail.
- 3 (subprocesses): not touched — no new subprocesses.
- 4 (.swarm containment): touched — new state file `.swarm/lane-delivery-cache.json` written only under the collect-call `directory` (ctx.directory) via `path.join(directory, '.swarm', ...)`; tests use `os.tmpdir()` fixtures; `git status` shows no `.swarm` artifacts staged.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — all validation via shell per-file loops.
- 7 (test writing): touched — three new bun:test files (`dispatch-lanes-orientation-block.test.ts` 312 lines / 14 tests, `dispatch-lanes-orientation-dispatch.test.ts` 391 lines / 12 tests, `dispatch-lanes-lane-delivery-cache.test.ts` 230 lines / 12 tests — all under the 500-line cap) plus `src/agents/explorer-repo-map-directive.test.ts` (39 lines; explorer directive tests live in their own file because `explorer-consumer-contract.test.ts` is over the FR-006 ratchet cap and must not grow — it ends net-zero at 510 lines). `bun run check:test-file-cap` (run post-commit from the worktree): New-file violations: 0 / Ratchet violations: 0. No `mock.module`; reset seams (`resetLaneOrientationDedupe`, `resetLaneDeliveryStoreForTests`, `resetGraphInjectionCache`) called in `beforeEach`; DI seam (`deps.buildBlock`) proves zero graph probes when `orientation: false`; falsifiability evidence recorded (reintroduced blind-scan opener → contract test fails → restored).
- 8 (session state): touched — orientation dedupe: 128 pointers/session FIFO, 16 sessions; delivery store: 1024 keys global FIFO, 16 sessions, 16 directories; all session-keyed, no cross-session pollution (the old Set's cross-session suppression bug is fixed).
- 9 (guardrails/retry): not touched — orientation is advisory and fail-open in every direction.
- 10 (chat/system msg): not touched — the block lands in lane prompts (dispatch payload), never in the chat system-message chain.
- 11 (tool registration): touched (schema-only field add to two existing tools) — `orientation` added to `DispatchLanesArgsSchema` (async inherits via `.extend`), both registered `args` blocks, and both tool descriptions; TOOL_NAMES, exports, and the plugin registration block unchanged. Evidence: `bun run drift:check` green (includes tool-registration check); `tests/unit/config/*.test.ts` → 88 files pass.
- 12 (release/cache): touched — release fragment `docs/releases/pending/issue-1988-graph-delivery-wiring.md` added; no version files hand-edited.

## Test plan

Exact commands (worktree `E:\ZCode\os1988`, base 34876f61, head a97040cf):

- `bun --smol test tests/unit/tools/dispatch-lanes-orientation-block.test.ts tests/unit/tools/dispatch-lanes-orientation-dispatch.test.ts --timeout 60000` → **26 pass, 0 fail** (floor emission; dedupe repeat; determinism builder- AND dispatch-level byte-identical; stale-beyond-cap; no-fingerprint; no-graph; enabled:false; same-session all-delivered suppression; per-session re-emission; scale-free floor both directions; 600-token gate; zero-probe on false; prefix position sync+async; overflow drop; fail-open; schema no-default; render seam; freshness mappings)
- `bun --smol test tests/unit/tools/dispatch-lanes-lane-delivery-cache.test.ts --timeout 60000` → **12 pass, 0 fail** (round-trip across simulated restart; session/directory scoping; 1024 FIFO incl. other-sessions-first; 17th-session eviction; corrupt rename + fail-open; heal-on-mark; version mismatch; memory-only bucket; recordToLaneResult integration)
- `bun --smol test src/agents/explorer-consumer-contract.test.ts src/agents/explorer-repo-map-directive.test.ts src/agents/coder.test.ts src/agents/reviewer.test.ts src/agents/explorer-role-boundary.test.ts` → **136 pass, 0 fail**
- `bun run check:test-file-cap` (post-commit, from the worktree) → "New-file violations: 0 / Ratchet violations: 0", exit 0
- Per-file isolation loop over all `tests/unit/tools/dispatch-lanes*.test.ts` (23 files) → **23/23 pass**
- Per-file loop over `tests/unit/agents/{explorer,coder,reviewer}*.test.ts` + `tests/unit/background/*.test.ts` (76 files) → **76/76 pass**
- `bun --smol test tests/unit/hooks/repo-graph-injection*.test.ts` + delivery cache → **29 pass, 0 fail**
- Per-file loop over `tests/unit/config/*.test.ts` (88 files) → **88/88 pass**
- `bun run drift:check` → exit 0, "No drift detected"
- `bun run typecheck` → exit 0
- `bun run check:test-file-cap` → 0 violations
- `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` → OK; bundle-portability + plugin-shape → 12 pass

### Real-repo acceptance evidence

Built the graph for this repository (3,463 nodes) and ran the actual builder with two real missions:

```
## REPO GRAPH — LANE ORIENTATION
Mission-relevant files (graph-ranked; orientation only — read before relying):
- src/config/schema.ts (score 0.01; ...)
- src/tools/index.ts (score 0.01; ...)
- src/commands/index.ts (score 0.01; ...)
- src/hooks/system-enhancer.ts (score 0.01; ...)
- src/tools/dispatch-lanes.ts (score 0.01; ...)
- src/hooks/repo-graph-injection.ts (score 0.00; ...)
Repo hubs (most imported): src/config/schema.ts, src/config/plan-schema.ts, src/config/constants.ts, src/plan/manager.ts
Freshness: fresh (probe clean)
```

Repeat dispatch in the same session: SUPPRESSED (dedupe). The full issue acceptance item ("lane transcripts show repo_map calls preceding file reads") additionally depends on live model behavior following the new explorer directive — the prompt-level contract is pinned by tests (directive is the FIRST explorer action; orientation block precedes per-lane text in dispatched prompts); the live transcript check is left as the maintainer's manual step (dispatch 2 lanes, inspect lane transcripts). All code work is delivered and wired; this is the one disclosed manual acceptance step.
