### PR TITLE
fix(workflow): reject unattributable coder launches and unwedge settlements

### DIFF
--- a/docs/releases/pending/fix-coder-settlement-wedge-2214.md
+++ b/docs/releases/pending/fix-coder-settlement-wedge-2214.md
@@ -16,4 +16,4 @@ No action required. Tasks previously stuck at DISPATCHED self-heal on first use 
 ### Known caveats
 
 - A workspace that is dirty at coder-dispatch time is now a hard dispatch error by design; attribution of same-path edits under a dirty baseline is provably impossible, and no bypass flag is offered.
-- Foreground background-flagged coder dispatches (`background: true` while background subagents are disabled) from a dirty root are now rejected at the same dispatch-time guard. True background dispatches (background subagents enabled) are unchanged: they fail at claim time with existing recovery handling, as before.
+- Background-flagged Task dispatches (`background: true`) with background subagents disabled (the default) are denied by the pre-existing experimental-feature gate (`SWARM_BACKGROUND_TASK_BLOCKED`, issue #1151) before the settlement system is ever engaged — dirty or clean alike. True background dispatches (background subagents enabled) are unchanged: they fail at claim time with existing recovery handling, as before.

--- a/docs/releases/pending/fix-coder-settlement-wedge-2214.md
+++ b/docs/releases/pending/fix-coder-settlement-wedge-2214.md
@@ -1,0 +1,19 @@
+## Coder settlements no longer wedge at DISPATCHED (issue #2214)
+
+### What changed
+
+- **Dirty-tree coder dispatches are rejected up front.** A coder `Task` dispatch from a workspace with uncommitted or untracked files now fails at dispatch time with `CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED` (naming the offending files) instead of running the coder and then failing mutation attribution at settlement time. Previously such dispatches permanently wedged `.swarm/coder-settlements/{taskId}.json` at `"state": "DISPATCHED"`, blocking reviewer/test_engineer dispatch with `CODER_DISPATCH_IN_PROGRESS`, `CODER_SETTLEMENT_RECOVERY_UNCERTAIN`, and `TASK_WORKFLOW_STAGE_A_REQUIRED` with no recovery path. Commit or stash your changes before dispatching a coder — exact-task settlement cannot attribute coder mutations from a dirty launch baseline.
+- **Abandoned settlements are now recoverable.** The `ABORTED` settlement state gained a real writer (`abortCoderSettlement`): a settlement whose launch baseline was structurally unattributable (no git history, or dirty at dispatch — the pre-fix wedge class) aborts instead of wedging. Legacy stuck DISPATCHED WALs self-heal: the next task-referencing `Task` dispatch, `check_gate_status`-style gated tool call, or `update_task_status` call after upgrading aborts them (recovery runs in the delegation gate's toolBefore and in `update_task_status`), after which the task can be repaired and a re-dispatch from a clean tree proceeds normally. With `hooks.delegation_gate: false` the self-heal runs only through `update_task_status`. Manually editing settlement JSON is not needed and still fails the WAL integrity check (`CODER_SETTLEMENT_WAL_UNREADABLE`) by design.
+- **Non-git projects fail cleanly instead of wedging.** Coder dispatches in projects without git remain allowed, but their settlement now aborts at completion with a `CODER_SETTLEMENT_ABORTED` advisory instead of hanging the task at DISPATCHED forever.
+- **Denied dispatches roll back.** When a fail-closed gate (full-auto, knowledge-enforce, skill-propagation) rejects a coder `Task` after the delegation gate already opened a settlement, the settlement WAL is rolled back to ABORTED so the task is not wedged despite the tool never running.
+- **Knowledge-disabled configurations finalize delegations again.** The tool-args snapshot used by `tool.execute.after` is now taken unconditionally. With `knowledge.enabled=false`, architect Task dispatches previously had no stored args at toolAfter, silently skipping coder settlement finalization, Stage B advancement, and gate-evidence recording.
+- **Settlement lifecycle is now observable.** `coder_settlement` events (`dispatched` / `settled` / `aborted`) are appended to `.swarm/events.jsonl`, so settlement progress can be diagnosed directly.
+
+### Migration
+
+No action required. Tasks previously stuck at DISPATCHED self-heal on first use after upgrading; re-dispatch coders from a clean (committed or stashed) workspace.
+
+### Known caveats
+
+- A workspace that is dirty at coder-dispatch time is now a hard dispatch error by design; attribution of same-path edits under a dirty baseline is provably impossible, and no bypass flag is offered.
+- Foreground background-flagged coder dispatches (`background: true` while background subagents are disabled) from a dirty root are now rejected at the same dispatch-time guard. True background dispatches (background subagents enabled) are unchanged: they fail at claim time with existing recovery handling, as before.

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -90,6 +90,8 @@ import type {
 import * as logger from '../utils/logger';
 import { isStrictTaskId } from '../validation/task-id';
 import {
+	abortCoderSettlement,
+	abortCoderSettlementIfDoomed,
 	beginCoderSettlement,
 	completeCoderSettlementCleanup,
 	recordCoderMergeProvenance,
@@ -2639,6 +2641,7 @@ export function createDelegationGateHook(
 	}) => Promise<void>;
 	sessionEnded: (sessionID: string, includeOwnedChildren?: boolean) => void;
 	backgroundCompletionClaimed: (record: BackgroundDelegationRecord) => void;
+	abortDeniedSettlementForCall: (callID: string) => Promise<void>;
 } {
 	// Initialize durable worktree merge-back status before any coders dispatch
 	initDurableStatusPath(directory);
@@ -2665,6 +2668,30 @@ export function createDelegationGateHook(
 		string,
 		BackgroundTaskChangeContext
 	>();
+	// Issue #2214: callID → the settlement this dispatch durably began. Used by
+	// (a) the toolBefore denial rollback when a LATER fail-closed hook rejects
+	// the Task call after the delegation gate already wrote the DISPATCHED WAL
+	// (no toolAfter will ever fire for a denied call), and (b) the toolAfter
+	// coder evidence block when resolveEvidenceTaskId cannot recover the task
+	// id the toolBefore scope preflight resolved. FIFO-capped like its siblings.
+	const begunCoderSettlementsByCallID = new Map<
+		string,
+		{ taskId: string | null; transitionId: string }
+	>();
+	const rememberBegunCoderSettlement = (
+		callID: string,
+		taskId: string | null,
+		transitionId: string,
+	): void => {
+		if (
+			!begunCoderSettlementsByCallID.has(callID) &&
+			begunCoderSettlementsByCallID.size >= MAX_PENDING_CODER_CHANGE_CONTEXTS
+		) {
+			const oldest = begunCoderSettlementsByCallID.keys().next().value;
+			if (oldest !== undefined) begunCoderSettlementsByCallID.delete(oldest);
+		}
+		begunCoderSettlementsByCallID.set(callID, { taskId, transitionId });
+	};
 	const backgroundCoderReservationByCallID = new Map<
 		string,
 		BackgroundCoderReservation
@@ -2898,6 +2925,24 @@ export function createDelegationGateHook(
 				`CODER_SETTLEMENT_CONTEXT_MISSING: no durable baseline or generation for task ${taskId}`,
 			);
 		}
+		// Issue #2214: a dirty launch baseline can never support mutation
+		// attribution — changedFilesSinceSnapshot fails closed for any
+		// pre-existing uncommitted/untracked path. Enforce the clean-baseline
+		// contract at dispatch time, BEFORE the coder runs and before the
+		// settlement WAL is written, so the dispatch fails fast with an
+		// actionable message instead of wedging the task at DISPATCHED after
+		// the coder's work is done.
+		const baselineDirtyFiles = Array.isArray(context.baseline.changedFiles)
+			? context.baseline.changedFiles
+			: [];
+		if (baselineDirtyFiles.length > 0) {
+			const sample = baselineDirtyFiles.slice(0, 5).join(', ');
+			throw new Error(
+				`CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED: ${String(baselineDirtyFiles.length)} uncommitted/untracked change(s) present at dispatch (${sample}${baselineDirtyFiles.length > 5 ? ', …' : ''}). ` +
+					'Commit or stash them before dispatching a coder — exact-task settlement cannot attribute coder mutations from a dirty launch baseline. ' +
+					`Task ${taskId} was not dispatched and no settlement state was created.`,
+			);
+		}
 		await beginCoderSettlement({
 			directory,
 			taskId,
@@ -2907,6 +2952,7 @@ export function createDelegationGateHook(
 			context,
 			...(worktree ? { worktree } : {}),
 		});
+		rememberBegunCoderSettlement(input.callID, taskId, `coder:${input.callID}`);
 	};
 	const shouldRememberCoderTaskChangeContext = (
 		_declaredFiles: string[] | null,
@@ -2918,6 +2964,7 @@ export function createDelegationGateHook(
 		const callID = record.callID;
 		clearPublishedScopeBindings(callID);
 		clearCoderTaskChangeContext(callID);
+		begunCoderSettlementsByCallID.delete(callID);
 		stageBDispatchGenerationsByCallID.delete(callID);
 		gateDispatchPrimaryTaskByCallID.delete(callID);
 		deleteStoredInputArgs(callID);
@@ -2956,6 +3003,8 @@ export function createDelegationGateHook(
 			taskMetadata,
 			sessionEnded,
 			backgroundCompletionClaimed,
+			// Disabled gate never begins a settlement; nothing to roll back.
+			abortDeniedSettlementForCall: async (): Promise<void> => {},
 		};
 	}
 
@@ -4707,13 +4756,28 @@ export function createDelegationGateHook(
 				// re-throw unexpected errors (EPERM, EBUSY on Windows) which previously
 				// escaped outside the evidence try-catch and propagated to safeHook.
 				if (typeof subagentType === 'string') {
+					let coderSettleTaskId: string | null = null;
 					try {
 						const mergedArgs = { ...(storedArgs ?? {}), ...directArgs };
-						const evidenceTaskId = await resolveEvidenceTaskId(
+						let evidenceTaskId = await resolveEvidenceTaskId(
 							mergedArgs,
 							session,
 							directory,
 						);
+						// Issue #2214 belt: the toolBefore scope preflight may have
+						// resolved the task via sources resolveEvidenceTaskId lacks
+						// (e.g. the declare_scope pending-scope map). For a coder
+						// dispatch whose settlement this call durably began, trust the
+						// begun-settlement record instead of silently skipping
+						// finalization — a skipped settle wedges the DISPATCHED WAL.
+						if (
+							!evidenceTaskId &&
+							stripKnownSwarmPrefix(subagentType) === 'coder'
+						) {
+							const begun = begunCoderSettlementsByCallID.get(input.callID);
+							if (begun?.taskId) evidenceTaskId = begun.taskId;
+						}
+						coderSettleTaskId = evidenceTaskId;
 						if (evidenceTaskId) {
 							const turbo = hasActiveTurboMode(input.sessionID);
 							const gateAgents = [
@@ -4870,10 +4934,51 @@ export function createDelegationGateHook(
 							`[delegation-gate] evidence recording failed: ${err instanceof Error ? err.message : String(err)}`,
 						);
 						if (normalizedAgent === 'coder') {
-							pushAdvisory(
-								session,
-								`CODER_SETTLEMENT_DURABILITY_FAILURE: task output remains fenced until accepted-mutation evidence for call ${input.callID} is recovered.`,
-							);
+							// Issue #2214: a coder settle failure that never reached
+							// settleCoderDispatch leaves the DISPATCHED WAL with its
+							// in-memory ownership key retained — same-process recovery
+							// would throw CODER_DISPATCH_IN_PROGRESS forever. Release the
+							// key (idempotent) so recoverCoderSettlement can retry, and
+							// abort the WAL outright when its recorded launch baseline
+							// was structurally attribution-doomed (non-git or dirty at
+							// dispatch) — that settlement can never complete.
+							let abortedAsDoomed = false;
+							if (coderSettleTaskId && !coderSettlementCommitted) {
+								releaseCoderDispatchOwnership(
+									directory,
+									coderSettleTaskId,
+									`coder:${input.callID}`,
+								);
+								try {
+									abortedAsDoomed = await abortCoderSettlementIfDoomed({
+										directory,
+										taskId: coderSettleTaskId,
+										transitionId: `coder:${input.callID}`,
+									});
+								} catch (abortErr) {
+									logger.warn(
+										`[delegation-gate] doomed settlement abort failed for ${coderSettleTaskId}: ${
+											abortErr instanceof Error
+												? abortErr.message
+												: String(abortErr)
+										}`,
+									);
+								}
+								if (abortedAsDoomed) {
+									begunCoderSettlementsByCallID.delete(input.callID);
+								}
+							}
+							if (abortedAsDoomed) {
+								pushAdvisory(
+									session,
+									`CODER_SETTLEMENT_ABORTED: task ${coderSettleTaskId} dispatch ${input.callID} was settled as ABORTED — its launch baseline was dirty or had no git history, so the coder's changes cannot be attributed. Reconcile the workspace (commit, stash, or discard the coder's output), then repair the task with update_task_status and re-dispatch from a clean tree.`,
+								);
+							} else {
+								pushAdvisory(
+									session,
+									`CODER_SETTLEMENT_DURABILITY_FAILURE: task output remains fenced until accepted-mutation evidence for call ${input.callID} is recovered.`,
+								);
+							}
 							throw err;
 						}
 					} finally {
@@ -4883,6 +4988,7 @@ export function createDelegationGateHook(
 						) {
 							clearCoderTaskChangeContext(input.callID);
 							clearPublishedScopeBindings(input.callID);
+							begunCoderSettlementsByCallID.delete(input.callID);
 						}
 					}
 				}
@@ -5374,5 +5480,37 @@ ${warningLines.join('\n')}`;
 		taskMetadata,
 		sessionEnded,
 		backgroundCompletionClaimed,
+		/**
+		 * Issue #2214: roll back a settlement this call durably began when a
+		 * LATER fail-closed hook denies the Task call (the delegation gate runs
+		 * at step 4; full-auto/knowledge/skill gates at steps 5-8 can still
+		 * throw). A denied call never fires toolAfter, so without this rollback
+		 * the DISPATCHED WAL and its in-memory ownership key wedge the task
+		 * until a process restart. Never throws — the denial itself propagates.
+		 */
+		abortDeniedSettlementForCall: async (callID: string): Promise<void> => {
+			const begun = begunCoderSettlementsByCallID.get(callID);
+			if (!begun?.taskId) return;
+			try {
+				const outcome = await abortCoderSettlement({
+					directory,
+					taskId: begun.taskId,
+					transitionId: begun.transitionId,
+					reason:
+						'dispatch denied by a fail-closed gate after settlement began',
+				});
+				if (outcome === 'aborted' || outcome === 'already-aborted') {
+					begunCoderSettlementsByCallID.delete(callID);
+					clearCoderTaskChangeContext(callID);
+					clearPublishedScopeBindings(callID);
+				}
+			} catch (error) {
+				logger.warn(
+					`[delegation-gate] denied-dispatch settlement rollback failed for call ${callID}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+		},
 	};
 }

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -2687,8 +2687,12 @@ export function createDelegationGateHook(
 			!begunCoderSettlementsByCallID.has(callID) &&
 			begunCoderSettlementsByCallID.size >= MAX_PENDING_CODER_CHANGE_CONTEXTS
 		) {
-			const oldest = begunCoderSettlementsByCallID.keys().next().value;
-			if (oldest !== undefined) begunCoderSettlementsByCallID.delete(oldest);
+			// Fail closed like the sibling callID maps (PRR-002): silent FIFO
+			// eviction here would drop a denial-rollback entry and could
+			// re-introduce the #2214 DISPATCHED wedge under load.
+			throw new Error(
+				`BEGUN_SETTLEMENT_CONTEXT_CAPACITY: refusing coder dispatch because ${MAX_PENDING_CODER_CHANGE_CONTEXTS} live begun settlements are already tracked`,
+			);
 		}
 		begunCoderSettlementsByCallID.set(callID, { taskId, transitionId });
 	};
@@ -4942,7 +4946,7 @@ export function createDelegationGateHook(
 							// abort the WAL outright when its recorded launch baseline
 							// was structurally attribution-doomed (non-git or dirty at
 							// dispatch) — that settlement can never complete.
-							let abortedAsDoomed = false;
+							let terminalAbort = false;
 							if (coderSettleTaskId && !coderSettlementCommitted) {
 								releaseCoderDispatchOwnership(
 									directory,
@@ -4950,11 +4954,14 @@ export function createDelegationGateHook(
 									`coder:${input.callID}`,
 								);
 								try {
-									abortedAsDoomed = await abortCoderSettlementIfDoomed({
+									const abortOutcome = await abortCoderSettlementIfDoomed({
 										directory,
 										taskId: coderSettleTaskId,
 										transitionId: `coder:${input.callID}`,
 									});
+									terminalAbort =
+										abortOutcome === 'aborted' ||
+										abortOutcome === 'already-aborted';
 								} catch (abortErr) {
 									logger.warn(
 										`[delegation-gate] doomed settlement abort failed for ${coderSettleTaskId}: ${
@@ -4964,11 +4971,13 @@ export function createDelegationGateHook(
 										}`,
 									);
 								}
-								if (abortedAsDoomed) {
-									begunCoderSettlementsByCallID.delete(input.callID);
+								if (terminalAbort) {
+									// PRR-001: the dispatch is terminally settled; its
+									// change context is exhausted (recovery reads the WAL).
+									clearCoderTaskChangeContext(input.callID);
 								}
 							}
-							if (abortedAsDoomed) {
+							if (terminalAbort) {
 								pushAdvisory(
 									session,
 									`CODER_SETTLEMENT_ABORTED: task ${coderSettleTaskId} dispatch ${input.callID} was settled as ABORTED — its launch baseline was dirty or had no git history, so the coder's changes cannot be attributed. Reconcile the workspace (commit, stash, or discard the coder's output), then repair the task with update_task_status and re-dispatch from a clean tree.`,
@@ -4982,13 +4991,25 @@ export function createDelegationGateHook(
 							throw err;
 						}
 					} finally {
-						if (
-							stripKnownSwarmPrefix(subagentType) === 'coder' &&
-							coderSettlementCommitted
-						) {
-							clearCoderTaskChangeContext(input.callID);
-							clearPublishedScopeBindings(input.callID);
+						if (stripKnownSwarmPrefix(subagentType) === 'coder') {
+							if (coderSettlementCommitted) {
+								clearCoderTaskChangeContext(input.callID);
+								clearPublishedScopeBindings(input.callID);
+							}
+							// PRR-001: both purposes of the begun-settlement entry —
+							// denial rollback (a denied call never reaches toolAfter)
+							// and the task-id fallback above — are exhausted once
+							// toolAfter has run for this callID.
 							begunCoderSettlementsByCallID.delete(input.callID);
+							// The coder settle failure above RETHROWS, so the post-block
+							// cleanup (stored args, Stage B generation bindings) never
+							// runs on that path — drain it here instead. Idempotent
+							// with the success-path deletes below.
+							if (!coderSettlementCommitted) {
+								stageBDispatchGenerationsByCallID.delete(input.callID);
+								gateDispatchPrimaryTaskByCallID.delete(input.callID);
+								deleteStoredInputArgs(input.callID);
+							}
 						}
 					}
 				}
@@ -5487,29 +5508,46 @@ ${warningLines.join('\n')}`;
 		 * throw). A denied call never fires toolAfter, so without this rollback
 		 * the DISPATCHED WAL and its in-memory ownership key wedge the task
 		 * until a process restart. Never throws — the denial itself propagates.
+		 *
+		 * F-002 (PR #2223 review): cleanup runs in a FINALLY so every failure
+		 * class (settlement-lock contention, WAL_MISSING/REPLACED/UNREADABLE,
+		 * write errors) still releases the in-memory ownership key and the
+		 * callID bookkeeping — an abort that throws must not leave a louder
+		 * in-process CODER_DISPATCH_IN_PROGRESS wedge behind.
 		 */
 		abortDeniedSettlementForCall: async (callID: string): Promise<void> => {
 			const begun = begunCoderSettlementsByCallID.get(callID);
 			if (!begun?.taskId) return;
 			try {
-				const outcome = await abortCoderSettlement({
+				await abortCoderSettlement({
 					directory,
 					taskId: begun.taskId,
 					transitionId: begun.transitionId,
 					reason:
 						'dispatch denied by a fail-closed gate after settlement began',
 				});
-				if (outcome === 'aborted' || outcome === 'already-aborted') {
-					begunCoderSettlementsByCallID.delete(callID);
-					clearCoderTaskChangeContext(callID);
-					clearPublishedScopeBindings(callID);
-				}
 			} catch (error) {
-				logger.warn(
-					`[delegation-gate] denied-dispatch settlement rollback failed for call ${callID}: ${
+				logger.criticalWarn(
+					`[delegation-gate] denied-dispatch settlement rollback failed for call ${callID} (task ${begun.taskId}): ${
 						error instanceof Error ? error.message : String(error)
 					}`,
 				);
+			} finally {
+				// Unconditional (idempotent) cleanup, mirroring
+				// backgroundCompletionClaimed: a denied call never reaches the
+				// toolAfter cleanup path, so this is the only drain for these
+				// entries.
+				releaseCoderDispatchOwnership(
+					directory,
+					begun.taskId,
+					begun.transitionId,
+				);
+				begunCoderSettlementsByCallID.delete(callID);
+				clearCoderTaskChangeContext(callID);
+				clearPublishedScopeBindings(callID);
+				stageBDispatchGenerationsByCallID.delete(callID);
+				gateDispatchPrimaryTaskByCallID.delete(callID);
+				deleteStoredInputArgs(callID);
 			}
 		},
 	};

--- a/src/hooks/guardrails/execution-stall.ts
+++ b/src/hooks/guardrails/execution-stall.ts
@@ -190,14 +190,17 @@ const stallStates = new Map<string, ExecutionStallState>();
 /**
  * callID → canonical role of the `Task` dispatch observed in `toolBefore`.
  *
- * This exists because `setStoredInputArgs` sits BELOW `if (!resolved) return;`
- * in `tool-before.ts`, and the architect is exactly the `resolved === null`
- * case. So for the session this lever targets, `getStoredInputArgs(callID)` is
- * always empty in `toolAfter` and the SDK's `toolAfter` input carries no
- * `args`. Recording the role at dispatch time is what makes "a coder
- * completion resets the counter, an explorer completion does not" observable
- * at all — without it, EVERY completion would look role-less and the hard rung
- * could fire on a session that is legitimately delegating.
+ * Historical rationale (pre-issue-#2214): guardrails' `setStoredInputArgs`
+ * sits BELOW `if (!resolved) return;` in `tool-before.ts`, and the architect
+ * is exactly the `resolved === null` case, so `getStoredInputArgs(callID)`
+ * was always empty in `toolAfter` for architect sessions. Since #2214 the
+ * main index.ts toolBefore chain stores the final args snapshot
+ * UNCONDITIONALLY, so stored args ARE present now — but `pendingDispatchRoles`
+ * remains the correct mechanism here: it records the role at dispatch time
+ * from the SDK-provided `output.args` directly, independent of any later
+ * snapshot timing or config gating. Keeping "a coder completion resets the
+ * counter, an explorer completion does not" observable must not depend on the
+ * stored-args side channel.
  */
 const pendingDispatchRoles = new Map<string, string>();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3068,6 +3068,17 @@ async function initializeOpenCodeSwarm(
 				// (steps 5-8) rejected it, roll the DISPATCHED WAL back to
 				// ABORTED so the task is not wedged until a process restart.
 				// Never throws — the original denial propagates unchanged.
+				//
+				// INVARIANT (PR #2223 review, advisory): rollback ELIGIBILITY reuses
+				// `failClosedRegionCompleted`, so this block only fires when the
+				// denial came from the fail-closed region. That is correct today
+				// because no uncaught await exists in the advisory tail below the
+				// flag set (verified empirically by review fault injection). Any
+				// future raw-awaited call added to that tail must either set the
+				// flag first or throw only after this rollback — otherwise an
+				// advisory-tail throw would reject the call WITHOUT rolling back a
+				// begun settlement, reopening the #2214 wedge class. The
+				// gate-denial-wiring static guard pins this contract.
 				if (
 					!failClosedRegionCompleted &&
 					(normalizeToolName(input.tool) === 'Task' ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -2926,14 +2926,18 @@ async function initializeOpenCodeSwarm(
 						},
 						knowledgeConfig,
 					);
-					// (#1849) Re-snapshot output.args AFTER directive injection so the
-					// tool.execute.after ack collector recovers the FINAL prompt (with
-					// the <delegate_knowledge_directives> block + trace_id). The guardrails
-					// snapshot at step 1 captured the PRE-injection args; without this
-					// re-snapshot the after path could not find the directive block and the
-					// entire delegate-ack reconciliation would be dark in production.
-					setStoredInputArgs(input.callID, output.args);
 				}
+				// (#1849) Re-snapshot output.args after (optional) directive injection
+				// so tool.execute.after consumers recover the FINAL args. This store is
+				// UNCONDITIONAL (issue #2214): the SDK toolAfter input carries no args,
+				// guardrails' snapshot sits below its `if (!resolved) return` early-out
+				// and therefore never runs for the architect session, and this line is
+				// the only production store site for architect Task dispatches. Gating
+				// it on knowledgeConfig.enabled left subagent_type unresolvable in
+				// toolAfter when knowledge is disabled, silently skipping coder
+				// settlement finalization, Stage B advancement, and gate-evidence
+				// recording for every architect delegation.
+				setStoredInputArgs(input.callID, output.args);
 
 				// v6.29: One-time 50% context pressure warning
 				const pressurePct = getSessionBudgetPct(input.sessionID);
@@ -3057,6 +3061,25 @@ async function initializeOpenCodeSwarm(
 						},
 						deniedArgs,
 					);
+				}
+				// Issue #2214: a denied Task call never fires toolAfter. If the
+				// delegation gate (step 4) already durably began a coder
+				// settlement for this callID before a later fail-closed gate
+				// (steps 5-8) rejected it, roll the DISPATCHED WAL back to
+				// ABORTED so the task is not wedged until a process restart.
+				// Never throws — the original denial propagates unchanged.
+				if (
+					!failClosedRegionCompleted &&
+					(normalizeToolName(input.tool) === 'Task' ||
+						normalizeToolName(input.tool) === 'task')
+				) {
+					try {
+						await delegationGateHooks.abortDeniedSettlementForCall(
+							input.callID,
+						);
+					} catch {
+						/* rollback is best-effort; the denial still propagates */
+					}
 				}
 				throw err;
 			}

--- a/src/workflow/coder-settlement.ts
+++ b/src/workflow/coder-settlement.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { appendFile } from 'node:fs/promises';
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import type {
 	BackgroundTaskChangeContext,
 	BackgroundWorktreeDescriptor,
@@ -98,6 +99,10 @@ async function writeWal(
  * settlement dispatch/settle/abort must be observable in events.jsonl). Never
  * throws — the WAL and evidence files remain the authoritative state; this is
  * the human-readable trail, matching the plan-critic audit-event precedent.
+ * The parent directory is created (future call sites may append before any WAL
+ * write) and a transient Windows EBUSY/EPERM gets one retry (PRR-003). Final
+ * failure surfaces via criticalWarn — always visible, not debug-gated — because
+ * a silently missing lifecycle event voids the observability claim.
  */
 async function appendSettlementEvent(
 	directory: string,
@@ -105,23 +110,38 @@ async function appendSettlementEvent(
 	wal: Pick<CoderSettlementWal, 'taskId' | 'transitionId' | 'actor'>,
 	extra?: Record<string, unknown>,
 ): Promise<void> {
+	const line = `${JSON.stringify({
+		type: 'coder_settlement',
+		action,
+		timestamp: new Date().toISOString(),
+		taskId: wal.taskId,
+		transitionId: wal.transitionId,
+		actor: wal.actor,
+		...(extra ?? {}),
+	})}\n`;
 	try {
 		const eventsPath = validateSwarmPath(directory, 'events.jsonl');
-		await appendFile(
-			eventsPath,
-			`${JSON.stringify({
-				type: 'coder_settlement',
-				action,
-				timestamp: new Date().toISOString(),
-				taskId: wal.taskId,
-				transitionId: wal.transitionId,
-				actor: wal.actor,
-				...(extra ?? {}),
-			})}\n`,
-			'utf-8',
-		);
+		await mkdir(dirname(eventsPath), { recursive: true });
+		await appendFile(eventsPath, line, 'utf-8');
 	} catch (error) {
-		logger.warn(
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === 'EBUSY' || code === 'EPERM') {
+			try {
+				const eventsPath = validateSwarmPath(directory, 'events.jsonl');
+				await appendFile(eventsPath, line, 'utf-8');
+				return;
+			} catch (retryError) {
+				logger.criticalWarn(
+					`[coder-settlement] lifecycle event write failed after retry (${action} ${wal.taskId}): ${
+						retryError instanceof Error
+							? retryError.message
+							: String(retryError)
+					}`,
+				);
+				return;
+			}
+		}
+		logger.criticalWarn(
 			`[coder-settlement] lifecycle event write failed (${action} ${wal.taskId}): ${
 				error instanceof Error ? error.message : String(error)
 			}`,
@@ -457,7 +477,7 @@ export async function abortCoderSettlement(options: {
 	transitionId: string;
 	reason: string;
 }): Promise<'aborted' | 'not-dispatched' | 'already-aborted'> {
-	return withSettlementLock(
+	const { outcome, worktree } = await withSettlementLock(
 		options.directory,
 		options.taskId,
 		'coder-abort',
@@ -469,6 +489,28 @@ export async function abortCoderSettlement(options: {
 				options.reason,
 			),
 	);
+	// F-001 (PR #2223 review): an aborted worktree-carrying settlement must
+	// not leak its git worktree and branch. recoverCoderSettlement
+	// short-circuits on ABORTED before the worktree merge/cleanup branch, so
+	// the abort path owns terminal cleanup. completeCoderSettlementCleanup
+	// runs under its own lock acquisition — we are post-lock here — and is
+	// best-effort: a cleanup failure must never un-abort the settlement.
+	if (worktree && outcome !== 'not-dispatched') {
+		try {
+			await completeCoderSettlementCleanup(
+				options.directory,
+				options.taskId,
+				options.transitionId,
+			);
+		} catch (error) {
+			logger.criticalWarn(
+				`[coder-settlement] aborted settlement worktree cleanup failed for task ${options.taskId}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
+	}
+	return outcome;
 }
 
 async function abortDispatchedWalUnderLock(
@@ -476,7 +518,10 @@ async function abortDispatchedWalUnderLock(
 	taskId: string,
 	transitionId: string,
 	reason: string,
-): Promise<'aborted' | 'not-dispatched' | 'already-aborted'> {
+): Promise<{
+	outcome: 'aborted' | 'not-dispatched' | 'already-aborted';
+	worktree: boolean;
+}> {
 	const filePath = walPath(directory, taskId);
 	// readWal validates the taskId (expectedTaskId) and throws the shared
 	// WAL_UNREADABLE/TASK_MISMATCH diagnostics on malformed content.
@@ -485,8 +530,12 @@ async function abortDispatchedWalUnderLock(
 	if (wal.transitionId !== transitionId) {
 		throw new Error('CODER_SETTLEMENT_WAL_REPLACED');
 	}
-	if (wal.state === 'ABORTED') return 'already-aborted';
-	if (wal.state !== 'DISPATCHED') return 'not-dispatched';
+	if (wal.state === 'ABORTED') {
+		return { outcome: 'already-aborted', worktree: wal.worktree !== undefined };
+	}
+	if (wal.state !== 'DISPATCHED') {
+		return { outcome: 'not-dispatched', worktree: false };
+	}
 	await writeWal(filePath, {
 		...wal,
 		state: 'ABORTED',
@@ -494,40 +543,49 @@ async function abortDispatchedWalUnderLock(
 	});
 	liveDispatches.delete(dispatchKey(directory, taskId, transitionId));
 	await appendSettlementEvent(directory, 'aborted', wal, { reason });
-	return 'aborted';
+	return { outcome: 'aborted', worktree: wal.worktree !== undefined };
 }
 
 /**
  * Abort a DISPATCHED settlement only when its own recorded launch baseline
  * was structurally attribution-doomed (non-git or dirty at dispatch — the
  * pre-fix #2214 wedge class). Transient capture failures (gitHead present)
- * stay recoverable and are NOT aborted.
+ * stay recoverable and are NOT aborted. Returns the terminal outcome so
+ * callers can distinguish a fresh abort, an already-terminal settlement, and
+ * a WAL that must stay recoverable (PRR-009: the already-aborted case is
+ * terminal, not a durability failure).
  */
 export async function abortCoderSettlementIfDoomed(options: {
 	directory: string;
 	taskId: string;
 	transitionId: string;
-}): Promise<boolean> {
+}): Promise<'aborted' | 'already-aborted' | 'not-doomed'> {
 	const filePath = walPath(options.directory, options.taskId);
 	let wal: CoderSettlementWal | null;
 	try {
 		wal = await readWal(filePath, options.taskId);
 	} catch {
 		// Unreadable WAL: cannot determine doomed-ness; leave it to recovery.
-		return false;
+		return 'not-doomed';
 	}
-	if (wal === null) return false;
+	if (wal === null) return 'not-doomed';
+	if (wal.state === 'ABORTED') return 'already-aborted';
 	if (wal.transitionId !== options.transitionId || wal.state !== 'DISPATCHED') {
-		return false;
+		return 'not-doomed';
 	}
-	if (!baselineAttributionDoomed(wal.context.baseline)) return false;
+	if (!baselineAttributionDoomed(wal.context.baseline)) return 'not-doomed';
 	const outcome = await abortCoderSettlement({
 		directory: options.directory,
 		taskId: options.taskId,
 		transitionId: options.transitionId,
 		reason: doomedReason(wal.context.baseline),
 	});
-	return outcome === 'aborted' || outcome === 'already-aborted';
+	// We re-verified state === 'DISPATCHED' above; a concurrent change can only
+	// have come from this same locked flow, so not-dispatched is unreachable
+	// here — map any residual case to not-doomed so callers stay recoverable.
+	return outcome === 'aborted' || outcome === 'already-aborted'
+		? outcome
+		: 'not-doomed';
 }
 
 export async function recordCoderMergeProvenance(options: {
@@ -648,7 +706,7 @@ export async function completeCoderSettlementCleanup(
 		if (wal.taskId !== taskId || wal.transitionId !== transitionId) {
 			throw new Error('CODER_SETTLEMENT_WAL_REPLACED');
 		}
-		if (wal.state !== 'COMMITTED') {
+		if (wal.state !== 'COMMITTED' && wal.state !== 'ABORTED') {
 			throw new Error('CODER_SETTLEMENT_NOT_COMMITTED');
 		}
 		if (!wal.worktree || wal.cleanupComplete === true) return;
@@ -834,13 +892,23 @@ export async function recoverCoderSettlement(
 			if (rawObserved === null) {
 				if (baselineAttributionDoomed(wal.context.baseline)) {
 					// recoverCoderSettlement already holds the settlement lock.
+					// Positional invariant (F-001 review): this doomed-abort is
+					// reachable only for NON-worktree WALs — every worktree-carrying
+					// DISPATCHED WAL was consumed by the `if (wal.worktree)` branch
+					// above, which fails closed with CODER_SETTLEMENT_RECOVERY_UNCERTAIN
+					// for a doomed baseline. So aborted.worktree is always false here
+					// and no worktree cleanup is needed on this path; the
+					// abortCoderSettlement entry point owns worktree cleanup.
 					const aborted = await abortDispatchedWalUnderLock(
 						directory,
 						taskId,
 						wal.transitionId,
 						doomedReason(wal.context.baseline),
 					);
-					if (aborted === 'aborted' || aborted === 'already-aborted') {
+					if (
+						aborted.outcome === 'aborted' ||
+						aborted.outcome === 'already-aborted'
+					) {
 						return null;
 					}
 				}

--- a/src/workflow/coder-settlement.ts
+++ b/src/workflow/coder-settlement.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
+import { appendFile } from 'node:fs/promises';
 import type {
 	BackgroundTaskChangeContext,
 	BackgroundWorktreeDescriptor,
@@ -15,6 +16,7 @@ import { isMarkdownOnlyTaskChange } from '../gate-evidence-classification.js';
 import { validateSwarmPath } from '../hooks/utils.js';
 import { tryAcquireLock } from '../parallel/file-locks.js';
 import { isPathWithinDeclaredScope } from '../scope/path-identity.js';
+import * as logger from '../utils/logger.js';
 import type { MergeOperationProvenance } from '../worktree/merge.js';
 import { reconcileLandedMerge } from '../worktree/merge.js';
 import {
@@ -91,6 +93,69 @@ async function writeWal(
 	await writeWorkflowWalFile('coder-settlement', filePath, wal);
 }
 
+/**
+ * Best-effort settlement lifecycle audit event (issue #2214 expected behavior:
+ * settlement dispatch/settle/abort must be observable in events.jsonl). Never
+ * throws — the WAL and evidence files remain the authoritative state; this is
+ * the human-readable trail, matching the plan-critic audit-event precedent.
+ */
+async function appendSettlementEvent(
+	directory: string,
+	action: 'dispatched' | 'settled' | 'aborted',
+	wal: Pick<CoderSettlementWal, 'taskId' | 'transitionId' | 'actor'>,
+	extra?: Record<string, unknown>,
+): Promise<void> {
+	try {
+		const eventsPath = validateSwarmPath(directory, 'events.jsonl');
+		await appendFile(
+			eventsPath,
+			`${JSON.stringify({
+				type: 'coder_settlement',
+				action,
+				timestamp: new Date().toISOString(),
+				taskId: wal.taskId,
+				transitionId: wal.transitionId,
+				actor: wal.actor,
+				...(extra ?? {}),
+			})}\n`,
+			'utf-8',
+		);
+	} catch (error) {
+		logger.warn(
+			`[coder-settlement] lifecycle event write failed (${action} ${wal.taskId}): ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+}
+
+/**
+ * True when a launch baseline can never support mutation attribution, no
+ * matter how many recovery attempts run: a non-git baseline (gitHead null) or
+ * a baseline that was already dirty at dispatch (pre-existing uncommitted or
+ * untracked paths). `changedFiles === null` with a gitHead present is a
+ * capture failure, which may be transient — it is deliberately NOT doomed
+ * (issue #2214: distinguish structural failure from retryable failure).
+ */
+function baselineAttributionDoomed(baseline: {
+	gitHead: string | null;
+	changedFiles?: string[] | null;
+}): boolean {
+	if (baseline.gitHead === null) return true;
+	return (
+		Array.isArray(baseline.changedFiles) && baseline.changedFiles.length > 0
+	);
+}
+
+function doomedReason(baseline: {
+	gitHead: string | null;
+	changedFiles?: string[] | null;
+}): string {
+	if (baseline.gitHead === null)
+		return 'launch workspace has no git baseline (not a git repository, or git unavailable at dispatch)';
+	return `launch baseline was dirty with ${String(baseline.changedFiles?.length ?? 0)} pre-existing uncommitted/untracked change(s)`;
+}
+
 function isProcessAlive(processId: number): boolean {
 	if (processId === process.pid) return true;
 	try {
@@ -152,6 +217,9 @@ async function commitPrepared(
 						cleanupComplete: lockedWal.worktree === undefined,
 					};
 					await writeWal(walPath(directory, wal.taskId), lockedWal);
+					await appendSettlementEvent(directory, 'settled', lockedWal, {
+						resumed: true,
+					});
 				}
 				return {
 					evidence: transaction.read() as TaskEvidence,
@@ -187,6 +255,7 @@ async function commitPrepared(
 				cleanupComplete: lockedWal.worktree === undefined,
 			};
 			await writeWal(walPath(directory, wal.taskId), lockedWal);
+			await appendSettlementEvent(directory, 'settled', lockedWal);
 			return {
 				evidence,
 				accepted: lockedWal.accepted === true,
@@ -278,6 +347,11 @@ export async function beginCoderSettlement(options: {
 						recordedAt: new Date().toISOString(),
 					});
 					ownsActiveDispatch = true;
+					await appendSettlementEvent(options.directory, 'dispatched', {
+						taskId: options.taskId,
+						transitionId: options.transitionId,
+						actor: options.actor,
+					});
 				},
 			),
 	);
@@ -365,6 +439,95 @@ export async function settleCoderDispatch(options: {
 			}
 		},
 	);
+}
+
+/**
+ * Abort a DISPATCHED settlement (issue #2214): the settlement's launch
+ * baseline can never support attribution, so the dispatch must reach a
+ * terminal state instead of wedging at DISPATCHED with an un-releasable
+ * in-memory ownership key. Idempotent: an already-ABORTED WAL is a no-op;
+ * PREPARED/COMMITTED WALs are recoverable/terminal and are left untouched.
+ *
+ * Callers already holding the settlement lock must use
+ * `abortDispatchedWalUnderLock` instead — this entry point acquires the lock.
+ */
+export async function abortCoderSettlement(options: {
+	directory: string;
+	taskId: string;
+	transitionId: string;
+	reason: string;
+}): Promise<'aborted' | 'not-dispatched' | 'already-aborted'> {
+	return withSettlementLock(
+		options.directory,
+		options.taskId,
+		'coder-abort',
+		async () =>
+			abortDispatchedWalUnderLock(
+				options.directory,
+				options.taskId,
+				options.transitionId,
+				options.reason,
+			),
+	);
+}
+
+async function abortDispatchedWalUnderLock(
+	directory: string,
+	taskId: string,
+	transitionId: string,
+	reason: string,
+): Promise<'aborted' | 'not-dispatched' | 'already-aborted'> {
+	const filePath = walPath(directory, taskId);
+	// readWal validates the taskId (expectedTaskId) and throws the shared
+	// WAL_UNREADABLE/TASK_MISMATCH diagnostics on malformed content.
+	const wal = await readWal(filePath, taskId);
+	if (wal === null) throw new Error('CODER_SETTLEMENT_WAL_MISSING');
+	if (wal.transitionId !== transitionId) {
+		throw new Error('CODER_SETTLEMENT_WAL_REPLACED');
+	}
+	if (wal.state === 'ABORTED') return 'already-aborted';
+	if (wal.state !== 'DISPATCHED') return 'not-dispatched';
+	await writeWal(filePath, {
+		...wal,
+		state: 'ABORTED',
+		abortReason: reason,
+	});
+	liveDispatches.delete(dispatchKey(directory, taskId, transitionId));
+	await appendSettlementEvent(directory, 'aborted', wal, { reason });
+	return 'aborted';
+}
+
+/**
+ * Abort a DISPATCHED settlement only when its own recorded launch baseline
+ * was structurally attribution-doomed (non-git or dirty at dispatch — the
+ * pre-fix #2214 wedge class). Transient capture failures (gitHead present)
+ * stay recoverable and are NOT aborted.
+ */
+export async function abortCoderSettlementIfDoomed(options: {
+	directory: string;
+	taskId: string;
+	transitionId: string;
+}): Promise<boolean> {
+	const filePath = walPath(options.directory, options.taskId);
+	let wal: CoderSettlementWal | null;
+	try {
+		wal = await readWal(filePath, options.taskId);
+	} catch {
+		// Unreadable WAL: cannot determine doomed-ness; leave it to recovery.
+		return false;
+	}
+	if (wal === null) return false;
+	if (wal.transitionId !== options.transitionId || wal.state !== 'DISPATCHED') {
+		return false;
+	}
+	if (!baselineAttributionDoomed(wal.context.baseline)) return false;
+	const outcome = await abortCoderSettlement({
+		directory: options.directory,
+		taskId: options.taskId,
+		transitionId: options.transitionId,
+		reason: doomedReason(wal.context.baseline),
+	});
+	return outcome === 'aborted' || outcome === 'already-aborted';
 }
 
 export async function recordCoderMergeProvenance(options: {
@@ -656,7 +819,43 @@ export async function recoverCoderSettlement(
 				return recovered;
 			}
 
-			const observed = scopedObservedFiles(directory, wal.context);
+			// Mirror the shared-root settle semantics: a dispatch with no declared
+			// scope settles as no-mutation (observed = []) rather than wedging on
+			// scopedObservedFiles' declaredFiles requirement. A structurally
+			// doomed baseline (non-git or dirty at dispatch — the pre-#2214-fix
+			// wedge class) can never be attributed: abort so the task becomes
+			// repairable instead of throwing RECOVERY_UNCERTAIN forever. A clean
+			// baseline whose current capture fails stays retryable.
+			const rawObserved = changedFilesSinceSnapshot(
+				directory,
+				wal.context.baseline,
+			);
+			let observed: string[] | null;
+			if (rawObserved === null) {
+				if (baselineAttributionDoomed(wal.context.baseline)) {
+					// recoverCoderSettlement already holds the settlement lock.
+					const aborted = await abortDispatchedWalUnderLock(
+						directory,
+						taskId,
+						wal.transitionId,
+						doomedReason(wal.context.baseline),
+					);
+					if (aborted === 'aborted' || aborted === 'already-aborted') {
+						return null;
+					}
+				}
+				observed = null;
+			} else if (wal.context.declaredFiles === null) {
+				observed = [];
+			} else {
+				observed = rawObserved.filter((filePath) =>
+					isPathWithinDeclaredScope(
+						filePath,
+						wal.context.declaredFiles ?? [],
+						directory,
+					),
+				);
+			}
 			if (observed === null) {
 				// #2202: still bare — names the task but not the WAL path or a recovery
 				// action. Reaching it needs a baseline snapshot changedFilesSinceSnapshot

--- a/src/workflow/workflow-wal-schema.ts
+++ b/src/workflow/workflow-wal-schema.ts
@@ -35,6 +35,8 @@ export interface CoderSettlementWal {
 	testEngineerExempt?: boolean;
 	settlementFailed?: boolean;
 	cleanupComplete?: boolean;
+	/** Human-readable abort explanation; string of 1..512 chars, present on ABORTED WALs (issue #2214). */
+	abortReason?: string;
 	recordedAt: string;
 }
 
@@ -308,7 +310,11 @@ export function parseCoderSettlementWal(
 		(parsed.cleanupComplete !== undefined &&
 			typeof parsed.cleanupComplete !== 'boolean') ||
 		(parsed.settlementFailed !== undefined &&
-			typeof parsed.settlementFailed !== 'boolean')
+			typeof parsed.settlementFailed !== 'boolean') ||
+		(parsed.abortReason !== undefined &&
+			(typeof parsed.abortReason !== 'string' ||
+				parsed.abortReason.length === 0 ||
+				parsed.abortReason.length > 512))
 	) {
 		formatUnreadableMessage(
 			'CODER_SETTLEMENT_WAL_UNREADABLE',

--- a/tests/unit/hooks/gate-denial-wiring.test.ts
+++ b/tests/unit/hooks/gate-denial-wiring.test.ts
@@ -127,4 +127,33 @@ describe('gate-denial tracker wiring in src/index.ts', () => {
 			/import \{[^}]*recordDeniedToolCall[^}]*\} from '\.\/hooks\/trajectory-logger';/s,
 		);
 	});
+
+	// Issue #2214 denial rollback (F-003, PR #2223 review): a denied Task call
+	// never fires toolAfter, so the catch must roll back any settlement the
+	// delegation gate durably began. These assertions pin the wiring the same
+	// way the tracker assertions above do — the runtime behavior is covered by
+	// tests/unit/workflow/coder-settlement-2214*.test.ts against the hook
+	// object; this guard proves src/index.ts actually calls it.
+	test('the denial catch rolls back a begun settlement for denied Task calls', () => {
+		const catchIdx = toolBeforeBlock.search(/\}\s*catch\s*\(err\)\s*\{/);
+		const catchBody = toolBeforeBlock.slice(catchIdx);
+
+		// The rollback must fire only for the fail-closed region's denials and
+		// only for Task calls...
+		expect(catchBody).toMatch(
+			/if\s*\(\s*!failClosedRegionCompleted\s*&&\s*\(\s*normalizeToolName\(input\.tool\) === 'Task'\s*\|\|\s*normalizeToolName\(input\.tool\) === 'task'\s*\)\s*\)\s*\{/,
+		);
+		// ...and must call the delegation gate's rollback entry point from
+		// inside its own try/catch so the original denial still propagates, with
+		// the rethrow landing AFTER the rollback attempt.
+		expect(catchBody).toMatch(
+			/try\s*\{\s*await delegationGateHooks\.abortDeniedSettlementForCall\(\s*input\.callID,?\s*\);?\s*\}\s*catch\s*\{/,
+		);
+		const callIdx = catchBody.indexOf(
+			'delegationGateHooks.abortDeniedSettlementForCall(',
+		);
+		expect(callIdx).toBeGreaterThan(0);
+		const throwIdx = catchBody.indexOf('throw err;', callIdx);
+		expect(throwIdx).toBeGreaterThan(callIdx);
+	});
 });

--- a/tests/unit/workflow/coder-settlement-2214-hardening.test.ts
+++ b/tests/unit/workflow/coder-settlement-2214-hardening.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import {
+	deleteStoredInputArgs,
+	getStoredInputArgs,
+	setStoredInputArgs,
+} from '../../../src/hooks/guardrails/stored-input-args';
+import { tryAcquireLock } from '../../../src/parallel/file-locks';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import {
+	abortCoderSettlement,
+	_internals as settlementInternals,
+} from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function readWal(directory: string, taskId: string): Record<string, unknown> {
+	const walPath = path.join(
+		directory,
+		'.swarm',
+		'coder-settlements',
+		`${taskId}.json`,
+	);
+	if (!fs.existsSync(walPath)) return {};
+	return JSON.parse(fs.readFileSync(walPath, 'utf8')) as Record<
+		string,
+		unknown
+	>;
+}
+
+function settlementEvents(directory: string): Array<Record<string, unknown>> {
+	const eventsPath = path.join(directory, '.swarm', 'events.jsonl');
+	if (!fs.existsSync(eventsPath)) return [];
+	return fs
+		.readFileSync(eventsPath, 'utf8')
+		.trim()
+		.split('\n')
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line) as Record<string, unknown>)
+		.filter((event) => event.type === 'coder_settlement');
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+/**
+ * PR #2223 review-feedback hardening: F-002 (denial rollback releases
+ * ownership under every failure class), PRR-004 (assertion strength),
+ * PRR-005 (module-state isolation), PRR-006 (background-flagged shape),
+ * PRR-009 (already-aborted advisory).
+ */
+describe('issue #2214 — review-feedback hardening', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+	const usedCallIDs: string[] = [];
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		({ dir: directory, cleanup } = createSafeTestDir('coder-settle-2214-h-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		// PRR-005: resetSwarmState does not cover the stored-args map; drain the
+		// callIDs this file used so later tests can never observe them.
+		for (const callID of usedCallIDs.splice(0)) {
+			deleteStoredInputArgs(callID);
+		}
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('F-002: denial rollback releases ownership even when the abort itself fails (lock contention)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'f2-locked' },
+			{ args: { ...CODER_ARGS } },
+		);
+		setStoredInputArgs('f2-locked', { ...CODER_ARGS });
+		usedCallIDs.push('f2-locked');
+		expect(readWal(directory, '1.1').state).toBe('DISPATCHED');
+
+		// Force the abort to throw CODER_SETTLED_LOCKED by holding the
+		// settlement lock from outside.
+		const lock = await tryAcquireLock(
+			directory,
+			'coder-settlements/1.1.json',
+			'test-contention',
+			'test-contention-id',
+		);
+		expect(lock.acquired).toBe(true);
+		await hook.abortDeniedSettlementForCall('f2-locked');
+		await lock.lock._release?.().catch(() => undefined);
+
+		// The WAL is still DISPATCHED (the abort failed), but the in-memory
+		// ownership key and callID bookkeeping were released unconditionally —
+		// recovery must not report CODER_DISPATCH_IN_PROGRESS.
+		expect(readWal(directory, '1.1').state).toBe('DISPATCHED');
+		const key = `${directory}\u00001.1\u0000coder:f2-locked`;
+		expect(settlementInternals.liveDispatches.has(key)).toBe(false);
+		expect(getStoredInputArgs('f2-locked')).toBeUndefined();
+		const recovered = await recoverAndSettle(directory);
+		expect(recovered).not.toBeNull();
+	});
+
+	test('PRR-004a: a clean workspace dispatch is admitted (guard positive control)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'clean-control' },
+				{ args: { ...CODER_ARGS } },
+			),
+		).resolves.toBeUndefined();
+		expect(readWal(directory, '1.1').state).toBe('DISPATCHED');
+	});
+
+	test('PRR-004b: a rejected dirty dispatch leaves zero settlement side effects', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		fs.writeFileSync(
+			path.join(directory, 'src', 'wip.md'),
+			'work in progress\n',
+		);
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'no-side-effects' },
+				{ args: { ...CODER_ARGS } },
+			),
+		).rejects.toThrow('CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED');
+		await expect(
+			hook.toolAfter(
+				{ tool: 'Task', sessionID: 'parent', callID: 'no-side-effects' },
+				{ state: 'completed', output: 'unreachable' },
+			),
+		).resolves.toBeUndefined();
+		// Non-tautological: prove toolAfter did NOTHING settlement-shaped.
+		expect(readWal(directory, '1.1').state).toBeUndefined();
+		expect(settlementEvents(directory)).toEqual([]);
+	});
+
+	test('PRR-004c: lifecycle events carry identity fields and include the aborted action', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'events-fields' },
+			{ args: { ...CODER_ARGS } },
+		);
+		await abortCoderSettlement({
+			directory,
+			taskId: '1.1',
+			transitionId: 'coder:events-fields',
+			reason: 'field assertion probe',
+		});
+		const events = settlementEvents(directory);
+		expect(events.map((event) => event.action)).toEqual([
+			'dispatched',
+			'aborted',
+		]);
+		expect(events[0]).toMatchObject({
+			taskId: '1.1',
+			transitionId: 'coder:events-fields',
+			actor: 'parent',
+		});
+		expect(typeof events[0].timestamp).toBe('string');
+		expect(events[1]).toMatchObject({ reason: 'field assertion probe' });
+	});
+
+	test('PRR-006: a background-flagged dispatch is denied by the experimental gate before any settlement state (subagents disabled)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		// Dirty or clean makes no difference: the fail-closed background block
+		// (issue #1151) fires before the coder dispatch flow, so the settlement
+		// system is never engaged for background-flagged calls while background
+		// subagents are disabled.
+		fs.writeFileSync(
+			path.join(directory, 'src', 'wip.md'),
+			'work in progress\n',
+		);
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'bg-dirty' },
+				{ args: { ...CODER_ARGS, background: 'true' } },
+			),
+		).rejects.toThrow('SWARM_BACKGROUND_TASK_BLOCKED');
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'bg-clean' },
+				{ args: { ...CODER_ARGS, background: true } },
+			),
+		).rejects.toThrow('SWARM_BACKGROUND_TASK_BLOCKED');
+		for (const callID of ['bg-dirty', 'bg-clean']) {
+			usedCallIDs.push(callID);
+		}
+		expect(readWal(directory, '1.1').state).toBeUndefined();
+		expect(settlementEvents(directory)).toEqual([]);
+	});
+
+	test('PRR-009: an already-aborted settlement reports the terminal advisory, not DURABILITY_FAILURE', async () => {
+		const nonGit = createSafeTestDir('coder-settle-2214-h-ng-');
+		try {
+			await writeApprovedPlan(nonGit.dir, [
+				{ id: '1.1', files: ['src/feature.ts'] },
+			]);
+			const session = ensureAgentSession('parent', 'architect', nonGit.dir);
+			session.currentTaskId = '1.1';
+			const hook = createDelegationGateHook(config, nonGit.dir);
+			await hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'already-aborted' },
+				{ args: { ...CODER_ARGS } },
+			);
+			// Terminate the settlement before toolAfter runs (e.g. an operator
+			// or a concurrent rollback got there first).
+			await abortCoderSettlement({
+				directory: nonGit.dir,
+				taskId: '1.1',
+				transitionId: 'coder:already-aborted',
+				reason: 'terminated before completion',
+			});
+			setStoredInputArgs('already-aborted', { ...CODER_ARGS });
+			usedCallIDs.push('already-aborted');
+			await expect(
+				hook.toolAfter(
+					{ tool: 'Task', sessionID: 'parent', callID: 'already-aborted' },
+					{ state: 'completed', output: 'implemented feature' },
+				),
+			).rejects.toThrow('CODER_SETTLEMENT_ATTRIBUTION_UNCERTAIN');
+			const advisories =
+				ensureAgentSession('parent', 'architect').pendingAdvisoryMessages ?? [];
+			expect(
+				advisories.some(
+					(message) =>
+						message.includes('CODER_SETTLEMENT_ABORTED') &&
+						message.includes('update_task_status'),
+				),
+			).toBe(true);
+			expect(
+				advisories.some((message) =>
+					message.includes('CODER_SETTLEMENT_DURABILITY_FAILURE'),
+				),
+			).toBe(false);
+		} finally {
+			nonGit.cleanup();
+		}
+	});
+});
+
+async function recoverAndSettle(directory: string): Promise<unknown> {
+	const { recoverCoderSettlement } = await import(
+		'../../../src/workflow/coder-settlement.js'
+	);
+	return recoverCoderSettlement(directory, '1.1');
+}

