### PR TITLE
fix(delegation-gate): make Stage B attribution exact and add semantic review routing

### DIFF
--- a/docs/releases/pending/2099-stage-b-attribution-semantic-review-routing.md
+++ b/docs/releases/pending/2099-stage-b-attribution-semantic-review-routing.md
@@ -1,0 +1,43 @@
+## Stage B attribution exact + semantic review routing
+
+### What changed
+
+- **Exact Stage B attribution**: The all-eligible-task fallback in
+  `delegation-gate.ts` is removed. `parsePerTaskVerdicts` now returns a typed
+  `StageBAttributionResult` with `VerdictEntry` (verdict + kind), duplicate
+  detection (identical verdicts are idempotent; conflicting verdicts emit
+  `STAGE_B_VERDICT_CONFLICT`), and `STAGE_B_ATTRIBUTION_MISSING` when agents
+  return no structured verdict lines.
+- **StageBDispatchContext**: Per-callID dispatch context captures `taskIds` and
+  `expectedVerdictKind` at dispatch time, wired to the verdict consumption
+  check.
+- **Semantic review routing**: AST-based classification via `computeASTDiff`
+  with git old-content detects high-risk categories (`GUARD_REMOVED`,
+  `SIGNATURE_CHANGE`, `API_CHANGE`, `DELETED_FUNCTION`) and triggers double
+  review regardless of heuristic metrics. Bounded by file count, byte size,
+  and timeout.
+- **Tier-3 classifier consolidation**: Shared `tier3-classifier.ts` with four
+  matching strategies replaces two duplicate copies in `update-task-status.ts`
+  and `task-completion.ts`.
+- **Telemetry fix**: `agentName` derived from per-callID stored args instead of
+  shared `activeAgent` map, fixing misattribution in concurrent dispatch.
+
+### Why
+
+Stage B attribution was inexact: when agents omitted structured verdict lines,
+the fallback attributed results to all eligible tasks. This caused spurious
+state transitions and noisy warnings. The semantic routing adds risk-aware
+review depth scaling that the heuristic-only path could not provide.
+
+### Migration
+
+No migration required. The new behavior is backward-compatible — agents that
+already emit structured `[REVIEWED]`/`[TESTED]` verdict lines are unaffected.
+
+### Known caveats
+
+- Semantic routing falls back to heuristic-only when AST analysis is
+  unavailable, times out, or exceeds bounds (50 files / 500 KB / 5 s).
+- The `git show HEAD:<file>` call for old-content requires a git repository;
+  non-git directories fall back to empty old-content (all changes classified
+  as additions).

--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -265,17 +265,21 @@ If no DIRECTIVES TO VERIFY block was provided, output "DIRECTIVE_COMPLIANCE: non
 FIXES: required changes if rejected
 Use INFO only inside ISSUES for non-blocking suggestions. RISK reflects the highest blocking severity, so it never uses INFO.
 
-## MULTI-TASK COVERAGE (FR-007)
-When you are asked to review multiple tasks in a single dispatch (set-dispatch), emit one structured verdict line PER TASK at the END of your output (after all other output fields). This enables per-task attribution in the gate tracker:
+## STRUCTURED VERDICT LINE (MANDATORY)
+You MUST emit exactly one structured verdict line PER TASK at the END of your output (after all other output fields). This is required for both single-task and multi-task (set-dispatch) reviews. The gate tracker uses this line for per-task attribution — omitting it blocks task completion.
 
 [REVIEWED] | task-<taskId> | APPROVED | <brief summary>
 [REVIEWED] | task-<taskId> | REJECTED | <brief summary>
+[REVIEWED] | task-<taskId> | CONCERNS | <brief summary>
 
-Example:
+Example (single task):
+[REVIEWED] | task-2.1 | APPROVED | No issues found in src/foo.ts
+
+Example (multi-task set-dispatch):
 [REVIEWED] | task-2.1 | APPROVED | No issues found in src/foo.ts
 [REVIEWED] | task-2.2 | REJECTED | Missing null check in bar() at line 42
 
-If covering a single task only, you do not need to emit the structured verdict line.
+Never omit this line. The task ID must match the TASK field exactly.
 
 ## OUTPUT ORDER FOR SKILL COMPLIANCE (when applicable)
 When SKILLS_USED_BY_CODER is provided, output TASK: immediately followed by SKILL_COMPLIANCE to ensure proper attribution:

--- a/src/agents/test-engineer.ts
+++ b/src/agents/test-engineer.ts
@@ -227,18 +227,21 @@ COVERAGE REPORTING:
 - If COVERAGE_PCT < 70%, add a note: "COVERAGE_WARNING: Below 70% threshold — consider additional test cases for uncovered paths."
 - The architect uses this to decide whether to request an additional test pass (Rule 10 / Phase 5 step 5h).
 
-## MULTI-TASK COVERAGE (FR-007)
-When you are asked to test multiple tasks in a single dispatch (set-dispatch), emit one structured verdict line PER TASK at the END of your output (after all other output fields). This enables per-task attribution in the gate tracker:
+## STRUCTURED VERDICT LINE (MANDATORY)
+You MUST emit exactly one structured verdict line PER TASK at the END of your output (after all other output fields). This is required for both single-task and multi-task (set-dispatch) test runs. The gate tracker uses this line for per-task attribution — omitting it blocks task completion.
 
 [TESTED] | task-<taskId> | PASS | <brief summary>
 [TESTED] | task-<taskId> | FAIL | <brief summary>
 [TESTED] | task-<taskId> | SKIPPED | <reason>
 
-Example:
+Example (single task):
+[TESTED] | task-2.1 | PASS | 10/10 tests passed, 85% coverage
+
+Example (multi-task set-dispatch):
 [TESTED] | task-2.1 | PASS | 10/10 tests passed, 85% coverage
 [TESTED] | task-2.2 | FAIL | 8/10 tests passed — bar.test.ts missing coverage for error path
 
-If covering a single task only, you do not need to emit the structured verdict line.
+Never omit this line. The task ID must match the TASK field exactly.
 `;
 
 export function createTestEngineerAgent(

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -636,7 +636,7 @@ export const TURBO_MODE_BANNER = `## 🚀 TURBO MODE ACTIVE
 
 While Turbo Mode is active:
 - **Stage A gates** (lint, imports, pre_check_batch) are still REQUIRED for ALL tasks
-- **Tier 3 tasks** (security-sensitive files matching: architect*.ts, delegation*.ts, guardrails*.ts, adversarial*.ts, sanitiz*.ts, auth*, permission*, crypto*, secret*, security) still require FULL review (Stage B)
+- **Tier 3 tasks** (security-sensitive files matching: architect*.ts, delegation*.ts, guardrails*.ts, adversarial*.ts, sanitiz*.ts, security*.ts; exact basenames: auth, permission(s), crypto, secret(s); keyword prefixes: auth-*, permission-*, crypto-*, secret-*, security-*; or files under auth/, security/, crypto/, permission/, secret/ directories) still require FULL review (Stage B)
 - **Tier 0-2 tasks** can skip Stage B (reviewer, test_engineer) to speed up execution
 - **Phase completion gates** (Gates 1–5: completion-verify, drift-verifier, hallucination-guard, mutation-gate, phase-council) are automatically bypassed via the orchestrator short-circuit at \`src/tools/phase-complete.ts:774–827\` when turbo is active; Gate 5b (architecture-supervisor), Gate 6 (final-council), and Gate 7 (full-auto) remain enforced. Note: turbo bypass is session-scoped; one session's turbo does not affect other sessions.
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -636,7 +636,7 @@ export const TURBO_MODE_BANNER = `## 🚀 TURBO MODE ACTIVE
 
 While Turbo Mode is active:
 - **Stage A gates** (lint, imports, pre_check_batch) are still REQUIRED for ALL tasks
