### PR TITLE
fix(apply-patch): accept payload aliases in tool schema and tolerate indented diffs

### DIFF
--- a/docs/releases/pending/2206-apply-patch-aliases-indented-diffs.md
+++ b/docs/releases/pending/2206-apply-patch-aliases-indented-diffs.md
@@ -1,0 +1,16 @@
+# swarm_apply_patch: payload aliases in tool schema + indented diff tolerance
+
+## What changed
+
+Two fixes for persistent `WRITE TARGET UNVERIFIABLE` failures (issue #2206, incomplete after PR #2062):
+
+1. **Payload aliases declared in the tool schema.** `swarm_apply_patch`'s args schema now declares `patchText`, `patch_text`, and `patchPayload` as optional aliases of `patch` (`patch` itself became optional). Strict hosts (e.g. OpenCode Desktop) enforce the declared tool schema and strip undeclared argument fields before the plugin runs, so PR #2062's resolver-side alias list never saw a hallucinated `patchText` argument. With the aliases declared, the field survives host validation; `execute` resolves the payload from `patch` first, then the aliases, and still fails cleanly when all are empty.
+2. **Uniform-indentation tolerance for patch payloads.** Models frequently emit unified diffs indented inside fenced markdown/YAML/JSON blocks (`  --- a/file`), which every column-0-anchored parser rejected. A new shared normalizer — `normalizePatchIndentation` (`src/utils/patch-dedent.ts`) — strips the minimum common leading whitespace across non-empty lines (and normalizes CRLF) at the entry of each LLM-payload parse site: the write-target resolver's `parsePatchPayload`, the guardrail's `extractPatchTargetPaths`, and `swarm_apply_patch`'s `parseUnifiedDiff`. No anchored regex was widened. For a column-0 patch the normalizer is a byte-identical no-op, so hunk context lines whose file content itself starts with `---` (e.g. markdown horizontal rules) can never gain a match. For uniformly indented patches the minimum is driven by the header/marker lines, so the structural context-marker space survives the strip and context-line content still cannot reach column 0 (pinned by `tests/unit/utils/patch-dedent.test.ts`, including the 1-space-wrapper case).
+
+## Why
+
+Both failure modes produced confusing hard blocks (`No patch payload was provided`, `patch: Native patch is missing *** Begin Patch`) on otherwise-valid patches.
+
+## Migration
+
+No migration required. Git-emitted diff parsers (`src/review/diff-source.ts`, `src/tools/diff.ts`, `src/tools/pre-check-batch.ts`) intentionally remain column-0-strict — they parse `git diff` output, which is never indented.

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -43,6 +43,7 @@ import {
 } from '../../state';
 import { telemetry } from '../../telemetry.js';
 import { warn } from '../../utils';
+import { normalizePatchIndentation } from '../../utils/patch-dedent';
 import { isPathUnderSwarmWorktreeBase } from '../../worktree/core.js';
 import { detectLoop } from '../loop-detector';
 import { normalizeToolName } from '../normalize-tool-name';
@@ -1708,34 +1709,40 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
 			);
 		}
+		// #2206: strip a uniform leading indentation block (models emit diffs
+		// indented inside fenced/YAML blocks) so the column-0 anchored patterns
+		// below resolve the real target paths. A column-0 patch is a byte-identical
+		// no-op, so hunk context lines whose file content itself starts with `---`
+		// can never gain a phantom match.
+		const normalizedPatchText = normalizePatchIndentation(patchText);
 		const patchPathPattern = /\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)/gi;
 		const diffPathPattern = /\+\+\+\s+b\/(.+)/gm;
 		const gitDiffPathPattern = /^diff --git a\/(.+?) b\/(.+?)$/gm;
 		const minusPathPattern = /^---\s+a\/(.+)$/gm;
 		const traditionalMinusPattern = /^---\s+([^\s].+?)(?:\t.*)?$/gm;
 		const traditionalPlusPattern = /^\+\+\+\s+([^\s].+?)(?:\t.*)?$/gm;
-		for (const match of patchText.matchAll(patchPathPattern))
+		for (const match of normalizedPatchText.matchAll(patchPathPattern))
 			paths.add(match[1].trim());