--- a/tests/unit/workflow/coder-settlement-2214.test.ts
+++ b/tests/unit/workflow/coder-settlement-2214.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { _internals as taskFileInternals } from '../../../src/evidence/task-file';
+import {
+	getTaskWorkflowSnapshot,
+	readTaskEvidence,
+} from '../../../src/gate-evidence';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { setStoredInputArgs } from '../../../src/hooks/guardrails/stored-input-args';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import {
+	abortCoderSettlement,
+	beginCoderSettlement,
+	recoverCoderSettlement,
+	settleCoderDispatch,
+	_internals as settlementInternals,
+} from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function writeFile(directory: string, file: string, content: string): void {
+	const absolute = path.join(directory, file);
+	fs.mkdirSync(path.dirname(absolute), { recursive: true });
+	fs.writeFileSync(absolute, content);
+}
+
+function readWal(directory: string, taskId: string): Record<string, unknown> {
+	const walPath = path.join(
+		directory,
+		'.swarm',
+		'coder-settlements',
+		`${taskId}.json`,
+	);
+	if (!fs.existsSync(walPath)) return {};
+	return JSON.parse(fs.readFileSync(walPath, 'utf8')) as Record<
+		string,
+		unknown
+	>;
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+/**
+ * Issue #2214: coder settlements wedged at DISPATCHED forever. Two production
+ * triggers, both reproduced against the REAL host boundary (#1849 — the SDK
+ * tool.execute.after input carries NO args):
+ *  1. a dirty workspace at dispatch made the settle-time attribution check
+ *     fail BEFORE settleCoderDispatch, leaving an un-abortable DISPATCHED WAL;
+ *  2. with knowledge disabled, architect Task calls had no stored args at
+ *     toolAfter, so the settle block silently skipped.
+ */
+describe('issue #2214 — coder settlement finalization', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+	const realRename = taskFileInternals.renameSync;
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		taskFileInternals.renameSync = realRename;
+		({ dir: directory, cleanup } = createSafeTestDir('coder-settle-2214-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		writeFile(directory, 'src/feature.ts', 'export const feature = 1;\n');
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		taskFileInternals.renameSync = realRename;
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('a dirty workspace at dispatch is rejected before any settlement state exists', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		writeFile(directory, 'src/wip-note.md', 'work in progress\n');
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'dirty-dispatch' },
+				{ args: { ...CODER_ARGS } },
+			),
+		).rejects.toThrow('CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED');
+		expect(readWal(directory, '1.1').state).toBeUndefined();
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence).toBeNull();
+	});
+
+	test('settle finalizes without toolAfter input args, using the stored-args snapshot (#1849 host shape)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'host-shape' },
+			{ args: { ...CODER_ARGS } },
+		);
+		setStoredInputArgs('host-shape', { ...CODER_ARGS });
+		writeFile(directory, 'src/feature.ts', 'export const feature = 2;\n');
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent', callID: 'host-shape' },
+			{ state: 'completed', output: 'implemented feature' },
+		);
+		expect(readWal(directory, '1.1').state).toBe('COMMITTED');
+		expect(
+			getTaskWorkflowSnapshot(await readTaskEvidence(directory, '1.1')),
+		).toMatchObject({
+			state: 'coder_delegated',
+			lastOutcome: 'accepted_mutation',
+		});
+	});
+
+	test('a no-mutation coder settles as COMMITTED dispatch_no_mutation', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'no-mutation' },
+			{ args: { ...CODER_ARGS } },
+		);
+		setStoredInputArgs('no-mutation', { ...CODER_ARGS });
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent', callID: 'no-mutation' },
+			{ state: 'completed', output: 'no changes required' },
+		);
+		expect(readWal(directory, '1.1').state).toBe('COMMITTED');
+		expect(
+			getTaskWorkflowSnapshot(await readTaskEvidence(directory, '1.1')),
+		).toMatchObject({ state: 'idle', lastOutcome: 'dispatch_no_mutation' });
+	});
+
+	test('a non-git launch baseline aborts at settle instead of wedging at DISPATCHED', async () => {
+		// Non-git projects stay dispatchable (C1 decision), but their settlement
+		// can never attribute mutations — the settle catch must abort it.
+		const nonGit = createSafeTestDir('coder-settle-2214-nogit-');
+		try {
+			await writeApprovedPlan(nonGit.dir, [
+				{ id: '1.1', files: ['src/feature.ts'] },
+			]);
+			const session = ensureAgentSession('parent', 'architect', nonGit.dir);
+			session.currentTaskId = '1.1';
+			const hook = createDelegationGateHook(config, nonGit.dir);
+			await hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'non-git' },
+				{ args: { ...CODER_ARGS } },
+			);
+			expect(readWal(nonGit.dir, '1.1').state).toBe('DISPATCHED');
+			setStoredInputArgs('non-git', { ...CODER_ARGS });
+			await expect(
+				hook.toolAfter(
+					{ tool: 'Task', sessionID: 'parent', callID: 'non-git' },
+					{ state: 'completed', output: 'implemented feature' },
+				),
+			).rejects.toThrow('CODER_SETTLEMENT_ATTRIBUTION_UNCERTAIN');
+			expect(readWal(nonGit.dir, '1.1').state).toBe('ABORTED');
+			expect(typeof readWal(nonGit.dir, '1.1').abortReason).toBe('string');
+			// The architect-visible advisory explains the abort and the way out.
+			const advisory = ensureAgentSession(
+				'parent',
+				'architect',
+			).pendingAdvisoryMessages?.find((message) =>
+				message.includes('CODER_SETTLEMENT_ABORTED'),
+			);
+			expect(advisory).toContain('update_task_status');
+			// Ownership released: same-process recovery is a stable no-op, not
+			// CODER_DISPATCH_IN_PROGRESS.
+			expect(await recoverCoderSettlement(nonGit.dir, '1.1')).toBeNull();
+		} finally {
+			nonGit.cleanup();
+		}
+	});
+
+	test('a denied-after-begin settlement rolls back to ABORTED (no toolAfter fires)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'denied-later' },
+			{ args: { ...CODER_ARGS } },
+		);
+		expect(readWal(directory, '1.1').state).toBe('DISPATCHED');
+		await hook.abortDeniedSettlementForCall('denied-later');
+		expect(readWal(directory, '1.1').state).toBe('ABORTED');
+		expect(await recoverCoderSettlement(directory, '1.1')).toBeNull();
+		// The task is repairable: no unsettled dispatch fences plan-status change.
+		const { assertNoUnsettledCoderDispatch } = await import(
+			'../../../src/workflow/coder-settlement.js'
+		);
+		await expect(
+			assertNoUnsettledCoderDispatch(directory, '1.1'),
+		).resolves.toBeUndefined();
+	});
+
+	test('a legacy dirty-baseline DISPATCHED WAL self-heals to ABORTED on recovery', async () => {
+		const head = spawnSync('git', ['-C', directory, 'rev-parse', 'HEAD'], {
+			encoding: 'utf8',
+			timeout: 10_000,
+		}).stdout.trim();
+		await beginCoderSettlement({
+			directory,
+			taskId: '1.1',
+			transitionId: 'coder:legacy-dirty',
+			actor: 'parent',
+			expectedGeneration: 0,
+			context: {
+				declaredFiles: ['src/feature.ts'],
+				baseline: {
+					directory,
+					gitHead: head,
+					dirtyHash: 'legacy',
+					changedFiles: ['src/wip.md'],
+					prHeadSha: null,
+					scope: null,
+				},
+			},
+		});
+		// Post-restart shape: the WAL persists, the per-process registry is empty.
+		settlementInternals.liveDispatches.clear();
+		expect(await recoverCoderSettlement(directory, '1.1')).toBeNull();
+		expect(readWal(directory, '1.1').state).toBe('ABORTED');
+	});
+
+	test('a clean-baseline DISPATCHED WAL whose current capture fails stays retryable (RECOVERY_UNCERTAIN)', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'transient-git' },
+			{ args: { ...CODER_ARGS } },
+		);
+		settlementInternals.liveDispatches.clear();
+		// Break the CURRENT capture (not the recorded baseline): remove the repo
+		// so changedFilesSinceSnapshot's current-snapshot leg returns null.
+		fs.rmSync(path.join(directory, '.git'), { recursive: true, force: true });
+		await expect(recoverCoderSettlement(directory, '1.1')).rejects.toThrow(
+			'CODER_SETTLEMENT_RECOVERY_UNCERTAIN',
+		);
+		expect(readWal(directory, '1.1').state).toBe('DISPATCHED');
+	});
+
+	test('abortCoderSettlement validates identity, is idempotent, and never touches PREPARED', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'abort-unit' },
+			{ args: { ...CODER_ARGS } },
+		);
+		await expect(
+			abortCoderSettlement({
+				directory,
+				taskId: '1.1',
+				transitionId: 'coder:someone-else',
+				reason: 'stale caller',
+			}),
+		).rejects.toThrow('CODER_SETTLEMENT_WAL_REPLACED');
+		expect(
+			await abortCoderSettlement({
+				directory,
+				taskId: '1.1',
+				transitionId: 'coder:abort-unit',
+				reason: 'unit abort',
+			}),
+		).toBe('aborted');
+		expect(
+			await abortCoderSettlement({
+				directory,
+				taskId: '1.1',
+				transitionId: 'coder:abort-unit',
+				reason: 'unit abort',
+			}),
+		).toBe('already-aborted');
+		expect(readWal(directory, '1.1')).toMatchObject({
+			state: 'ABORTED',
+			abortReason: 'unit abort',
+		});
+	});
+
+	test('abortCoderSettlement never touches a PREPARED WAL — it stays recoverable', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'prepared-keep' },
+			{ args: { ...CODER_ARGS } },
+		);
+		// Freeze the WAL at PREPARED: settleCoderDispatch writes PREPARED, then
+		// commitPrepared fails on an injected evidence-rename error (the same
+		// recoverable mid-commit crash shape the #2098 suite exercises).
+		taskFileInternals.renameSync = (source, target) => {
+			if (target.includes(`${path.sep}evidence${path.sep}1.1.json`)) {
+				throw new Error('injected evidence rename failure');
+			}
+			return realRename(source, target);
+		};
+		await expect(
+			settleCoderDispatch({
+				directory,
+				taskId: '1.1',
+				transitionId: 'coder:prepared-keep',
+				accepted: false,
+				testEngineerExempt: false,
+			}),
+		).rejects.toThrow('injected evidence rename failure');
+		taskFileInternals.renameSync = realRename;
+		expect(readWal(directory, '1.1').state).toBe('PREPARED');
+		expect(
+			await abortCoderSettlement({
+				directory,
+				taskId: '1.1',
+				transitionId: 'coder:prepared-keep',
+				reason: 'must not fire',
+			}),
+		).toBe('not-dispatched');
+		expect(readWal(directory, '1.1').state).toBe('PREPARED');
+		// PREPARED remains recoverable: a later recovery commits it.
+		settlementInternals.liveDispatches.clear();
+		const recovered = await recoverCoderSettlement(directory, '1.1');
+		expect(getTaskWorkflowSnapshot(recovered?.evidence ?? null)).toMatchObject({
+			lastOutcome: 'dispatch_no_mutation',
+		});
+		expect(readWal(directory, '1.1').state).toBe('COMMITTED');
+	});
+
+	test('settlement lifecycle events are recorded in events.jsonl', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'events' },
+			{ args: { ...CODER_ARGS } },
+		);
+		setStoredInputArgs('events', { ...CODER_ARGS });
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent', callID: 'events' },
+			{ state: 'completed', output: 'no changes required' },
+		);
+		await expect(
+			abortCoderSettlement({
+				directory,
+				taskId: '1.9',
+				transitionId: 'coder:missing-probe',
+				reason: 'probe',
+			}),
+		).rejects.toThrow('CODER_SETTLEMENT_WAL_MISSING');
+		const events = fs
+			.readFileSync(path.join(directory, '.swarm', 'events.jsonl'), 'utf8')
+			.trim()
+			.split('\n')
+			.map((line) => JSON.parse(line) as { type?: string; action?: string })
+			.filter((event) => event.type === 'coder_settlement');
+		expect(events.map((event) => event.action)).toEqual([
+			'dispatched',
+			'settled',
+		]);
+	});
+
+	test('dual-witness: dirty tree is rejected even when toolAfter stored args are absent', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		writeFile(directory, 'src/wip-note.md', 'work in progress\n');
+		await expect(
+			hook.toolBefore(
+				{ tool: 'Task', sessionID: 'parent', callID: 'dual-witness' },
+				{ args: { ...CODER_ARGS } },
+			),
+		).rejects.toThrow('CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED');
+		await expect(
+			hook.toolAfter(
+				{ tool: 'Task', sessionID: 'parent', callID: 'dual-witness' },
+				{ state: 'completed', output: 'unreachable' },
+			),
+		).resolves.toBeUndefined();
+		expect(readWal(directory, '1.1').state).toBeUndefined();
+	});
+});

