### PR TITLE
fix(session): retry transient windows rename failures in snapshot writer

### DIFF
--- a/docs/releases/pending/snapshot-writer-windows-rename-retry.md
+++ b/docs/releases/pending/snapshot-writer-windows-rename-retry.md
@@ -1,0 +1,65 @@
+# Session snapshot writer: retry transient Windows rename failures
+
+## What
+
+`writeSnapshot` (`src/session/snapshot-writer.ts`) performed its atomic
+temp-file swap with a bare `renameSync`, inside a `catch` block that only logs.
+The rename now retries on the transient Windows sharing-violation codes
+(`EEXIST` / `EBUSY` / `EPERM`) with the same bounded policy the repository's
+own write shim already applies — 3 attempts, 50 ms apart — and breaks
+immediately on any other error code.
+
+Two supporting changes:
+
+- On permanent rename failure the writer best-effort `unlink`s its own temp
+  file, so a persistently locked `state.json` no longer accumulates one
+  orphaned `state.json.tmp.*` per `tool.execute.after` under
+  `.swarm/session/`.
+- The rename is routed through the module's existing `_internals`
+  dependency-injection seam (`_internals.rename`), so the retry path is
+  testable without `mock.module`.
+
+`invalidateCachedArtifact` still runs only after a genuinely successful swap,
+preserving the issue #1729 cache-invalidation ordering.
+
+## Why
+
+`src/utils/bun-compat.ts` documents this exact failure mode and defends against
+it: `WINDOWS_RENAME_MAX_RETRIES = 3` with an `EEXIST`/`EBUSY`/`EPERM` retry loop
+in `bunWrite`. On Windows, a second process holding the destination open — an
+external reader tailing `.swarm/session/state.json`, or an antivirus scanner —
+makes `rename` fail transiently.
+
+The snapshot writer was the one writer in the repository without that defense.
+Because its `catch` only logs, a transient failure silently degraded an atomic
+update into a dropped one: the snapshot on disk stayed at its previous
+contents while the in-memory `swarmState` moved on. The writer runs on every
+`tool.execute.after`, so any consumer reading the snapshot (handoff, phase
+resume, session rehydration) could observe stale session state with no error
+surfaced anywhere.
+
+## Migration
+
+No migration required. The change is internal to the snapshot write path:
+
+- No schema, format, or field change to `.swarm/session/state.json` — the
+  snapshot is still `version: 3`.
+- No public tool, agent, or command surface changes.
+- Error behavior is unchanged from the caller's perspective: `writeSnapshot`
+  still swallows failures and never throws, so it cannot crash the plugin.
+
+## Caveats
+
+- The retry budget is deliberately duplicated in `snapshot-writer.ts` rather
+  than imported from `src/utils/bun-compat.ts`. Several test files mock
+  `../utils/bun-compat` with non-spreading `mock.module` factories, and Bun
+  fails module resolution when a real module imports an export such a factory
+  omits — so adding a new shared export to `bun-compat` would break unrelated
+  suites. The budget is exported as `SNAPSHOT_RENAME_MAX_ATTEMPTS` so tests
+  assert against the real constant instead of a hand-copied literal.
+- The retry covers transient *rename* failures only. It does not attempt to
+  make the write durable against a permanently locked target; after the budget
+  is exhausted the failure is still logged and swallowed, as before.
+- Simulated retry behavior is verified through the `_internals.rename` seam.
+  The underlying Windows sharing-violation timing is not reproduced in CI —
+  the same limitation applies to the pre-existing `bunWrite` retry loop.

--- a/docs/releases/pending/snapshot-writer-windows-rename-retry.md
+++ b/docs/releases/pending/snapshot-writer-windows-rename-retry.md
@@ -6,7 +6,9 @@
 temp-file swap with a bare `renameSync`, inside a `catch` block that only logs.
 The rename now retries on the transient Windows sharing-violation codes
 (`EEXIST` / `EBUSY` / `EPERM`) with the same bounded policy the repository's
