### PR TITLE
fix(sast-scan): attach error to zero-coverage failures and log the actual gate reason

### DIFF
--- a/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
+++ b/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
@@ -13,4 +13,4 @@ The validation bypass let invalid-anchor runs produce mixed, misleading tool res
 
 ## Migration
 
-No migration required. Runs anchored at a boundary-less subdirectory of an existing Swarm project that previously "passed" (with per-tool evidence errors buried in the payload) now fail fast with a clear message.
+No migration required. Runs anchored at a boundary-less subdirectory of an existing Swarm project that previously "passed" (with per-tool evidence errors buried in the payload) now fail fast with a clear message. Note: `assertProjectRoot` is reused unmodified and therefore also surfaces its pre-existing fail-CLOSED branches — a directory whose `realpathSync` throws, whose `.swarm`-bearing ancestor state is inaccessible (EPERM / ENOTDIR-class), whose ancestor search exceeds 20 levels, or whose ancestor project indicators are unreadable will now hard-fail at the pre-check-batch guard instead of deferring to evidence-write time.

--- a/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
+++ b/docs/releases/pending/2209-pre-check-batch-root-fail-fast.md
@@ -1,0 +1,16 @@
+# pre_check_batch: fail fast on invalid project roots; secretscan evidence failures now fail the gate
+
+## What changed
+
+Two consistency fixes for `pre_check_batch` (issue #2209):
+
+1. **Fail-fast project-root validation.** When invoked with `directory` equal to the workspace anchor (the CLI-invoked-from-a-subdirectory shape), the tool's early boundary validation passed unconditionally, deferring the violation to evidence-write time — where it surfaced inconsistently: `secretscan` reported success while swallowing its evidence-write error, and `sast_scan`/`quality_budget` failed with `Cannot write evidence in "<sub>" — parent directory "<root>" already contains a .swarm/ folder…`. `runPreCheckBatch` now calls `assertProjectRoot` (reused unmodified — the same invariant the evidence writers enforce) before any tool executes: a directory nested inside an existing Swarm project without its own boundary marker fails immediately with a single consistent error across all four tool slots. Standalone directories without a `.swarm`-bearing ancestor and nested independent roots (own `.git`/`.opencode`) continue to pass.
+2. **Secretscan evidence-write parity.** A failed secretscan evidence persistence is no longer a swallowed `warn()`: it sets the `secretscan` slot's `error` and fails the batch gate (`gates_passed: false`), mirroring how `sast_scan` and `quality_budget` treat evidence-write failures. The scan result itself (`ran: true`, findings) is unchanged.
+
+## Why
+
+The validation bypass let invalid-anchor runs produce mixed, misleading tool results; the swallowed evidence error hid critical runtime-state failures from the gate.
+
+## Migration
+
+No migration required. Runs anchored at a boundary-less subdirectory of an existing Swarm project that previously "passed" (with per-tool evidence errors buried in the payload) now fail fast with a clear message.

--- a/docs/releases/pending/2210-sast-zero-coverage-error-context.md
+++ b/docs/releases/pending/2210-sast-zero-coverage-error-context.md
@@ -1,0 +1,16 @@
+# SAST zero-coverage failure carries an error reason; pre_check_batch logs the actual cause
+
+## What changed
+
+When `sast_scan` scans exactly zero files (clean worktree, empty or all-skipped `files`), it correctly fails the gate but used to return `verdict: "fail"` with **no `error` field** — leaving no diagnostic context and causing `pre_check_batch` to log the hardcoded, misleading `SAST scan found new findings above threshold - GATE FAILED` even with zero findings (issue #2210).
+
+- `sast_scan` (`src/tools/sast-scan.ts`) now attaches `error: 'SAST requires at least one file to scan; zero files were scanned'` to the zero-coverage failure payload, mirroring the `capture_baseline` path's explicit error contract. The error field appears only on zero-coverage failures — findings-driven failures are unchanged.
+- `pre_check_batch` needs no new logging branch: its existing result-level `if (sastResult.error)` gate branch already surfaces the scan's error verbatim, so the zero-coverage reason now reaches the operator through that path instead of falling through to the misleading findings message. Comments at both verdict-driven branches now record that a result carrying `error` is always consumed upstream.
+
+## Why
+
+Silent zero-coverage failures wasted triage time on a nonexistent findings investigation.
+
+## Migration
+
+No migration required. Consumers string-matching `SAST scan found new findings above threshold` for zero-coverage scans should match the new `SAST requires at least one file to scan; zero files were scanned` error string instead.

--- a/docs/releases/pending/2210-sast-zero-coverage-error-context.md
+++ b/docs/releases/pending/2210-sast-zero-coverage-error-context.md
@@ -4,7 +4,7 @@
 
 When `sast_scan` scans exactly zero files (clean worktree, empty or all-skipped `files`), it correctly fails the gate but used to return `verdict: "fail"` with **no `error` field** — leaving no diagnostic context and causing `pre_check_batch` to log the hardcoded, misleading `SAST scan found new findings above threshold - GATE FAILED` even with zero findings (issue #2210).
 
-- `sast_scan` (`src/tools/sast-scan.ts`) now attaches `error: 'SAST requires at least one file to scan; zero files were scanned'` to the zero-coverage failure payload, mirroring the `capture_baseline` path's explicit error contract. The error field appears only on zero-coverage failures — findings-driven failures are unchanged.
+- `sast_scan` (`src/tools/sast-scan.ts`) now attaches `error: 'SAST requires at least one file to scan; zero files were scanned'` to the zero-coverage failure payload, mirroring the `capture_baseline` path's explicit error contract. The error field on non-capture scan results now also covers zero-coverage; cancellation (`'SAST scan cancelled'`) and Semgrep-execution / capture-mode errors remain unchanged.
 - `pre_check_batch` needs no new logging branch: its existing result-level `if (sastResult.error)` gate branch already surfaces the scan's error verbatim, so the zero-coverage reason now reaches the operator through that path instead of falling through to the misleading findings message. Comments at both verdict-driven branches now record that a result carrying `error` is always consumed upstream.
 
 ## Why

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -1497,10 +1497,13 @@ export async function runPreCheckBatch(
 				}
 			}
 			// Verdict is already correctly set by sastScan — do not override.
+			// (#2210 note: a result carrying `error` was already consumed by the
+			// `if (sastResult.error)` branch above, so this branch is by
+			// construction the findings-driven case.)
 			if (sastResult.verdict === 'fail') {
 				gatesPassed = false;
 				warn(
-					`pre_check_batch: SAST scan found new findings above threshold - GATE FAILED`,
+					'pre_check_batch: SAST scan found new findings above threshold - GATE FAILED',
 				);
 			}
 		} else if (sastResult.verdict === 'fail') {
@@ -1537,7 +1540,9 @@ export async function runPreCheckBatch(
 				}
 			} else {
 				// SAST failed but no HIGH/CRITICAL findings (lower severity only)
-				// Original behavior: fail the gate
+				// Original behavior: fail the gate. (#2210 note: a result carrying
+				// `error` was already consumed by the `if (sastResult.error)`
+				// branch above.)
 				gatesPassed = false;
 				warn('pre_check_batch: SAST scan found vulnerabilities - GATE FAILED');
 			}

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -14,6 +14,7 @@ import { saveEvidence } from '../evidence/manager.js';
 import { warn } from '../utils';
 import { runExternalTool } from '../utils/external-tool-runner';
 import {
+	assertProjectRoot,
 	hasExplicitProjectBoundary,
 	isStrictPathDescendant,
 } from '../utils/project-boundary';
@@ -1319,6 +1320,35 @@ export async function runPreCheckBatch(
 		};
 	}
 
