### PR TITLE
fix(pre-check-batch): fail fast on invalid project roots and propagate secretscan evidence errors

### DIFF
--- a/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
+++ b/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
@@ -1,0 +1,16 @@
+# pre_check_batch: fail fast on invalid project roots; secretscan evidence failures now fail the gate
+
+## What changed
+
+Two consistency fixes for `pre_check_batch` (issue #2209):
+
+1. **Fail-fast project-root validation.** When invoked with `directory` equal to the workspace anchor (the CLI-invoked-from-a-subdirectory shape), the tool's early boundary validation passed unconditionally, deferring the violation to evidence-write time — where it surfaced inconsistently: `secretscan` reported success while swallowing its evidence-write error, and `sast_scan`/`quality_budget` failed with `Cannot write evidence in "<sub>" — parent directory "<root>" already contains a .swarm/ folder…`. `runPreCheckBatch` now calls `assertProjectRoot` (reused unmodified — the same invariant the evidence writers enforce) before any tool executes: a directory nested inside an existing Swarm project without its own boundary marker fails immediately with a single consistent error across all four tool slots. Standalone directories without a `.swarm`-bearing ancestor and nested independent roots (own `.git`/`.opencode`) continue to pass.
+2. **Secretscan evidence-write parity.** A failed secretscan evidence persistence is no longer a swallowed `warn()`: it sets the `secretscan` slot's `error` and fails the batch gate (`gates_passed: false`), mirroring how `sast_scan` and `quality_budget` treat evidence-write failures. The scan result itself (`ran: true`, findings) is unchanged.
+
+## Why
+
+The validation bypass let invalid-anchor runs produce mixed, misleading tool results; the swallowed evidence error hid critical runtime-state failures from the gate.
+
+## Migration
+
+No migration required. Runs anchored at a boundary-less subdirectory of an existing Swarm project that previously "passed" (with per-tool evidence errors buried in the payload) now fail fast with a clear message.

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -14,6 +14,7 @@ import { saveEvidence } from '../evidence/manager.js';
 import { warn } from '../utils';
 import { runExternalTool } from '../utils/external-tool-runner';
 import {
+	assertProjectRoot,
 	hasExplicitProjectBoundary,
 	isStrictPathDescendant,
 } from '../utils/project-boundary';
@@ -1319,6 +1320,35 @@ export async function runPreCheckBatch(
 		};
 	}
 
+	// #2209: fail fast when the directory is not a valid project root for
+	// evidence writes. isAcceptedProjectRootForPlatform's equality branch
+	// (directory === workspaceDir — the CLI-invoked-from-a-subdirectory case)
+	// bypasses the explicit-boundary check, so a boundary-less subdirectory of
+	// an existing Swarm project used to pass validation above and surface the
+	// violation only at evidence-write time — inconsistently (secretscan
+	// swallowed it; sast_scan/quality_budget failed). assertProjectRoot is the
+	// same invariant the evidence writers enforce (reused, unmodified): a
+	// directory with its own boundary marker passes, a standalone directory
+	// with no `.swarm`-bearing ancestor passes, and a subdirectory nested
+	// under a `.swarm/`-owning project root throws — still BEFORE any tool
+	// executes (this runs after the no-files fail-closed checks so their
+	// distinct 'No files provided' contract is preserved).
+	try {
+		assertProjectRoot(directory);
+	} catch (error) {
+		const rootError = error instanceof Error ? error.message : String(error);
+		warn(`pre_check_batch: Project-root validation failed: ${rootError}`);
+		return {
+			batch_status: 'invalid',
+			gates_passed: false,
+			lint: { ran: false, error: rootError, duration_ms: 0 },
+			secretscan: { ran: false, error: rootError, duration_ms: 0 },
+			sast_scan: { ran: false, error: rootError, duration_ms: 0 },
+			quality_budget: { ran: false, error: rootError, duration_ms: 0 },
+			total_duration_ms: 0,
+		};
+	}
+
 	// Limit files to prevent abuse
 	if (changedFiles.length > MAX_FILES) {
 		throw new Error(
@@ -1423,9 +1453,18 @@ export async function runPreCheckBatch(
 				abortSignal,
 			);
 		} catch (e) {
-			warn(
-				`Failed to persist secretscan evidence: ${e instanceof Error ? e.message : String(e)}`,
-			);
+			// #2209: an evidence persistence failure is a runtime-state failure
+			// and must fail the scan identically to sast_scan/quality_budget
+			// (whose saveEvidence errors propagate into their ToolResult.error
+			// and hard-fail the gate). The gate evaluation above already ran on
+			// the clean scan result, so fail the gate directly here and surface
+			// the error on the payload.
+			const persistError = `Failed to persist secretscan evidence: ${
+				e instanceof Error ? e.message : String(e)
+			}`;
+			secretscanResult.error = persistError;
+			gatesPassed = false;
+			warn(`pre_check_batch: ${persistError} - GATE FAILED`);
 		}
 	}
 