-own write shim already applies — 3 attempts, 50 ms apart — and breaks
+own write shim already applies — 3 attempts, 50 ms apart, same codes (one
+deliberate difference: `bunWrite` also sleeps after its final attempt; this
+loop skips that pointless terminal sleep) — and breaks
 immediately on any other error code.
 
 Two supporting changes:
@@ -30,8 +32,13 @@ in `bunWrite`. On Windows, a second process holding the destination open — an
 external reader tailing `.swarm/session/state.json`, or an antivirus scanner —
 makes `rename` fail transiently.
 
-The snapshot writer was the one writer in the repository without that defense.
-Because its `catch` only logs, a transient failure silently degraded an atomic
+The snapshot writer was the highest-frequency writer without this defense on
+its canonical-file swap — it is not the only one: `src/commands/handoff.ts`
+(`handoff.md`, `handoff-prompt.md`) and `src/evidence/task-file.ts`
+(`atomicWriteFile`) still perform bare `renameSync` swaps with the same
+transient exposure; unifying those behind a shared retrying helper is the
+remaining scope of #2035. Because the snapshot writer's `catch` only logs, a
+transient failure silently degraded an atomic
 update into a dropped one: the snapshot on disk stayed at its previous
 contents while the in-memory `swarmState` moved on. The writer runs on every
 `tool.execute.after`, so any consumer reading the snapshot (handoff, phase
@@ -60,6 +67,10 @@ No migration required. The change is internal to the snapshot write path:
 - The retry covers transient *rename* failures only. It does not attempt to
   make the write durable against a permanently locked target; after the budget
   is exhausted the failure is still logged and swallowed, as before.
+- The post-failure temp cleanup is best-effort: the `finally` `unlink` swallows
+  its own errors, so if something (e.g. a scanner holding the freshly written
+  temp open on Windows) blocks that unlink, an orphaned `.tmp.*` file can
+  still remain.
 - Simulated retry behavior is verified through the `_internals.rename` seam.
   The underlying Windows sharing-violation timing is not reproduced in CI —
   the same limitation applies to the pre-existing `bunWrite` retry loop.

--- a/src/session/snapshot-writer.ts
+++ b/src/session/snapshot-writer.ts
@@ -3,7 +3,15 @@
  * Serializes swarmState to .swarm/session/state.json using atomic write (temp-file + rename).
  */
 
-import { closeSync, fsyncSync, mkdirSync, openSync, renameSync } from 'node:fs';
+import {
+	closeSync,
+	existsSync,
+	fsyncSync,
+	mkdirSync,
+	openSync,
+	unlinkSync,
+} from 'node:fs';
+import { rename as fsRename } from 'node:fs/promises';
 import * as path from 'node:path';
 import { TASK_WORKFLOW_SCHEMA_MARKER } from '../gate-evidence.js';
 import { validateSwarmPath } from '../hooks/utils';
@@ -24,6 +32,68 @@ import { invalidateCachedArtifact } from '../utils/swarm-artifact-cache';
  * ensures only one write is in flight at a time so the last writer wins.
  */
 let _writeInFlight: Promise<void> = Promise.resolve();
+
+/**
+ * Windows can transiently fail a rename with EEXIST/EBUSY/EPERM while another
+ * process (an external snapshot reader, an AV scanner) briefly holds the
+ * target open. Mirrors the retry policy in `bunWrite`
+ * (src/utils/bun-compat.ts:36) — kept local rather than imported so this
+ * module adds no new bun-compat exports for existing non-spread
+ * `mock.module('../utils/bun-compat', ...)` test factories to miss.
+ */
+export const SNAPSHOT_RENAME_MAX_ATTEMPTS = 3;
+const SNAPSHOT_RENAME_RETRY_DELAY_MS = 50;
+
+/**
+ * Atomic swap for the snapshot temp file, retrying the transient Windows
+ * sharing violations. A bare rename converts an external reader briefly
+ * holding `state.json` open into silent snapshot staleness: `writeSnapshot`'s
+ * catch only logs, so the update is dropped while the in-memory state moves
+ * on. Any non-transient code fails immediately — retrying an EACCES or
+ * ENOENT would only delay the log.
+ *
+ * Throws the last rename error when the budget is exhausted; the caller owns
+ * temp-file cleanup and error swallowing.
+ */
+async function renameWithTransientRetry(
+	tempPath: string,
+	targetPath: string,
+): Promise<void> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < SNAPSHOT_RENAME_MAX_ATTEMPTS; attempt++) {
+		try {
+			await _internals.rename(tempPath, targetPath);
+			return;
+		} catch (error) {
+			lastError = error;
+			const code = (error as NodeJS.ErrnoException).code;
+			// Windows can report a sharing violation for a rename that actually
+			// committed, so a retry then finds the source already gone. Treating
+			// that as a failure would skip the caller's cache invalidation for a
+			// file that really did change — the precise stale-read the #1729
+			// invalidation exists to prevent. Only a retry can observe this, so
+			// the check is scoped to attempt > 0.
+			if (
+				code === 'ENOENT' &&
+				attempt > 0 &&
+				!existsSync(tempPath) &&
+				existsSync(targetPath)
+			) {
+				return;
+			}
+			if (code !== 'EEXIST' && code !== 'EBUSY' && code !== 'EPERM') {
+				break;
+			}
+			// No point sleeping after the final attempt — nothing follows it.
+			if (attempt < SNAPSHOT_RENAME_MAX_ATTEMPTS - 1) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, SNAPSHOT_RENAME_RETRY_DELAY_MS),
+				);
+			}
+		}
+	}
+	throw lastError;
+}
 
 /**
  * Serialized form of AgentSessionState with Map/Set fields converted to plain arrays/objects
@@ -343,7 +413,19 @@ export async function writeSnapshot(
 			// fsync is best-effort; OSes / filesystems that don't support it
 			// (e.g. tmpfs, ramdisk) shouldn't block the main path.
 		}
-		renameSync(tempPath, resolvedPath);
+		try {
+			await renameWithTransientRetry(tempPath, resolvedPath);
+		} finally {
+			// No-op after a successful swap (the temp path no longer exists);
+			// drops the orphan when every retry failed, so a persistently locked
+			// target cannot litter .swarm/session with one .tmp file per
+			// tool.execute.after. Mirrors src/evidence/task-file.ts:atomicWriteFile.
+			try {
+				unlinkSync(tempPath);
+			} catch {
+				/* already renamed or never created */
+			}
+		}
 		// Only after a SUCCESSFUL rename. `session/state.json` is read through the
 		// cached reader (`readSwarmFileAsync(directory, 'session/state.json')` at
 		// src/services/handoff-service.ts:376), and this writer runs on every