+	// #2209: fail fast when the directory is not a valid project root for
+	// evidence writes. isAcceptedProjectRootForPlatform's equality branch
+	// (directory === workspaceDir — the CLI-invoked-from-a-subdirectory case)
+	// bypasses the explicit-boundary check, so a boundary-less subdirectory of
+	// an existing Swarm project used to pass validation above and surface the
+	// violation only at evidence-write time — inconsistently (secretscan
+	// swallowed it; sast_scan/quality_budget failed). assertProjectRoot is the
+	// same invariant the evidence writers enforce (reused, unmodified): a
+	// directory with its own boundary marker passes, a standalone directory
+	// with no `.swarm`-bearing ancestor passes, and a subdirectory nested
+	// under a `.swarm/`-owning project root throws — still BEFORE any tool
+	// executes (this runs after the no-files fail-closed checks so their
+	// distinct 'No files provided' contract is preserved).
+	try {
+		assertProjectRoot(directory);
+	} catch (error) {
+		const rootError = error instanceof Error ? error.message : String(error);
+		warn(`pre_check_batch: Project-root validation failed: ${rootError}`);
+		return {
+			batch_status: 'invalid',
+			gates_passed: false,
+			lint: { ran: false, error: rootError, duration_ms: 0 },
+			secretscan: { ran: false, error: rootError, duration_ms: 0 },
+			sast_scan: { ran: false, error: rootError, duration_ms: 0 },
+			quality_budget: { ran: false, error: rootError, duration_ms: 0 },
+			total_duration_ms: 0,
+		};
+	}
+
 	// Limit files to prevent abuse
 	if (changedFiles.length > MAX_FILES) {
 		throw new Error(
@@ -1423,9 +1453,18 @@ export async function runPreCheckBatch(
 				abortSignal,
 			);
 		} catch (e) {
-			warn(
-				`Failed to persist secretscan evidence: ${e instanceof Error ? e.message : String(e)}`,
-			);
+			// #2209: an evidence persistence failure is a runtime-state failure
+			// and must fail the scan identically to sast_scan/quality_budget
+			// (whose saveEvidence errors propagate into their ToolResult.error
+			// and hard-fail the gate). The gate evaluation above already ran on
+			// the clean scan result, so fail the gate directly here and surface
+			// the error on the payload.
+			const persistError = `Failed to persist secretscan evidence: ${
+				e instanceof Error ? e.message : String(e)
+			}`;
+			secretscanResult.error = persistError;
+			gatesPassed = false;
+			warn(`pre_check_batch: ${persistError} - GATE FAILED`);
 		}
 	}
 

