### PR TITLE
fix(worktree): recover prunable registrations instead of stalling provisioning

### DIFF
--- a/docs/releases/pending/2208-prunable-worktree-recovery.md
+++ b/docs/releases/pending/2208-prunable-worktree-recovery.md
@@ -1,0 +1,25 @@
+# Worktree provisioning: recover `prunable` registrations instead of stalling
+
+## What changed
+
+When an opencode-swarm session is killed mid-task, the task's `git worktree` directory can be deleted while git's index still tracks the registration as `prunable`. Restarting the task used to fail in two ways (issue #2208):
+
+- inside the 5-minute provisioning-lease window: `STANDARD_WORKTREE_OWNER_PROTECTED` (the pre-provision collision check classified the stale registration as an active lane, routing into the ownership inspector, which trusts the live lease unconditionally);
+- after lease expiry: `Branch already exists and expected worktree is dirty` (`provisionWorktree` ran `isCleanWorktree` against the missing directory, and git failures are treated as dirty).
+
+Both porcelain parsers now understand the `prunable` attribute:
+
+- `preProvisionCollisionCheck` (`src/hooks/delegation-gate/worktree-isolation.ts`) skips `prunable` entries when scanning for lane collisions — a stale registration is not an active lane, so the protected-owner hard-stop is never reached for prunable lanes and recovery works inside the lease window. This is safe because `git worktree add` is atomic (a registration exists iff the worktree exists), so a provisioning-in-progress lane can never appear as prunable.
+- `provisionWorktree` (`src/worktree/core.ts`) detects a `prunable` registration for the expected path or branch, runs `git worktree prune`, and re-enumerates before classifying — the leftover branch then reconciles through the existing stale-branch path (ahead-count check → `git branch -d` → re-add) and provisioning succeeds.
+
+`locked` worktrees are unaffected (`git worktree prune` never removes them, and they never carry `prunable`).
+
+Known bound (documented per review): the recovery keys on git's own `prunable` attribute — i.e. git has noticed the directory is gone. A registration whose directory was deleted by an external process in the instant before git has re-examined it is not yet marked `prunable` and still classifies as an active collision (fail-closed), which is the pre-existing behavior and the safe direction for a destructive-cleanup guard.
+
+## Why
+
+Aborted tasks required manual lock clearing and waiting out the lease before the worktree could be re-provisioned.
+
+## Migration
+
+No migration required.

--- a/src/hooks/delegation-gate/worktree-isolation.ts
+++ b/src/hooks/delegation-gate/worktree-isolation.ts
@@ -538,16 +538,37 @@ export async function preProvisionCollisionCheck(
 	interface ParsedEntry {
 		path: string;
 		branch: string | undefined;
+		/**
+		 * #2208: git marks a registration `prunable` when the worktree's
+		 * directory is gone (crash/kill mid-task, interrupted remove). A
+		 * prunable registration is stale metadata, not an active lane —
+		 * excluding it below lets a restart recover the task instead of
+		 * stalling on STANDARD_WORKTREE_OWNER_PROTECTED for the full
+		 * provisioning-lease window. `git worktree add` is atomic
+		 * (registration exists iff the worktree exists), so a provisioning
+		 * lane that is mid-creation can never appear as prunable.
+		 */
+		prunable: boolean;
 	}
 	const entries: ParsedEntry[] = [];
-	let current: ParsedEntry = { path: '', branch: undefined };
+	let current: ParsedEntry = {
+		path: '',
+		branch: undefined,
+		prunable: false,
+	};
 	for (const rawLine of stdout.split('\n')) {
 		const line = rawLine.trim();
 		if (line.startsWith('worktree ')) {
 			if (current.path) entries.push(current);
-			current = { path: line.slice('worktree '.length), branch: undefined };
+			current = {
+				path: line.slice('worktree '.length),
+				branch: undefined,
+				prunable: false,
+			};
 		} else if (line.startsWith('branch ')) {
 			current.branch = line.slice('branch '.length);
+		} else if (line === 'prunable' || line.startsWith('prunable ')) {
+			current.prunable = true;
 		}
 	}
 	if (current.path) entries.push(current);
@@ -555,9 +576,12 @@ export async function preProvisionCollisionCheck(
 	// SC-004: Scan ALL worktrees to find ANY lane for this taskId
 	// (regardless of which session owns it). A lane is identified by a branch
 	// whose last path segment equals taskId and whose prefix matches the
-	// swarm lane naming convention.
+	// swarm lane naming convention. #2208: prunable (stale) registrations are
+	// skipped — the recovery path in provisionWorktree prunes the stale
+	// registration and reconciles the leftover branch.
 	for (const entry of entries) {
 		if (!entry.branch) continue;
+		if (entry.prunable) continue;
 		// Strip "refs/heads/" prefix
 		const branchName = entry.branch.startsWith('refs/heads/')
 			? entry.branch.slice('refs/heads/'.length)

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -677,9 +677,15 @@ export async function provisionWorktree(
 		interface ParsedWorktree {
 			path: string;
 			branch: string | undefined;
+			/** #2208: git marks a registration `prunable` when its directory is gone. */
+			prunable: boolean;
 		}
-		const entries: ParsedWorktree[] = [];
-		let current: ParsedWorktree = { path: '', branch: undefined };
+		let entries: ParsedWorktree[] = [];
+		let current: ParsedWorktree = {
+			path: '',
+			branch: undefined,
+			prunable: false,
+		};
 
 		if (listResult.exitCode !== 0) {
 			const raw = listResult.stderr.trim() || listResult.stdout.trim();
@@ -690,19 +696,69 @@ export async function provisionWorktree(
 			};
 		}
 
-		for (const rawLine of listResult.stdout.split('\n')) {
-			const line = rawLine.trim();
-			if (line.startsWith('worktree ')) {
-				if (current.path) entries.push(current);
-				current = {
-					path: normalizeGitPath(line.slice('worktree '.length)),
-					branch: undefined,
-				};
-			} else if (line.startsWith('branch ')) {
-				current.branch = line.slice('branch '.length);
+		const parsePorcelain = (stdout: string): ParsedWorktree[] => {
+			const parsed: ParsedWorktree[] = [];
+			let cur: ParsedWorktree = {
+				path: '',
+				branch: undefined,
+				prunable: false,
+			};
+			for (const rawLine of stdout.split('\n')) {
+				const line = rawLine.trim();
+				if (line.startsWith('worktree ')) {
+					if (cur.path) parsed.push(cur);
+					cur = {
+						path: normalizeGitPath(line.slice('worktree '.length)),
+						branch: undefined,
+						prunable: false,
+					};
+				} else if (line.startsWith('branch ')) {
+					cur.branch = line.slice('branch '.length);
+				} else if (line === 'prunable' || line.startsWith('prunable ')) {
+					cur.prunable = true;
+				}
 			}
+			if (cur.path) parsed.push(cur);
+			return parsed;
+		};
+		entries = parsePorcelain(listResult.stdout);
+
+		// #2208: a registration git itself marks `prunable` (worktree directory
+		// deleted by a crash/kill mid-task while the branch survived) is stale
+		// metadata, not an active lane. Without this, the classification below
+		// treats the deleted path as an active collision and isCleanWorktree
+		// fails on the missing directory — surfacing "expected worktree is
+		// dirty" and stalling recovery. Prune the stale registration and
+		// re-enumerate; the leftover branch then reconciles through the normal
+		// stale-branch path below (ahead-count check + branch -d + re-add).
+		const hasPrunableCollision = entries.some(
+			(e) =>
+				e.prunable &&
+				(e.path === expectedPath || e.branch === `refs/heads/${branchName}`),
+		);
+		if (hasPrunableCollision) {
+			const pruneResult = await runGit(['worktree', 'prune'], directory);
+			if (pruneResult.exitCode !== 0) {
+				return {
+					error: `Failed to prune stale worktree registration: ${
+						pruneResult.stderr.trim() || pruneResult.stdout.trim()
+					}`,
+				};
+			}
+			const relistResult = await runGit(
+				['worktree', 'list', '--porcelain'],
+				directory,
+			);
+			if (relistResult.exitCode !== 0) {
+				const raw = relistResult.stderr.trim() || relistResult.stdout.trim();
+				const bounded =
+					raw.length > 500 ? `${raw.slice(0, 500)}... (truncated)` : raw;
+				return {
+					error: `worktree enumeration failed after prune: ${bounded}`,
+				};
+			}
+			entries = parsePorcelain(relistResult.stdout);
 		}
-		if (current.path) entries.push(current);
 
 		// Case (b) active collision: branch is checked out in ANY registered
 		// worktree, OR the expected path is itself registered (regardless of

--- a/tests/unit/hooks/delegation-gate-worktree-isolation-prunable.test.ts
+++ b/tests/unit/hooks/delegation-gate-worktree-isolation-prunable.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Worktree isolation prunable-lane recovery — issue #2208.
+ *
+ * A `prunable` registration (directory deleted, git index still tracks it) is
+ * stale metadata, not an active lane. The pre-provision collision check must
+ * NOT classify it as a collision — that classification is what routed the
+ * restart into `inspectStandardWorktreeCollisionOwnership`, which trusts a
+ * live provisioning-owner lease for the full 5-minute window and hard-stops
+ * with STANDARD_WORKTREE_OWNER_PROTECTED. With prunable lanes excluded, a
+ * restart inside the lease window proceeds to provisioning, where
+ * provisionWorktree prunes the stale registration (#2208, core.ts).
+ *
+ * @note Uses the _internals DI seam (no mock.module leakage), mirroring
+ * delegation-gate-worktree-isolation-preprovision.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	preProvisionCollisionCheck,
+	resetStandardWorktreeIsolationState,
+	_internals as worktreeIsolationInternals,
+} from '../../../src/hooks/delegation-gate/worktree-isolation';
+import { recordWorktreeProvisioningOwner } from '../../../src/hooks/delegation-gate/worktree-provisioning-owner';
+import { resetSwarmState } from '../../../src/state';
+import type { bunSpawn } from '../../../src/utils/bun-compat';
+
+function normalizeGitPath(p: string): string {
+	return p.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function makeTempDir(prefix: string): string {
+	return path.join(
+		fs.realpathSync(os.tmpdir()),
+		`${prefix}-${Math.random().toString(36).slice(2)}`,
+	);
+}
+
+function mockGitWorktreeList(porcelainOutput: string, exitCode = 0) {
+	return mock(() => ({
+		exited: Promise.resolve(exitCode),
+		stdout: { text: () => Promise.resolve(porcelainOutput) },
+		stderr: { text: () => Promise.resolve('') },
+		kill: () => {},
+	}));
+}
+
+describe('preProvisionCollisionCheck — prunable registrations (#2208)', () => {
+	let originalBunSpawn: typeof bunSpawn;
+	let tempDir: string;
+
+	beforeEach(() => {
+		resetSwarmState();
+		resetStandardWorktreeIsolationState();
+		originalBunSpawn = worktreeIsolationInternals.bunSpawn as typeof bunSpawn;
+		tempDir = makeTempDir('preprov-prunable');
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		(worktreeIsolationInternals as Record<string, unknown>).bunSpawn =
+			originalBunSpawn;
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+		resetSwarmState();
+		resetStandardWorktreeIsolationState();
+	});
+
+	it('does NOT classify a prunable same-session lane as a collision — recovery inside the lease window', async () => {
+		const sessionId = 'ses-crashed';
+		const taskId = '4.1';
+		const lanePath = path.join(tempDir, '.swarm-worktrees', sessionId, taskId);
+		const porcelain = [
+			`worktree ${normalizeGitPath(tempDir)}`,
+			'branch refs/heads/main',
+			'',
+			`worktree ${normalizeGitPath(lanePath)}`,
+			`branch refs/heads/swarm/lane/${sessionId}/${taskId}`,
+			'prunable',
+			'',
+		].join('\n');
+
+		// A LIVE provisioning-owner record exists for the crashed session —
+		// pre-#2208 the collision classification routed this into the
+		// ownership inspector, which trusts the live lease and hard-stops with
+		// STANDARD_WORKTREE_OWNER_PROTECTED for the full 5-minute window.
+		recordWorktreeProvisioningOwner(tempDir, {
+			callID: 'call-crashed',
+			parentSessionId: sessionId,
+			worktreeSessionId: sessionId,
+			taskId,
+		});
+
+		worktreeIsolationInternals.bunSpawn = mockGitWorktreeList(porcelain);
+		const result = await preProvisionCollisionCheck(taskId, tempDir, sessionId);
+		// No collision → the caller never reaches the protected-owner hard-stop;
+		// provisioning proceeds and prunes the stale registration (#2208).
+		expect(result.collision).toBe(false);
+		expect(result.uncertainty).toBeUndefined();
+	});
+
+	it('still classifies a NON-prunable same-session lane as a collision (unchanged behavior)', async () => {
+		const sessionId = 'ses-live';
+		const taskId = '4.1';
+		const lanePath = path.join(tempDir, '.swarm-worktrees', sessionId, taskId);
+		const porcelain = [
+			`worktree ${normalizeGitPath(tempDir)}`,
+			'branch refs/heads/main',
+			'',
+			`worktree ${normalizeGitPath(lanePath)}`,
+			`branch refs/heads/swarm/lane/${sessionId}/${taskId}`,
+			'',
+		].join('\n');
+
+		worktreeIsolationInternals.bunSpawn = mockGitWorktreeList(porcelain);
+		const result = await preProvisionCollisionCheck(taskId, tempDir, sessionId);
+		expect(result.collision).toBe(true);
+		if (result.collision) {
+			expect(result.existingBranch).toBe(`swarm/lane/${sessionId}/${taskId}`);
+		}
+	});
+
+	it('a prunable OTHER-session lane for the same task is also not a collision (task is recoverable)', async () => {
+		const ownerSession = 'ses-other';
+		const taskId = '4.1';
+		const lanePath = path.join(
+			tempDir,
+			'.swarm-worktrees',
+			ownerSession,
+			taskId,
+		);
+		const porcelain = [
+			`worktree ${normalizeGitPath(tempDir)}`,
+			'branch refs/heads/main',
+			'',
+			`worktree ${normalizeGitPath(lanePath)}`,
+			`branch refs/heads/swarm/lane/${ownerSession}/${taskId}`,
+			'prunable gitdir file points to non-existent location',
+			'',
+		].join('\n');
+
+		worktreeIsolationInternals.bunSpawn = mockGitWorktreeList(porcelain);
+		const result = await preProvisionCollisionCheck(
+			taskId,
+			tempDir,
+			'ses-recovering',
+		);
+		expect(result.collision).toBe(false);
+	});
+
+	it('a prunable entry with a bare `prunable` line and a non-lane branch is ignored as before', async () => {
+		const porcelain = [
+			`worktree ${normalizeGitPath(tempDir)}`,
+			'branch refs/heads/main',
+			'',
+			`worktree ${normalizeGitPath(path.join(tempDir, 'gone'))}`,
+			'branch refs/heads/feature/x',
+			'prunable',
+			'',
+		].join('\n');
+		worktreeIsolationInternals.bunSpawn = mockGitWorktreeList(porcelain);
+		const result = await preProvisionCollisionCheck('4.1', tempDir, 'ses-a');
+		expect(result.collision).toBe(false);
+	});
+});

--- a/tests/unit/worktree/provision-worktree.prunable.test.ts
+++ b/tests/unit/worktree/provision-worktree.prunable.test.ts
@@ -1,0 +1,148 @@
+/**
+ * provisionWorktree `prunable` recovery — issue #2208.
+ *
+ * When a session is killed mid-task, the worktree directory may be deleted
+ * while git's index still tracks it as `prunable`. Re-provisioning used to
+ * parse the prunable registration as an active collision and fail with
+ * "Branch already exists and expected worktree is dirty" (isCleanWorktree on
+ * the missing directory). provisionWorktree must detect the `prunable`
+ * attribute, run `git worktree prune`, and re-provision seamlessly.
+ *
+ * Uses a real git repo; skips gracefully if the installed git does not emit
+ * the `prunable` attribute in porcelain output.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { bunSpawn } from '../../../src/utils/bun-compat';
+import { provisionWorktree } from '../../../src/worktree/core';
+
+async function runGit(
+	args: string[],
+	cwd: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const proc = bunSpawn(['git', ...args], {
+		cwd,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+	const exitCode = await proc.exited;
+	const stdout = await proc.stdout.text();
+	const stderr = await proc.stderr.text();
+	try {
+		proc.kill();
+	} catch {
+		// best-effort — process may already have exited
+	}
+	return { exitCode, stdout, stderr };
+}
+
+function tmpDir(): string {
+	// NOTE: the prefix must not contain the word "prunable" — this repo's
+	// parent path leaks into `git worktree list --porcelain` output and would
+	// defeat the not.toContain('prunable') assertion below.
+	return path.join(
+		fs.realpathSync(os.tmpdir()),
+		'pw-stale-' + Math.random().toString(36).slice(2),
+	);
+}
+
+describe('provisionWorktree — prunable registration recovery (#2208)', () => {
+	let repoDir: string;
+
+	beforeEach(() => {
+		repoDir = tmpDir();
+		fs.mkdirSync(repoDir, { recursive: true });
+		// provisionWorktree's default base dir is shared across the process
+		// (the canonical OS temp root plus .swarm-worktrees/<sessionId>/<id>) —
+		// remove this suite's session dirs so a failed earlier run cannot leave
+		// "already exists" collisions (same pattern as provision-worktree.test.ts).
+		for (const sessionId of ['ses_crash', 'ses_dead', 'ses_alive']) {
+			fs.rmSync(
+				path.join(fs.realpathSync(os.tmpdir()), '.swarm-worktrees', sessionId),
+				{ recursive: true, force: true },
+			);
+		}
+	});
+
+	afterEach(() => {
+		fs.rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	async function initGitRepo(): Promise<void> {
+		await runGit(['init', '-b', 'main'], repoDir);
+		await runGit(['config', 'user.email', 'test@test.com'], repoDir);
+		await runGit(['config', 'user.name', 'Test'], repoDir);
+		await runGit(['commit', '--allow-empty', '-m', 'init'], repoDir);
+	}
+
+	test('re-provisions a task whose worktree registration is prunable (#2208)', async () => {
+		await initGitRepo();
+
+		// Provision once, then simulate the crash: delete the worktree
+		// directory WITHOUT unregistering it, so git reports it prunable.
+		const first = await provisionWorktree(repoDir, '4.1', 'ses_crash', {
+			purpose: 'lane',
+		});
+		expect(first).toHaveProperty('worktreePath');
+		const firstHandle = first as { worktreePath: string; branchName: string };
+		fs.rmSync(firstHandle.worktreePath, { recursive: true, force: true });
+
+		const listAfterDelete = await runGit(
+			['worktree', 'list', '--porcelain'],
+			repoDir,
+		);
+		if (!listAfterDelete.stdout.includes('prunable')) {
+			// Git only emits `prunable` when it notices the missing directory
+			// (version/behavior dependent). Without the attribute this
+			// scenario is indistinguishable from a live lane, so the recovery
+			// contract cannot be exercised on this git. LOUD skip (final-critic
+			// item): a silent return would hide coverage loss on a CI image
+			// whose git stopped emitting the attribute.
+			console.warn(
+				'[2208] SKIP: installed git does not emit the porcelain `prunable` attribute; the prune+relist recovery path is unexercised on this runner.',
+			);
+			return;
+		}
+
+		// Pre-#2208: "Branch already exists and expected worktree is dirty"
+		// (isCleanWorktree fails on the deleted directory → treated as dirty).
+		const second = await provisionWorktree(repoDir, '4.1', 'ses_crash', {
+			purpose: 'lane',
+		});
+		expect(second).toHaveProperty('worktreePath');
+		const secondHandle = second as {
+			worktreePath: string;
+			branchName: string;
+		};
+		expect(secondHandle.branchName).toBe('swarm/lane/ses_crash/4.1');
+		// The new worktree exists on disk and is a healthy registration.
+		expect(fs.existsSync(secondHandle.worktreePath)).toBe(true);
+		const finalList = await runGit(
+			['worktree', 'list', '--porcelain'],
+			repoDir,
+		);
+		expect(finalList.stdout).not.toContain('prunable');
+	});
+
+	test('a prunable OTHER-task lane does not break provisioning of a fresh task (#2208)', async () => {
+		await initGitRepo();
+
+		const stale = await provisionWorktree(repoDir, '9.9', 'ses_dead', {
+			purpose: 'lane',
+		});
+		const staleHandle = stale as { worktreePath: string };
+		fs.rmSync(staleHandle.worktreePath, { recursive: true, force: true });
+
+		const result = await provisionWorktree(repoDir, '4.2', 'ses_alive', {
+			purpose: 'lane',
+		});
+		expect(result).toHaveProperty('worktreePath');
+		const handle = result as { worktreePath: string; branchName: string };
+		expect(handle.branchName).toBe('swarm/lane/ses_alive/4.2');
+		expect(fs.existsSync(handle.worktreePath)).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #2208

## Summary
- Both `git worktree list --porcelain` parsers now understand the `prunable` attribute: `preProvisionCollisionCheck` (src/hooks/delegation-gate/worktree-isolation.ts) skips prunable registrations when scanning for lane collisions — a stale registration whose directory is gone is not an active lane, so a restart inside the 5-minute provisioning-lease window no longer hard-stops with `STANDARD_WORKTREE_OWNER_PROTECTED`.
- `provisionWorktree` (src/worktree/core.ts) detects a prunable registration for the expected path or branch, runs `git worktree prune` (via the existing runGit helper — array-form spawn, explicit cwd, stdin ignore, timeout, kill-in-finally), re-enumerates, and lets the leftover branch reconcile through the existing stale-branch path (ahead-count check, `branch -d`, re-add). The post-lease `Branch already exists and expected worktree is dirty` stall is gone.
- Safety: `git worktree add` is atomic (a registration exists iff the worktree exists), so a provisioning-in-progress lane can never appear prunable; `locked` worktrees never carry the attribute. Known bound documented in the release fragment: deletions git has not yet noticed still classify as active collisions (fail-closed — the pre-existing, safe direction).
- Tests: mocked-porcelain suite (live-owner lease-window case, cross-session prunable, non-prunable control) + real-git recovery suite (re-provision succeeds, final porcelain prunable-free; skips loudly on git builds without the attribute).

## Invariant audit
- 1: not touched — no init-path changes; repro-704 init deadline passed anyway (documented in test plan)
- 2: not touched — no bun: imports, no Bun.* calls, no export-shape changes; full build + Node dist import ran (see test plan)
- 3: touched — one new `git worktree prune` call plus a re-list through the existing runGit helper (array-form, explicit cwd, stdin ignore, timeout, kill-in-finally); `git diff origin/main..HEAD | grep -nE "bunSpawn\(|spawn\(|spawnSync\("` shows no other new spawn sites
- 4: not touched — worktree lanes live outside .swarm; no .swarm writes
- 5: not touched — no plan-ledger/projection changes
- 6: not touched — no test_runner scope changes
- 7: touched — new bun:test files; real-git suite follows the realpath-canonicalized tmpdir convention (issue #1729); mocked suite uses the _internals DI seam, no mock.module
- 8: not touched — no session/global state changes
- 10: not touched — no chat/system-message changes
- 11: not touched — no tool registration/agent-map changes (bun run scripts/check-tool-registration.ts green)
- 12: not touched — version files untouched; release fragment added per contract

## Test plan
- `bun run test:unit:ci tests/unit/worktree/provision-worktree.prunable.test.ts tests/unit/hooks/delegation-gate-worktree-isolation-prunable.test.ts tests/unit/worktree/provision-worktree.test.ts tests/unit/worktree/provision-worktree.adversarial.test.ts tests/unit/hooks/delegation-gate-worktree-isolation-preprovision.test.ts tests/unit/hooks/worktree-collision-ownership.test.ts` — green.
- `bun run typecheck` / `bun run lint:ci` / full Tier-1 check stack / build + dist import + repro-704 + package:smoke — green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

