### PR TITLE
fix(state): evict activeAgent ghost entries alongside agentSessions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1773,7 +1773,7 @@ Agent awareness tracks what each agent is doing and shares relevant context acro
 ### Shared State
 
 `src/state.ts` exports a module-scoped singleton (`swarmState`) with:
-- `activeAgent: Map<sessionId, agentName>` — Which agent is active in each session (updated by chat.message hook)
+- `activeAgent: Map<sessionId, agentName>` — Which agent is active in each session (updated by chat.message hook; evicted in lockstep with its `agentSessions` entry — stale-session sweep, `endAgentSession`, `/swarm reset-session`, and rehydration ghost-filtering — so entries never outlive their sessions)
 - `agentSessions: Map<sessionId, AgentSessionState>` — Per-session guardrail tracking. Key fields:
   - `toolCallCount`, `startTime`, `delegationActive` — Guardrail counters
   - `taskWorkflowStates: Map<string, TaskWorkflowState>` — Bounded diagnostic projection of the authoritative exact-task state machine. States: `'idle' | 'coder_delegated' | 'pre_check_passed' | 'reviewer_run' | 'tests_run' | 'rework_required' | 'complete' | 'blocked' | 'closed'`. Normal verification transitions are generation-bound; `complete`, `blocked`, and `closed` are terminal, and only the audited exact-CAS repair path returns a settled non-success task to `idle`.

--- a/docs/releases/pending/active-agent-ghost-entry-eviction.md
+++ b/docs/releases/pending/active-agent-ghost-entry-eviction.md
@@ -18,6 +18,11 @@ now follows the same eviction lifecycle as `agentSessions`:
   next plugin load instead of being resurrected forever.
 - `/swarm reset-session` clears `activeAgent` alongside `agentSessions` and
   `delegationChains` (previously it left every `activeAgent` entry orphaned).
+- The `/swarm close` summary line now reads "Cleared agent sessions,
+  delegation chains, and active-agent mappings" — close already cleared all
+  three via `endAgentSession`/reset; the line previously under-reported it.
+  The `/swarm reset-session` and `/swarm finalize` command help text lists
+  active-agent mappings for the same reason.
 
 ## Why
 