@@ -400,8 +482,10 @@ export const _internals: {
 	writeSnapshot: typeof writeSnapshot;
 	createSnapshotWriterHook: typeof createSnapshotWriterHook;
 	flushPendingSnapshot: typeof flushPendingSnapshot;
+	rename: typeof fsRename;
 } = {
 	writeSnapshot,
 	createSnapshotWriterHook,
 	flushPendingSnapshot,
+	rename: fsRename,
 } as const;

--- a/src/session/snapshot-writer.ts
+++ b/src/session/snapshot-writer.ts
@@ -36,9 +36,10 @@ let _writeInFlight: Promise<void> = Promise.resolve();
 /**
  * Windows can transiently fail a rename with EEXIST/EBUSY/EPERM while another
  * process (an external snapshot reader, an AV scanner) briefly holds the
- * target open. Mirrors the retry policy in `bunWrite`
- * (src/utils/bun-compat.ts:36) — kept local rather than imported so this
- * module adds no new bun-compat exports for existing non-spread
+ * target open. Same codes, budget, and delay as the retry policy in `bunWrite`
+ * (src/utils/bun-compat.ts:36) — except this loop skips the sleep after the
+ * final attempt, which bunWrite still takes. Kept local rather than imported
+ * so this module adds no new bun-compat exports for existing non-spread
  * `mock.module('../utils/bun-compat', ...)` test factories to miss.
  */
 export const SNAPSHOT_RENAME_MAX_ATTEMPTS = 3;
