### PR TITLE
fix(cli): pass packageRoot in CommandContext from CLI run() entry point

### DIFF
--- a/docs/releases/pending/fix-cli-package-root-passthrough.md
+++ b/docs/releases/pending/fix-cli-package-root-passthrough.md
@@ -1,0 +1,42 @@
+## Fix: CLI-invoked mode commands now receive a correct `packageRoot`
+
+### What changed
+
+`run()` in `src/cli/index.ts` now resolves a `PACKAGE_ROOT` constant and passes
+it as `packageRoot` in the `CommandContext` given to command handlers.
+Previously `packageRoot` was omitted entirely.
+
+The resolution walks up **two** directory levels from the module
+(`path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')`),
+because the CLI entry point is one level deeper than the main plugin entry:
+the CLI builds to `<root>/dist/cli/index.js` and runs from
+`<root>/src/cli/index.ts` in dev, whereas `src/index.ts` builds to
+`<root>/dist/index.js`. This matches the existing `resolvePackageRoot`
+(`src/commands/gate-audit.ts`) and `resolvePackageRootFromModule`
+(`src/commands/memory.ts`) helpers, which both special-case a `cli`/`commands`
+leaf with two `'..'`.
+
+### Why
+
+When mode commands (e.g. brainstorm) are invoked from the CLI instead of the
+plugin chat interface, the `syncBundledProjectSkillsIfMissingAsync` backstop in
+`handleModeCommandWithBundledSkills` (`src/commands/registry.ts`) was skipped
+because `ctx.packageRoot` was `undefined`. The backstop now runs against the
+real package root, so it can find the bundled-skill source tree at
+`<packageRoot>/.opencode/skills`.
+
+A single-level resolution would have been worse than the original bug: it would
+point at `<root>/dist` (or `<root>/src`), where the sync would silently find no
+source skills and no-op, while also overriding `gate-audit`'s correct
+`DEFAULT_PACKAGE_ROOT` with a path that hard-throws `ENOENT`.
+
+### Testing
+
+`tests/unit/cli/package-root-resolution.test.ts` pins the arity: it derives the
+level count from the shipped source expression and asserts the result is the
+real package root from both the dev (`src/cli`) and built (`dist/cli`)
+locations, including the presence of `.opencode/skills`.
+
+### Migration
+
+No migration required.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import packageJson from '../../package.json' with { type: 'json' };
 import {
 	COMMAND_REGISTRY,
@@ -17,6 +18,23 @@ import { DEFAULT_AGENT_CONFIGS } from '../config/constants.js';
 import { safeRealpathSync } from '../tools/repo-graph/safe-realpath.js';
 
 const { version } = packageJson;
+
+// Two levels up, NOT one. This module lives one directory deeper than the main
+// plugin entry: the CLI builds to `<root>/dist/cli/index.js` (`bun build
+// src/cli/index.ts --outdir dist/cli`) and runs from `<root>/src/cli/index.ts`
+// in dev, whereas `src/index.ts` builds to `<root>/dist/index.js`. Copying that
+// module's single `'..'` here would resolve to `<root>/dist` (or `<root>/src`),
+// which silently breaks every consumer: the bundled-skill sync would look for a
+// nonexistent `<root>/dist/.opencode/skills` and no-op, and `gate-audit` would
+// override its correct DEFAULT_PACKAGE_ROOT with a path that hard-throws ENOENT.
+// Matches resolvePackageRoot (src/commands/gate-audit.ts) and
+// resolvePackageRootFromModule (src/commands/memory.ts), which both special-case
+// a `cli`/`commands` leaf with two `'..'`.
+const PACKAGE_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	'..',
+	'..',
+);
 
 const CONFIG_DIR = getPluginConfigDir();
 
@@ -825,6 +843,7 @@ export async function run(args: string[]): Promise<number> {
 		sessionID: '',
 		agents: {},
 		source: 'cli',
+		packageRoot: PACKAGE_ROOT,
 	});
 
 	console.log(result);