--- a/src/tools/sast-scan.ts
+++ b/src/tools/sast-scan.ts
@@ -742,8 +742,14 @@ export async function sastScan(
 	}
 
 	// Zero-coverage fail: preserved in both modes (only skip for capture mode, handled above)
+	// #2210: attach the reason so the payload carries WHY it failed — without
+	// it, pre_check_batch assumed findings above threshold and logged a
+	// misleading "found new findings" message for a zero-file scan.
+	let zeroCoverageError: string | undefined;
 	if (filesScanned === 0) {
 		verdict = 'fail';
+		zeroCoverageError =
+			'SAST requires at least one file to scan; zero files were scanned';
 	}
 
 	// Build summary
@@ -783,6 +789,9 @@ export async function sastScan(
 		verdict,
 		findings: finalFindings,
 		summary,
+		// #2210: surface the zero-coverage reason (mirrors the capture_baseline
+		// path's explicit error contract).
+		...(zeroCoverageError ? { error: zeroCoverageError } : {}),
 	};
 
 	if (baselineUsed) {

--- a/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
+++ b/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
@@ -1,0 +1,190 @@
+/**
+ * pre_check_batch boundary-bypass fail-fast + secretscan evidence parity —
+ * issue #2209.
+ *
+ * 1. Boundary bypass: when invoked with `directory === workspaceDir` (the
+ *    CLI-from-a-subdirectory shape), `isAcceptedProjectRootForPlatform`'s
+ *    equality branch skips the explicit-boundary check, so a boundary-less
+ *    subdirectory of an existing Swarm project used to pass validation and
+ *    surface the violation only at evidence-write time — inconsistently
+ *    (secretscan swallowed the error; sast_scan/quality_budget failed).
+ *    runPreCheckBatch now reuses assertProjectRoot (unmodified) to fail fast
+ *    BEFORE any tool executes.
+ * 2. Secretscan evidence-write failures now fail the gate identically to
+ *    sast_scan instead of being swallowed by a warn().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals,
+	runPreCheckBatch,
+	type ToolResult,
+} from '../../../src/tools/pre-check-batch';
+import {
+	createNestedBoundaryFixture,
+	type NestedBoundaryFixture,
+	removeNestedBoundaryFixture,
+} from '../../helpers/nested-project-boundary';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const originals = { ..._internals };
+
+function wrapped<T>(result: T): ToolResult<T> {
+	return { ran: true, result, duration_ms: 0 };
+}
+
+function mockPassingTools(): void {
+	_internals.runLintWrapped = (async () =>
+		wrapped({ success: true })) as typeof _internals.runLintWrapped;
+	_internals.runSecretscanWrapped = (async () =>
+		wrapped({
+			scan_dir: '.',
+			findings: [],
+			count: 0,
+			files_scanned: 1,
+			skipped_files: 0,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		})) as typeof _internals.runSecretscanWrapped;
+	_internals.runSastScanWrapped = (async () =>
+		wrapped({
+			verdict: 'pass',
+			findings: [],
+			summary: {
+				engine: 'tier_a',
+				files_scanned: 1,
+				findings_count: 0,
+				findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0 },
+			},
+		})) as typeof _internals.runSastScanWrapped;
+	_internals.runQualityBudgetWrapped = (async () =>
+		wrapped({
+			verdict: 'pass',
+			violations: [],
+		})) as typeof _internals.runQualityBudgetWrapped;
+	_internals.saveEvidence =
+		(async () => ({})) as typeof _internals.saveEvidence;
+}
+
+beforeEach(() => {
+	mockPassingTools();
+});
+
+afterEach(() => {
+	Object.assign(_internals, originals);
+});
+
+describe('pre_check_batch boundary fail-fast (#2209)', () => {
+	let fixture: NestedBoundaryFixture;
+
+	beforeEach(() => {
+		fixture = createNestedBoundaryFixture('git-directory');
+		fs.writeFileSync(path.join(fixture.ordinary, 'changed.txt'), 'clean\n');
+		fs.writeFileSync(path.join(fixture.outer, 'changed.txt'), 'clean\n');
+		fs.writeFileSync(path.join(fixture.nested, 'changed.txt'), 'clean\n');
+	});
+
+	afterEach(() => {
+		removeNestedBoundaryFixture(fixture);
+	});
+
+	test('boundary-less subdirectory of a Swarm project (directory === workspaceDir) fails fast before tools run', async () => {
+		// CLI-cwd simulation: workspaceDir falls back to input.directory, so the
+		// equality branch of isAcceptedProjectRootForPlatform passes — exactly
+		// the #2209 bypass. assertProjectRoot must reject it BEFORE tools run.
+		const result = await runPreCheckBatch(
+			{ directory: fixture.ordinary, files: ['changed.txt'] },
+			fixture.ordinary,
+		);
+		expect(result.batch_status).toBe('invalid');
+		expect(result.gates_passed).toBe(false);
+		// All four tools failed with the SAME root-cause error — no mixed
+		// secretscan-silent / sast-hard-fail results, and no tool executed.
+		expect(result.lint.ran).toBe(false);
+		expect(result.secretscan.ran).toBe(false);
+		expect(result.sast_scan.ran).toBe(false);
+		expect(result.quality_budget.ran).toBe(false);
+		const expectedMsg = `Cannot write runtime state in "${path.resolve(fixture.ordinary)}" — parent directory "${path.resolve(fixture.outer)}" already contains a .swarm/ folder. Runtime state must be written to the project root.`;
+		expect(result.lint.error).toContain('already contains a .swarm/ folder');
+		expect(result.secretscan.error).toBe(expectedMsg);
+		expect(result.sast_scan.error).toBe(expectedMsg);
+		expect(result.quality_budget.error).toBe(expectedMsg);
+	});
+
+	test('the Swarm project root itself still passes (regression guard)', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: fixture.outer, files: ['changed.txt'] },
+			fixture.outer,
+		);
+		expect(result.batch_status).not.toBe('invalid');
+		expect(result.gates_passed).toBe(true);
+	});
+
+	test('a nested independent root (own .git marker) still passes', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: fixture.nested, files: ['changed.txt'] },
+			fixture.nested,
+		);
+		expect(result.batch_status).not.toBe('invalid');
+		expect(result.gates_passed).toBe(true);
+	});
+
+	test('a standalone boundary-less directory with no .swarm ancestor still passes (rootless standalone preserved)', async () => {
+		const standalone = canonicalMkdtemp('pcb-standalone-');
+		try {
+			fs.writeFileSync(path.join(standalone, 'changed.txt'), 'clean\n');
+			const result = await runPreCheckBatch(
+				{ directory: standalone, files: ['changed.txt'] },
+				standalone,
+			);
+			expect(result.batch_status).not.toBe('invalid');
+			expect(result.gates_passed).toBe(true);
+		} finally {
+			fs.rmSync(standalone, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('pre_check_batch secretscan evidence persistence failure (#2209)', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = canonicalMkdtemp('pcb-evidence-fail-');
+		fs.writeFileSync(path.join(tempDir, 'changed.txt'), 'clean\n');
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('a secretscan evidence write failure fails the gate identically to sast_scan', async () => {
+		_internals.saveEvidence = (async () => {
+			throw new Error('evidence disk full');
+		}) as typeof _internals.saveEvidence;
+
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.txt'] },
+			tempDir,
+		);
+		// The scan itself ran and found nothing; the persistence failure must
+		// still fail the gate and surface on the payload (pre-#2209 this was a
+		// warn() only and gates_passed stayed true).
+		expect(result.secretscan.ran).toBe(true);
+		expect(result.secretscan.error).toContain(
+			'Failed to persist secretscan evidence',
+		);
+		expect(result.secretscan.error).toContain('evidence disk full');
+		expect(result.gates_passed).toBe(false);
+	});
+
+	test('a successful secretscan evidence write leaves the gate unaffected', async () => {
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.txt'] },
+			tempDir,
+		);
+		expect(result.secretscan.error).toBeUndefined();
+		expect(result.gates_passed).toBe(true);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
+++ b/tests/unit/tools/pre-check-batch-boundary-bypass.test.ts
@@ -188,3 +188,101 @@ describe('pre_check_batch secretscan evidence persistence failure (#2209)', () =
 		expect(result.gates_passed).toBe(true);
 	});
 });
+
+describe('pre_check_batch SAST zero-coverage failure reason (#2210)', () => {
+	let tempDir: string;
+	let warnSpy: { mock: { calls: string[][] }; restore: () => void };
+
+	beforeEach(() => {
+		tempDir = canonicalMkdtemp('pcb-sast-zero-');
+		fs.writeFileSync(path.join(tempDir, 'changed.xyz'), 'content\n');
+		// warn() is gated behind OPENCODE_SWARM_DEBUG — enable it and capture
+		// console.warn so the gate's failure reason is assertable.
+		process.env.OPENCODE_SWARM_DEBUG = '1';
+		const calls: string[][] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			calls.push(args.map((a) => String(a)));
+		};
+		warnSpy = {
+			mock: { calls },
+			restore: () => {
+				console.warn = originalWarn;
+			},
+		};
+	});
+
+	afterEach(() => {
+		warnSpy.restore();
+		delete process.env.OPENCODE_SWARM_DEBUG;
+		Object.assign(_internals, originals);
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function joinedWarns(): string {
+		return warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+	}
+
+	test('baseline mode surfaces the zero-coverage error, not "found new findings"', async () => {
+		// Zero-coverage shape produced by sastScan on an empty/all-skipped
+		// file set (issue #2210 repro payload): verdict fail, 0 findings,
+		// and the #2210 error reason.
+		_internals.runSastScanWrapped = (async () =>
+			wrapped({
+				verdict: 'fail',
+				error:
+					'SAST requires at least one file to scan; zero files were scanned',
+				findings: [],
+				new_findings: [],
+				pre_existing_findings: [],
+				baseline_used: true,
+				summary: {
+					engine: 'tier_a',
+					files_scanned: 0,
+					findings_count: 0,
+					findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0 },
+				},
+			})) as typeof _internals.runSastScanWrapped;
+
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.xyz'] },
+			tempDir,
+		);
+		expect(result.gates_passed).toBe(false);
+		// The gate-reason log carries the actual zero-coverage error (via the
+		// result-level error branch), and the misleading "found new findings
+		// above threshold" message is NOT emitted.
+		expect(joinedWarns()).toContain(
+			'SAST requires at least one file to scan; zero files were scanned',
+		);
+		expect(joinedWarns()).not.toContain(
+			'SAST scan found new findings above threshold',
+		);
+	});
+
+	test('a verdict-fail with no error field keeps the threshold message', async () => {
+		_internals.runSastScanWrapped = (async () =>
+			wrapped({
+				verdict: 'fail',
+				findings: [],
+				new_findings: [],
+				pre_existing_findings: [],
+				baseline_used: true,
+				summary: {
+					engine: 'tier_a',
+					files_scanned: 1,
+					findings_count: 0,
+					findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0 },
+				},
+			})) as typeof _internals.runSastScanWrapped;
+
+		const result = await runPreCheckBatch(
+			{ directory: tempDir, files: ['changed.xyz'] },
+			tempDir,
+		);
+		expect(result.gates_passed).toBe(false);
+		expect(joinedWarns()).toContain(
+			'SAST scan found new findings above threshold - GATE FAILED',
+		);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
@@ -275,26 +275,57 @@ describe('secretscan evidence persistence', () => {
 		expect(evidence.skipped_files).toBeGreaterThanOrEqual(0);
 	});
 
-	// ============ Non-fatal: Evidence persistence failure doesn't crash pipeline ============
+	// ============ Evidence persistence failure: gate fails, no crash (#2209) ============
 
-	test('evidence persistence failure does not crash the pipeline', async () => {
+	test('secretscan evidence persistence failure fails the gate and surfaces on the payload (#2209)', async () => {
 		// Create a clean file
 		fs.writeFileSync(path.join(tempDir, 'clean.ts'), 'export const x = 1;\n');
 
-		// Make saveEvidence throw an error
-		mockSaveEvidence.mockRejectedValueOnce(new Error('Filesystem error'));
-
-		const input: PreCheckBatchInput = {
-			files: ['clean.ts'],
-			directory: tempDir,
+		// Make ONLY the secretscan evidence write reject. A bare
+		// mockRejectedValueOnce historically missed this path entirely: the
+		// quality_budget evidence write runs first and consumed the single
+		// rejection, so this test never actually exercised the secretscan
+		// catch (surfaced by the #2209 final critic).
+		const defaultImpl = async (
+			directory: string,
+			taskId: string,
+			evidence: SecretscanEvidence,
+		): Promise<unknown> => {
+			savedEvidence.push({ directory, taskId, evidence });
+			return {};
 		};
+		mockSaveEvidence.mockImplementation(
+			async (
+				directory: string,
+				taskId: string,
+				evidence: SecretscanEvidence,
+			): Promise<unknown> => {
+				if (taskId === 'secretscan') {
+					throw new Error('Filesystem error');
+				}
+				return defaultImpl(directory, taskId, evidence);
+			},
+		);
+		try {
+			const input: PreCheckBatchInput = {
+				files: ['clean.ts'],
+				directory: tempDir,
+			};
 
-		// Should not throw - errors are caught and logged
-		const result = await runPreCheckBatch(input);
+			// Should not throw — but per #2209 the persistence failure now
+			// fails the gate identically to sast_scan instead of being
+			// swallowed as a warn().
+			const result = await runPreCheckBatch(input);
 
-		// Pipeline should complete successfully despite evidence save failure
-		expect(result.gates_passed).toBe(true);
-		expect(result.secretscan.ran).toBe(true);
+			expect(result.secretscan.ran).toBe(true);
+			expect(result.secretscan.error).toContain(
+				'Failed to persist secretscan evidence',
+			);
+			expect(result.secretscan.error).toContain('Filesystem error');
+			expect(result.gates_passed).toBe(false);
+		} finally {
+			mockSaveEvidence.mockImplementation(defaultImpl);
+		}
 	});
 
 	// ============ Verdict Logic: findings_count > 0 → 'fail' ============

--- a/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
+++ b/tests/unit/tools/pre-check-batch-secretscan-evidence.test.ts
@@ -20,21 +20,6 @@ const mockRunLint = mock(async () => ({
 	output: '',
 	message: 'No issues found',
 }));
-const mockSastScan = mock(async () => ({
-	verdict: 'pass' as const,
-	findings: [],
-	summary: {
-		engine: 'tier_a' as const,
-		files_scanned: 0,
-		findings_count: 0,
-		findings_by_severity: {
-			critical: 0,
-			high: 0,
-			medium: 0,
-			low: 0,
-		},
-	},
-}));
 const mockQualityBudget = mock(async () => ({
 	verdict: 'pass' as const,
 	metrics: {
@@ -71,10 +56,6 @@ mock.module('../../../src/tools/secretscan', () => ({
 		files_scanned: 0,
 		skipped_files: 0,
 	})),
-}));
-
-mock.module('../../../src/tools/sast-scan', () => ({
-	sastScan: mockSastScan,
 }));
 
 mock.module('../../../src/tools/quality-budget', () => ({
@@ -141,7 +122,6 @@ describe('secretscan evidence persistence', () => {
 		// Reset mock call counts
 		mockDetectAvailableLinter.mockClear();
 		mockRunLint.mockClear();
-		mockSastScan.mockClear();
 		mockQualityBudget.mockClear();
 		mockSaveEvidence.mockClear();
 		_internals.saveEvidence = mockSaveEvidence;

--- a/tests/unit/tools/sast-scan-zero-coverage-error.test.ts
+++ b/tests/unit/tools/sast-scan-zero-coverage-error.test.ts
@@ -8,7 +8,7 @@
  * for findings above threshold.
  */
 
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { type SastScanInput, sastScan } from '../../../src/tools/sast-scan';
@@ -22,6 +22,10 @@ describe('sast_scan zero-coverage error payload (#2210)', () => {
 
 	beforeEach(() => {
 		tempDir = canonicalMkdtemp('sast-zero-2210-');
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	test('empty changed_files returns verdict fail with an explicit error reason', async () => {

--- a/tests/unit/tools/sast-scan-zero-coverage-error.test.ts
+++ b/tests/unit/tools/sast-scan-zero-coverage-error.test.ts
@@ -1,0 +1,51 @@
+/**
+ * sast_scan zero-coverage error payload — issue #2210.
+ *
+ * Split into its own file (FR-006 ratchet: tests/unit/tools/sast-scan.test.ts
+ * is over the 500-line cap and must not grow). A zero-file scan must return
+ * verdict 'fail' WITH an explicit `error` reason (mirroring capture_baseline's
+ * contract) so pre_check_batch and other consumers never mistake the failure
+ * for findings above threshold.
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { type SastScanInput, sastScan } from '../../../src/tools/sast-scan';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+// No evidence-manager mock needed: the tempdir is a standalone project root,
+// so the real saveEvidence writes land harmlessly inside it.
+
+describe('sast_scan zero-coverage error payload (#2210)', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = canonicalMkdtemp('sast-zero-2210-');
+	});
+
+	test('empty changed_files returns verdict fail with an explicit error reason', async () => {
+		const input: SastScanInput = {
+			changed_files: [],
+			severity_threshold: 'medium',
+		};
+		const result = await sastScan(input, tempDir);
+		expect(result.verdict).toBe('fail');
+		expect(result.findings).toEqual([]);
+		expect(result.summary.files_scanned).toBe(0);
+		expect(result.error).toBe(
+			'SAST requires at least one file to scan; zero files were scanned',
+		);
+	});
+
+	test('all files skipped (unsupported language) also carries the error reason', async () => {
+		const skipped = path.join(tempDir, 'unsupported.xyz');
+		fs.writeFileSync(skipped, 'content');
+		const result = await sastScan({ changed_files: [skipped] }, tempDir);
+		expect(result.summary.files_scanned).toBe(0);
+		expect(result.verdict).toBe('fail');
+		expect(result.error).toBe(
+			'SAST requires at least one file to scan; zero files were scanned',
+		);
+	});
+});


### PR DESCRIPTION
Closes #2210

## Summary
- `sast_scan` (src/tools/sast-scan.ts) attaches `error: 'SAST requires at least one file to scan; zero files were scanned'` to the zero-coverage failure payload (every affected mode), mirroring the `capture_baseline` path's explicit error contract. The error field appears only on zero-coverage — findings-driven failures are unchanged.
- `pre_check_batch` needs no new logging branch: its existing result-level `if (sastResult.error)` gate branch already surfaces a scan's error verbatim, so the zero-coverage reason now reaches operators through that path instead of falling through to the misleading hardcoded `SAST scan found new findings above threshold - GATE FAILED` (unreachable for error-bearing results). Comments at both verdict-driven branches record that error-bearing results are consumed upstream — no dead preference logic.
- Tests: `tests/unit/tools/sast-scan-zero-coverage-error.test.ts` pins the producer side (empty file set and all-files-skipped both carry the exact error string); the boundary-bypass suite pins the consumer side (zero-coverage reason surfaced, misleading message absent; error-less verdict-fail keeps the threshold message).

## Invariant audit
- 1: not touched — no init-path changes; repro-704 init deadline passed anyway (documented in test plan)
- 2: not touched — no bun: imports, no Bun.* calls, no export-shape changes; full build + Node dist import ran (see test plan)
- 3: not touched — no subprocess changes
- 4: touched — assertProjectRoot reused unmodified at pre-check time (src/tools/pre-check-batch.ts:1337); verified by pre-check-batch-boundary-bypass.test.ts; secretscan evidence-write parity at src/tools/pre-check-batch.ts:1455-1468 changes the evidence-write failure contract
- 5: not touched — no plan-ledger/projection changes
- 6: not touched — no test_runner scope changes
- 7: touched — new focused test file split from the over-cap sast-scan.test.ts per the FR-006 ratchet; no mock.module in the new file; gate-level assertions use the documented OPENCODE_SWARM_DEBUG warn spy
- 8: not touched — no session/global state changes
- 9: touched — zero-coverage failures now carry a diagnostic error; secretscan evidence-write failure now fails the gate identically to sast_scan/quality_budget (src/tools/pre-check-batch.ts:1455-1468), mirroring #2209
- 10: not touched — no chat/system-message changes
- 11: not touched — no tool registration/agent-map changes (bun run scripts/check-tool-registration.ts green)
- 12: not touched — version files untouched; release fragment added per contract

## Test plan
- `bun run test:unit:ci tests/unit/tools/sast-scan-zero-coverage-error.test.ts tests/unit/tools/pre-check-batch-boundary-bypass.test.ts tests/unit/tools/sast-scan.test.ts tests/unit/tools/pre-check-batch-sast-gate.test.ts tests/unit/tools/pre-check-batch-sast-preexisting.test.ts` — green.
- `bun run typecheck` / `bun run lint:ci` / full Tier-1 check stack / build + dist import + repro-704 + package:smoke — green.

Closes #2210
Closes #2209