--- a/tests/unit/workflow/coder-settlement-worktree-recovery-2098.test.ts
+++ b/tests/unit/workflow/coder-settlement-worktree-recovery-2098.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../src/hooks/delegation-gate/worktree-provisioning-owner';
 import {
 	_internals,
+	abortCoderSettlement,
 	beginCoderSettlement,
 	recordCoderMergeProvenance,
 	recoverCoderSettlement,
@@ -353,5 +354,62 @@ describe('issue #2098 coder settlement isolated-worktree recovery', () => {
 				fixture.callID,
 			]);
 		}
+	});
+
+	// F-001 (PR #2223 review): the first-ever ABORTED writer must not leak the
+	// worktree. recoverCoderSettlement short-circuits on ABORTED before its
+	// worktree branch, so abortCoderSettlement owns terminal cleanup — and the
+	// provisioning-owner marker must go too, or the init orphan sweep's
+	// marker/liveness mutual-protection loop can never reclaim the lane.
+	test('aborting a worktree-carrying settlement cleans the worktree, branch, and owner marker', async () => {
+		const fixture = createFixture('abort-cleanup');
+		await begin(fixture);
+		expect(fs.existsSync(fixture.worktree)).toBe(true);
+		expect(branchExists(fixture)).toBe(true);
+
+		const outcome = await abortCoderSettlement({
+			directory: fixture.repo,
+			taskId: TASK_ID,
+			transitionId: fixture.transitionId,
+			reason: 'denied dispatch rollback probe',
+		});
+		expect(outcome).toBe('aborted');
+		expect(fs.existsSync(fixture.worktree)).toBe(false);
+		expect(branchExists(fixture)).toBe(false);
+		expect(scanWorktreeProvisioningOwnersForRecovery(fixture.repo)).toEqual({
+			status: 'ok',
+			owners: [],
+		});
+		expect(readWal(fixture)).toMatchObject({
+			state: 'ABORTED',
+			cleanupComplete: true,
+			abortReason: 'denied dispatch rollback probe',
+		});
+		// Recovery stays a stable no-op on the terminal state.
+		expect(await recoverCoderSettlement(fixture.repo, TASK_ID)).toBeNull();
+	});
+
+	// F-001 review follow-up: pin the positional invariant that a
+	// worktree-carrying DISPATCHED WAL with a DOOMED (hand-corrupted) baseline
+	// fails closed in the worktree branch (CODER_SETTLEMENT_RECOVERY_UNCERTAIN)
+	// and can NEVER reach the non-worktree doomed-abort, which does not run
+	// worktree cleanup. The abort entry point (tested above) owns that.
+	test('a worktree WAL with a doomed baseline fails closed in the worktree branch, never the doomed-abort', async () => {
+		const fixture = createFixture('doomed-worktree');
+		await begin(fixture);
+		const wal = readWal(fixture) as {
+			context: { baseline: { changedFiles: string[] } };
+		};
+		wal.context.baseline.changedFiles = ['src/untracked-wip.ts'];
+		fs.writeFileSync(walPath(fixture), `${JSON.stringify(wal, null, 2)}\n`);
+		_internals.liveDispatches.clear();
+
+		await expect(recoverCoderSettlement(fixture.repo, TASK_ID)).rejects.toThrow(
+			'CODER_SETTLEMENT_RECOVERY_UNCERTAIN: isolated task',
+		);
+		// Fail-closed: the WAL was NOT aborted (no silent worktree abandonment)
+		// and the worktree is still there for manual reconciliation.
+		expect(readWal(fixture)).toMatchObject({ state: 'DISPATCHED' });
+		expect(fs.existsSync(fixture.worktree)).toBe(true);
 	});
 });