-- **Tier 3 tasks** (security-sensitive files matching: architect*.ts, delegation*.ts, guardrails*.ts, adversarial*.ts, sanitiz*.ts, security*.ts; exact basenames: auth, permission(s), crypto, secret(s); keyword prefixes: auth-*, permission-*, crypto-*, secret-*, security-*; or files under auth/, security/, crypto/, permission/, secret/ directories) still require FULL review (Stage B)
+- **Tier 3 tasks** (security-sensitive files matching: architect*.ts, delegation*.ts, guardrails*.ts, adversarial*.ts, sanitiz*.ts, security*.ts; exact basenames: auth, authenticate, authentication, authorization, permission(s), crypto, secret(s), secretscan; keyword prefixes: auth-*, permission-*, crypto-*, secret-*, security-*; or files under auth/, security/, crypto/, permission/, secret/ directories) still require FULL review (Stage B)
 - **Tier 0-2 tasks** can skip Stage B (reviewer, test_engineer) to speed up execution
 - **Phase completion gates** (Gates 1–5: completion-verify, drift-verifier, hallucination-guard, mutation-gate, phase-council) are automatically bypassed via the orchestrator short-circuit at \`src/tools/phase-complete.ts:774–827\` when turbo is active; Gate 5b (architecture-supervisor), Gate 6 (final-council), and Gate 7 (full-auto) remain enforced. Note: turbo bypass is session-scoped; one session's turbo does not affect other sessions.
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -4602,6 +4602,34 @@ export function createDelegationGateHook(
 										logger.warn(
 											`[delegation-gate] STAGE_B_ATTRIBUTION_MISSING: ${targetAgent} dispatch for call ${input.callID} returned no structured verdict lines. Expected tasks: ${expectedTasks}. Agent output must include [REVIEWED] or [TESTED] verdict lines.`,
 										);
+										const failClosedTaskIds = dispatchCtx
+											? [...dispatchCtx.taskIds]
+											: gateDispatchPrimaryTaskByCallID.has(input.callID)
+												? [
+														gateDispatchPrimaryTaskByCallID.get(
+															input.callID,
+														)!,
+													]
+												: [];
+										for (const failTaskId of failClosedTaskIds) {
+											const failState =
+												session.taskWorkflowStates.get(failTaskId);
+											if (
+												failState &&
+												(
+													stageBEligibleStates as readonly string[]
+												).includes(failState)
+											) {
+												session.taskWorkflowStates.set(
+													failTaskId,
+													'rework_required',
+												);
+												session.stageBCompletion?.delete(failTaskId);
+												logger.warn(
+													`[delegation-gate] STAGE_B_ATTRIBUTION_MISSING fail-closed: task ${failTaskId} → rework_required`,
+												);
+											}
+										}
 										break;
 									}
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -1836,26 +1836,45 @@ function extractTaskFileDirectives(
  * Lines that don't match the pattern are silently ignored.
  *
  * @param outputText - Raw text output from the agent dispatch
- * @returns Map of taskId -> verdict string
+ * @returns StageBAttributionResult with typed verdicts and any parsing errors
  */
-export function parsePerTaskVerdicts(outputText: string): Map<string, string> {
-	const result = new Map<string, string>();
-	// Match [REVIEWED] or [TESTED] tag lines with task ID and verdict
-	// Supports formats like "[REVIEWED] | task-2.1 | APPROVED | details"
-	// and "[TESTED] | 2.1 | PASS | details"
-	const reviewedPattern =
-		/^\[REVIEWED\]\s*\|\s*(?:task-)?(\d+\.\d+(?:\.\d+)*)\s*\|\s*(APPROVED|REJECTED|CONCERNS)\s*\|/im;
-	const testedPattern =
-		/^\[TESTED\]\s*\|\s*(?:task-)?(\d+\.\d+(?:\.\d+)*)\s*\|\s*(PASS|FAIL|SKIPPED)\s*\|/im;
+export interface VerdictEntry {
+	verdict: string;
+	kind: 'REVIEWED' | 'TESTED';
+}
 
-	for (const line of outputText.split('\n')) {
+export interface StageBAttributionResult {
+	verdicts: Map<string, VerdictEntry>;
+	errors: string[];
+}
+
+export function parsePerTaskVerdicts(
+	outputText: string,
+): StageBAttributionResult {
+	const verdicts = new Map<string, VerdictEntry>();
+	const errors: string[] = [];
+	const reviewedPattern =
+		/^\[REVIEWED\]\s*\|\s*(?:task-)?(\d+\.\d+(?:\.\d+)*)\s*\|\s*(APPROVED|REJECTED|CONCERNS)\s*\|?/im;
+	const testedPattern =
+		/^\[TESTED\]\s*\|\s*(?:task-)?(\d+\.\d+(?:\.\d+)*)\s*\|\s*(PASS|FAIL|SKIPPED)\s*\|?/im;
+
+	for (const line of outputText.split(/\r?\n/)) {
 		const trimmed = line.trim();
 		let match = reviewedPattern.exec(trimmed);
 		if (match) {
 			const taskId = match[1];
 			const verdict = match[2];
 			if (isStrictTaskId(taskId)) {
-				result.set(taskId, verdict);
+				const existing = verdicts.get(taskId);
+				if (existing) {
+					if (existing.verdict !== verdict || existing.kind !== 'REVIEWED') {
+						errors.push(
+							`STAGE_B_VERDICT_CONFLICT: task ${taskId} has conflicting verdicts: ${existing.kind}/${existing.verdict} vs REVIEWED/${verdict}`,
+						);
+					}
+				} else {
+					verdicts.set(taskId, { verdict, kind: 'REVIEWED' });
+				}
 			}
 			continue;
 		}
@@ -1864,11 +1883,20 @@ export function parsePerTaskVerdicts(outputText: string): Map<string, string> {
 			const taskId = match[1];
 			const verdict = match[2];
 			if (isStrictTaskId(taskId)) {
-				result.set(taskId, verdict);
+				const existing = verdicts.get(taskId);
+				if (existing) {
+					if (existing.verdict !== verdict || existing.kind !== 'TESTED') {
+						errors.push(
+							`STAGE_B_VERDICT_CONFLICT: task ${taskId} has conflicting verdicts: ${existing.kind}/${existing.verdict} vs TESTED/${verdict}`,
+						);
+					}
+				} else {
+					verdicts.set(taskId, { verdict, kind: 'TESTED' });
+				}
 			}
 		}
 	}
-	return result;
+	return { verdicts, errors };
 }
 
 /**
@@ -2675,6 +2703,15 @@ export function createDelegationGateHook(
 		Map<string, number>
 	>();
 	const gateDispatchPrimaryTaskByCallID = new Map<string, string | null>();
+
+	interface StageBDispatchContext {
+		taskIds: Set<string>;
+		expectedVerdictKind: 'REVIEWED' | 'TESTED';
+	}
+	const stageBDispatchContextByCallID = new Map<
+		string,
+		StageBDispatchContext
+	>();
 	const publishedScopeBindingsByCallID = new Map<
 		string,
 		Array<{ directory: string; binding: PreparedCoderScope['binding'] }>
@@ -2920,6 +2957,7 @@ export function createDelegationGateHook(
 		clearCoderTaskChangeContext(callID);
 		stageBDispatchGenerationsByCallID.delete(callID);
 		gateDispatchPrimaryTaskByCallID.delete(callID);
+		stageBDispatchContextByCallID.delete(callID);
 		deleteStoredInputArgs(callID);
 	};
 
@@ -3372,6 +3410,11 @@ export function createDelegationGateHook(
 			}
 			rememberStageBDispatchGenerations(input.callID, generations);
 			gateDispatchPrimaryTaskByCallID.set(input.callID, resolvedTaskId);
+			stageBDispatchContextByCallID.set(input.callID, {
+				taskIds: new Set(generations.keys()),
+				expectedVerdictKind:
+					targetAgent === 'test_engineer' ? 'TESTED' : 'REVIEWED',
+			});
 			return;
 		}
 
@@ -4282,6 +4325,7 @@ export function createDelegationGateHook(
 					clearCoderTaskChangeContext(input.callID);
 					stageBDispatchGenerationsByCallID.delete(input.callID);
 					gateDispatchPrimaryTaskByCallID.delete(input.callID);
+					stageBDispatchContextByCallID.delete(input.callID);
 					if (storedArgs !== undefined) deleteStoredInputArgs(input.callID);
 				}
 				if (!backgroundCorrelationConflict) {
@@ -4540,163 +4584,174 @@ export function createDelegationGateHook(
 								//   [TESTED] | task-2.1 | PASS | ...
 								// If parseable, attribute per-task rather than over-attributing to
 								// every task in taskWorkflowStates.
-								const perTaskVerdicts = parsePerTaskVerdicts(
+								const attributionResult = parsePerTaskVerdicts(
 									outputText(_output),
 								);
-								const hasPerTaskAttribution = perTaskVerdicts.size > 0;
-
-								// FR-007: When per-task verdicts are parseable, iterate ONLY over the
-								// task IDs mentioned in those verdicts — skip all other eligible tasks
-								// to prevent over-attribution. When no verdicts are parseable, iterate
-								// over all eligible tasks (existing fallback behavior).
-
-								const {
-									getTaskWorkflowSnapshot,
-									readTaskEvidence,
-									transitionTaskWorkflowEvidence,
-								} = await import('../gate-evidence');
-								for (const [taskId, state] of session.taskWorkflowStates) {
-									if (
-										!(stageBEligibleStates as readonly string[]).includes(state)
-									)
-										continue;
-									// FR-007: Skip tasks NOT mentioned in per-task verdicts
-									if (hasPerTaskAttribution && !perTaskVerdicts.has(taskId))
-										continue;
-									if (
-										!hasPerTaskAttribution &&
-										gateDispatchPrimaryTaskByCallID.get(input.callID) !== taskId
-									) {
-										continue;
-									}
-									const eligibleState = state as EligibleState;
-									const launchGeneration = stageBDispatchGenerationsByCallID
-										.get(input.callID)
-										?.get(taskId);
-									if (launchGeneration === undefined) {
-										logger.warn(
-											`[delegation-gate] ignoring unbound Stage B settlement for ${taskId} from call ${input.callID}`,
+								for (const err of attributionResult.errors) {
+									logger.warn(`[delegation-gate] ${err}`);
+								}
+								do {
+									if (attributionResult.verdicts.size === 0) {
+										const dispatchCtx = stageBDispatchContextByCallID.get(
+											input.callID,
 										);
-										continue;
+										const expectedTasks = dispatchCtx
+											? [...dispatchCtx.taskIds].join(', ')
+											: (gateDispatchPrimaryTaskByCallID.get(input.callID) ??
+												'unknown');
+										logger.warn(
+											`[delegation-gate] STAGE_B_ATTRIBUTION_MISSING: ${targetAgent} dispatch for call ${input.callID} returned no structured verdict lines. Expected tasks: ${expectedTasks}. Agent output must include [REVIEWED] or [TESTED] verdict lines.`,
+										);
+										break;
 									}
-									const verdict = perTaskVerdicts.get(taskId);
-									const positiveVerdict =
-										targetAgent === 'reviewer'
-											? verdict === 'APPROVED'
-											: verdict === 'PASS';
-									if (!positiveVerdict) {
+
+									const {
+										getTaskWorkflowSnapshot,
+										readTaskEvidence,
+										transitionTaskWorkflowEvidence,
+									} = await import('../gate-evidence');
+									for (const [taskId, state] of session.taskWorkflowStates) {
+										if (
+											!(stageBEligibleStates as readonly string[]).includes(
+												state,
+											)
+										)
+											continue;
+										if (!attributionResult.verdicts.has(taskId)) continue;
+										const eligibleState = state as EligibleState;
+										const launchGeneration = stageBDispatchGenerationsByCallID
+											.get(input.callID)
+											?.get(taskId);
+										if (launchGeneration === undefined) {
+											logger.warn(
+												`[delegation-gate] ignoring unbound Stage B settlement for ${taskId} from call ${input.callID}`,
+											);
+											continue;
+										}
+										const verdictEntry = attributionResult.verdicts.get(taskId);
+										const dispatchCtxForVerdict =
+											stageBDispatchContextByCallID.get(input.callID);
+										const positiveVerdict =
+											dispatchCtxForVerdict?.expectedVerdictKind === 'TESTED'
+												? verdictEntry?.verdict === 'PASS'
+												: verdictEntry?.verdict === 'APPROVED';
+										if (!positiveVerdict) {
+											try {
+												const rejected = await transitionTaskWorkflowEvidence(
+													directory,
+													taskId,
+													{
+														type: 'stage_b_failed',
+														gate: targetAgent as 'reviewer' | 'test_engineer',
+														expectedGeneration: launchGeneration,
+														transitionId: `gate-failed:${input.callID}:${taskId}`,
+													},
+												);
+												session.taskWorkflowStates.set(
+													taskId,
+													'rework_required',
+												);
+												session.stageBCompletion?.delete(taskId);
+												updateTaskWorkflowCache(
+													session,
+													taskId,
+													getTaskWorkflowSnapshot(rejected),
+												);
+											} catch (err) {
+												logger.warn(
+													`[delegation-gate] Stage B rejection could not be persisted for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+												);
+											}
+											continue;
+										}
 										try {
-											const rejected = await transitionTaskWorkflowEvidence(
+											const turbo = hasActiveTurboMode(input.sessionID);
+											const { recordGateEvidence } = await import(
+												'../gate-evidence'
+											);
+											await recordGateEvidence(
 												directory,
 												taskId,
+												targetAgent as 'reviewer' | 'test_engineer',
+												input.sessionID,
+												turbo,
 												{
-													type: 'stage_b_failed',
-													gate: targetAgent as 'reviewer' | 'test_engineer',
 													expectedGeneration: launchGeneration,
-													transitionId: `gate-failed:${input.callID}:${taskId}`,
+													transitionId: `gate:${input.callID}:${taskId}`,
 												},
 											);
-											session.taskWorkflowStates.set(taskId, 'rework_required');
-											session.stageBCompletion?.delete(taskId);
-											updateTaskWorkflowCache(
-												session,
-												taskId,
-												getTaskWorkflowSnapshot(rejected),
-											);
 										} catch (err) {
 											logger.warn(
-												`[delegation-gate] Stage B rejection could not be persisted for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+												`[delegation-gate] Stage B settlement rejected for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
 											);
+											continue;
 										}
-										continue;
-									}
-									try {
-										const turbo = hasActiveTurboMode(input.sessionID);
-										const { recordGateEvidence } = await import(
-											'../gate-evidence'
-										);
-										await recordGateEvidence(
-											directory,
+										recordStageBCompletion(
+											session,
 											taskId,
 											targetAgent as 'reviewer' | 'test_engineer',
-											input.sessionID,
-											turbo,
-											{
-												expectedGeneration: launchGeneration,
-												transitionId: `gate:${input.callID}:${taskId}`,
-											},
 										);
-									} catch (err) {
-										logger.warn(
-											`[delegation-gate] Stage B settlement rejected for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
-										);
-										continue;
-									}
-									recordStageBCompletion(
-										session,
-										taskId,
-										targetAgent as 'reviewer' | 'test_engineer',
-									);
 
-									const taskEvidence = await readTaskEvidence(
-										directory,
-										taskId,
-									);
-									const reviewerCompletesStageB =
-										targetAgent === 'reviewer' &&
-										taskEvidence?.test_engineer_exempt === true;
-									if (
-										hasBothStageBCompletions(session, taskId) ||
-										reviewerCompletesStageB
-									) {
-										// Barrier reached: both reviewer and test_engineer have completed.
-										// Advance through reviewer_run → tests_run in a single compound
-										// step so the state machine stays consistent.
-										try {
-											if (eligibleState === 'pre_check_passed') {
-												advanceTaskState(session, taskId, 'reviewer_run', {
-													telemetrySessionId: input.sessionID,
-												});
-											}
-											advanceTaskState(session, taskId, 'tests_run', {
-												telemetrySessionId: input.sessionID,
-											});
-										} catch (err) {
-											logger.warn(
-												`[delegation-gate] toolAfter stage-b-parallel: could not advance ${taskId} (${eligibleState}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
-											);
-										}
-									} else {
-										// Intermediate advancement: advance state immediately when a
-										// single Stage B agent completes, without waiting for the barrier.
-										// This preserves the sequential-equivalent state machine contract:
-										//   coder_delegated → reviewer_run  (when reviewer completes)
-										//   reviewer_run → tests_run        (when test_engineer completes)
-										// The barrier path above handles the case where both complete
-										// while state is still coder_delegated (compound step).
-										try {
-											if (
-												targetAgent === 'reviewer' &&
-												eligibleState === 'pre_check_passed'
-											) {
-												advanceTaskState(session, taskId, 'reviewer_run', {
-													telemetrySessionId: input.sessionID,
-												});
-											} else if (
-												targetAgent === 'test_engineer' &&
-												eligibleState === 'reviewer_run'
-											) {
+										const taskEvidence = await readTaskEvidence(
+											directory,
+											taskId,
+										);
+										const reviewerCompletesStageB =
+											targetAgent === 'reviewer' &&
+											taskEvidence?.test_engineer_exempt === true;
+										if (
+											hasBothStageBCompletions(session, taskId) ||
+											reviewerCompletesStageB
+										) {
+											// Barrier reached: both reviewer and test_engineer have completed.
+											// Advance through reviewer_run → tests_run in a single compound
+											// step so the state machine stays consistent.
+											try {
+												if (eligibleState === 'pre_check_passed') {
+													advanceTaskState(session, taskId, 'reviewer_run', {
+														telemetrySessionId: input.sessionID,
+													});
+												}
 												advanceTaskState(session, taskId, 'tests_run', {
 													telemetrySessionId: input.sessionID,
 												});
+											} catch (err) {
+												logger.warn(
+													`[delegation-gate] toolAfter stage-b-parallel: could not advance ${taskId} (${eligibleState}) → tests_run: ${err instanceof Error ? err.message : String(err)}`,
+												);
 											}
-										} catch (err) {
-											logger.warn(
-												`[delegation-gate] toolAfter stage-b-parallel intermediate: could not advance ${taskId} (${eligibleState}) after ${targetAgent}: ${err instanceof Error ? err.message : String(err)}`,
-											);
+										} else {
+											// Intermediate advancement: advance state immediately when a
+											// single Stage B agent completes, without waiting for the barrier.
+											// This preserves the sequential-equivalent state machine contract:
+											//   coder_delegated → reviewer_run  (when reviewer completes)
+											//   reviewer_run → tests_run        (when test_engineer completes)
+											// The barrier path above handles the case where both complete
+											// while state is still coder_delegated (compound step).
+											try {
+												if (
+													targetAgent === 'reviewer' &&
+													eligibleState === 'pre_check_passed'
+												) {
+													advanceTaskState(session, taskId, 'reviewer_run', {
+														telemetrySessionId: input.sessionID,
+													});
+												} else if (
+													targetAgent === 'test_engineer' &&
+													eligibleState === 'reviewer_run'
+												) {
+													advanceTaskState(session, taskId, 'tests_run', {
+														telemetrySessionId: input.sessionID,
+													});
+												}
+											} catch (err) {
+												logger.warn(
+													`[delegation-gate] toolAfter stage-b-parallel intermediate: could not advance ${taskId} (${eligibleState}) after ${targetAgent}: ${err instanceof Error ? err.message : String(err)}`,
+												);
+											}
 										}
 									}
-								}
+								} while (false as boolean);
 							}
 						}
 					} // end if (!councilActive) — primary Stage B path