--- a/docs/releases/pending/active-agent-ghost-entry-eviction.md
+++ b/docs/releases/pending/active-agent-ghost-entry-eviction.md
@@ -1,0 +1,69 @@
+# Evict activeAgent ghost entries — snapshot no longer grows without bound
+
+## What
+
+`swarmState.activeAgent` (and, on two leak paths, `swarmState.delegationChains`)
+now follows the same eviction lifecycle as `agentSessions`:
+
+- `sweepStaleSessions` deletes the evicted session's `activeAgent` entry
+  alongside its `delegationChains` entry (previously only the chain was
+  dropped, leaving a permanent ghost `activeAgent` entry per evicted session).
+- `endAgentSession` deletes the session's `activeAgent` and `delegationChains`
+  entries alongside the `agentSessions` entry (previously both satellite maps
+  were orphaned; orphans are unreachable by the sweep, which iterates
+  `agentSessions`, so they persisted until process exit).
+- `rehydrateState` restores `activeAgent` / `delegationChains` entries only
+  for session IDs actually restored into `agentSessions`, so ghosts already
+  persisted in `.swarm/session/state.json` by older builds are purged on the
+  next plugin load instead of being resurrected forever.
+- `/swarm reset-session` clears `activeAgent` alongside `agentSessions` and
+  `delegationChains` (previously it left every `activeAgent` entry orphaned).
+
+## Why
+
+The snapshot writer re-serializes every `activeAgent` entry to
+`.swarm/session/state.json` on every `tool.execute.after`. With no eviction,
+the map grew one ghost entry per evicted/ended session, across restarts,
+without bound — a production snapshot carried 69 `activeAgent` entries against
+23 (pruned) `agentSessions`, 46 of them ghosts. Whole-map consumers (e.g. the
+curator model-resolution heuristic scan) saw mostly dead sessions.
+
+Verified against that real snapshot: after this change a load → write cycle
+drops `activeAgent` from 69 entries to 23 (exactly one per live session) and
+the ghost entries never return. Every production path that removes an
+`agentSessions` entry (stale sweep, `endAgentSession`, `/swarm
+reset-session`, full reset) now removes the matching `activeAgent` entry in
+the same pass, so the map stays in lockstep with `agentSessions` (transient
+in-turn divergence aside), whose size the 2-hour idle TTL sweep already
+bounds (AGENTS.md invariant 8).
+
+## Migration
+
+None. No schema change — older snapshots load as before; their ghost entries
+are simply filtered on rehydration and disappear from the next written
+snapshot. Rehydration runs at plugin init, before any turn is in flight; a
+session that resumes afterwards gets its `activeAgent` entry re-established
+by chat.message (delegation-tracker), and until then every point reader
+falls back to the orchestrator name — the same treatment a fresh process
+gives an unknown session.
+
+## Caveats
+
+- Per-session `delegationChains` arrays remain uncapped within a single live
+  session (entries are appended on agent switches). Production data shows
+  single-digit chain lengths; the array is reclaimed with the session at the
+  2-hour idle TTL, at `endAgentSession`, or on `/swarm reset-session`, so no
+  cap was added.
+- Dropping ghost `delegationChains` on rehydration slightly tightens the
+  `update_task_status` QA gate's unscoped reviewer/test-engineer detection:
+  a chain from a session that no longer exists can no longer satisfy it.
+  This is fail-closed (the gate asks for a fresh reviewer run instead of
+  accepting a dead session's evidence); the production snapshot contained
+  zero ghost chains.
+- A subagent turn that stays silent past the 2-hour session TTL between two
+  tool calls now loses its `activeAgent` entry along with its (already
+  evicted, pre-existing behavior) session state, so its next tool call runs
+  under the orchestrator identity until the next chat.message. Previously a
+  ghost entry masked this for the first few seconds of the recreated
+  session; the recreated session's `delegationActive: false` forced the same
+  convergence regardless.

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -2395,7 +2395,7 @@ export async function handleCloseCommand(
 			'',
 			'## Context',
 			'- Reset context.md for next session',
-			'- Cleared agent sessions and delegation chains',
+			'- Cleared agent sessions, delegation chains, and active-agent mappings',
 			...(cleanResult.configBackupsRemoved > 0
 				? [
 						`- Removed ${cleanResult.configBackupsRemoved} stale config backup file(s)`,

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -927,7 +927,7 @@ export const COMMAND_REGISTRY = {
 		description:
 			'Use /swarm finalize to finalize the swarm project and archive evidence',
 		details:
-			'Idempotent 4-stage terminal finalization: (1) finalize writes retrospectives for in-progress phases, (2) archive creates timestamped bundle of swarm artifacts and evidence, (3) clean removes active-state files for a clean slate, (4) align performs aggressive git reset --hard to the default remote branch, discarding uncommitted changes and gitignored build artifacts (user-created untracked files are preserved); falls back to a cautious reset that preserves uncommitted changes when the aggressive path cannot proceed. WARNING: alignment discards local changes and gitignored files. Resets agent sessions and delegation chains. Reads .swarm/close-lessons.md for explicit lessons and runs curation. Use --skill-review to run the quota-bounded skill_improver in proposal mode. Use --dry-run to preview what finalize would archive, clean, and align without taking the lock or changing anything.',
+			'Idempotent 4-stage terminal finalization: (1) finalize writes retrospectives for in-progress phases, (2) archive creates timestamped bundle of swarm artifacts and evidence, (3) clean removes active-state files for a clean slate, (4) align performs aggressive git reset --hard to the default remote branch, discarding uncommitted changes and gitignored build artifacts (user-created untracked files are preserved); falls back to a cautious reset that preserves uncommitted changes when the aggressive path cannot proceed. WARNING: alignment discards local changes and gitignored files. Resets agent sessions, delegation chains, and active-agent mappings. Reads .swarm/close-lessons.md for explicit lessons and runs curation. Use --skill-review to run the quota-bounded skill_improver in proposal mode. Use --dry-run to preview what finalize would archive, clean, and align without taking the lock or changing anything.',
 		args: '--prune-branches, --skill-review, --dry-run',
 		category: 'core',
 		toolPolicy: 'none',
@@ -1409,7 +1409,7 @@ export const COMMAND_REGISTRY = {
 		description:
 			'Clear session state while preserving plan, evidence, and knowledge',
 		details:
-			'Deletes only .swarm/session/state.json and any other session files. Clears in-memory agent sessions and delegation chains. Preserves plan, evidence, and knowledge for cross-session continuity. Before deleting, auto-backs up the session files it removes to .swarm/reset-backups/<timestamp>/ (newest 5 kept).',
+			'Deletes only .swarm/session/state.json and any other session files. Clears in-memory agent sessions, delegation chains, and active-agent mappings. Preserves plan, evidence, and knowledge for cross-session continuity. Before deleting, auto-backs up the session files it removes to .swarm/reset-backups/<timestamp>/ (newest 5 kept).',
 		args: '',
 		category: 'utility',
 		toolPolicy: 'restricted',

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -142,6 +142,13 @@ export async function handleResetSessionCommand(
 	swarmState.delegationChains.clear();
 	results.push(`✅ Cleared ${chainCount} delegation chain(s)`);
 
+	// Clear activeAgent alongside the sessions it is keyed by. With
+	// agentSessions cleared above, any surviving entry is an orphan no sweep
+	// can ever reclaim, and the snapshot writer would persist it forever.
+	const activeAgentCount = swarmState.activeAgent.size;
+	swarmState.activeAgent.clear();
+	results.push(`✅ Cleared ${activeAgentCount} active-agent mapping(s)`);
+
 	// Best-effort: clean stale worktree directories and orphan branches
 	const worktreesDir = path.resolve(
 		path.dirname(directory),

--- a/src/session/snapshot-reader.ts
+++ b/src/session/snapshot-reader.ts
@@ -357,6 +357,17 @@ export async function readSnapshot(
  * Rehydrate swarmState from a SnapshotData object.
  * Clears existing maps first, then populates from snapshot.
  * Does NOT touch activeToolCalls or pendingEvents (remain at defaults).
+ *
+ * activeAgent and delegationChains are restored only for session IDs that are
+ * actually restored into agentSessions. Snapshots written before ghost-entry
+ * eviction existed can carry far more activeAgent entries than agentSessions
+ * (sessions were evicted but their satellite entries never were); restoring
+ * those wholesale would resurrect the ghosts into memory and re-serialize them
+ * into every subsequent snapshot forever. Rehydration runs at plugin init,
+ * before any turn is in flight; a session that resumes afterwards gets its
+ * entry re-established by chat.message (delegation-tracker), and until then
+ * tool-path readers fall back to ORCHESTRATOR_NAME — the same treatment a
+ * fresh process gives an unknown session.
  */
 export async function rehydrateState(
 	snapshot: SnapshotData,
@@ -380,20 +391,6 @@ export async function rehydrateState(
 	if (snapshot.toolAggregates) {
 		for (const [key, value] of Object.entries(snapshot.toolAggregates)) {
 			swarmState.toolAggregates.set(key, value);
-		}
-	}
-
-	// Populate activeAgent
-	if (snapshot.activeAgent) {
-		for (const [key, value] of Object.entries(snapshot.activeAgent)) {
-			swarmState.activeAgent.set(key, value);
-		}
-	}
-
-	// Populate delegationChains
-	if (snapshot.delegationChains) {
-		for (const [key, value] of Object.entries(snapshot.delegationChains)) {
-			swarmState.delegationChains.set(key, value);
 		}
 	}
 
@@ -491,6 +488,29 @@ export async function rehydrateState(
 			}
 
 			swarmState.agentSessions.set(sessionId, session);
+		}
+	}
+
+	// Populate activeAgent — only for sessions that were actually restored
+	// above. Entries keyed by any other session ID are ghosts (their session
+	// was evicted, ended, or rejected as malformed) and must not be
+	// resurrected: nothing would ever evict them again, and the snapshot
+	// writer would re-serialize them on every tool call forever.
+	if (snapshot.activeAgent) {
+		for (const [key, value] of Object.entries(snapshot.activeAgent)) {
+			if (swarmState.agentSessions.has(key)) {
+				swarmState.activeAgent.set(key, value);
+			}
+		}
+	}
+
+	// Populate delegationChains — same session-keyed ghost filter as
+	// activeAgent above.
+	if (snapshot.delegationChains) {
+		for (const [key, value] of Object.entries(snapshot.delegationChains)) {
+			if (swarmState.agentSessions.has(key)) {
+				swarmState.delegationChains.set(key, value);
+			}
 		}
 	}
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1605,9 +1605,10 @@ let _lastIdleSweepAtMs = 0;
 
 /**
  * Evict every agent session whose last tool activity is older than
- * staleDurationMs, and drop the delegation chain keyed by that same sessionID
- * (delegationChains is keyed by sessionID — see delegation-tracker.ts, which
- * does `delegationChains.set(input.sessionID, ...)`). This is the single
+ * staleDurationMs, and drop the delegation chain and activeAgent entry keyed
+ * by that same sessionID (both maps are keyed by sessionID — see
+ * delegation-tracker.ts, which does `delegationChains.set(input.sessionID,
+ * ...)` and `activeAgent.set(input.sessionID, ...)`). This is the single
  * eviction loop reused by BOTH startAgentSession (eager, on new session start)
  * and maybeSweepStaleSessions (opportunistic, on the hot path) so the logic is
  * never duplicated.
@@ -1633,6 +1634,25 @@ export function sweepStaleSessions(
 		// delegationChains is keyed by sessionID; the evicted session's chain is
 		// now unreachable, so drop it in the same pass to reclaim its memory.
 		swarmState.delegationChains.delete(id);
+		// activeAgent is keyed by sessionID too. Without this, evicted sessions
+		// leave permanent ghost entries that the snapshot writer re-serializes
+		// on every tool.execute.after, growing state.json without bound and
+		// polluting whole-map consumers (curator-llm-factory's heuristic scan).
+		// A session active on the tool path is never its own victim —
+		// ensureAgentSession refreshes lastToolCallTime before it sweeps.
+		// Known bounded edge: a subagent turn that goes >staleDurationMs
+		// between two tool calls loses this entry along with its session state
+		// (the session eviction itself is pre-existing); the next tool call
+		// re-bootstraps the entry to ORCHESTRATOR_NAME (src/index.ts
+		// tool.execute.before) until the next chat.message re-establishes the
+		// real agent. The recreated session's delegationActive=false already
+		// forces that same identity convergence, so the ghost entry this
+		// replaces only masked the edge briefly, at unbounded-growth cost.
+		// Do not "fix" the edge by skipping sessions with pending
+		// pendingToolExecutions: those entries are shell-only and carry no
+		// timestamp, so an interrupted turn would make its session permanently
+		// unevictable — a worse leak than the one this pass closes.
+		swarmState.activeAgent.delete(id);
 	}
 	return staleIds;
 }
@@ -1871,6 +1891,12 @@ export function endAgentSession(sessionId: string): void {
 		});
 	}
 	swarmState.agentSessions.delete(sessionId);
+	// Drop the session-keyed satellite maps in the same pass. Leaving them
+	// behind orphans entries that no sweep can ever reclaim (sweepStaleSessions
+	// iterates agentSessions, which no longer contains this id), so they would
+	// persist in memory and in every state.json snapshot until process exit.
+	swarmState.activeAgent.delete(sessionId);
+	swarmState.delegationChains.delete(sessionId);
 	clearRealtimeLearningNudgeSession(sessionId);
 	// #1821: the same-session learning loop keeps per-session module state (the
 	// candidate queue and the PRM pattern-support/cooldown ledger). Both are

--- a/tests/unit/commands/close.test.ts
+++ b/tests/unit/commands/close.test.ts
@@ -686,7 +686,7 @@ describe('handleCloseCommand', () => {
 			expect(summary).toContain('## Lessons Committed');
 			expect(summary).toContain('Archived');
 			expect(summary).toContain(
-				'- Cleared agent sessions and delegation chains',
+				'- Cleared agent sessions, delegation chains, and active-agent mappings',
 			);
 			expect(summary).toContain(
 				'- Set non-completed phases/tasks to closed status',

--- a/tests/unit/commands/reset-session.test.ts
+++ b/tests/unit/commands/reset-session.test.ts
@@ -96,6 +96,21 @@ describe('handleResetSessionCommand', () => {
 		expect(result).toContain('Cleared 2 in-memory agent session(s)');
 	});
 
+	it('clears activeAgent alongside agentSessions — regression: reset orphaned activeAgent entries', async () => {
+		// startAgentSession populates activeAgent too. Previous code cleared
+		// agentSessions + delegationChains here but left activeAgent populated;
+		// with the sessions gone, no sweep could ever reclaim those entries, so
+		// they leaked into every subsequent state.json snapshot.
+		startAgentSession('session-1', 'coder');
+		startAgentSession('session-2', 'reviewer');
+		expect(swarmState.activeAgent.size).toBe(2);
+
+		const result = await handleResetSessionCommand(testDir, []);
+
+		expect(swarmState.activeAgent.size).toBe(0);
+		expect(result).toContain('Cleared 2 active-agent mapping(s)');
+	});
+
 	it('clears in-memory sessions even when state.json does not exist', async () => {
 		startAgentSession('session-1', 'coder');
 		startAgentSession('session-2', 'architect');

--- a/tests/unit/session/snapshot-ghost-entry-eviction.test.ts
+++ b/tests/unit/session/snapshot-ghost-entry-eviction.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests: rehydrateState must not resurrect ghost activeAgent /
+ * delegationChains entries from old snapshots.
+ *
+ * Prior behavior under test: rehydrateState restored activeAgent and
+ * delegationChains WHOLESALE, with no filtering against the restored
+ * agentSessions. Snapshots written before eviction existed carry entries for
+ * long-dead sessions (observed in production: 69 activeAgent entries, only 23
+ * agentSessions — 46 ghosts). Once resurrected, nothing could ever evict the
+ * ghosts (sweepStaleSessions iterates agentSessions only), so the snapshot
+ * writer re-serialized them on every tool call and state.json grew without
+ * bound across restarts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import {
+	loadSnapshot,
+	rehydrateState,
+} from '../../../src/session/snapshot-reader';
+import type {
+	SerializedAgentSession,
+	SnapshotData,
+} from '../../../src/session/snapshot-writer';
+import { writeSnapshot } from '../../../src/session/snapshot-writer';
+import { resetSwarmState, swarmState } from '../../../src/state';
+import { canonicalTmpDir } from '../../helpers/tmpdir.js';
+
+const TEST_TIME = 1_700_000_000_000;
+
+function makeSerializedSession(agentName: string): SerializedAgentSession {
+	return {
+		agentName,
+		lastToolCallTime: TEST_TIME,
+		lastAgentEventTime: TEST_TIME,
+		delegationActive: false,
+		activeInvocationId: 1,
+		lastInvocationIdByAgent: {},
+		windows: {},
+		lastCompactionHint: 0,
+		architectWriteCount: 0,
+		lastCoderDelegationTaskId: null,
+		currentTaskId: null,
+		gateLog: {},
+		reviewerCallCount: {},
+		lastGateFailure: null,
+		partialGateWarningsIssuedForTask: [],
+		selfFixAttempted: false,
+		catastrophicPhaseWarnings: [],
+		lastPhaseCompleteTimestamp: 0,
+		lastPhaseCompletePhase: 0,
+		phaseAgentsDispatched: [],
+		qaSkipCount: 0,
+		qaSkipTaskIds: [],
+	};
+}
+
+function makeGhostSnapshot(): SnapshotData {
+	return {
+		version: 3,
+		writtenAt: TEST_TIME,
+		toolAggregates: {},
+		activeAgent: {
+			'live-a': 'architect',
+			'live-b': 'coder',
+			'ghost-1': 'reviewer',
+			'ghost-2': 'coder',
+			'malformed-c': 'test_engineer',
+		},
+		delegationChains: {
+			'live-a': [{ from: 'architect', to: 'coder', timestamp: TEST_TIME }],
+			'ghost-1': [{ from: 'architect', to: 'reviewer', timestamp: TEST_TIME }],
+		},
+		agentSessions: {
+			'live-a': makeSerializedSession('architect'),
+			'live-b': makeSerializedSession('coder'),
+			// Malformed: fails the required-field validation in rehydrateState
+			// (agentName must be a string), so the session itself is skipped.
+			'malformed-c': {
+				...makeSerializedSession('test_engineer'),
+				agentName: undefined as unknown as string,
+			},
+		},
+	};
+}
+
+beforeEach(() => {
+	resetSwarmState();
+});
+
+afterEach(() => {
+	resetSwarmState();
+});
+
+describe('rehydrateState — regression: ghost satellite entries resurrected wholesale', () => {
+	it('restores activeAgent only for sessions restored into agentSessions', async () => {
+		await rehydrateState(makeGhostSnapshot());
+
+		// Previous code restored all five activeAgent entries; the two ghosts
+		// and the malformed session's entry then leaked forever.
+		expect([...swarmState.activeAgent.keys()].sort()).toEqual([
+			'live-a',
+			'live-b',
+		]);
+		expect(swarmState.activeAgent.get('live-a')).toBe('architect');
+		expect(swarmState.activeAgent.get('live-b')).toBe('coder');
+	});
+
+	it('restores delegationChains only for sessions restored into agentSessions', async () => {
+		await rehydrateState(makeGhostSnapshot());
+
+		expect([...swarmState.delegationChains.keys()]).toEqual(['live-a']);
+		expect(swarmState.delegationChains.get('live-a')).toEqual([
+			{ from: 'architect', to: 'coder', timestamp: TEST_TIME },
+		]);
+	});
+
+	it('drops the satellite entries of a session rejected as malformed', async () => {
+		await rehydrateState(makeGhostSnapshot());
+
+		expect(swarmState.agentSessions.has('malformed-c')).toBe(false);
+		expect(swarmState.activeAgent.has('malformed-c')).toBe(false);
+	});
+
+	it('restores nothing into satellite maps when agentSessions is empty', async () => {
+		const snapshot = makeGhostSnapshot();
+		snapshot.agentSessions = {};
+
+		await rehydrateState(snapshot);
+
+		expect(swarmState.activeAgent.size).toBe(0);
+		expect(swarmState.delegationChains.size).toBe(0);
+	});
+
+	it('filters ghosts from version-2 snapshots (the shape shipped in production)', async () => {
+		const snapshot = makeGhostSnapshot();
+		snapshot.version = 2;
+
+		await rehydrateState(snapshot);
+
+		expect([...swarmState.activeAgent.keys()].sort()).toEqual([
+			'live-a',
+			'live-b',
+		]);
+	});
+});
+
+describe('snapshot round-trip — the rewritten snapshot shrinks', () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(path.join(canonicalTmpDir(), 'snapshot-ghost-'));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('loadSnapshot end-to-end: restores live entries, filters ghosts', async () => {
+		const sessionDir = path.join(tempDir, '.swarm', 'session');
+		mkdirSync(sessionDir, { recursive: true });
+		writeFileSync(
+			path.join(sessionDir, 'state.json'),
+			JSON.stringify(makeGhostSnapshot(), null, 2),
+		);
+
+		await loadSnapshot(tempDir);
+
+		expect([...swarmState.agentSessions.keys()].sort()).toEqual([
+			'live-a',
+			'live-b',
+		]);
+		expect(swarmState.activeAgent.get('live-a')).toBe('architect');
+		expect(swarmState.activeAgent.get('live-b')).toBe('coder');
+		expect(swarmState.activeAgent.has('ghost-1')).toBe(false);
+		expect(swarmState.activeAgent.has('ghost-2')).toBe(false);
+		expect(swarmState.delegationChains.has('ghost-1')).toBe(false);
+	});
+
+	it('writes back exactly one activeAgent entry per restored session', async () => {
+		const ghostSnapshot = makeGhostSnapshot();
+		expect(Object.keys(ghostSnapshot.activeAgent).length).toBe(5);
+
+		await rehydrateState(ghostSnapshot);
+		await writeSnapshot(tempDir, swarmState);
+
+		const written = JSON.parse(
+			readFileSync(
+				path.join(tempDir, '.swarm', 'session', 'state.json'),
+				'utf-8',
+			),
+		) as SnapshotData;
+
+		const sessionIds = Object.keys(written.agentSessions).sort();
+		expect(sessionIds).toEqual(['live-a', 'live-b']);
+		// The load → write cycle previously preserved all five entries; now the
+		// satellite maps carry no keys outside the restored session set.
+		expect(Object.keys(written.activeAgent).sort()).toEqual(sessionIds);
+		expect(Object.keys(written.delegationChains)).toEqual(['live-a']);
+	});
+});

--- a/tests/unit/session/snapshot-integration.test.ts
+++ b/tests/unit/session/snapshot-integration.test.ts
@@ -56,12 +56,14 @@ describe('Snapshot Integration', () => {
 				totalDuration: 1000,
 			});
 
-			// Explicitly set activeAgent for both sessions
+			// Explicitly set activeAgent for both sessions. session-2 has no
+			// agentSessions entry, so it is a ghost: written to disk (the writer
+			// serializes the in-memory map as-is) but filtered on rehydration.
 			swarmState.activeAgent.set(sessionId, 'coder');
 			swarmState.activeAgent.set('session-2', 'reviewer');
 
-			// Add delegation chain
-			swarmState.delegationChains.set('session-1', [
+			// Add delegation chain for the real session
+			swarmState.delegationChains.set(sessionId, [
 				{ from: 'architect', to: 'coder', timestamp: Date.now() },
 			]);
 
@@ -102,12 +104,14 @@ describe('Snapshot Integration', () => {
 			expect(toolAgg?.failureCount).toBe(1);
 			expect(toolAgg?.totalDuration).toBe(1000);
 
-			expect(swarmState.activeAgent.size).toBe(2);
+			// The ghost session-2 entry was written to disk but must not be
+			// resurrected: only entries whose session was restored survive.
+			expect(swarmState.activeAgent.size).toBe(1);
 			expect(swarmState.activeAgent.get(sessionId)).toBe('coder');
-			expect(swarmState.activeAgent.get('session-2')).toBe('reviewer');
+			expect(swarmState.activeAgent.get('session-2')).toBeUndefined();
 
 			expect(swarmState.delegationChains.size).toBe(1);
-			const chain = swarmState.delegationChains.get('session-1');
+			const chain = swarmState.delegationChains.get(sessionId);
 			expect(chain).toBeDefined();
 			expect(chain?.length).toBe(1);
 			expect(chain?.[0].from).toBe('architect');

--- a/tests/unit/session/snapshot-reader-adversarial.test.ts
+++ b/tests/unit/session/snapshot-reader-adversarial.test.ts
@@ -508,7 +508,8 @@ describe('snapshot-reader ADVERSARIAL tests', () => {
 			};
 
 			await expect(rehydrateState(snapshot)).resolves.toBeUndefined();
-			expect(swarmState.delegationChains.size).toBe(100);
+			// All 100 chains are ghosts (no restored session) → filtered.
+			expect(swarmState.delegationChains.size).toBe(0);
 		});
 
 		it('should handle multiple rapid calls to rehydrateState with last-call data', async () => {
@@ -549,11 +550,10 @@ describe('snapshot-reader ADVERSARIAL tests', () => {
 			await rehydrateState(snapshot1);
 			await rehydrateState(snapshot2);
 
-			// Should have data from last call
+			// Data from last call; ghost activeAgent entries stay filtered.
 			expect(swarmState.toolAggregates.size).toBe(1);
 			expect(swarmState.toolAggregates.get('tool2')).toBeTruthy();
-			expect(swarmState.activeAgent.size).toBe(1);
-			expect(swarmState.activeAgent.get('session2')).toBe('agent2');
+			expect(swarmState.activeAgent.size).toBe(0);
 		});
 
 		it('should handle rehydrating over already-populated state (clears first)', async () => {
@@ -586,13 +586,13 @@ describe('snapshot-reader ADVERSARIAL tests', () => {
 
 			await rehydrateState(snapshot);
 
-			// Should have cleared old data and populated new data
+			// Old data cleared, new data populated; session2's activeAgent
+			// entry is a ghost so the map ends empty (session1 must be gone).
 			expect(swarmState.toolAggregates.size).toBe(1);
 			expect(swarmState.toolAggregates.get('tool1')).toBeUndefined();
 			expect(swarmState.toolAggregates.get('tool2')).toBeTruthy();
-			expect(swarmState.activeAgent.size).toBe(1);
+			expect(swarmState.activeAgent.size).toBe(0);
 			expect(swarmState.activeAgent.get('session1')).toBeUndefined();
-			expect(swarmState.activeAgent.get('session2')).toBe('agent2');
 		});
 	});
 

--- a/tests/unit/session/snapshot-reader.test.ts
+++ b/tests/unit/session/snapshot-reader.test.ts
@@ -697,7 +697,10 @@ describe('rehydrateState', () => {
 		});
 	});
 
-	it('populates activeAgent from snapshot', async () => {
+	it('filters activeAgent entries whose session is not restored (ghosts)', async () => {
+		// Positive restore coverage (entries kept when the session IS restored)
+		// lives in snapshot-ghost-entry-eviction.test.ts. With no restored
+		// sessions, every satellite entry is a ghost and must be dropped.
 		const snapshot: SnapshotData = {
 			version: 1,
 			writtenAt: Date.now(),
@@ -713,13 +716,10 @@ describe('rehydrateState', () => {
 
 		await rehydrateState(snapshot);
 
-		expect(swarmState.activeAgent.size).toBe(3);
-		expect(swarmState.activeAgent.get('session-1')).toBe('architect');
-		expect(swarmState.activeAgent.get('session-2')).toBe('coder');
-		expect(swarmState.activeAgent.get('session-3')).toBe('reviewer');
+		expect(swarmState.activeAgent.size).toBe(0);
 	});
 
-	it('populates delegationChains from snapshot', async () => {
+	it('filters delegationChains whose session is not restored (ghosts)', async () => {
 		const snapshot: SnapshotData = {
 			version: 1,
 			writtenAt: Date.now(),
@@ -739,14 +739,7 @@ describe('rehydrateState', () => {
 
 		await rehydrateState(snapshot);
 
-		expect(swarmState.delegationChains.size).toBe(2);
-		expect(swarmState.delegationChains.get('session-1')).toEqual([
-			{ from: 'architect', to: 'coder', timestamp: 123456 },
-			{ from: 'coder', to: 'reviewer', timestamp: 123457 },
-		]);
-		expect(swarmState.delegationChains.get('session-2')).toEqual([
-			{ from: 'architect', to: 'test_engineer', timestamp: 123458 },
-		]);
+		expect(swarmState.delegationChains.size).toBe(0);
 	});
 
 	it('populates agentSessions using deserializeAgentSession', async () => {
@@ -1084,7 +1077,11 @@ describe('loadSnapshot', () => {
 			failureCount: 2,
 			totalDuration: 5000,
 		});
-		expect(swarmState.activeAgent.get('session-1')).toBe('architect');
+		// session-1 has no agentSessions entry in the fixture, so its
+		// activeAgent entry is a ghost and is filtered on rehydration. The
+		// restored-session positive case is covered end-to-end in
+		// snapshot-ghost-entry-eviction.test.ts.
+		expect(swarmState.activeAgent.get('session-1')).toBeUndefined();
 	});
 
 	it('with missing file: leaves swarmState at defaults (no-op)', async () => {

--- a/tests/unit/state/active-agent-eviction.test.ts
+++ b/tests/unit/state/active-agent-eviction.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression tests: session-keyed satellite maps (activeAgent,
+ * delegationChains) must be evicted with the same lifecycle as their
+ * agentSessions entry.
+ *
+ * Prior behavior under test:
+ *  - sweepStaleSessions deleted agentSessions + delegationChains but NOT
+ *    activeAgent, so every evicted session left a permanent ghost entry that
+ *    the snapshot writer re-serialized on every tool.execute.after (observed
+ *    in production: 69 activeAgent entries vs 23 agentSessions).
+ *  - endAgentSession deleted ONLY agentSessions, orphaning both satellite
+ *    maps. Orphans are unreachable by any later sweep (the sweep iterates
+ *    agentSessions, which no longer contains the id), so they persisted until
+ *    process exit and into every snapshot.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { DelegationEntry } from '../../../src/state';
+import {
+	endAgentSession,
+	ensureAgentSession,
+	resetSwarmState,
+	swarmState,
+	sweepStaleSessions,
+} from '../../../src/state';
+import { withFrozenClock } from '../../helpers/test-clock';
+
+const NOW = 1_700_000_000_000;
+const TTL_MS = 7_200_000; // matches STALE_SESSION_TTL_MS
+
+function makeChain(): DelegationEntry[] {
+	return [{ from: 'architect', to: 'coder', timestamp: NOW - 1 }];
+}
+
+beforeEach(() => {
+	resetSwarmState();
+});
+
+afterEach(() => {
+	resetSwarmState();
+});
+
+describe('sweepStaleSessions — regression: activeAgent entries never evicted', () => {
+	it('deletes the activeAgent entry of every evicted stale session', () => {
+		// ensureAgentSession creates the session AND sets activeAgent.
+		const stale = ensureAgentSession('stale-session', 'coder');
+		ensureAgentSession('fresh-session', 'architect');
+		swarmState.delegationChains.set('stale-session', makeChain());
+
+		// Age only the stale session past the TTL.
+		stale.lastToolCallTime = NOW - TTL_MS - 1;
+		const fresh = swarmState.agentSessions.get('fresh-session');
+		if (fresh) fresh.lastToolCallTime = NOW;
+
+		const evicted = sweepStaleSessions(TTL_MS, NOW);
+
+		expect(evicted).toEqual(['stale-session']);
+		// Previous code deleted agentSessions + delegationChains here but left
+		// activeAgent['stale-session'] behind forever.
+		expect(swarmState.activeAgent.has('stale-session')).toBe(false);
+		expect(swarmState.delegationChains.has('stale-session')).toBe(false);
+		expect(swarmState.agentSessions.has('stale-session')).toBe(false);
+	});
+
+	it('preserves the activeAgent entry of sessions that are not stale', () => {
+		const live = ensureAgentSession('live-session', 'reviewer');
+		live.lastToolCallTime = NOW;
+
+		sweepStaleSessions(TTL_MS, NOW);
+
+		expect(swarmState.activeAgent.get('live-session')).toBe('reviewer');
+		expect(swarmState.agentSessions.has('live-session')).toBe(true);
+	});
+
+	it('never evicts the activeAgent entry of a session refreshed on the hot path', () => {
+		// ensureAgentSession refreshes lastToolCallTime before its opportunistic
+		// sweep runs, so a session that is actively calling tools cannot become
+		// its own eviction victim — and therefore cannot lose its activeAgent
+		// entry mid-turn. ensureAgentSession reads Date.now() internally
+		// (not clock-injectable), so the clock is frozen for determinism.
+		withFrozenClock(
+			() => {
+				const session = ensureAgentSession('hot-session', 'coder');
+				session.lastToolCallTime = NOW - TTL_MS - 1;
+
+				// Re-entering via ensureAgentSession refreshes the timestamp first.
+				ensureAgentSession('hot-session', 'coder');
+				sweepStaleSessions(TTL_MS, NOW);
+
+				expect(swarmState.activeAgent.get('hot-session')).toBe('coder');
+				expect(swarmState.agentSessions.has('hot-session')).toBe(true);
+			},
+			{ fixedNow: NOW },
+		);
+	});
+});
+
+describe('endAgentSession — regression: satellite maps orphaned on session end', () => {
+	it('deletes activeAgent and delegationChains along with the session', () => {
+		ensureAgentSession('ending-session', 'coder');
+		swarmState.delegationChains.set('ending-session', makeChain());
+
+		endAgentSession('ending-session');
+
+		expect(swarmState.agentSessions.has('ending-session')).toBe(false);
+		// Previous code left both satellite entries behind: with the session
+		// gone, sweepStaleSessions could never reach them again, so they
+		// leaked until process exit and were written into every snapshot.
+		expect(swarmState.activeAgent.has('ending-session')).toBe(false);
+		expect(swarmState.delegationChains.has('ending-session')).toBe(false);
+	});
+
+	it('does not disturb other sessions when one ends', () => {
+		ensureAgentSession('ending-session', 'coder');
+		ensureAgentSession('other-session', 'architect');
+		swarmState.delegationChains.set('other-session', makeChain());
+
+		endAgentSession('ending-session');
+
+		expect(swarmState.activeAgent.get('other-session')).toBe('architect');
+		expect(swarmState.delegationChains.has('other-session')).toBe(true);
+		expect(swarmState.agentSessions.has('other-session')).toBe(true);
+	});
+
+	it('is a safe no-op for an unknown session id', () => {
+		ensureAgentSession('only-session', 'architect');
+
+		expect(() => endAgentSession('never-existed')).not.toThrow();
+		expect(swarmState.activeAgent.get('only-session')).toBe('architect');
+	});
+});


### PR DESCRIPTION
## Summary
- `swarmState.activeAgent` (`Map<sessionID, agentName>`) had no eviction lifecycle: `sweepStaleSessions` and `endAgentSession` pruned `agentSessions` but never `activeAgent`, `/swarm reset-session` cleared `agentSessions`/`delegationChains` but not `activeAgent`, and `rehydrateState` restored `activeAgent`/`delegationChains` from disk wholesale. A production `.swarm/session/state.json` snapshot showed 69 `activeAgent` entries against 23 (correctly pruned) `agentSessions` — 46 permanent ghost entries, re-serialized into the file on every `tool.execute.after`.
- All four paths now evict/filter `activeAgent` in lockstep with `agentSessions` (and `delegationChains` on the two paths that were also missing it): `sweepStaleSessions`, `endAgentSession`, `/swarm reset-session`, and `rehydrateState` (which now restores `agentSessions` first, then filters both satellite maps to only the session IDs actually restored).
- Verified against the real production snapshot via a read-only probe (rehydrate → write-back): `activeAgent` 69 → 23 entries, file 43,261 → 41,542 bytes, and the ghosts do not return.
- Two new regression test files, proven falsifiable (9/13 assertions fail with the fix reverted): `tests/unit/state/active-agent-eviction.test.ts`, `tests/unit/session/snapshot-ghost-entry-eviction.test.ts`. Four existing test files updated where fixtures asserted the old wholesale-restore/no-op behavior.
- Went through an independent reviewer pass (caught a missed round-trip regression and the `reset-session` leak, both fixed) and a critic pass (adjudicated and closed a documented edge-case: a subagent turn silent for >2h between tool calls loses its `activeAgent` entry along with its already-evicted session state — negligible in practice since the recreated session already forces the same identity convergence; documented in code comments and the release fragment rather than "fixed" with a riskier remedy).

## Invariant audit
- 1 (plugin init): not touched — no change to plugin registration, `server()` resolution, or init-path timing; `rehydrateState`/`loadSnapshot` call sites and their bounded-work shape are unchanged, only their in-loop filtering predicate.
- 2 (runtime portability): not touched — `bun run build` succeeds; `node --input-type=module -e "await import('./dist/index.js')"` → `dist import OK`.
- 3 (subprocesses): not touched — `git diff --name-only origin/main..HEAD | xargs -r grep -nE "bunSpawn\(|spawn\(|spawnSync\("` → no matches.
- 4 (.swarm containment): not touched — no new `.swarm/` write paths; `reset-session.ts` change only clears an in-memory Map, no new file I/O.
- 5 (plan durability): not touched — no `plan-ledger.jsonl`/`plan.json`/`plan.md` code paths touched.
- 6 (test_runner safety): not touched — `test_runner` was not used for repo validation; all validation used the shell/bun commands directly.
- 7 (test writing): touched — new tests use `bun:test` only, per-file isolation verified (`bun --smol test <file> --timeout 30000` per new/modified file, all green), no new `mock.module` usage (mock.module allowlist ratchet: 0 added, `scripts/check-invariants.sh` Check 4 confirms `Added in this PR: 0`).
- 8 (session state): touched — this is the core of the change. `activeAgent`/`delegationChains` are session-keyed Maps that previously lacked a matching eviction strategy to `agentSessions`; all four session-teardown paths now evict them together, with tests (`tests/unit/state/active-agent-eviction.test.ts`, `tests/unit/session/snapshot-ghost-entry-eviction.test.ts`, updated `reset-session.test.ts`) and a real-data probe as evidence the bound now holds.
- 9 (guardrails/retry): not touched — no changes to retry semantics, circuit-breaker accounting, or transient/non-transient classification.
- 10 (chat/system msg): not touched — no `output.system`/`output.messages` transform changes.
- 11 (tool registration): not touched — `bun run scripts/check-tool-registration.ts` → "121 tools, coherent across metadata, handlers, the plugin object, TOOL_NAMES, and AGENT_TOOL_MAP."
- 12 (release/cache): touched (docs only) — added `docs/releases/pending/active-agent-ghost-entry-eviction.md`; no manual edits to `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan
- [x] `bun run build` — succeeds
- [x] `node --input-type=module -e "await import('./dist/index.js')"` — `dist import OK`
- [x] `bun run typecheck` — exit 0
- [x] `bun run lint:ci` (pinned Biome) — "Checked 3442 files ... No fixes applied."
- [x] `bun run scripts/check-tool-registration.ts` — passed (121 tools coherent)
- [x] `bash scripts/check-mock-cleanup.sh` — 10 pre-existing (non-blocking) warnings, none in touched files
- [x] `bash scripts/check-invariants.sh` — all 6 checks passed, mock.module ratchet: 0 added
- [x] `bash scripts/check-cross-contamination.sh` — pre-existing non-blocking warnings only, exit 0
- [x] `bash scripts/check-test-clock.sh` — 0 new violations (436 pre-existing, non-blocking)
- [x] `bun run check:runtime-src-refs` — passed
- [x] `bun run check:events` — passed (42 catalogued event kinds coherent)
- [x] `bun run check:test-file-cap` — 0 new/ratchet violations (verified after rebasing onto current `origin/main`, which resolved an unrelated pre-existing ratchet violation caused by base drift)
- [x] `bun run check:gate-portability` — passed
- [x] `bash scripts/check-test-tmpdir.sh` — no test file changes matched, passed
- [x] `bash scripts/check-bash-portability.sh` — passed, 0 bash4+-only constructs
- [x] `(cd scripts/swarm-model && node --test)` — 19/19 passed
- [x] `bun run package:smoke` — "package smoke OK: opencode-swarm-7.143.0.tgz (1082 files)"
- [x] Tier 2 (scoped, CI-equivalent): `bun run test:unit:ci <16 touched/adjacent files>` — 16/16 files, exit 0
- [x] Tier 3 integration: `bun test tests/integration ./test --timeout 120000` — 720 pass / 251 fail; **proven pre-existing**: identical 251 test names fail byte-for-byte on a freshly-checked-out clean `origin/main` worktree run through the identical command (batch-mode cross-file test pollution, not this change — see "Pre-existing failures" below)
- [x] Tier 4 security: `bun test tests/security --timeout 120000` — 168 pass / 0 fail
- [x] Tier 4 adversarial: `bun test tests/adversarial --timeout 120000` — 845 pass / 1 fail (Windows `EBUSY` temp-dir teardown flake in `council-quorum-adversarial.test.ts`, unrelated file, same class as a separately-confirmed pre-existing flake below)
- [x] Tier 5 smoke: `bun test tests/smoke --timeout 120000` — 10 pass / 0 fail
- [x] Full 174-file blast-radius sweep of every test file referencing `activeAgent`/`delegationChains`/`endAgentSession`/`sweepStaleSessions`/`rehydrateState`/`loadSnapshot`, run per-file — 1 failure, reproduced identically on clean `origin/main` (`tests/unit/index-background-advisory-delivery.test.ts`, Windows `EBUSY` temp-dir teardown, pre-existing)

## Pre-existing failures
- Tier 3 integration (`bun test tests/integration ./test`): 251/971 failures reproduce byte-for-byte on a clean `origin/main` worktree run through the identical batch command — cross-file test pollution inherent to running the whole `tests/integration` + `./test` trees in one process, not caused by this change.
- `tests/adversarial/council-quorum-adversarial.test.ts` and `tests/unit/index-background-advisory-delivery.test.ts`: Windows `EBUSY: resource busy or locked` on temp-directory teardown (`rmSync`), a known Windows-host flake class independent of this change.


## Follow-up: swarm-pr-review findings addressed (1faabce3)

A structured swarm-pr-review pass (6 explorer lanes + 11 micro risk families, independent reviewer + critic) approved the core fix and surfaced docs-accuracy findings, all addressed in 1faabce3:

- `docs/architecture.md` Shared State bullet for `activeAgent` now names the full eviction lifecycle (stale sweep, `endAgentSession`, `/swarm reset-session`, rehydration ghost-filtering) instead of "updated by chat.message hook" only.
- `/swarm close` summary line and its test assertion now read "Cleared agent sessions, delegation chains, and active-agent mappings" (close already cleared all three via `endAgentSession`/reset; the line under-reported it).
- `/swarm reset-session` and `/swarm finalize` command help (`src/commands/registry.ts`) list active-agent mappings — the reset-session help text was stale from this PR's own diff (invariant 11(d)).
- Release fragment extended with the user-visible wording changes.

Follow-up validation: `bun test tests/unit/commands/close.test.ts` (76/76), `bun test tests/unit/config/` (2034 tests, 0 fail), registry/help tests (122/122), `bun run drift:check` clean, `bun run lint:ci` clean, `bun run typecheck` exit 0. Reviewer + final-critic gates both APPROVE (see `.zcode/session/tasks/pr-2231-feedback/gates.md` trace).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