### PR DESCRIPTION
Closes #2214

## Summary

The exact-task coder settlement system never finalized: `.swarm/coder-settlements/{taskId}.json` stayed `"state": "DISPATCHED"` forever after a coder Task completed, permanently blocking reviewer/test_engineer dispatch (the reported `CODER_SETTLEMENT_RECOVERY_UNCERTAIN` / `TASK_WORKFLOW_STAGE_A_REQUIRED` / `CODER_DISPATCH_IN_PROGRESS` / `CODER_SETTLEMENT_WAL_CORRUPT` cascade — historical names from the issue; the malformed-WAL diagnostic is `CODER_SETTLEMENT_WAL_UNREADABLE` on this branch after #2195's WAL-module refactor).

**Root causes (both reproduced end-to-end against the real host boundary, with the report's exact error strings):**

1. **Dirty workspace at dispatch (the reporter's trigger).** `changedFilesSinceSnapshot` fails closed for any launch baseline with pre-existing uncommitted/untracked files, but that check only fired at settle time — after the coder had already run. The DISPATCHED WAL then wedged permanently: the in-memory `liveDispatches` ownership fence made same-process recovery throw `CODER_DISPATCH_IN_PROGRESS` forever, post-reload recovery threw `CODER_SETTLEMENT_RECOVERY_UNCERTAIN` (attribution still impossible), and the `ABORTED` WAL state had **no writer anywhere**, so even `update_task_status` repair stayed fenced by `assertNoUnsettledCoderDispatch`.
2. **Knowledge-disabled configs.** The SDK `tool.execute.after` input carries no args (#1849); guardrails' arg store sits below its architect-session early-return, and the only architect-path store was gated on `knowledgeConfig.enabled`. With knowledge disabled, `subagentType` was undefined at toolAfter and the entire settlement / Stage B / gate-evidence block silently skipped — same wedge, zero diagnostics.
3. **Denied-after-begin (found while fixing).** A fail-closed hook running after the delegation gate (full-auto, knowledge-enforce, skill-propagation) could reject the Task call after the WAL was written; a denied call never fires toolAfter, wedging the settlement.

**Fix:**

- Reject a dirty launch baseline at dispatch (`CODER_SETTLEMENT_CLEAN_BASELINE_REQUIRED`, naming the files) **before** any settlement state exists; commit or stash before dispatching a coder.
- Give `ABORTED` a real writer: `abortCoderSettlement` (settlement-locked, identity-validated, idempotent, DISPATCHED→ABORTED only, `abortReason` recorded and parseWal-validated) plus `abortCoderSettlementIfDoomed` (doomed = non-git baseline or dirty-at-dispatch; transient capture failures stay retryable).
- In the toolAfter settle catch: release the in-memory ownership key and abort doomed settlements, with an actionable `CODER_SETTLEMENT_ABORTED` advisory (reconcile workspace → `update_task_status` repair → re-dispatch from a clean tree).
- `recoverCoderSettlement` self-heals legacy doomed DISPATCHED WALs (the reporter's nine stuck files) to ABORTED on the next recovery-triggering call, and mirrors settle semantics for no-declared-scope dispatches instead of wedging them.
- Snapshot tool args for toolAfter **unconditionally** (settlement identity no longer depends on `knowledge.enabled`), and roll back a begun settlement when a later fail-closed gate denies the Task call.
- Append `coder_settlement` lifecycle events (`dispatched` / `settled` / `aborted`) to `.swarm/events.jsonl` (best-effort) so settlement progress is directly observable.
- Close all review findings (independent swarm review + structured handoff): aborting a worktree-carrying settlement now cleans up the worktree, branch, and provisioning-owner marker; the denial rollback releases the in-memory ownership key and drains callID bookkeeping under every failure class (finally-based); the begun-settlement map fails closed at capacity like its siblings; lifecycle events are written with parent-dir creation, a transient-EBUSY/EPERM retry, and always-visible criticalWarn on failure; an already-aborted settlement reports the terminal advisory instead of CODER_SETTLEMENT_DURABILITY_FAILURE; the denial-rollback wiring is pinned by a static guard test.

## Invariant audit

- 1 (plugin init): touched — `src/index.ts` changed but no init-path work added; `node scripts/repro-704.mjs` OK (T1 301.8 ms / T2 236.5 ms / T3 219.2 ms vs the 400 ms deadline).
- 2 (runtime portability): touched — `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` → `NODE-ESM-LOAD-OK`; `tests/unit/build` (bundle-portability + plugin-shape) green; no new `bun:`-scheme resolution.
- 3 (subprocesses): not touched — no new spawn sites in the diff.
- 4 (.swarm containment): touched — new WAL field and `events.jsonl` appends both route through `validateSwarmPath`; no new directories outside `.swarm/`.
- 5 (plan durability): not touched — no plan-schema/status changes; `assertNoUnsettledCoderDispatch` semantics preserved (ABORTED passes, as before).
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — new bun:test file (401 lines by wc -l) (<500), no `mock.module` (public `createSafeTestDir` + the `_internals.renameSync` DI seam); test-clock / test-tmpdir / test-file-cap / mock-allowlist ratchets green.
- 8 (session state): touched — new `begunCoderSettlementsByCallID` map is FIFO-capped at 128 and cleared on every terminal path; `liveDispatches` usage unchanged; no cross-session keying.
- 9 (guardrails/retry): touched — an unattributable coder dispatch now fails closed at toolBefore with an actionable error before the tool runs; the denial rollback is best-effort and never masks the original denial.
- 10 (chat/system msg): not touched — new advisories route through `pushAdvisory` (invariants Check 6 green).
- 11 (tool registration): not touched — no new plugin tools/commands/agents; `abortCoderSettlement` / `abortDeniedSettlementForCall` are internal module/hook exports.
- 12 (release/cache): touched — pending fragment `docs/releases/pending/fix-coder-settlement-wedge-2214.md` added; no version/CHANGELOG/manifest edits.

## Test plan

- [x] New `tests/unit/workflow/coder-settlement-2214.test.ts` (11 tests) plus review-feedback hardening (dd2dd42b): `coder-settlement-2214-hardening.test.ts` (6 tests: denial-rollback release under real lock contention, guard positive control, zero-side-effect rejection, lifecycle event identity fields, background-flagged experimental-gate shape, already-aborted advisory), worktree-abort cleanup + doomed-worktree fail-closed invariant tests in `coder-settlement-worktree-recovery-2098.test.ts`, and a denial-rollback wiring pin in `gate-denial-wiring.test.ts`. Original 11 tests (real git temp repos, no args in toolAfter input): dirty-dispatch rejection with no WAL/evidence; host-shape settle (accepted_mutation + dispatch_no_mutation); non-git settle-abort with `CODER_SETTLEMENT_ABORTED` advisory naming `update_task_status`; denied-after-begin rollback + repair unfenced; legacy dirty-baseline self-heal; transient capture failure stays retryable (`CODER_SETTLEMENT_RECOVERY_UNCERTAIN`); abort identity validation / idempotency / PREPARED-untouched and still recoverable; lifecycle events; dual-witness (dirty tree + no stored args).
- [x] Falsifiability: the pre-fix reproduction reproduced both wedges against unmodified `main` with the report's exact evidence shape (`state: idle`, `lastOutcome: dispatch_attempted`) and error strings; the same assertions pass post-fix, and the new error codes do not exist on `main`.
- [x] `bun run typecheck`, `bun run lint:ci`, and the 13-check quality tier (tool-registration, mock-cleanup, invariants, cross-contamination, test-clock, runtime-src-refs, events, test-file-cap, gate-portability, test-tmpdir, bash-portability, swarm-model, package:smoke) — all green.
- [x] Suites: workflow (29), all 90 delegation-gate files, guardrails, build, evidence, gate-evidence, stored-args consumers, `src/state.rehydrate.test.ts` — 0 failures; `bun run test:unit:ci` scoped gate green.
- [x] `tests/security` (172), `tests/adversarial` (846), `tests/smoke` (10) — pass.
- [x] Integration (CI-equivalent per-file loop with quarantine + retries): 4 files fail identically on clean `main` (verified in an isolated worktree) — pre-existing Windows-local failures, documented, not from this change.