@@ -4938,6 +4993,7 @@ export function createDelegationGateHook(
 
 				stageBDispatchGenerationsByCallID.delete(input.callID);
 				gateDispatchPrimaryTaskByCallID.delete(input.callID);
+				stageBDispatchContextByCallID.delete(input.callID);
 
 				// ── Completion gate: push advisory if a task awaits completion ──
 				// B3 (issue #1976): the `break` below only caps pushes to one per

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -4605,20 +4605,16 @@ export function createDelegationGateHook(
 										const failClosedTaskIds = dispatchCtx
 											? [...dispatchCtx.taskIds]
 											: gateDispatchPrimaryTaskByCallID.has(input.callID)
-												? [
-														gateDispatchPrimaryTaskByCallID.get(
-															input.callID,
-														)!,
-													]
+												? [gateDispatchPrimaryTaskByCallID.get(input.callID)!]
 												: [];
 										for (const failTaskId of failClosedTaskIds) {
 											const failState =
 												session.taskWorkflowStates.get(failTaskId);
 											if (
 												failState &&
-												(
-													stageBEligibleStates as readonly string[]
-												).includes(failState)
+												(stageBEligibleStates as readonly string[]).includes(
+													failState,
+												)
 											) {
 												session.taskWorkflowStates.set(
 													failTaskId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3463,7 +3463,14 @@ async function initializeOpenCodeSwarm(
 				const backgroundResultIsRunning =
 					outputLooksLikeBackgroundRunning(output);
 				const sessionId = input.sessionID;
-				const agentName = swarmState.activeAgent.get(sessionId) || 'unknown';
+				const storedSubagentType =
+					typeof afterCtx.args?.subagent_type === 'string'
+						? afterCtx.args.subagent_type
+						: undefined;
+				const agentName =
+					storedSubagentType ||
+					swarmState.activeAgent.get(sessionId) ||
+					'unknown';
 				const baseAgentName = stripKnownSwarmPrefix(agentName);
 				const preHandoffSession = swarmState.agentSessions.get(sessionId);
 				const activeWindow = getActiveWindow(sessionId);

--- a/src/parallel/review-router.ts
+++ b/src/parallel/review-router.ts
@@ -1,3 +1,9 @@
+import type { ASTDiffResult } from '../diff/ast-diff.js';
+import type {
+	ChangeCategory,
+	ClassifiedChange,
+} from '../diff/semantic-classifier.js';
+
 export type ReviewDepth = 'single' | 'double';
 
 export interface ReviewRouting {
@@ -13,6 +19,22 @@ export interface ComplexityMetrics {
 	astChangeCount: number;
 	maxFileComplexity: number;
 }
+
+export interface SemanticRoutingResult {
+	routing: ReviewRouting;
+	classifications: ClassifiedChange[];
+}
+
+const HIGH_RISK_CATEGORIES: ReadonlySet<ChangeCategory> = new Set([
+	'GUARD_REMOVED',
+	'SIGNATURE_CHANGE',
+	'API_CHANGE',
+	'DELETED_FUNCTION',
+]);
+
+const MAX_FILES_FOR_AST = 50;
+const MAX_BYTES_FOR_AST = 500_000;
+const AST_TIMEOUT_MS = 5000;
 
 /**
  * Compute complexity metrics for a set of files
@@ -99,6 +121,100 @@ export function routeReview(metrics: ComplexityMetrics): ReviewRouting {
 }
 
 /**
+ * Attempt AST-based semantic classification of changes.
+ * Returns null if AST analysis is unavailable, times out, or exceeds bounds.
+ */
+export async function computeSemanticClassifications(
+	directory: string,
+	changedFiles: string[],
+): Promise<ClassifiedChange[] | null> {
+	if (changedFiles.length > MAX_FILES_FOR_AST) return null;
+
+	try {
+		const fs = await import('node:fs');
+		const path = await import('node:path');
+
+		let totalBytes = 0;
+		for (const file of changedFiles) {
+			if (!/\.(ts|js|tsx|jsx|py|go|rs)$/.test(file)) continue;
+			try {
+				const filePath = path.join(directory, file);
+				const stat = fs.statSync(filePath);
+				totalBytes += stat.size;
+				if (totalBytes > MAX_BYTES_FOR_AST) return null;
+			} catch {
+				// missing file — skip
+			}
+		}
+
+		const { computeASTDiff } = await import('../diff/ast-diff.js');
+		const { classifyChanges } = await import('../diff/semantic-classifier.js');
+		const { execFileSync } = await import('node:child_process');
+
+		const astResults: ASTDiffResult[] = [];
+		const deadline = Date.now() + AST_TIMEOUT_MS;
+
+		for (const file of changedFiles) {
+			if (Date.now() > deadline) break;
+			if (!/\.(ts|js|tsx|jsx|py|go|rs)$/.test(file)) continue;
+
+			try {
+				const filePath = path.join(directory, file);
+				if (!fs.existsSync(filePath)) continue;
+				const content = fs.readFileSync(filePath, 'utf-8');
+				let oldContent = '';
+				try {
+					oldContent = execFileSync('git', ['show', `HEAD:${file}`], {
+						cwd: directory,
+						encoding: 'utf-8',
+						timeout: 2000,
+					});
+				} catch {
+					// new file or not in git — old content stays empty
+				}
+				const result = await computeASTDiff(file, oldContent, content);
+				astResults.push(result);
+			} catch {
+				// skip files that can't be parsed
+			}
+		}
+
+		if (astResults.length === 0) return null;
+		return classifyChanges(astResults);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Route review based on semantic classifications.
+ * High-risk categories (GUARD_REMOVED, SIGNATURE_CHANGE, API_CHANGE,
+ * DELETED_FUNCTION) trigger double review regardless of heuristic metrics.
+ */
+export function routeReviewSemantic(
+	metrics: ComplexityMetrics,
+	classifications: ClassifiedChange[],
+): ReviewRouting {
+	const highRiskChanges = classifications.filter((c) =>
+		HIGH_RISK_CATEGORIES.has(c.category),
+	);
+
+	if (highRiskChanges.length > 0) {
+		const categories = [
+			...new Set(highRiskChanges.map((c) => c.category)),
+		].join(', ');
+		return {
+			reviewerCount: 2,
+			testEngineerCount: 2,
+			depth: 'double',
+			reason: `Semantic risk: ${categories} detected in ${highRiskChanges.length} change(s)`,
+		};
+	}
+
+	return routeReview(metrics);
+}
+
+/**
  * Route review with full analysis
  */
 export async function routeReviewForChanges(
@@ -106,6 +222,15 @@ export async function routeReviewForChanges(
 	changedFiles: string[],
 ): Promise<ReviewRouting> {
 	const metrics = await computeComplexity(directory, changedFiles);
+	const classifications = await computeSemanticClassifications(
+		directory,
+		changedFiles,
+	);
+
+	if (classifications && classifications.length > 0) {
+		return routeReviewSemantic(metrics, classifications);
+	}
+
 	return routeReview(metrics);
 }
 

--- a/src/parallel/tier3-classifier.ts
+++ b/src/parallel/tier3-classifier.ts
@@ -1,0 +1,71 @@
+const TIER_3_BASENAME_PATTERNS = [
+	/^architect.*\.ts$/i,
+	/^delegation.*\.ts$/i,
+	/^guardrails?.*\.ts$/i,
+	/^adversarial.*\.ts$/i,
+	/^sanitiz.*\.ts$/i,
+	/^security.*\.ts$/i,
+];
+
+const TIER_3_EXACT_BASENAMES = new Set([
+	'auth',
+	'authenticate',
+	'authentication',
+	'authorization',
+	'permission',
+	'permissions',
+	'crypto',
+	'secret',
+	'secrets',
+]);
+
+const TIER_3_KEYWORD_PREFIX_RE =
+	/^(auth|permission|crypto|secret|security)[-_.]/i;
+
+const TIER_3_DIRECTORY_SEGMENTS = new Set([
+	'auth',
+	'security',
+	'crypto',
+	'permission',
+	'secret',
+]);
+
+function normalizeToForwardSlash(filePath: string): string {
+	return filePath.replace(/\\/g, '/');
+}
+
+export function matchesTier3(files: string[]): boolean {
+	for (const file of files) {
+		if (isTier3Path(file)) return true;
+	}
+	return false;
+}
+
+export function isTier3Path(filePath: string): boolean {
+	const normalized = normalizeToForwardSlash(filePath);
+	const segments = normalized.split('/');
+	const fileName = segments[segments.length - 1] || '';
+	const fileBaseName = fileName.replace(/\.[^.]*$/, '').toLowerCase();
+
+	if (TIER_3_EXACT_BASENAMES.has(fileBaseName)) return true;
+
+	if (TIER_3_KEYWORD_PREFIX_RE.test(fileBaseName)) return true;
+
+	for (const pattern of TIER_3_BASENAME_PATTERNS) {
+		if (pattern.test(fileName)) return true;
+	}
+
+	for (let i = 0; i < segments.length - 1; i++) {
+		if (TIER_3_DIRECTORY_SEGMENTS.has(segments[i].toLowerCase())) return true;
+	}
+
+	return false;
+}
+
+export const _internals = {
+	TIER_3_BASENAME_PATTERNS,
+	TIER_3_EXACT_BASENAMES,
+	TIER_3_KEYWORD_PREFIX_RE,
+	TIER_3_DIRECTORY_SEGMENTS,
+	normalizeToForwardSlash,
+};

--- a/src/parallel/tier3-classifier.ts
+++ b/src/parallel/tier3-classifier.ts
@@ -17,6 +17,7 @@ const TIER_3_EXACT_BASENAMES = new Set([
 	'crypto',
 	'secret',
 	'secrets',
+	'secretscan',
 ]);
 
 const TIER_3_KEYWORD_PREFIX_RE =

--- a/src/tools/update-task-status.ts
+++ b/src/tools/update-task-status.ts
@@ -19,6 +19,7 @@ import {
 import { validateDiffScope } from '../hooks/diff-scope';
 import { validateSwarmPath } from '../hooks/utils.js';
 import { tryAcquireLock } from '../parallel/file-locks.js';
+import { matchesTier3 } from '../parallel/tier3-classifier.js';
 import { loadPlan, updateTaskStatus } from '../plan/manager';
 import { formatLegacyQaBindingRecovery } from '../qa-gate/recovery.js';
 import {
@@ -299,40 +300,6 @@ function reviewerGateDecision(
 	return result;
 }
 
-/**
- * Tier 3 patterns that require full gate review even in Turbo Mode.
- * These are critical security-sensitive files that must always pass Stage B.
- */
-const TIER_3_PATTERNS = [
-	/^architect.*\.ts$/i,
-	/^delegation.*\.ts$/i,
-	/^guardrails.*\.ts$/i,
-	/^adversarial.*\.ts$/i,
-	/^sanitiz.*\.ts$/i,
-	/^auth.*$/i,
-	/^permission.*$/i,
-	/^crypto.*$/i,
-	/^secret.*$/i,
-	/^security.*\.ts$/i,
-];
-
-/**
- * Check if any file in the list matches a Tier 3 pattern.
- * @param files - Array of file paths/names to check
- * @returns true if any file matches a Tier 3 pattern
- */
-function matchesTier3Pattern(files: string[]): boolean {
-	for (const file of files) {
-		const fileName = path.basename(file);
-		for (const pattern of TIER_3_PATTERNS) {
-			if (pattern.test(fileName)) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
-
 function hasPassedDurableGateEvidence(
 	workingDirectory: string,
 	taskId: string,
@@ -432,7 +399,7 @@ export function checkReviewerGate(
 					for (const task of planPhase.tasks ?? []) {
 						if (task.id === taskId && task.files_touched) {
 							// If no Tier 3 patterns matched, bypass Stage B
-							if (!matchesTier3Pattern(task.files_touched)) {
+							if (!matchesTier3(task.files_touched)) {
 								return reviewerGateDecision(
 									taskId,
 									sessionID,

--- a/src/turbo/lean/task-completion.ts
+++ b/src/turbo/lean/task-completion.ts
@@ -9,6 +9,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { listActiveLocks } from '../../parallel/file-locks';
+import { matchesTier3 } from '../../parallel/tier3-classifier.js';
 import type { LeanTurboPersistedState, LeanTurboRunState } from './state';
 
 /**
@@ -35,39 +36,6 @@ export interface LeanTurboTaskCompletionResult {
 		laneStatus: string;
 		taskIds: string[];
 	};
-}
-
-/**
- * Tier 3 patterns that require full gate review even in Turbo Mode.
- * These are critical security-sensitive files that must always pass Stage B.
- * Copied from src/tools/update-task-status.ts.
- */
-const TIER_3_PATTERNS = [
-	/^architect.*\.ts$/i,
-	/^delegation.*\.ts$/i,
-	/^guardrails.*\.ts$/i,
-	/^adversarial.*\.ts$/i,
-	/^sanitiz.*\.ts$/i,
-	/^auth.*$/i,
-	/^permission.*$/i,
-	/^crypto.*$/i,
-	/^secret.*$/i,
-	/^security.*\.ts$/i,
-];
-
-/**
- * Check if any file in the list matches a Tier 3 pattern.
- */
-function matchesTier3Pattern(files: string[]): boolean {
-	for (const file of files) {
-		const fileName = path.basename(file);
-		for (const pattern of TIER_3_PATTERNS) {
-			if (pattern.test(fileName)) {
-				return true;
-			}
-		}
-	}
-	return false;
 }
 
 /**
@@ -330,7 +298,7 @@ export function verifyLeanTurboTaskCompletion(
 		};
 	}
 
-	if (filesTouched.length > 0 && matchesTier3Pattern(filesTouched)) {
+	if (filesTouched.length > 0 && matchesTier3(filesTouched)) {
 		return {
 			ok: false,
 			reason: `Task ${taskId} touches Tier-3 security-sensitive files and cannot bypass Stage B`,

--- a/tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts
+++ b/tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts
@@ -185,8 +185,10 @@ describe('delegation-gate: set-dispatch reviewed row parsing', () => {
 			'[reviewed] | task-2.1 | APPROVED | duplicate | ignored',
 		].join('\n');
 
-		const reviewedTaskIds = Array.from(parsePerTaskVerdicts(output)).flatMap(
-			([taskId, verdict]) => (verdict === 'APPROVED' ? [taskId] : []),
+		const reviewedTaskIds = Array.from(
+			parsePerTaskVerdicts(output).verdicts,
+		).flatMap(([taskId, entry]) =>
+			entry.verdict === 'APPROVED' ? [taskId] : [],
 		);
 		expect(reviewedTaskIds).toEqual(['2.1', '2.3']);
 	});

--- a/tests/unit/hooks/delegation-gate.set-dispatch-parser.test.ts
+++ b/tests/unit/hooks/delegation-gate.set-dispatch-parser.test.ts
@@ -7,55 +7,60 @@ const { parsePerTaskVerdicts } = _internals;
 
 describe('parsePerTaskVerdicts', () => {
 	it('SC-024.1: parses [REVIEWED] verdict line with task- prefix', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 Some review content here.
 
 [REVIEWED] | task-2.1 | APPROVED | No issues found in src/foo.ts
 `);
 		expect(verdicts.size).toBe(1);
-		expect(verdicts.get('2.1')).toBe('APPROVED');
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.1')?.kind).toBe('REVIEWED');
 	});
 
 	it('SC-024.2: parses [REVIEWED] verdict line with bare task ID', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [REVIEWED] | 2.2 | REJECTED | Missing null check at line 42
 `);
 		expect(verdicts.size).toBe(1);
-		expect(verdicts.get('2.2')).toBe('REJECTED');
+		expect(verdicts.get('2.2')?.verdict).toBe('REJECTED');
+		expect(verdicts.get('2.2')?.kind).toBe('REVIEWED');
 	});
 
 	it('SC-024.3: parses multiple [REVIEWED] verdict lines from single output', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [REVIEWED] | task-2.1 | APPROVED | No issues found
 [REVIEWED] | task-2.2 | APPROVED | Minor suggestion only
 [REVIEWED] | task-2.3 | REJECTED | Critical bug at line 88
 `);
 		expect(verdicts.size).toBe(3);
-		expect(verdicts.get('2.1')).toBe('APPROVED');
-		expect(verdicts.get('2.2')).toBe('APPROVED');
-		expect(verdicts.get('2.3')).toBe('REJECTED');
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.3')?.verdict).toBe('REJECTED');
 	});
 
 	it('SC-024.4: parses [TESTED] verdict lines', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [TESTED] | task-2.1 | PASS | 10/10 tests passed
 [TESTED] | task-2.2 | FAIL | 8/10 tests passed — bar.test.ts missing error path
 `);
 		expect(verdicts.size).toBe(2);
-		expect(verdicts.get('2.1')).toBe('PASS');
-		expect(verdicts.get('2.2')).toBe('FAIL');
+		expect(verdicts.get('2.1')?.verdict).toBe('PASS');
+		expect(verdicts.get('2.1')?.kind).toBe('TESTED');
+		expect(verdicts.get('2.2')?.verdict).toBe('FAIL');
+		expect(verdicts.get('2.2')?.kind).toBe('TESTED');
 	});
 
 	it('SC-024.5: parses [TESTED] with SKIPPED verdict', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [TESTED] | task-3.1 | SKIPPED | Test file does not exist
 `);
 		expect(verdicts.size).toBe(1);
-		expect(verdicts.get('3.1')).toBe('SKIPPED');
+		expect(verdicts.get('3.1')?.verdict).toBe('SKIPPED');
+		expect(verdicts.get('3.1')?.kind).toBe('TESTED');
 	});
 
 	it('SC-024.6: ignores lines that do not match verdict pattern', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 This is just some review text.
 VERDICT: APPROVED
 TASK: 2.1
@@ -64,11 +69,11 @@ But no structured verdict line here.
 Random line without format.
 `);
 		expect(verdicts.size).toBe(1);
-		expect(verdicts.get('2.1')).toBe('APPROVED');
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
 	});
 
 	it('SC-024.7: ignores invalid task ID formats', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [REVIEWED] | task-invalid | APPROVED | Should be ignored
 [REVIEWED] | task-2 | APPROVED | Should be ignored (missing patch number)
 [REVIEWED] | task-2.1.3.4.5 | APPROVED | Valid (deeper nesting)
@@ -76,40 +81,146 @@ Random line without format.
 		expect(verdicts.size).toBe(1);
 		expect(verdicts.has('invalid')).toBe(false);
 		expect(verdicts.has('2')).toBe(false);
-		expect(verdicts.get('2.1.3.4.5')).toBe('APPROVED');
+		expect(verdicts.get('2.1.3.4.5')?.verdict).toBe('APPROVED');
 	});
 
 	it('SC-024.8: handles empty output gracefully', () => {
-		expect(parsePerTaskVerdicts('').size).toBe(0);
+		const { verdicts, errors } = parsePerTaskVerdicts('');
+		expect(verdicts.size).toBe(0);
+		expect(errors.length).toBe(0);
 	});
 
 	it('SC-024.9: handles output with no verdict lines', () => {
-		expect(
-			parsePerTaskVerdicts(
-				'Just some regular output without any verdict markers.',
-			).size,
-		).toBe(0);
+		const { verdicts } = parsePerTaskVerdicts(
+			'Just some regular output without any verdict markers.',
+		);
+		expect(verdicts.size).toBe(0);
 	});
 
 	it('SC-024.10: case-insensitive tag matching', () => {
-		const verdicts = parsePerTaskVerdicts(`
+		const { verdicts } = parsePerTaskVerdicts(`
 [reviewed] | task-2.1 | APPROVED | lowercase tag
 [Reviewed] | task-2.2 | APPROVED | Mixed case tag
 [TESTED] | task-2.3 | PASS | Uppercase tag
 [tested] | task-2.4 | PASS | Lowercase tag
 `);
 		expect(verdicts.size).toBe(4);
-		expect(verdicts.get('2.1')).toBe('APPROVED');
-		expect(verdicts.get('2.2')).toBe('APPROVED');
-		expect(verdicts.get('2.3')).toBe('PASS');
-		expect(verdicts.get('2.4')).toBe('PASS');
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.3')?.verdict).toBe('PASS');
+		expect(verdicts.get('2.4')?.verdict).toBe('PASS');
 	});
 
-	it('SC-022.4: complex three-digit task IDs are parsed correctly', () => {
-		const verdicts = parsePerTaskVerdicts(`
+	it('SC-022.4: mixed REVIEWED and TESTED for same taskId produces conflict error', () => {
+		const { verdicts, errors } = parsePerTaskVerdicts(`
 [REVIEWED] | task-10.1.2 | APPROVED | Valid
 [TESTED] | task-10.1.2 | PASS | All tests pass
 `);
-		expect(verdicts.get('10.1.2')).toBe('PASS');
+		expect(verdicts.size).toBe(1);
+		expect(verdicts.get('10.1.2')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('10.1.2')?.kind).toBe('REVIEWED');
+		expect(errors.length).toBe(1);
+		expect(errors[0]).toContain('STAGE_B_VERDICT_CONFLICT');
+		expect(errors[0]).toContain('10.1.2');
+	});
+
+	it('SC-024.11: optional trailing pipe — verdict without trailing details', () => {
+		const { verdicts } = parsePerTaskVerdicts(`
+[REVIEWED] | task-2.1 | APPROVED
+[TESTED] | task-2.2 | PASS
+`);
+		expect(verdicts.size).toBe(2);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('PASS');
+	});
+
+	it('SC-024.12: optional trailing pipe — mixed with and without details', () => {
+		const { verdicts } = parsePerTaskVerdicts(`
+[REVIEWED] | task-2.1 | APPROVED | Full details here
+[REVIEWED] | task-2.2 | REJECTED
+`);
+		expect(verdicts.size).toBe(2);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('REJECTED');
+	});
+
+	it('SC-024.13: CRLF line endings are handled', () => {
+		const { verdicts } = parsePerTaskVerdicts(
+			'[REVIEWED] | task-2.1 | APPROVED | ok\r\n[TESTED] | task-2.2 | PASS | ok\r\n',
+		);
+		expect(verdicts.size).toBe(2);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('PASS');
+	});
+
+	it('SC-024.14: mixed LF and CRLF in same output', () => {
+		const { verdicts } = parsePerTaskVerdicts(
+			'[REVIEWED] | task-2.1 | APPROVED\r\nSome text\n[TESTED] | task-2.2 | PASS\n',
+		);
+		expect(verdicts.size).toBe(2);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(verdicts.get('2.2')?.verdict).toBe('PASS');
+	});
+
+	it('SC-024.15: identical duplicate verdicts are idempotent (no error)', () => {
+		const { verdicts, errors } = parsePerTaskVerdicts(`
+[REVIEWED] | task-2.1 | APPROVED | First mention
+[REVIEWED] | task-2.1 | APPROVED | Second mention
+`);
+		expect(verdicts.size).toBe(1);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(errors.length).toBe(0);
+	});
+
+	it('SC-024.16: conflicting verdict values produce VERDICT_CONFLICT error', () => {
+		const { verdicts, errors } = parsePerTaskVerdicts(`
+[REVIEWED] | task-2.1 | APPROVED | First
+[REVIEWED] | task-2.1 | REJECTED | Second
+`);
+		expect(verdicts.size).toBe(1);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+		expect(errors.length).toBe(1);
+		expect(errors[0]).toContain('STAGE_B_VERDICT_CONFLICT');
+		expect(errors[0]).toContain('2.1');
+		expect(errors[0]).toContain('REVIEWED/APPROVED');
+		expect(errors[0]).toContain('REVIEWED/REJECTED');
+	});
+
+	it('SC-024.17: CONCERNS verdict is parsed for REVIEWED', () => {
+		const { verdicts } = parsePerTaskVerdicts(`
+[REVIEWED] | task-4.1 | CONCERNS | Minor issues noted
+`);
+		expect(verdicts.size).toBe(1);
+		expect(verdicts.get('4.1')?.verdict).toBe('CONCERNS');
+		expect(verdicts.get('4.1')?.kind).toBe('REVIEWED');
+	});
+
+	it('SC-024.18: verdict kind is correctly tracked for all entries', () => {
+		const { verdicts } = parsePerTaskVerdicts(`
+[REVIEWED] | task-1.1 | APPROVED | ok
+[TESTED] | task-1.2 | PASS | ok
+[REVIEWED] | task-1.3 | REJECTED | bad
+[TESTED] | task-1.4 | FAIL | broken
+`);
+		expect(verdicts.get('1.1')?.kind).toBe('REVIEWED');
+		expect(verdicts.get('1.2')?.kind).toBe('TESTED');
+		expect(verdicts.get('1.3')?.kind).toBe('REVIEWED');
+		expect(verdicts.get('1.4')?.kind).toBe('TESTED');
+	});
+
+	it('SC-024.19: trailing whitespace after optional pipe does not break parsing', () => {
+		const { verdicts } = parsePerTaskVerdicts(
+			'[REVIEWED] | task-2.1 | APPROVED |   \n',
+		);
+		expect(verdicts.size).toBe(1);
+		expect(verdicts.get('2.1')?.verdict).toBe('APPROVED');
+	});
+
+	it('SC-024.20: errors array is empty when no conflicts exist', () => {
+		const { errors } = parsePerTaskVerdicts(`
+[REVIEWED] | task-1.1 | APPROVED | ok
+[TESTED] | task-1.2 | PASS | ok
+`);
+		expect(errors).toEqual([]);
 	});
 });

--- a/tests/unit/parallel/review-router.test.ts
+++ b/tests/unit/parallel/review-router.test.ts
@@ -7,12 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { ClassifiedChange } from '../../../src/diff/semantic-classifier';
 import {
 	type ComplexityMetrics,
 	computeComplexity,
 	type ReviewRouting,
 	routeReview,
 	routeReviewForChanges,
+	routeReviewSemantic,
 	shouldParallelizeReview,
 } from '../../../src/parallel/review-router';
 
@@ -225,7 +227,94 @@ class MyClass:
 		});
 	});
 
-	// ========== GROUP 4: routeReviewForChanges integration test ==========
+	// ========== GROUP 4: routeReviewSemantic tests ==========
+	describe('Group 4: routeReviewSemantic', () => {
+		const lowMetrics: ComplexityMetrics = {
+			fileCount: 1,
+			functionCount: 2,
+			astChangeCount: 5,
+			maxFileComplexity: 3,
+		};
+
+		function makeClassification(
+			category: ClassifiedChange['category'],
+		): ClassifiedChange {
+			return {
+				category,
+				riskLevel: 'High',
+				filePath: 'src/test.ts',
+				symbolName: 'testFn',
+				changeType: 'modified',
+				lineStart: 1,
+				lineEnd: 10,
+				description: `${category} detected`,
+			};
+		}
+
+		it('triggers double review for GUARD_REMOVED', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('GUARD_REMOVED'),
+			]);
+			expect(routing.depth).toBe('double');
+			expect(routing.reason).toContain('GUARD_REMOVED');
+		});
+
+		it('triggers double review for SIGNATURE_CHANGE', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('SIGNATURE_CHANGE'),
+			]);
+			expect(routing.depth).toBe('double');
+			expect(routing.reason).toContain('SIGNATURE_CHANGE');
+		});
+
+		it('triggers double review for API_CHANGE', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('API_CHANGE'),
+			]);
+			expect(routing.depth).toBe('double');
+			expect(routing.reason).toContain('Semantic risk');
+		});
+
+		it('triggers double review for DELETED_FUNCTION', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('DELETED_FUNCTION'),
+			]);
+			expect(routing.depth).toBe('double');
+		});
+
+		it('falls back to heuristic for low-risk categories', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('COSMETIC'),
+				makeClassification('REFACTOR'),
+			]);
+			expect(routing.depth).toBe('single');
+			expect(routing.reason).toContain('Standard complexity');
+		});
+
+		it('includes all distinct high-risk categories in reason', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('GUARD_REMOVED'),
+				makeClassification('API_CHANGE'),
+			]);
+			expect(routing.reason).toContain('GUARD_REMOVED');
+			expect(routing.reason).toContain('API_CHANGE');
+		});
+
+		it('reports change count in reason', () => {
+			const routing = routeReviewSemantic(lowMetrics, [
+				makeClassification('GUARD_REMOVED'),
+				makeClassification('GUARD_REMOVED'),
+			]);
+			expect(routing.reason).toContain('2 change(s)');
+		});
+
+		it('empty classifications fall back to heuristic', () => {
+			const routing = routeReviewSemantic(lowMetrics, []);
+			expect(routing.depth).toBe('single');
+		});
+	});
+
+	// ========== GROUP 5: routeReviewForChanges integration test ==========
 	describe('Group 4: routeReviewForChanges integration', () => {
 		it('computes and routes in one call', async () => {
 			fs.writeFileSync(

--- a/tests/unit/parallel/tier3-classifier.test.ts
+++ b/tests/unit/parallel/tier3-classifier.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	isTier3Path,
+	matchesTier3,
+} from '../../../src/parallel/tier3-classifier';
+
+describe('isTier3Path', () => {
+	test('exact basename: auth.ts', () => {
+		expect(isTier3Path('auth.ts')).toBe(true);
+	});
+
+	test('exact basename: permission.ts', () => {
+		expect(isTier3Path('permission.ts')).toBe(true);
+	});
+
+	test('exact basename: permissions.ts', () => {
+		expect(isTier3Path('permissions.ts')).toBe(true);
+	});
+
+	test('exact basename: crypto.ts', () => {
+		expect(isTier3Path('crypto.ts')).toBe(true);
+	});
+
+	test('exact basename: secret.ts', () => {
+		expect(isTier3Path('secret.ts')).toBe(true);
+	});
+
+	test('exact basename: secrets.ts', () => {
+		expect(isTier3Path('secrets.ts')).toBe(true);
+	});
+
+	test('keyword prefix with separator: auth-handler.ts', () => {
+		expect(isTier3Path('auth-handler.ts')).toBe(true);
+	});
+
+	test('keyword prefix with underscore: auth_middleware.ts', () => {
+		expect(isTier3Path('auth_middleware.ts')).toBe(true);
+	});
+
+	test('keyword prefix with dot: auth.config.ts', () => {
+		expect(isTier3Path('auth.config.ts')).toBe(true);
+	});
+
+	test('keyword prefix: permission-checker.ts', () => {
+		expect(isTier3Path('permission-checker.ts')).toBe(true);
+	});
+
+	test('keyword prefix: secret-key.ts', () => {
+		expect(isTier3Path('secret-key.ts')).toBe(true);
+	});
+
+	test('keyword prefix: crypto-utils.ts', () => {
+		expect(isTier3Path('crypto-utils.ts')).toBe(true);
+	});
+
+	test('keyword prefix: security-config.ts', () => {
+		expect(isTier3Path('security-config.ts')).toBe(true);
+	});
+
+	test('directory segment: src/auth/session.ts', () => {
+		expect(isTier3Path('src/auth/session.ts')).toBe(true);
+	});
+
+	test('directory segment: src/security/validator.ts', () => {
+		expect(isTier3Path('src/security/validator.ts')).toBe(true);
+	});
+
+	test('nested directory: src/security/crypto/keys.ts', () => {
+		expect(isTier3Path('src/security/crypto/keys.ts')).toBe(true);
+	});
+
+	test('directory segment: packages/auth/index.ts', () => {
+		expect(isTier3Path('packages/auth/index.ts')).toBe(true);
+	});
+
+	test('directory segment: src/permission/checker.ts', () => {
+		expect(isTier3Path('src/permission/checker.ts')).toBe(true);
+	});
+
+	test('directory segment: src/secret/store.ts', () => {
+		expect(isTier3Path('src/secret/store.ts')).toBe(true);
+	});
+
+	test('basename pattern: architect.ts', () => {
+		expect(isTier3Path('architect.ts')).toBe(true);
+	});
+
+	test('basename pattern: delegation-gate.ts', () => {
+		expect(isTier3Path('delegation-gate.ts')).toBe(true);
+	});
+
+	test('basename pattern: guardrails.ts', () => {
+		expect(isTier3Path('guardrails.ts')).toBe(true);
+	});
+
+	test('basename pattern: guardrail-check.ts', () => {
+		expect(isTier3Path('guardrail-check.ts')).toBe(true);
+	});
+
+	test('basename pattern: adversarial-test.ts', () => {
+		expect(isTier3Path('adversarial-test.ts')).toBe(true);
+	});
+
+	test('basename pattern: sanitize-input.ts', () => {
+		expect(isTier3Path('sanitize-input.ts')).toBe(true);
+	});
+
+	test('basename pattern: security-middleware.ts', () => {
+		expect(isTier3Path('security-middleware.ts')).toBe(true);
+	});
+
+	test('Windows separators: src\\auth\\session.ts', () => {
+		expect(isTier3Path('src\\auth\\session.ts')).toBe(true);
+	});
+
+	test('Windows separators: src\\security\\crypto\\keys.ts', () => {
+		expect(isTier3Path('src\\security\\crypto\\keys.ts')).toBe(true);
+	});
+
+	test('case insensitivity: AUTH.ts', () => {
+		expect(isTier3Path('AUTH.ts')).toBe(true);
+	});
+
+	test('case insensitivity: Security.ts (basename pattern)', () => {
+		expect(isTier3Path('Security.ts')).toBe(true);
+	});
+
+	test('false positive rejection: author.ts', () => {
+		expect(isTier3Path('author.ts')).toBe(false);
+	});
+
+	test('false positive rejection: authority.ts', () => {
+		expect(isTier3Path('authority.ts')).toBe(false);
+	});
+
+	test('false positive rejection: secretary.ts', () => {
+		expect(isTier3Path('secretary.ts')).toBe(false);
+	});
+
+	test('exact basename match: authenticate.ts', () => {
+		expect(isTier3Path('authenticate.ts')).toBe(true);
+	});
+
+	test('exact basename match: authorization.ts', () => {
+		expect(isTier3Path('authorization.ts')).toBe(true);
+	});
+
+	test('false positive rejection: cryptographic.ts', () => {
+		expect(isTier3Path('cryptographic.ts')).toBe(false);
+	});
+
+	test('benign file in non-sensitive directory: src/utils/helper.ts', () => {
+		expect(isTier3Path('src/utils/helper.ts')).toBe(false);
+	});
+
+	test('benign file: index.ts', () => {
+		expect(isTier3Path('index.ts')).toBe(false);
+	});
+
+	test('benign file: config.ts', () => {
+		expect(isTier3Path('config.ts')).toBe(false);
+	});
+});
+
+describe('matchesTier3', () => {
+	test('returns true if any file matches', () => {
+		expect(matchesTier3(['src/utils/helper.ts', 'src/auth/session.ts'])).toBe(
+			true,
+		);
+	});
+
+	test('returns false if no files match', () => {
+		expect(matchesTier3(['src/utils/helper.ts', 'src/models/user.ts'])).toBe(
+			false,
+		);
+	});
+
+	test('returns false for empty array', () => {
+		expect(matchesTier3([])).toBe(false);
+	});
+});

--- a/tests/unit/parallel/tier3-classifier.test.ts
+++ b/tests/unit/parallel/tier3-classifier.test.ts
@@ -28,6 +28,9 @@ describe('isTier3Path', () => {
 	test('exact basename: secrets.ts', () => {
 		expect(isTier3Path('secrets.ts')).toBe(true);
 	});
+	test('exact basename: secretscan.ts', () => {
+		expect(isTier3Path('secretscan.ts')).toBe(true);
+	});
 
 	test('keyword prefix with separator: auth-handler.ts', () => {
 		expect(isTier3Path('auth-handler.ts')).toBe(true);


### PR DESCRIPTION
Closes #2099
Absorbs #2066, #1308
Refs #2045

## Summary

- **Exact Stage B attribution**: Replace the all-eligible-task fallback with per-task structured verdict parsing. `parsePerTaskVerdicts` returns `StageBAttributionResult` with typed `VerdictEntry` (kind + verdict), duplicate detection (identical = idempotent, conflicting = `STAGE_B_VERDICT_CONFLICT`), and `STAGE_B_ATTRIBUTION_MISSING` when agents return no structured verdict lines
- **StageBDispatchContext**: Per-callID dispatch context capturing `taskIds` and `expectedVerdictKind`, wired to the verdict consumption check (replaces duplicated `targetAgent === 'reviewer'` branching)
- **Semantic review routing**: AST-based `computeSemanticClassifications` using `computeASTDiff` with git old-content (`execFileSync` for shell safety); `HIGH_RISK_CATEGORIES` (`GUARD_REMOVED`, `SIGNATURE_CHANGE`, `API_CHANGE`, `DELETED_FUNCTION`) trigger double review regardless of heuristic metrics
- **Tier-3 classifier consolidation**: Shared `tier3-classifier.ts` with four matching strategies (exact basenames, keyword prefix regex, basename patterns, directory segments) replacing two duplicate copies in `update-task-status.ts` and `task-completion.ts`
- **Telemetry attribution fix**: `agentName` derived from per-callID stored args (`afterCtx.args?.subagent_type`) instead of shared `swarmState.activeAgent` map which gets overwritten before `delegationEnd` is called

## Invariant audit

- 1 (plugin init): not touched - no changes to init path
- 2 (runtime portability): not touched - no new bun: imports, `bun run build` + `node --input-type=module` dist import OK
- 3 (subprocesses): touched - `execFileSync('git', ['show', ...], { cwd, timeout: 2000, encoding: 'utf-8' })` in `review-router.ts:167`. Array-form spawn (no shell), explicit cwd, 2s timeout, bounded output via encoding. Wrapped in try-catch for graceful fallback. `git diff --name-only | xargs grep` audit confirms single subprocess call, compliant.
- 4 (.swarm containment): not touched - no new .swarm/ writes
- 5 (plan durability): not touched - no plan schema/ledger changes
- 6 (test_runner safety): not touched - no test_runner scope changes
- 7 (test writing): touched - 3 new/modified test files use bun:test, all under 500 lines (FR-006 check:test-file-cap passes), no mock.module usage, tests use direct import of `_internals` seam
- 8 (session state): touched - new `stageBDispatchContextByCallID` Map keyed by callID (not sessionID). Cleanup at all 3 sites where sibling `stageBDispatchGenerationsByCallID.delete` appears (lines 2958, 4326, 4994). Map is function-scoped inside the hook closure, not module-level global.
- 9 (guardrails/retry): not touched - Stage B attribution changes are in the verdict consumption path, not guardrail retry logic
- 10 (chat/system msg): not touched - no message shape changes
- 11 (tool registration): not touched - `check-tool-registration.ts` passes (121 tools, coherent). `constants.ts` change is TURBO_MODE_BANNER text only.
- 12 (release/cache): not touched - release fragment added at `docs/releases/pending/2099-stage-b-attribution-semantic-review-routing.md`

## Test plan

- [x] `bun run test:unit:ci tests/unit/hooks/delegation-gate.set-dispatch-parser.test.ts` - 21 tests, exit 0
- [x] `bun run test:unit:ci tests/unit/hooks/delegation-gate-evidence-taskid.extraction.test.ts` - exit 0
- [x] `bun run test:unit:ci tests/unit/parallel/review-router.test.ts` - 22 tests, exit 0
- [x] `bun run test:unit:ci tests/unit/parallel/tier3-classifier.test.ts` - 43 tests, exit 0
- [x] `bun run typecheck` - clean
- [x] `bun run lint:ci` - 3440 files checked, no errors
- [x] `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` - dist import OK
- [x] `bun run scripts/check-tool-registration.ts` - 121 tools coherent
- [x] `bun run check:test-file-cap` - all pass
- [x] `bun run check:gate-portability` - all pass
- [x] `bun run check:runtime-src-refs` - 46 refs, all covered
- [x] `bun run check:events` - 42 event kinds coherent
- [x] `bash scripts/check-cross-contamination.sh` - pass (pre-existing warnings only)
- [x] `bash scripts/check-bash-portability.sh` - 0 bash4+ constructs
- [x] `bash scripts/check-invariants.sh` - exit 0
- [x] `(cd scripts/swarm-model && node --test)` - all pass
- [x] `bun run package:smoke` - OK (1087 files)
- [x] Independent opus reviewer (Phase 4.5): 5 findings, all addressed
- [x] Independent opus critic (Phase 4.6): 2 findings, all addressed

Generated with [Claude Code](https://claude.com/claude-code)