--- a/tests/unit/cli/package-root-resolution.test.ts
+++ b/tests/unit/cli/package-root-resolution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Guard for the CLI's PACKAGE_ROOT arithmetic (PR #2226 regression).
+ *
+ * `src/cli/index.ts` sits one directory deeper than the main plugin entry:
+ *   - main entry  builds to  <root>/dist/index.js      (src/index.ts)
+ *   - CLI  entry  builds to  <root>/dist/cli/index.js  (src/cli/index.ts)
+ *
+ * Copying `src/index.ts`'s single `'..'` into the CLI resolves PACKAGE_ROOT to
+ * `<root>/dist` (built) or `<root>/src` (dev). Both are wrong, and both fail
+ * SILENTLY: `performBundledProjectSkillSyncAsync` looks for a nonexistent
+ * `<packageRoot>/.opencode/skills` and no-ops, while `gate-audit` overrides its
+ * correct DEFAULT_PACKAGE_ROOT with a path that hard-throws ENOENT.
+ *
+ * These tests derive the level count from the actual source expression rather
+ * than restating it, so they fail if the arity regresses.
+ */
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+const CLI_SOURCE = path.join(REPO_ROOT, 'src', 'cli', 'index.ts');
+
+/** Directories this module can run from: dev (bun src) and built (bin). */
+const RUNTIME_MODULE_DIRS = [
+	path.join(REPO_ROOT, 'src', 'cli'),
+	path.join(REPO_ROOT, 'dist', 'cli'),
+];
+
+/** Count the `'..'` segments in the PACKAGE_ROOT expression as shipped. */
+function parsePackageRootLevels(source: string): number {
+	const match = source.match(
+		/const\s+PACKAGE_ROOT\s*=\s*path\.resolve\(([\s\S]*?)\);/,
+	);
+	if (!match) throw new Error('PACKAGE_ROOT expression not found');
+	return (match[1].match(/'\.\.'/g) ?? []).length;
+}
+
+describe('CLI PACKAGE_ROOT resolution', () => {
+	const source = readFileSync(CLI_SOURCE, 'utf-8');
+	const levels = parsePackageRootLevels(source);
+
+	it('is derived from import.meta.url, not cwd', () => {
+		expect(source).toContain('fileURLToPath(import.meta.url)');
+	});
+
+	it('walks up two levels (cli/ is one deeper than the main entry)', () => {
+		expect(levels).toBe(2);
+	});
+
+	it.each(
+		RUNTIME_MODULE_DIRS,
+	)('resolves to the real package root from %s', (moduleDir) => {
+		const resolved = path.resolve(moduleDir, ...Array(levels).fill('..'));
+
+		expect(resolved).toBe(REPO_ROOT);
+
+		// The package root must actually look like this package...
+		const manifest = path.join(resolved, 'package.json');
+		expect(existsSync(manifest)).toBe(true);
+		expect(JSON.parse(readFileSync(manifest, 'utf-8')).name).toBe(
+			'opencode-swarm',
+		);
+
+		// ...and must contain the bundled-skill source tree the sync reads,
+		// which is the exact lookup that silently no-oped with a wrong root.
+		expect(existsSync(path.join(resolved, '.opencode', 'skills'))).toBe(true);
+	});
+
+	it('would not resolve correctly with a single level (regression pin)', () => {
+		for (const moduleDir of RUNTIME_MODULE_DIRS) {
+			const wrong = path.resolve(moduleDir, '..');
+			expect(wrong).not.toBe(REPO_ROOT);
+			expect(existsSync(path.join(wrong, '.opencode', 'skills'))).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- `run()` in `src/cli/index.ts` built a `CommandContext` without `packageRoot`, so CLI-invoked mode commands skipped the `syncBundledProjectSkillsIfMissingAsync` backstop in `handleModeCommandWithBundledSkills` (`src/commands/registry.ts`)
- Resolves `PACKAGE_ROOT` from `import.meta.url` and passes it through
- **Walks up two levels, not one.** The CLI entry sits a directory deeper than the main plugin entry (`dist/cli/index.js` vs `dist/index.js`), so copying `src/index.ts`'s single `'..'` resolves to `<root>/dist` when built and `<root>/src` in dev. Matches `resolvePackageRoot` (`src/commands/gate-audit.ts:35-42`) and `resolvePackageRootFromModule` (`src/commands/memory.ts:607-617`), which both special-case a `cli`/`commands` leaf with two `'..'`
- Adds `tests/unit/cli/package-root-resolution.test.ts`, which derives the level count from the shipped source expression and asserts it lands on the real package root from both the dev and built module locations

### Review feedback addressed
This PR was revised after review. The initial commit used a single `'..'`, which was wrong in every layout and failed silently two ways: the skill sync would look for a nonexistent `<root>/dist/.opencode/skills` and no-op, and `gate-audit` would override its correct `DEFAULT_PACKAGE_ROOT` with a path that hard-throws `ENOENT` via `resolveContainedExistingPath`. Verified empirically against the real built artifact:

| Module location | `'..'` | `'..','..'` |
|---|---|---|
| `dist/cli` (built bin) | `<root>/dist` âŒ 0 skills | `<root>` âœ… 42 skills |
| `src/cli` (dev) | `<root>/src` âŒ 0 skills | `<root>` âœ… 42 skills |

Also rebased onto current `main` (was 5 commits behind), which clears an inherited `check:test-file-cap` ratchet violation in `delegation-gate-acceptance-coverage.adversarial.test.ts` (507 lines at the old base, 436 on current main).

## Invariant audit
- 1 (plugin init): not touched - change is in the CLI entry point (`src/cli/index.ts`), not the plugin init path; `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` both pass
- 2 (runtime portability): not touched - `fileURLToPath` is a standard `node:url` API, no `bun:` or `Bun.*` usage added; `bundle-portability.test.ts` and `bundle-plugin-shape.test.ts` pass
- 3 (subprocesses): not touched - no subprocess changes
- 4 (.swarm containment): not touched - no `.swarm/` path changes; `packageRoot` is a read-only source location for the bundled-skill sync
- 5 (plan durability): not touched - no plan/ledger changes
- 6 (test_runner safety): not touched - validation used scoped `bun run test:unit:ci <files>`, never a broad scope
- 7 (test writing): touched - adds one `bun:test` file with no `mock.module` (avoids growing the allowlist debt surface per the DI preference); 78 lines, under the 500 cap; `check:test-file-cap`, `check-mock-cleanup.sh`, `check-test-tmpdir.sh`, `check-test-clock.sh` all pass
- 8 (session state): not touched - `PACKAGE_ROOT` is a module constant derived from the module's own location, not session-scoped
- 9 (guardrails/retry): not touched - no guardrail/retry changes
- 10 (chat/system msg): not touched - no chat/message changes
- 11 (tool registration): not touched - no tool/agent-map/command changes; `check-tool-registration.ts` passes (121 tools coherent)
- 12 (release/cache): not touched - version files untouched; ships `docs/releases/pending/fix-cli-package-root-passthrough.md`

## Test plan
- [x] `bun run build` succeeds; built bundle contains the two-level resolution
- [x] `node --input-type=module -e "await import('./dist/index.js')"` passes
- [x] Executed from the real built bin location (`dist/cli/index.js`): `PACKAGE_ROOT` equals the repo root and the sync's `sourceRoot` resolves to `.opencode/skills` with 42 skills present
- [x] New guard test verified to FAIL on the buggy single-level version and PASS on the fix
- [x] `bun run typecheck`, `bun run lint:ci` pass
- [x] All 16 CI quality-job gates pass (tool-registration, mock-cleanup, invariants, cross-contamination, test-clock, runtime-src-refs, events, test-file-cap, gate-portability, test-tmpdir, bash-portability, swarm-model, package:smoke)
- [x] CLI unit tests pass: package-root-resolution, run-command, run-command.adversarial, run-dispatch, run-dispatch.adversarial, main-wiring, main-wiring.adversarial
- [x] Build tests pass: bundle-portability, bundle-plugin-shape
- [x] Consumer tests pass: gate-audit, gate-audit-storage, commands/memory