-		for (const match of patchText.matchAll(diffPathPattern)) {
+		for (const match of normalizedPatchText.matchAll(diffPathPattern)) {
 			const p = match[1].trim();
 			if (p !== '/dev/null') paths.add(p);
 		}
-		for (const match of patchText.matchAll(gitDiffPathPattern)) {
+		for (const match of normalizedPatchText.matchAll(gitDiffPathPattern)) {
 			const aPath = match[1].trim();
 			const bPath = match[2].trim();
 			if (aPath !== '/dev/null') paths.add(aPath);
 			if (bPath !== '/dev/null') paths.add(bPath);
 		}
-		for (const match of patchText.matchAll(minusPathPattern)) {
+		for (const match of normalizedPatchText.matchAll(minusPathPattern)) {
 			const p = match[1].trim();
 			if (p !== '/dev/null') paths.add(p);
 		}
-		for (const match of patchText.matchAll(traditionalMinusPattern)) {
+		for (const match of normalizedPatchText.matchAll(traditionalMinusPattern)) {
 			const p = match[1].trim();
 			if (p !== '/dev/null' && !p.startsWith('a/') && !p.startsWith('b/'))
 				paths.add(p);
 		}
-		for (const match of patchText.matchAll(traditionalPlusPattern)) {
+		for (const match of normalizedPatchText.matchAll(traditionalPlusPattern)) {
 			const p = match[1].trim();
 			if (p !== '/dev/null' && !p.startsWith('a/') && !p.startsWith('b/'))
 				paths.add(p);

--- a/src/hooks/write-target-resolver.ts
+++ b/src/hooks/write-target-resolver.ts
@@ -4,6 +4,7 @@ import {
 	type ExtractCodeBlocksArgs,
 	getOrPlanExtractCodeBlocks,
 } from '../tools/file-extractor-planner';
+import { normalizePatchIndentation } from '../utils/patch-dedent';
 
 export const MAX_PATCH_FIELD_BYTES = 1_000_000;
 export const MAX_PATCH_AGGREGATE_BYTES = 2_000_000;
@@ -169,7 +170,11 @@ function parsePatchPayload(payload: string): ParsedPatch | string {
 	// `(.*)$` path-extraction regex failed on CRLF input — so *every* CRLF
 	// patch resolved to "Patch contains no recognizable write targets" (F-011).
 	// `parseTarget` keeps its own trailing-`\r` strip as defence in depth.
-	const lines = payload.split(/\r?\n/);
+	// #2206: normalizePatchIndentation first strips a uniform leading
+	// indentation block (models emit diffs indented inside fenced/YAML
+	// blocks) and performs the \r\n normalization, restoring column-0 anchors
+	// for every regex below without widening them.
+	const lines = normalizePatchIndentation(payload).split(/\r?\n/);
 	const beginIndices: number[] = [];
 	const endIndices: number[] = [];
 	const nativeOperationIndices: number[] = [];

--- a/src/tools/apply-patch.2206.test.ts
+++ b/src/tools/apply-patch.2206.test.ts
@@ -245,6 +245,90 @@ describe('swarm_apply_patch #2206 alias + indent tolerance', () => {
 		expect(result.success).toBe(false);
 		expect(JSON.stringify(result)).toContain('patch text cannot be empty');
 	});
+
+	// === PRR-006: review-handoff test-gap coverage (closure of #2206 review) ===
+
+	test('canonical patch wins when all four payload fields are populated (#2206 review)', async () => {
+		const targetFile = 'precedence.txt';
+		createFile(workspace, targetFile, 'a\n');
+		const canonicalPatch = buildDiff(
+			targetFile,
+			targetFile,
+			'a\n',
+			'CANONICAL\n',
+		);
+		const aliasPatch = buildDiff(targetFile, targetFile, 'a\n', 'ALIAS\n');
+		const args: Record<string, unknown> = {
+			files: [targetFile],
+			patch: canonicalPatch,
+			patchText: aliasPatch,
+			patch_text: aliasPatch,
+			patchPayload: aliasPatch,
+		};
+		const result = parseResult(
+			await swarmApplyPatch.execute(args, workspaceOf(workspace) as any),
+		);
+		expect(result.success).toBe(true);
+		// Canonical `patch` wins; alias fields are silently ignored.
+		expect(readFileContent(workspace, targetFile)).toBe('CANONICAL\n');
+	});
+
+	test('alias precedence is positional first-truthy: patchText > patch_text > patchPayload (#2206 review)', async () => {
+		const targetFile = 'positional.txt';
+		createFile(workspace, targetFile, 'a\n');
+		const patchA = buildDiff(targetFile, targetFile, 'a\n', 'A\n');
+		const patchB = buildDiff(targetFile, targetFile, 'a\n', 'B\n');
+		const patchC = buildDiff(targetFile, targetFile, 'a\n', 'C\n');
+		const args: Record<string, unknown> = {
+			files: [targetFile],
+			patch_text: patchB,
+			patchPayload: patchC,
+			patchText: patchA,
+		};
+		const result = parseResult(
+			await swarmApplyPatch.execute(args, workspaceOf(workspace) as any),
+		);
+		expect(result.success).toBe(true);
+		// patchText is the first positional among the aliases → wins.
+		expect(readFileContent(workspace, targetFile)).toBe('A\n');
+	});
+
+	test('an empty canonical patch falls through to the first non-empty alias (#2206 review)', async () => {
+		const targetFile = 'empty-canonical.txt';
+		createFile(workspace, targetFile, 'a\n');
+		const aliasPatch = buildDiff(targetFile, targetFile, 'a\n', 'ALIAS\n');
+		const args: Record<string, unknown> = {
+			files: [targetFile],
+			patch: '',
+			patchText: aliasPatch,
+		};
+		const result = parseResult(
+			await swarmApplyPatch.execute(args, workspaceOf(workspace) as any),
+		);
+		expect(result.success).toBe(true);
+		// Schema accepts empty-string patch (now optional); execute-side
+		// find() predicate `value.length > 0` falls through to the alias.
+		expect(readFileContent(workspace, targetFile)).toBe('ALIAS\n');
+	});
+
+	test('applies a uniformly TAB-indented unified diff (#2206 review / edge parity)', async () => {
+		const targetFile = 'tab-indent.txt';
+		createFile(workspace, targetFile, 'a\nb\n');
+		const inner = buildDiff(targetFile, targetFile, 'a\nb\n', 'a\nB\n');
+		// Single leading tab per non-empty line.
+		const tabbed = inner
+			.split('\n')
+			.map((line) => (line.length === 0 ? line : '\t' + line))
+			.join('\n');
+		const result = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch: tabbed, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('a\nB\n');
+	});
 });
 
 // ===== Issue #2206 (final-critic finding): pin the DECLARED schema surface =====

--- a/src/tools/apply-patch.2206.test.ts
+++ b/src/tools/apply-patch.2206.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { z } from 'zod';
+import type { ApplyPatchResult } from './apply-patch';
+import { swarmApplyPatch } from './apply-patch';
+
+// Split out of the over-cap src/tools/apply-patch.test.ts (FR-006 ratchet):
+// issue #2206 scenarios — payload alias args and uniformly indented diffs.
+
+function createTempDir(): string {
+	return mkdtempSync(path.join(realpathSync(tmpdir()), 'apply-patch-2206-'));
+}
+function createFile(dir: string, relativePath: string, content: string): void {
+	writeFileSync(path.join(dir, relativePath), content, 'utf-8');
+}
+function readFileContent(dir: string, relativePath: string): string {
+	return readFileSync(path.join(dir, relativePath), 'utf-8');
+}
+function parseResult(result: string): ApplyPatchResult {
+	return JSON.parse(result) as ApplyPatchResult;
+}
+function workspaceOf(dir: string) {
+	return { directory: dir, worktree: dir };
+}
+
+// Helper: build a simple unified diff for a single file
+function buildDiff(
+	oldPath: string,
+	newPath: string,
+	oldContent: string,
+	newContent: string,
+): string {
+	const oldLines = oldContent.split('\n');
+	const newLines = newContent.split('\n');
+
+	// Find the common prefix and suffix
+	let prefixLen = 0;
+	while (
+		prefixLen < oldLines.length &&
+		prefixLen < newLines.length &&
+		oldLines[prefixLen] === newLines[prefixLen]
+	) {
+		prefixLen++;
+	}
+
+	let suffixLen = 0;
+	while (
+		suffixLen < oldLines.length - prefixLen &&
+		suffixLen < newLines.length - prefixLen &&
+		oldLines[oldLines.length - 1 - suffixLen] ===
+			newLines[newLines.length - 1 - suffixLen]
+	) {
+		suffixLen++;
+	}
+
+	const oldBody = oldLines.slice(prefixLen, oldLines.length - suffixLen);
+	const newBody = newLines.slice(prefixLen, newLines.length - suffixLen);
+
+	// Compute adjusted suffix length excluding trailing empty element (newline artifact)
+	// When content ends with '\n', split('\n') produces a trailing empty element.
+	// This trailing empty should NOT be counted as a suffix line.
+	const trailingEmptyOld =
+		oldLines.length > 0 && oldLines[oldLines.length - 1] === '' ? 1 : 0;
+	const trailingEmptyNew =
+		newLines.length > 0 && newLines[newLines.length - 1] === '' ? 1 : 0;
+	const adjustedSuffixLen = Math.max(0, suffixLen - trailingEmptyOld);
+	const adjustedSuffixLenNew = Math.max(0, suffixLen - trailingEmptyNew);
+
+	// oldStart is the position of the first line in the hunk (0-indexed prefix)
+	const oldStart = prefixLen;
+	const oldCount = oldBody.length + prefixLen + adjustedSuffixLen;
+	const newStart = prefixLen;
+	const newCount = newBody.length + prefixLen + adjustedSuffixLenNew;
+
+	const hunkLines: string[] = [];
+	// Add prefix context lines
+	for (let i = 0; i < prefixLen; i++) {
+		hunkLines.push(` ${oldLines[i]}`);
+	}
+	// Add removal and addition lines
+	for (const line of oldBody) {
+		hunkLines.push(`-${line}`);
+	}
+	for (const line of newBody) {
+		hunkLines.push(`+${line}`);
+	}
+	// Add suffix context lines (only non-empty ones)
+	for (let i = 0; i < adjustedSuffixLen; i++) {
+		const contextLine = oldLines[prefixLen + oldBody.length + i] ?? '';
+		hunkLines.push(` ${contextLine}`);
+	}
+
+	return `--- ${oldPath}\n+++ ${newPath}\n@@ -${oldStart},${oldCount} +${newStart},${newCount} @@\n${hunkLines.join('\n')}\n`;
+}
+
+// Helper: build a new file creation diff
+function buildCreateDiff(newPath: string, content: string): string {
+	// Split and filter out empty trailing element from trailing newline
+	const lines = content
+		.split('\n')
+		.filter((l, i, arr) => i < arr.length - 1 || l !== '');
+	const hunkLines: string[] = [];
+	for (const line of lines) {
+		hunkLines.push(`+${line}`);
+	}
+	return `--- /dev/null\n+++ ${newPath}\n@@ -0,0 +1,${lines.length} @@\n${hunkLines.join('\n')}\n`;
+}
+
+// Helper: build a delete diff
+function buildDeleteDiff(delPath: string, content: string): string {
+	const lines = content.split('\n');
+	const hunkLines: string[] = [];
+	for (const line of lines) {
+		hunkLines.push(`-${line}`);
+	}
+	return `--- ${delPath}\n+++ /dev/null\n@@ -1,${lines.length} +0,0 @@\n${hunkLines.join('\n')}\n`;
+}
+
+// NOTE on call shape: `swarmApplyPatch.execute(args, ctx)` receives the
+// ToolContext-shaped second argument that the createSwarmTool wrapper passes
+// through (directory derived from ctx.directory) — the same `workspaceOf(...)
+// as any` pattern as the parent apply-patch.test.ts suite. A future
+// createSwarmTool signature change breaks these call sites intentionally
+// loudly.
+
+// ===== Issue #2206: schema aliases + uniformly indented patch payloads =====
+
+describe('swarm_apply_patch #2206 alias + indent tolerance', () => {
+	let workspace: string;
+
+	beforeEach(() => {
+		workspace = createTempDir();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(workspace, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	// Indent every non-empty line by N spaces — simulates a diff pasted inside
+	// a fenced markdown / YAML / JSON block.
+	function indent(diffText: string, spaces: number): string {
+		const pad = ' '.repeat(spaces);
+		return diffText
+			.split('\n')
+			.map((line) => (line.length === 0 ? line : pad + line))
+			.join('\n');
+	}
+
+	test('applies a uniformly 2-space-indented unified diff (#2206)', async () => {
+		const targetFile = 'indented2.txt';
+		createFile(workspace, targetFile, 'alpha\nbeta\ngamma\n');
+		const patch = indent(
+			buildDiff(
+				targetFile,
+				targetFile,
+				'alpha\nbeta\ngamma\n',
+				'alpha\nBETA\ngamma\n',
+			),
+			2,
+		);
+		const result = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(result.success).toBe(true);
+		expect(result.summary.applied).toBe(1);
+		expect(readFileContent(workspace, targetFile)).toBe('alpha\nBETA\ngamma\n');
+	});
+
+	test('applies a uniformly 4-space-indented unified diff with CRLF line endings (#2206)', async () => {
+		const targetFile = 'indented4.txt';
+		createFile(workspace, targetFile, 'one\ntwo\n');
+		const patch = indent(
+			buildDiff(targetFile, targetFile, 'one\ntwo\n', 'one\nTWO\n'),
+			4,
+		).replace(/\n/g, '\r\n');
+		const result = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('one\nTWO\n');
+	});
+
+	test('preserves real content indentation beyond the stripped block indent (#2206)', async () => {
+		// Python-style body: content lines themselves start with spaces. The
+		// min-common-indent strip removes only the wrapper indent; the hunk
+		// marker space and the content's own indentation survive.
+		const targetFile = 'code.py';
+		createFile(workspace, targetFile, 'def f():\n    return 1\n');
+		const inner = `--- ${targetFile}\n+++ ${targetFile}\n@@ -1,2 +1,2 @@\n def f():\n-    return 1\n+    return 2\n`;
+		const patch = indent(inner, 2);
+		const result = parseResult(
+			await swarmApplyPatch.execute(
+				{ patch, files: [targetFile] },
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe(
+			'def f():\n    return 2\n',
+		);
+	});
+
+	test.each([
+		'patchText',
+		'patch_text',
+		'patchPayload',
+	] as const)('applies the patch when only the %s alias carries the payload (#2206)', async (aliasKey) => {
+		const targetFile = 'alias.txt';
+		createFile(workspace, targetFile, 'a\n');
+		const patch = buildDiff(targetFile, targetFile, 'a\n', 'b\n');
+		const args: Record<string, unknown> = { files: [targetFile] };
+		args[aliasKey] = patch;
+		const result = parseResult(
+			await swarmApplyPatch.execute(args, workspaceOf(workspace) as any),
+		);
+		expect(result.success).toBe(true);
+		expect(readFileContent(workspace, targetFile)).toBe('b\n');
+	});
+
+	test('errors with patch text cannot be empty when no canonical or alias payload is present (#2206)', async () => {
+		const result = parseResult(
+			await swarmApplyPatch.execute(
+				{ files: ['whatever.txt'] } as Record<string, unknown>,
+				workspaceOf(workspace) as any,
+			),
+		);
+		expect(result.success).toBe(false);
+		expect(JSON.stringify(result)).toContain('patch text cannot be empty');
+	});
+});
+
+// ===== Issue #2206 (final-critic finding): pin the DECLARED schema surface =====
+// `tool()` from @opencode-ai/plugin is an identity function and createSwarmTool
+// passes `args` through, so execute-path tests never touch the schema. Strict
+// hosts strip undeclared fields BEFORE execute runs — this suite pins that the
+// alias names are actually declared on the tool contract.
+
+describe('swarm_apply_patch args schema declares the payload aliases (#2206)', () => {
+	const args = swarmApplyPatch.args as Record<string, unknown>;
+
+	test('patch, patchText, patch_text, and patchPayload are all declared', () => {
+		expect(Object.keys(args)).toContain('patch');
+		expect(Object.keys(args)).toContain('patchText');
+		expect(Object.keys(args)).toContain('patch_text');
+		expect(Object.keys(args)).toContain('patchPayload');
+	});
+
+	test('an alias-only invocation validates against the declared schema (strict hosts pass it through)', () => {
+		const schema = z.object(args as z.ZodRawShape);
+		const aliasOnly = schema.safeParse({
+			patchText: '--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n',
+			files: ['f'],
+		});
+		expect(aliasOnly.success).toBe(true);
+		// `patch` is optional: an alias-only payload must not fail on the
+		// missing canonical field.
+		const noCanonicalIssues = aliasOnly.success
+			? (aliasOnly.data as Record<string, unknown>)
+			: {};
+		expect(noCanonicalIssues.patchText).toBeDefined();
+	});
+
+	test('the declared schema still rejects invalid shapes (files min 1)', () => {
+		const schema = z.object(args as z.ZodRawShape);
+		expect(schema.safeParse({ patch: 'x', files: [] }).success).toBe(false);
+		expect(schema.safeParse({ files: ['f'] }).success).toBe(true);
+	});
+});

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -1245,7 +1245,7 @@ function isUnsupportedPatchFormat(patchText: string): boolean {
  */
 export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 	description:
-		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool. Use standard unified diff format (--- a/file / +++ b/file / @@ hunks). Does NOT support *** Begin Patch / *** Update File payloads — use the native apply_patch tool for those.',
+		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool. Use standard unified diff format (--- a/file / +++ b/file / @@ hunks). Indented patches (e.g. inside a fenced markdown/YAML block) are automatically dedented to column 0 before parsing — the diff body itself may be indented. Does NOT support *** Begin Patch / *** Update File payloads — use the native apply_patch tool for those. Accepts the payload as `patch` (canonical) or any of the aliases `patchText`, `patch_text`, `patchPayload` (#2206); the resolver picks the first non-empty one.',
 	args: {
 		patch: z
 			.string()

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -23,6 +23,7 @@ import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta } from '../config';
 import { findClosestLines, fuzzyFindAndReplace } from '../utils/fuzzy-match';
+import { normalizePatchIndentation } from '../utils/patch-dedent';
 import {
 	containsControlChars,
 	containsPathTraversal,
@@ -358,8 +359,11 @@ function parseUnifiedDiff(patchText: string): {
 		};
 	}
 
-	// Normalize line endings to \n for consistent parsing
-	const normalized = patchText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+	// Normalize line endings to \n for consistent parsing, and strip a uniform
+	// leading indentation block (#2206: models emit diffs indented inside
+	// fenced/YAML blocks; min-common-indent stripping restores column-0 anchors
+	// without widening any parser regex).
+	const normalized = normalizePatchIndentation(patchText);
 	let lines = normalized.split('\n');
 	// Strip trailing empty element produced by split when patch ends with \n
 	if (lines.length > 0 && lines[lines.length - 1] === '') {
@@ -1243,7 +1247,30 @@ export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 	description:
 		'Apply a unified diff patch to workspace files. Validates paths, matches context exactly, and writes atomically. Coder-scoped write tool. Use standard unified diff format (--- a/file / +++ b/file / @@ hunks). Does NOT support *** Begin Patch / *** Update File payloads — use the native apply_patch tool for those.',
 	args: {
-		patch: z.string().min(1).describe('Unified diff text to parse and apply'),
+		patch: z
+			.string()
+			.optional()
+			.describe(
+				'Unified diff text to parse and apply (optional when an alias below carries the payload)',
+			),
+		patchText: z
+			.string()
+			.optional()
+			.describe(
+				'Alias for patch — unified diff payload; accepted because models frequently hallucinate alternative argument names (#2206)',
+			),
+		patch_text: z
+			.string()
+			.optional()
+			.describe(
+				'Alias for patch — unified diff payload; accepted because models frequently hallucinate alternative argument names (#2206)',
+			),
+		patchPayload: z
+			.string()
+			.optional()
+			.describe(
+				'Alias for patch — unified diff payload; accepted because models frequently hallucinate alternative argument names (#2206)',
+			),
 		files: z
 			.array(z.string())
 			.min(1)
@@ -1281,7 +1308,16 @@ export const swarmApplyPatch: ToolDefinition = createSwarmTool({
 		}
 
 		const obj = args as Record<string, unknown>;
-		const patchText = (obj.patch as string) ?? '';
+		// #2206 mode (a): resolve the patch payload from the canonical `patch`
+		// argument first, then the declared aliases. The aliases exist in the args
+		// schema so strict hosts (which strip undeclared fields before execute
+		// runs) pass them through; the write-target resolver's PATCH_PAYLOAD_KEYS
+		// already accepts the same alias set.
+		const patchText =
+			[obj.patch, obj.patchText, obj.patch_text, obj.patchPayload].find(
+				(value): value is string =>
+					typeof value === 'string' && value.length > 0,
+			) ?? '';
 		const files = (obj.files as string[]) ?? [];
 		const dryRun = (obj.dryRun as boolean) ?? false;
 		const allowCreates = (obj.allowCreates as boolean) ?? false;

--- a/src/utils/patch-dedent.ts
+++ b/src/utils/patch-dedent.ts
@@ -19,7 +19,13 @@
  *  - A uniformly indented patch (wrapper indent N) has every line stripped by
  *    exactly N chars: `+`/`-`/`\` markers return to column 0 and context lines
  *    keep their structural space marker (position N+1 is content, not wrapper).
- *  - Empty lines are skipped when computing the minimum and never sliced.
+ *  - Empty lines (and whitespace-only lines) are skipped when computing the
+ *    minimum indent. Truly empty lines (`line.length === 0`) carry no
+ *    characters so the length-guarded slice leaves them intact. Whitespace-only
+ *    lines whose length is >= minIndent ARE sliced to the prefix-stripped
+ *    remainder (e.g. a 3-space line with minIndent=3 becomes ''), which is
+ *    safe for downstream parsers because they treat whitespace-only lines as
+ *    no-content.
  *  - Mixed indentation (some lines shallower than others) yields minIndent 0 →
  *    no-op; the payload fails to parse exactly as it does today (fail-clean,
  *    no corruption).

--- a/src/utils/patch-dedent.ts
+++ b/src/utils/patch-dedent.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #2206: models routinely emit unified diffs / native patches indented
+ * inside a fenced markdown, YAML, or JSON block (e.g. `  --- a/file`). Every
+ * diff parser in this repo anchors `diff --git` / `---` / `+++` / `@@` at
+ * column 0, so an indented payload is not recognized — the write-target
+ * resolver reports "no recognizable write targets", `swarm_apply_patch` fails
+ * to parse hunks, and a stray `*** End Patch` trailer misclassifies the payload
+ * as a malformed native patch.
+ *
+ * This normalizer strips the MINIMUM COMMON leading whitespace across all
+ * non-empty lines, restoring column-0 semantics in one place instead of
+ * widening every anchored regex (which would misclassify hunk context lines
+ * whose file content itself starts with `---` — see the plan-critic analysis
+ * for #2206).
+ *
+ * Properties:
+ *  - A column-0 patch has minIndent 0 → returned byte-identical (after \r\n
+ *    normalization), so existing behavior is unchanged.
+ *  - A uniformly indented patch (wrapper indent N) has every line stripped by
+ *    exactly N chars: `+`/`-`/`\` markers return to column 0 and context lines
+ *    keep their structural space marker (position N+1 is content, not wrapper).
+ *  - Empty lines are skipped when computing the minimum and never sliced.
+ *  - Mixed indentation (some lines shallower than others) yields minIndent 0 →
+ *    no-op; the payload fails to parse exactly as it does today (fail-clean,
+ *    no corruption).
+ */
+export function normalizePatchIndentation(text: string): string {
+	const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+	const lines = normalized.split('\n');
+	let minIndent = Number.POSITIVE_INFINITY;
+	for (const line of lines) {
+		if (line.trim().length === 0) continue;
+		const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+		if (indent < minIndent) minIndent = indent;
+	}
+	if (minIndent === 0 || !Number.isFinite(minIndent)) return normalized;
+	return lines
+		.map((line) => (line.length >= minIndent ? line.slice(minIndent) : line))
+		.join('\n');
+}

--- a/tests/unit/hooks/guardrails-v622-patch-aliases.test.ts
+++ b/tests/unit/hooks/guardrails-v622-patch-aliases.test.ts
@@ -108,3 +108,94 @@ describe('guardrails - v6.22 OBJECTIVE 2: patch path extraction alias coverage (
 		await hooks.toolBefore(input, output);
 	});
 });
+
+describe('guardrails - #2206: indented patch payloads and no phantom context-line paths', () => {
+	beforeEach(() => {
+		resetSwarmState();
+	});
+
+	async function startArchitect(sessionId: string) {
+		startAgentSession(sessionId, ORCHESTRATOR_NAME);
+		const { swarmState } = await import('../../../src/state');
+		swarmState.activeAgent.set(sessionId, ORCHESTRATOR_NAME);
+	}
+
+	it('an indented patchText targeting .swarm/plan.json → throws PLAN STATE VIOLATION (#2206)', async () => {
+		const hooks = createGuardrailsHooks(defaultConfig());
+		const sessionId = 'test-2206-indented';
+		await startArchitect(sessionId);
+
+		// Uniformly 2-space-indented unified diff (e.g. pasted inside a fenced
+		// block). Pre-#2206 the column-0 anchored extraction regexes found no
+		// paths and the plan-state guard was silently bypassed.
+		const patchContent = [
+			'  --- a/.swarm/plan.json',
+			'  +++ b/.swarm/plan.json',
+			'  @@ -1 +1 @@',
+			'  -old',
+			'  +new',
+		].join('\n');
+
+		const input = makeInput(sessionId, 'apply_patch', 'call-1');
+		const output = makeOutput({ patchText: patchContent });
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			'PLAN STATE VIOLATION',
+		);
+	});
+
+	it('a column-0 patch whose CONTEXT line mentions --- .swarm/plan.json → NOT blocked (no phantom header match)', async () => {
+		const hooks = createGuardrailsHooks(defaultConfig());
+		const sessionId = 'test-2206-phantom';
+		await startArchitect(sessionId);
+
+		// A README patch whose context line documents the plan path with a
+		// markdown horizontal-rule prefix: ` --- .swarm/plan.json`. The line's
+		// single leading space is the diff CONTEXT marker, so it must never be
+		// parsed as a `---` header — otherwise the guard would extract a phantom
+		// plan-state target and block a legitimate documentation patch.
+		const patchContent = [
+			'--- a/README.md',
+			'+++ b/README.md',
+			'@@ -1,3 +1,3 @@',
+			' # Project',
+			' --- .swarm/plan.json holds the plan',
+			'+ # Project (docs updated)',
+		].join('\n');
+
+		const input = makeInput(sessionId, 'patch', 'call-1');
+		const output = makeOutput({ patch: patchContent });
+
+		// must not throw: the context line is body content, never a header, so
+		// no phantom plan-state target is extracted. The sibling test above
+		// ('an indented patchText targeting .swarm/plan.json → throws PLAN STATE
+		// VIOLATION') is the positive control proving extraction + the plan-state
+		// guard ARE active for this harness — so this not-throwing means the
+		// context line genuinely contributed no path.
+		await hooks.toolBefore(input, output);
+	});
+
+	it('positive control: a REAL column-0 --- header for .swarm/plan.json → throws PLAN STATE VIOLATION', async () => {
+		const hooks = createGuardrailsHooks(defaultConfig());
+		const sessionId = 'test-2206-positive';
+		await startArchitect(sessionId);
+
+		// Identical patch, but the plan path sits on a genuine --- header line
+		// instead of a space-prefixed context line — extraction must see it and
+		// the plan-state guard must block.
+		const patchContent = [
+			'--- .swarm/plan.json',
+			'+++ .swarm/plan.json',
+			'@@ -1 +1 @@',
+			'-old',
+			'+new',
+		].join('\n');
+
+		const input = makeInput(sessionId, 'patch', 'call-1');
+		const output = makeOutput({ patch: patchContent });
+
+		await expect(hooks.toolBefore(input, output)).rejects.toThrow(
+			'PLAN STATE VIOLATION',
+		);
+	});
+});

--- a/tests/unit/hooks/write-target-resolver.test.ts
+++ b/tests/unit/hooks/write-target-resolver.test.ts
@@ -371,3 +371,59 @@ describe('write-target resolver — multi-field and non-string payload guards (F
 		});
 	});
 });
+
+describe('write-target resolver — uniformly indented payloads (#2206)', () => {
+	// Models emit diffs indented inside fenced markdown / YAML / JSON blocks.
+	// The resolver dedents the min common leading whitespace before the
+	// column-0 anchored classification/extraction regexes run.
+	test('a 2-space-indented unified diff resolves its target', () => {
+		const payload = [
+			'  --- a/src/a.ts',
+			'  +++ b/src/a.ts',
+			'  @@ -1 +1 @@',
+			'  -a',
+			'  +b',
+		].join('\n');
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+
+	test('a 2-space-indented native patch classifies native and resolves its targets', () => {
+		const payload = [
+			'  *** Begin Patch',
+			'  *** Update File: src/old.ts',
+			'  *** Move to: src/new.ts',
+			'  *** End Patch',
+		].join('\n');
+		const result = resolveWriteTargets(
+			'apply_patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({
+			status: 'resolved',
+			paths: ['src/old.ts', 'src/new.ts'],
+		});
+	});
+
+	test('an indented unified diff with a stray *** End Patch trailer resolves as unified (no native misclassification)', () => {
+		const payload = [
+			'  --- a/src/a.ts',
+			'  +++ b/src/a.ts',
+			'  @@ -1 +1 @@',
+			'  -a',
+			'  +b',
+			'  *** End Patch',
+		].join('\n');
+		const result = resolveWriteTargets(
+			'patch',
+			{ patch: payload },
+			{ directory: process.cwd() },
+		);
+		expect(result).toEqual({ status: 'resolved', paths: ['src/a.ts'] });
+	});
+});

--- a/tests/unit/utils/patch-dedent.test.ts
+++ b/tests/unit/utils/patch-dedent.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #2206: normalizePatchIndentation — strips the minimum common leading
+ * whitespace across non-empty lines so uniformly indented diff payloads
+ * (fenced markdown / YAML / JSON blocks) regain column-0 anchors, while
+ * column-0 payloads are returned unchanged (after \r\n normalization).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { normalizePatchIndentation } from '../../../src/utils/patch-dedent';
+
+describe('normalizePatchIndentation (#2206)', () => {
+	it('is a byte-identical no-op (post newline normalization) for column-0 patches', () => {
+		const patch = '--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n';
+		expect(normalizePatchIndentation(patch)).toBe(patch);
+	});
+
+	it('strips a uniform 2-space wrapper indent', () => {
+		const indented = '  --- a/x\n  +++ b/x\n  @@ -1 +1 @@\n  -old\n  +new\n';
+		expect(normalizePatchIndentation(indented)).toBe(
+			'--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n',
+		);
+	});
+
+	it('strips a uniform 4-space wrapper indent, keeping the context-line marker space', () => {
+		// context line = 4 wrapper spaces + 1 marker space + content
+		const indented =
+			'    --- a/x\n    +++ b/x\n    @@ -1,2 +1,2 @@\n     keep\n    -old\n    +new\n';
+		expect(normalizePatchIndentation(indented)).toBe(
+			'--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n keep\n-old\n+new\n',
+		);
+	});
+
+	it('normalizes CRLF to LF before computing the indent', () => {
+		const indented = '  --- a/x\r\n  +++ b/x\r\n';
+		expect(normalizePatchIndentation(indented)).toBe('--- a/x\n+++ b/x\n');
+	});
+
+	it('is a no-op when indentation is not uniform (min indent is 0)', () => {
+		const mixed = '  --- a/x\n+++ b/x\n';
+		// The +++ line is at column 0 → minIndent 0 → unchanged.
+		expect(normalizePatchIndentation(mixed)).toBe('  --- a/x\n+++ b/x\n');
+	});
+
+	it('skips empty lines when computing the minimum and never slices them', () => {
+		const indented = '  --- a/x\n\n  +++ b/x\n';
+		expect(normalizePatchIndentation(indented)).toBe('--- a/x\n\n+++ b/x\n');
+	});
+
+	it('returns the normalized text unchanged for whitespace-only input', () => {
+		expect(normalizePatchIndentation('')).toBe('');
+		expect(normalizePatchIndentation('\n\n')).toBe('\n\n');
+	});
+
+	it('a column-0 diff whose context line content starts with --- is NOT transformed', () => {
+		// Guardrail against the false-positive class the plan critic flagged:
+		// a markdown-file hunk whose context line is ` --- rule` (space marker +
+		// literal hr content). Column-0 diff → no slicing → the context line
+		// keeps its leading space and stays non-header-shaped.
+		const patch =
+			'--- a/README.md\n+++ b/README.md\n@@ -1,3 +1,3 @@\n # Title\n --- rule\n+body\n';
+		expect(normalizePatchIndentation(patch)).toBe(patch);
+	});
+});
+
+describe('normalizePatchIndentation — 1-space wrapper preserves the context marker (#2206 review)', () => {
+	it('a 1-space-indented diff keeps the context line marker space after slicing (no header phantom)', () => {
+		// Headers carry exactly 1 wrapper space, so minIndent = 1 — driven by
+		// the headers, NOT the context line. The context line is wrapper(1) +
+		// marker(1) + '--- rule' content; slicing 1 leaves ' --- rule' with the
+		// structural marker space intact, which no column-0 '^---' regex can
+		// match. (Pins the review question about marker/wrapper collapse.)
+		const indented = [
+			' --- a/x',
+			' +++ b/x',
+			' @@ -1,2 +1,2 @@',
+			'  --- rule',
+			' +body',
+		].join('\n');
+		expect(normalizePatchIndentation(indented)).toBe(
+			'--- a/x\n+++ b/x\n@@ -1,2 +1,2 @@\n --- rule\n+body',
+		);
+	});
+});


### PR DESCRIPTION
Closes #2206

## Summary

- Mode 1 (alias stripping by strict hosts): `swarm_apply_patch`'s args schema now declares `patchText`, `patch_text`, and `patchPayload` as optional string aliases (`patch` itself became optional); `execute` resolves the payload canonical-first across the four names and still fails cleanly with `patch text cannot be empty` when all are absent. The write-target resolver's `PATCH_PAYLOAD_KEYS` already accepted the same alias set (PR #2062) — the missing piece was the declared schema that strict hosts enforce. The declared surface is pinned by tests (keys asserted; alias-only payload safeParses; invalid shapes still fail).
- Mode 2 (indented diffs): new shared pure normalizer `normalizePatchIndentation` (src/utils/patch-dedent.ts) strips the minimum common leading whitespace across non-empty lines (and CRLF-normalizes) at the entry of each LLM-payload parse site — write-target-resolver `parsePatchPayload`, guardrails `extractPatchTargetPaths`, and `parseUnifiedDiff`'s normalization point. No column-0-anchored regex was widened: a column-0 patch is a byte-identical no-op, and for indented patches the min-indent is driven by the header/marker lines so hunk context lines keep their structural marker space and can never reach column 0 (pinned by tests including the 1-space-wrapper case).
- This also fixes the stray `*** End Patch` misclassification: an indented unified diff is recognized by its headers post-dedent and resolves as unified instead of failing with `Native patch is missing *** Begin Patch`.
- Deliberately unchanged: git-emitted diff parsers (`src/review/diff-source.ts`, `src/tools/diff.ts`, `src/tools/pre-check-batch.ts`) stay column-0-strict — `git diff` output is never indented.

## Review-handoff closure (commit 5d6e876a)

Three LOW/INFO review findings addressed in a follow-up commit:

- **PRR-001 (LOW)** — `src/utils/patch-dedent.ts:22-28` JSDoc inaccuracy. The original "Empty lines are skipped when computing the minimum and never sliced" was imprecise: truly empty lines are length-guarded and never sliced, but whitespace-only lines whose length is >= minIndent ARE sliced to the prefix-stripped remainder. Replaced with an accurate description that calls out both cases.
- **PRR-003 (LOW)** — `src/tools/apply-patch.ts:1248` tool description extended to mention the indentation tolerance (so models emitting indented diffs learn the dedent happens automatically) and the alias names (`patchText`, `patch_text`, `patchPayload`) with their precedence.
- **PRR-006 (INFO)** — `src/tools/apply-patch.2206.test.ts` adds four content-discriminating tests: (a) canonical `patch` wins when all four payload fields are populated; (b) alias precedence is positional first-truthy (patchText > patch_text > patchPayload); (c) empty canonical `patch` falls through to the first non-empty alias; (d) uniformly TAB-indented unified diff applies successfully.

**PRR-002 (no-action, pre-existing at main HEAD, NOT a regression), PRR-004/005/007 (no-action, harmless / context-clarified / already correct)** are documented in the review handoff `.zcode/pr-review/pr-2217/feedback-handoff.md` but not addressed here. PRR-002 in particular is a pre-existing column-0-anchored regex limitation in `write-target-resolver.ts:227` that existed at `main HEAD 19a257e9` and is out of scope for #2206.

## Invariant audit
- 1: not touched — no init-path changes; repro-704 init deadline passed anyway (documented in test plan)
- 2: touched — source changes are bundled into dist; evidence: `bun run build` green, Node import of ./dist/index.js green, tests/unit/build/bundle-portability.test.ts green, `bun run package:smoke` (npm pack + install + import + CLI) green
- 3: not touched — no subprocess changes
- 4: not touched — no .swarm containment changes
- 5: not touched — no plan-ledger/projection changes
- 6: not touched — no test_runner scope changes
- 7: touched — new colocated suite src/tools/apply-patch.2206.test.ts (split from the over-cap parent per the FR-006 ratchet, +4 review-handoff tests at lines 251-331), new tests/unit/utils/patch-dedent.test.ts, resolver/guardrails describe extensions; no mock.module
- 8: not touched — no session/global state changes
- 9: touched — guardrail patch-path extraction now dedents before the anchored patterns — phantom-path safety pinned with a positive control (real column-0 header for .swarm/plan.json throws PLAN STATE VIOLATION) and the context-line negative
- 10: not touched — no chat/system-message changes
- 11: not touched — no tool registration/agent-map changes (bun run scripts/check-tool-registration.ts green)
- 12: not touched — version files untouched; release fragment added per contract

## Test plan
- `bun run test:unit:ci src/tools/apply-patch.test.ts src/tools/apply-patch.2206.test.ts tests/unit/hooks/write-target-resolver.test.ts tests/unit/hooks/guardrails-v622-patch-aliases.test.ts tests/unit/utils/patch-dedent.test.ts tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts` — green.
- `bun run typecheck` / `bun run lint:ci` / full Tier-1 check stack — green.
- `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` + `node scripts/repro-704.mjs` + `bun run package:smoke` + `bun run scripts/drift-check.ts` — green.

## Out-of-scope TODO (PRR-002)

Pre-existing at main HEAD: mixed-indent unified-diff payloads (column-0 header + indented header) silently drop the indented header from the extracted path set in `write-target-resolver.ts:227` (`/^(---|\+\+\+)\s+/`). Defense-in-depth improvement opportunity (out of scope for #2206). Reproduced byte-identically at `main HEAD 19a257e9`.