--- a/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
+++ b/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
@@ -1,0 +1,190 @@
+/**
+ * pre_check_batch boundary-bypass fail-fast + secretscan evidence parity —
+ * issue #2209.
+ *
+ * 1. Boundary bypass: when invoked with `directory === workspaceDir` (the
+ *    CLI-from-a-subdirectory shape), `isAcceptedProjectRootForPlatform`'s
+ *    equality branch skips the explicit-boundary check, so a boundary-less
+ *    subdirectory of an existing Swarm project used to pass validation and
+ *    surface the violation only at evidence-write time — inconsistently
+ *    (secretscan swallowed the error; sast_scan/quality_budget failed).
+ *    runPreCheckBatch now reuses assertProjectRoot (unmodified) to fail fast
+ *    BEFORE any tool executes.
+ * 2. Secretscan evidence-write failures now fail the gate identically to
+ *    sast_scan instead of being swallowed by a warn().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals,
+	runPreCheckBatch,
+	type ToolResult,
+} from '../../../src/tools/pre-check-batch';
+import {
+	createNestedBoundaryFixture,
+	type NestedBoundaryFixture,
+	removeNestedBoundaryFixture,
+} from '../../helpers/nested-project-boundary';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const originals = { ..._internals };
+
+function wrapped<T>(result: T): ToolResult<T> {
+	return { ran: true, result, duration_ms: 0 };
+}
+
+function mockPassingTools(): void {
+	_internals.runLintWrapped = (async () =>
+		wrapped({ success: true })) as typeof _internals.runLintWrapped;
+	_internals.runSecretscanWrapped = (async () =>
+		wrapped({
+			scan_dir: '.',
+			findings: [],
+			count: 0,
+			files_scanned: 1,
+			skipped_files: 0,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		})) as typeof _internals.runSecretscanWrapped;
+	_internals.runSastScanWrapped = (async () =>
+		wrapped({
+			verdict: 'pass',
+			findings: [],
+			summary: {
+				engine: 'tier_a',
+				files_scanned: 1,
+				findings_count: 0,
+				findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0 },
+			},
+		})) as typeof _internals.runSastScanWrapped;
+	_internals.runQualityBudgetWrapped = (async () =>
+		wrapped({
+			verdict: 'pass',
+			violations: [],
+		})) as typeof _internals.runQualityBudgetWrapped;
+	_internals.saveEvidence =
+		(async () => ({})) as typeof _internals.saveEvidence;
+}
+
+beforeEach(() => {
+	mockPassingTools();
+});
+
+afterEach(() => {
+	Object.assign(_internals, originals);
+});
+
+describe('pre_check_batch boundary fail-fast (#2209)', () => {
+	let fixture: NestedBoundaryFixture;
+
+	beforeEach(() => {
+		fixture = createNestedBoundaryFixture('git-directory');
+		fs.writeFileSync(path.join(fixture.ordinary, 'changed.txt'), 'clean\n');
+		fs.writeFileSync(path.join(fixture.outer, 'changed.txt'), 'clean\n');
+		fs.writeFileSync(path.join(fixture.nested, 'changed.txt'), 'clean\n');
+	});
+
+	afterEach(() => {
+		removeNestedBoundaryFixture(fixture);
+	});
+
+	test('boundary-less subdirectory of a Swarm project (directory === workspaceDir) fails fast before tools run', async () => {
+		// CLI-cwd simulation: workspaceDir falls back to input.directory, so the
+		// equality branch of isAcceptedProjectRootForPlatform passes — exactly
+		// the #2209 bypass. assertProjectRoot must reject it BEFORE tools run.
+		const result = await runPreCheckBatch(
+			{ directory: fixture.ordinary, files: ['changed.txt'] },
+			fixture.ordinary,
+		);
+		expect(result.batch_status).toBe('invalid');
+		expect(result.gates_passed).toBe(false);
+		// All four tools failed with the SAME root-cause error — no mixed
+		// secretscan-silent / sast-hard-fail results, and no tool executed.
+		expect(result.lint.ran).toBe(false);
+		expect(result.secretscan.ran).toBe(false);
+		expect(result.sast_scan.ran).toBe(false);
+		expect(result.quality_budget.ran).toBe(false);
+		const expectedMsg = `Cannot write runtime state in "${path.resolve(fixture.ordinary)}" — parent directory "${path.resolve(fixture.outer)}" already contains a .swarm/ folder. Runtime state must be written to the project root.`;
+		expect(result.lint.error).toContain('already contains a .swarm/ folder');
+		expect(result.secretscan.error).toBe(expectedMsg);
+		expect(result.sast_scan.error).toBe(expectedMsg);
+		expect(result.quality_budget.error).toBe(expectedMsg);
+	});
+
+	test('the Swarm project root itself still passes (regression guard)', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: fixture.outer, files: ['changed.txt'] },
+			fixture.outer,
+		);
+		expect(result.batch_status).not.toBe('invalid');
+		expect(result.gates_passed).toBe(true);
+	});
+
+	test('a nested independent root (own .git marker) still passes', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: fixture.nested, files: ['changed.txt'] },
+			fixture.nested,
+		);
+		expect(result.batch_status).not.toBe('invalid');
+		expect(result.gates_passed).toBe(true);
+	});
+
+	test('a standalone boundary-less directory with no .swarm ancestor still passes (rootless standalone preserved)', async () => {
+		const standalone = canonicalMkdtemp('pcb-standalone-');
+		try {
+			fs.writeFileSync(path.join(standalone, 'changed.txt'), 'clean\n');
+			const result = await runPreCheckBatch(
+				{ directory: standalone, files: ['changed.txt'] },
+				standalone,
+			);
+			expect(result.batch_status).not.toBe('invalid');
+			expect(result.gates_passed).toBe(true);
+		} finally {
+			fs.rmSync(standalone, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('pre_check_batch secretscan evidence persistence failure (#2209)', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = canonicalMkdtemp('pcb-evidence-fail-');
+		fs.writeFileSync(path.join(tempDir, 'changed.txt'), 'clean\n');
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('a secretscan evidence write failure fails the gate identically to sast_scan', async () => {
+		_internals.saveEvidence = (async () => {
+			throw new Error('evidence disk full');
+		}) as typeof _internals.saveEvidence;
+
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.txt'] },
+			tempDir,
+		);
+		// The scan itself ran and found nothing; the persistence failure must
+		// still fail the gate and surface on the payload (pre-#2209 this was a
+		// warn() only and gates_passed stayed true).
+		expect(result.secretscan.ran).toBe(true);
+		expect(result.secretscan.error).toContain(
+			'Failed to persist secretscan evidence',
+		);
+		expect(result.secretscan.error).toContain('evidence disk full');
+		expect(result.gates_passed).toBe(false);
+	});
+
+	test('a successful secretscan evidence write leaves the gate unaffected', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.txt'] },
+			tempDir,
+		);
+		expect(result.secretscan.error).toBeUndefined();
+		expect(result.gates_passed).toBe(true);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
@@ -275,26 +275,57 @@ describe('secretscan evidence persistence', () => {
 		expect(evidence.skipped_files).toBeGreaterThanOrEqual(0);
 	});
 
-	// ============ Non-fatal: Evidence persistence failure doesn't crash pipeline ============
+	// ============ Evidence persistence failure: gate fails, no crash (#2209) ============
 
-	test('evidence persistence failure does not crash the pipeline', async () => {
+	test('secretscan evidence persistence failure fails the gate and surfaces on the payload (#2209)', async () => {
 		// Create a clean file
 		fs.writeFileSync(path.join(tempDir, 'clean.ts'), 'export const x = 1;\n');
 
-		// Make saveEvidence throw an error
-		mockSaveEvidence.mockRejectedValueOnce(new Error('Filesystem error'));
-
-		const input: PreCheckBatchInput = {
-			files: ['clean.ts'],
-			directory: tempDir,
+		// Make ONLY the secretscan evidence write reject. A bare
+		// mockRejectedValueOnce historically missed this path entirely: the
+		// quality_budget evidence write runs first and consumed the single
+		// rejection, so this test never actually exercised the secretscan
+		// catch (surfaced by the #2209 final critic).
+		const defaultImpl = async (
+			directory: string,
+			taskId: string,
+			evidence: SecretscanEvidence,
+		): Promise<unknown> => {
+			savedEvidence.push({ directory, taskId, evidence });
+			return {};
 		};
+		mockSaveEvidence.mockImplementation(
+			async (
+				directory: string,
+				taskId: string,
+				evidence: SecretscanEvidence,
+			): Promise<unknown> => {
+				if (taskId === 'secretscan') {
+					throw new Error('Filesystem error');
+				}
+				return defaultImpl(directory, taskId, evidence);
+			},
+		);
+		try {
+			const input: PreCheckBatchInput = {
+				files: ['clean.ts'],
+				directory: tempDir,
+			};
 
-		// Should not throw - errors are caught and logged
-		const result = await runPreCheckBatch(input);
+			// Should not throw — but per #2209 the persistence failure now
+			// fails the gate identically to sast_scan instead of being
+			// swallowed as a warn().
+			const result = await runPreCheckBatch(input);
 
-		// Pipeline should complete successfully despite evidence save failure
-		expect(result.gates_passed).toBe(true);
-		expect(result.secretscan.ran).toBe(true);
+			expect(result.secretscan.ran).toBe(true);
+			expect(result.secretscan.error).toContain(
+				'Failed to persist secretscan evidence',
+			);
+			expect(result.secretscan.error).toContain('Filesystem error');
+			expect(result.gates_passed).toBe(false);
+		} finally {
+			mockSaveEvidence.mockImplementation(defaultImpl);
+		}
 	});
 
 	// ============ Verdict Logic: findings_count > 0 → 'fail' ============


### PR DESCRIPTION
Closes #2209

## Summary
- Fail-fast project-root validation: `runPreCheckBatch` now calls `assertProjectRoot(directory)` (reused unmodified — the exact invariant the evidence writers enforce) after the no-files early returns and BEFORE any tool executes. A boundary-less subdirectory of an existing Swarm project (the CLI-cwd `directory === workspaceDir` equality-bypass shape) now fails immediately with the single consistent `Cannot write runtime state in "<sub>" — parent "<root>" already contains a .swarm/ folder...` error across all four tool slots — instead of the old mixed result where secretscan reported success with a swallowed evidence warning while sast_scan/quality_budget failed mid-batch. Standalone rootless directories and nested independent roots still pass (assertProjectRoot's ancestor walk finds nothing / the boundary marker returns early).
- Secretscan evidence parity: a failed secretscan evidence write is no longer a swallowed `warn()` — the catch sets the `secretscan` slot's `error` and fails the batch gate (`gates_passed: false`), mirroring how a sast_scan evidence failure propagates. `ran: true` is preserved (the scan itself ran).
- The pre-existing "persistence failure" test was rewritten to genuinely target the secretscan write (rejection keyed by taskId): the old `mockRejectedValueOnce` was silently consumed by the quality_budget evidence write (the first saveEvidence call), so it had never exercised the secretscan catch — it now asserts the new gate-failure contract with no vacuous-pass path.
- `hasExplicitProjectBoundary` / `assertProjectRoot` / `isAcceptedProjectRootForPlatform` are untouched (issue acceptance criterion 3).

## Invariant audit
- 1: not touched — no init-path changes; repro-704 init deadline passed anyway (documented in test plan)
- 2: not touched — no bun: imports, no Bun.* calls, no export-shape changes; full build + Node dist import ran (see test plan)
- 3: not touched — no subprocess changes
- 4: touched — reuses assertProjectRoot (unmodified) as an early read-only validation; no new .swarm writes; new boundary-bypass suite pins fail-fast for the nested case and pass-through for root/nested/standalone
- 5: not touched — no plan-ledger/projection changes
- 6: not touched — no test_runner scope changes
- 7: touched — new tests/unit/tools/pre-check-batch-boundary-bypass.test.ts using the existing _internals DI harness; rewritten secretscan-evidence test keyed by taskId with try/finally restore; full pre-check-batch family green with zero fixture churn
- 8: not touched — no session/global state changes
- 9: touched — secretscan evidence failures now fail closed (gate + payload) instead of warn-only — the requested consistency; rewritten test asserts gates_passed false + surfaced error
- 10: not touched — no chat/system-message changes
- 11: not touched — no tool registration/agent-map changes (bun run scripts/check-tool-registration.ts green)
- 12: not touched — version files untouched; release fragment added per contract

## Test plan
- `bun run test:unit:ci tests/unit/tools/pre-check-batch-boundary-bypass.test.ts tests/unit/tools/pre-check-batch.test.ts tests/unit/tools/pre-check-batch.adversarial.test.ts tests/unit/tools/pre-check-batch-cwd.test.ts tests/unit/tools/pre-check-batch-cwd.adversarial.test.ts tests/unit/tools/nested-project-boundary-tools.test.ts tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts tests/unit/tools/pre-check-batch-secretscan-failure-evidence.test.ts` — green.
- `bun run typecheck` / `bun run lint:ci` / full Tier-1 check stack / build + dist import + repro-704 + package:smoke — green.
- Pre-existing (proven on origin/main): running pre-check-batch.test.ts and sast-scan.test.ts in ONE bun process fails from documented mock.module cross-file pollution; CI's per-file isolation gate is unaffected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