@@ -419,7 +420,9 @@ export async function writeSnapshot(
 			// No-op after a successful swap (the temp path no longer exists);
 			// drops the orphan when every retry failed, so a persistently locked
 			// target cannot litter .swarm/session with one .tmp file per
-			// tool.execute.after. Mirrors src/evidence/task-file.ts:atomicWriteFile.
+			// tool.execute.after. Best-effort: an unlink blocked by something
+			// holding the fresh temp open can still leave the orphan behind.
+			// Mirrors src/evidence/task-file.ts:atomicWriteFile.
 			try {
 				unlinkSync(tempPath);
 			} catch {

--- a/tests/unit/session/snapshot-writer-rename-retry.test.ts
+++ b/tests/unit/session/snapshot-writer-rename-retry.test.ts
@@ -6,7 +6,8 @@
  * EPERM — an external reader or AV scanner briefly holding
  * .swarm/session/state.json open) silently dropped the snapshot update and
  * left the on-disk state stale. The writer now retries the rename with the
- * same bounded policy as `bunWrite` (src/utils/bun-compat.ts:36) and cleans
+ * same codes/budget/delay as `bunWrite` (src/utils/bun-compat.ts:36 — except
+ * this loop skips the sleep after the final attempt) and best-effort cleans
  * up the orphaned temp file when the rename fails permanently.
  *
  * The rename is intercepted through the module's `_internals.rename` DI seam

--- a/tests/unit/session/snapshot-writer-rename-retry.test.ts
+++ b/tests/unit/session/snapshot-writer-rename-retry.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for the snapshot writer's atomic-swap rename retry.
+ *
+ * Previous code performed the swap with a bare `renameSync` inside a catch
+ * that only logs, so a transient Windows sharing violation (EEXIST/EBUSY/
+ * EPERM — an external reader or AV scanner briefly holding
+ * .swarm/session/state.json open) silently dropped the snapshot update and
+ * left the on-disk state stale. The writer now retries the rename with the
+ * same bounded policy as `bunWrite` (src/utils/bun-compat.ts:36) and cleans
+ * up the orphaned temp file when the rename fails permanently.
+ *
+ * The rename is intercepted through the module's `_internals.rename` DI seam
+ * (Tier 1) — no `mock.module`, no cross-file pollution.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	_internals,
+	SNAPSHOT_RENAME_MAX_ATTEMPTS,
+	type SnapshotData,
+	writeSnapshot,
+} from '../../../src/session/snapshot-writer';
+import {
+	_internals as artifactCacheInternals,
+	readCachedTextFile,
+	resetSwarmArtifactCache,
+} from '../../../src/utils/swarm-artifact-cache';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let testDir: string;
+const originalRename = _internals.rename;
+const originalCacheStat = artifactCacheInternals.stat;
+
+const emptyState = () => ({
+	toolAggregates: new Map(),
+	activeAgent: new Map(),
+	delegationChains: new Map(),
+	activeToolCalls: new Map(),
+	pendingEvents: 0,
+	agentSessions: new Map(),
+});
+
+const transientError = (code: string): NodeJS.ErrnoException => {
+	const err: NodeJS.ErrnoException = new Error(
+		`${code}: simulated transient rename failure`,
+	);
+	err.code = code;
+	return err;
+};
+
+beforeEach(() => {
+	// canonicalMkdtemp closes the macOS /var -> /private/var symlink gap and
+	// the Windows 8.3 short-name mismatch (FR-011, issue #1737).
+	testDir = canonicalMkdtemp('snapshot-rename-retry-');
+	resetSwarmArtifactCache();
+});
+
+afterEach(() => {
+	_internals.rename = originalRename;
+	artifactCacheInternals.stat = originalCacheStat;
+	resetSwarmArtifactCache();
+	if (existsSync(testDir)) {
+		rmSync(testDir, { recursive: true, force: true });
+	}
+});
+
+describe('writeSnapshot — regression: transient rename failure must not drop the snapshot (bun-compat parity)', () => {
+	const sessionDir = () => path.join(testDir, '.swarm', 'session');
+	const statePath = () => path.join(sessionDir(), 'state.json');
+
+	it.each([
+		'EEXIST',
+		'EBUSY',
+		'EPERM',
+	])('retries %s and eventually completes the atomic swap', async (code) => {
+		let calls = 0;
+		_internals.rename = mock(async (oldPath: string, newPath: string) => {
+			calls++;
+			// Fail every attempt but the last so the test exercises the full
+			// retry budget rather than a single lucky retry.
+			if (calls < SNAPSHOT_RENAME_MAX_ATTEMPTS) {
+				throw transientError(code);
+			}
+			return originalRename(oldPath, newPath);
+		});
+
+		await writeSnapshot(testDir, emptyState());
+
+		expect(calls).toBe(SNAPSHOT_RENAME_MAX_ATTEMPTS);
+		expect(existsSync(statePath())).toBe(true);
+		const parsed = JSON.parse(
+			await Bun.file(statePath()).text(),
+		) as SnapshotData;
+		expect(parsed.version).toBe(3);
+		// The successful swap consumed the temp file — nothing left behind.
+		expect(
+			readdirSync(sessionDir()).filter((f) => f.includes('.tmp.')),
+		).toEqual([]);
+	});
+
+	it('gives up after the retry budget on a persistent transient code and removes the temp file', async () => {
+		let calls = 0;
+		_internals.rename = mock(async () => {
+			calls++;
+			throw transientError('EBUSY');
+		});
+
+		// Still swallows the error (never crash the plugin)...
+		await expect(writeSnapshot(testDir, emptyState())).resolves.toBeUndefined();
+
+		// ...but only after exhausting the full retry budget.
+		expect(calls).toBe(SNAPSHOT_RENAME_MAX_ATTEMPTS);
+		expect(existsSync(statePath())).toBe(false);
+		// Permanent failure must not litter .swarm/session with temp files.
+		expect(
+			readdirSync(sessionDir()).filter((f) => f.includes('.tmp.')),
+		).toEqual([]);
+	});
+
+	it('treats ENOENT on a retry as the spurious-failure success it is, so the cache is still invalidated', async () => {
+		// Windows can report a sharing violation for a rename that actually
+		// committed; the retry then finds the temp already gone. Reporting that
+		// as a failure would skip invalidateCachedArtifact for a file that
+		// really did change — the exact stale cached read issue #1729 guards
+		// against.
+		//
+		// The assertion has to be the cache entry, not the file: on this path
+		// the snapshot lands on disk either way, so asserting file contents
+		// would pass with or without the fix. Same frozen-stat technique as
+		// tests/unit/utils/swarm-write-cache-invalidation-wiring.test.ts —
+		// under a frozen stamp the cache can only miss if the entry was
+		// dropped, so a directRead the file never contains proves invalidation.
+		mkdirSync(sessionDir(), { recursive: true });
+		writeFileSync(statePath(), 'OLD SNAPSHOT', 'utf-8');
+		const primed = await readCachedTextFile(statePath(), async () =>
+			readFileSync(statePath(), 'utf-8'),
+		);
+		expect(primed).toBe('OLD SNAPSHOT');
+		const frozenStat = await fsp.stat(statePath());
+		artifactCacheInternals.stat = (async () =>
+			frozenStat) as typeof artifactCacheInternals.stat;
+
+		let calls = 0;
+		_internals.rename = mock(async (oldPath: string, newPath: string) => {
+			calls++;
+			if (calls === 1) {
+				// The move lands despite the reported sharing violation.
+				await originalRename(oldPath, newPath);
+				throw transientError('EPERM');
+			}
+			// The real filesystem now fails this way: the source is gone.
+			throw transientError('ENOENT');
+		});
+
+		await writeSnapshot(testDir, emptyState());
+
+		expect(calls).toBe(2);
+		const second = await readCachedTextFile(statePath(), async () => 'FRESH');
+		expect(second).toBe('FRESH');
+	});
+
+	it('does not retry a non-transient rename error', async () => {
+		let calls = 0;
+		_internals.rename = mock(async () => {
+			calls++;
+			throw transientError('EACCES');
+		});
+
+		await expect(writeSnapshot(testDir, emptyState())).resolves.toBeUndefined();
+
+		expect(calls).toBe(1);
+		expect(existsSync(statePath())).toBe(false);
+		expect(
+			readdirSync(sessionDir()).filter((f) => f.includes('.tmp.')),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

`writeSnapshot` (`src/session/snapshot-writer.ts`) performed its atomic temp-file swap with a bare `renameSync`, inside a `catch` that only logs. On Windows a second process briefly holding `.swarm/session/state.json` open — an external snapshot reader, or an antivirus scanner — makes `rename` fail transiently with `EEXIST`/`EBUSY`/`EPERM`. Because the surrounding `catch` only logs, that transient failure silently degraded an atomic update into a **dropped** one: the on-disk snapshot stayed at its previous contents while the in-memory `swarmState` moved on, with no error surfaced to any consumer.

The repository already documents and defends against this exact failure mode one module over: `bunWrite` retries `EEXIST`/`EBUSY`/`EPERM` three times, 50 ms apart (`src/utils/bun-compat.ts:36`, `:163-187`). The snapshot writer was the highest-frequency writer without that defense on its canonical-file swap — and it is not the only one: `src/commands/handoff.ts` (`handoff.md`, `handoff-prompt.md`) and `src/evidence/task-file.ts` (`atomicWriteFile`) still perform bare `renameSync` swaps with the same transient exposure; unifying those is the remaining scope of #2035. The snapshot writer runs on every `tool.execute.after`.

- Extracted `renameWithTransientRetry`: retries the swap on `EEXIST`/`EBUSY`/`EPERM` only (3 attempts, 50 ms apart), breaking immediately on any other error code.
- Temp-file cleanup moved into a `finally`, mirroring the reference pattern at `src/evidence/task-file.ts:63-79`. It is a no-op after a successful swap and drops the orphan when every retry failed (best-effort: an unlink blocked by something holding the fresh temp open can still leave one behind), so a persistently locked target can no longer leave one `state.json.tmp.*` per `tool.execute.after` under `.swarm/session/`.
- The rename routes through the module's existing `_internals` DI seam, so the retry path is testable without `mock.module`.

**Hardening added after independent adversarial review.** Introducing a retry made one previously-unreachable failure mode reachable: a Windows rename can report a sharing violation for a move that *actually committed*, so the retry then sees `ENOENT`, throws, and skips `invalidateCachedArtifact` — for a file that really did change. That is precisely the stale cached read issue #1729 exists to prevent. That case is now treated as the success it is (guarded on `attempt > 0`, temp gone, target present). The pointless sleep after the final attempt was also removed, taking up to 150 ms off the `flushPendingSnapshot` path used by `src/tools/phase-complete.ts`.

`invalidateCachedArtifact` still runs only after a genuinely successful rename, preserving the #1729 ordering. Behavior from the caller's perspective is unchanged: `writeSnapshot` still swallows all failures and never throws, and the snapshot schema is untouched (still `version: 3`).

Related to #2035 (the broader "unify atomic writes" epic), but this PR does **not** close it — no shared-helper migration, residue scanner, or quarantine work is included here.

## Invariant audit

- 1 (plugin init): **touched** (the module is on the `src/index.ts` init import graph via `createSnapshotWriterHook`) — no init-path work was added; the changed code path runs on `tool.execute.after`, not during init. Verified anyway: `node scripts/repro-704.mjs` → `T1[500-file tight deadline] OK, server() resolved in 322.1ms (deadline=400ms)`, T2 299.5 ms, T3 284.8 ms.
- 2 (runtime portability): **touched** — added a top-level `import { rename as fsRename } from 'node:fs/promises'` to a module bundled into `dist/index.js`. `node:` scheme, not `bun:`. Verified: `bun run build` clean; `tests/unit/build/bundle-portability.test.ts` passes; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`.
- 3 (subprocesses): **not touched** — `git diff --name-only origin/main..HEAD | xargs grep -nE "bunSpawn\(|spawn\(|spawnSync\("` returns no matches.
- 4 (.swarm containment): **touched** — writes and now also unlinks under `.swarm/session/`. The temp path is derived from the validated target (`resolvedPath = validateSwarmPath(directory, 'session/state.json')`, then `tempPath = ${resolvedPath}.tmp.…`), so the new `unlinkSync` cannot escape the validated root, and `tempPath` is a function-local that can only ever name the temp this invocation created. Tests assert no `.tmp.` residue remains under `.swarm/session` on both the success and permanent-failure paths.
- 5 (plan durability): **not touched** — no ledger, projection, or checkpoint code in the diff.
- 6 (test_runner safety): **not touched** — validation used `bun run test:unit:ci` (scoped) and direct `bun --smol test` per-file runs; the `test_runner` tool was not used.
- 7 (test writing): **touched** — one new `bun:test` file. Uses the `_internals` DI seam (no new `mock.module` target; `src/session/snapshot-writer` was already at `scripts/mock-allowlist.txt:118` and the allowlist ratchet is unchanged), `canonicalMkdtemp` per FR-011, and is 187 lines (under the 500-line FR-006 cap). `check-mock-cleanup`, `check-test-tmpdir`, `check:test-file-cap`, and `check-test-clock` all report 0 new violations.
- 8 (session state): **touched** — this is the session snapshot writer. Snapshot shape is unchanged (`version: 3`); no new session-keyed or module-global state was introduced (the retry state is loop-local). The `_writeInFlight` chain still serializes whole `writeSnapshot` promises, so the added awaits cannot introduce a new interleaving between chained writes. Verified: all 15 `tests/unit/session/*.test.ts` files pass, including reader/round-trip and snapshot-shape regressions.
- 9 (guardrails/retry): **not touched** — invariant 9 governs *agent/provider* transient-retry accounting (`transientRetryCount`, circuit breaker), which is untouched. The retry added here is a filesystem `rename` retry with no interaction with guardrail state.
- 10 (chat/system msg): **not touched** — no chat or system-message transform in the diff.
- 11 (tool registration): **not touched** — no new tool, agent, command, or map entry. Verified: `bun run scripts/check-tool-registration.ts` → `121 tools, coherent across metadata, handlers, the plugin object, TOOL_NAMES, and AGENT_TOOL_MAP`.
- 12 (release/cache): **touched** — added `docs/releases/pending/snapshot-writer-windows-rename-retry.md`. No cache-layout code changed. `package.json#version`, `CHANGELOG.md`, and `.release-please-manifest.json` are untouched (they do not appear in `git diff --name-only origin/main..HEAD`).

## Test plan

- [x] **New regression coverage** — `tests/unit/session/snapshot-writer-rename-retry.test.ts`, 6 tests: retry-then-succeed for each of `EEXIST`/`EBUSY`/`EPERM`; budget exhaustion on persistent `EBUSY` (error still swallowed, temp removed); no-retry on a non-transient code (`EACCES`, exactly one attempt); and the spurious-success `ENOENT` path. 6 pass / 0 fail.
- [x] **Falsifiability proven for every branch** — retry neutered to a single attempt → 4 of 6 fail (the non-transient test correctly still expects one call). For the `ENOENT` branch, an initial version of that test was **test theater**: it passed with the branch removed, because the snapshot lands on disk either way. It was rewritten to assert the only thing the branch changes — that the artifact cache is invalidated — using the frozen-stat technique from `swarm-write-cache-invalidation-wiring.test.ts`. It now fails with `Expected "FRESH", Received "OLD SNAPSHOT"` (the literal #1729 stale read) when the branch is removed. Each mutation was verified to have reached disk before its result was interpreted.
- [x] **Tree-scanning invariant** — `tests/unit/build/swarm-write-cache-invalidation-scan.test.ts` 12/12. This gate **failed on the first draft**: the inline retry loop pushed `invalidateCachedArtifact` 33 lines from the rename, past the scanner's 25-line proximity window. Fixed properly by extracting the retry helper so the write and its invalidation are adjacent, matching `src/evidence/task-file.ts:atomicWriteFile`. Confirmed this is real coverage, not gate evasion: deleting the invalidation still fails the gate (it moves from scanner rule R to rule H).
- [x] **Tier 1 quality — all 14 CI quality-job gates enumerated directly from `.github/workflows/ci.yml`, plus `package:smoke`**: `typecheck`, `lint:ci` (biome, 3439 files), `check-mock-cleanup`, `check-invariants`, `check-tool-registration`, `check:runtime-src-refs`, `check:events`, `check-cross-contamination`, `check-test-clock`, `check:test-file-cap`, `check:gate-portability`, `check-test-tmpdir`, `check-bash-portability`, `swarm-model node --test`, `package:smoke` — all exit 0.
- [x] **Tier 2 unit (CI-equivalent `bun run test:unit:ci`, per-file isolation)** — 18 files re-run on the rebased base (all 15 `tests/unit/session/`, cache-invalidation scan + wiring, `bundle-portability`): 18/18 exit 0. Before the rebase, a wider 90-file sweep of every transitive consumer (`tests/unit/tools/phase-complete*`, `tests/unit/state/*`, `tests/unit/commands/close*`, `tests/unit/commands/handoff*`, `src/commands/handoff.error-handling*`) ran 89/90 clean, with one pre-existing failure (below).
- [x] **Tier 3/4/5** — security 172 tests 0 fail; adversarial 846 tests 0 fail; smoke 10 tests 0 fail. Integration: see pre-existing note.
- [x] **Build + runtime portability** — `bun run build`, `node scripts/repro-704.mjs`, `node --input-type=module -e "await import('./dist/index.js')"`.
- [x] **Independent adversarial review** — a separate reviewer context audited the retry-loop bounds, `finally`-unlink safety (confirmed by execution that it cannot delete the real `state.json`), the sync→async concurrency change, the #1729 ordering, DI-seam honesty, and Windows `rename` destination-exists semantics. No CRITICAL or HIGH findings; its one substantive finding is the `ENOENT` gap, fixed above.
- [x] **Rebased onto current `origin/main`** (which advanced by PR #2216 mid-work) and the full gate set + scoped unit suite re-run on the new base, since diff-scoped ratchets compare against `origin/main`.

### Pre-existing failures

Both were proven pre-existing by restoring `origin/main`'s version of `src/session/snapshot-writer.ts` — the only executable file this PR changes — and re-running:

1. `tests/unit/tools/phase-complete-phase-council.adversarial.test.ts` — 5 of 17 tests fail (`AV5`, `AV7`, and 3 others, all asserting `parsed.success === true` on phase-council Zod config-rejection paths). Identical 12 pass / 5 fail with `main`'s file. Not in `scripts/ci/quarantined-tests*.txt`.
2. `bun test tests/integration ./test` reports 720 pass / 251 fail — **byte-identical counts** with and without this change. These are the known `mock.module` cross-file pollution failures from running many files in one process; CI runs per-file isolation and does not hit them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


