### PR TITLE
fix: Auto-detected flaky tests (merge-group) — review for quarantine (#2233)

### DIFF
--- a/docs/releases/pending/2233-fix-prod-store-tripwire-first-run-flake.md
+++ b/docs/releases/pending/2233-fix-prod-store-tripwire-first-run-flake.md
@@ -1,0 +1,69 @@
+# Fix deterministic first-run flake in prod-store-tripwire test (issue #2233)
+
+## What changed
+
+`tests/helpers/prod-store-tripwire.test.ts` (the issue #2033 production-store
+tripwire safety-guard suite) no longer leaves the real `links/` store root
+behind when its "link-store writes throw" probe materializes it. The test now
+records whether `<dataDir>/links` existed before the probe (via the unguarded
+`existsSync`) and removes it again after the probe (via the unguarded
+`rmdirSync`) when the probe created it, restoring the store's top-level
+listing to its process-start state.
+
+## Why
+
+The merge-group flake-detection workflow (issue #1782) flagged the file in CI
+run 32190439859 (issue #2233) and again behind issue #2235. The mechanism was
+deterministic, not environmental:
+
+1. The probe test calls `mkdirSync(<dataDir>/links/regression-probe,
+   { recursive: true })` — `mkdirSync` is intentionally unguarded by the
+   tripwire, so on a fresh CI runner (no `~/.local/share/opencode-swarm` etc.)
+   this creates the real `links/` store root.
+2. The guarded `writeFileSync` throws as designed, and the old cleanup
+   `rmdirSync` removed only the `regression-probe` leaf — the newly
+   materialized `links/` root stayed behind.
+3. The preload's global `afterAll` bookend (`verifyRealStoresUnchanged`,
+   registered by `tests/preload/prod-store-tripwire.ts`) then saw the data
+   dir's top-level listing drift from `[]` to `['links']` and failed the whole
+   file — with all 8 tests passing.
+4. The CI retry ran on the same runner: attempt 2 captured `links/` in its
+   start-of-process fingerprint, before/after matched, and the file passed.
+
+Hence attempt-1-fail / pass-on-retry-1 on **all three OSes in the same run**
+(`unit (ubuntu-latest, 2)` 22:00:51Z, `unit (windows-latest, 2)` 22:02:14Z,
+`unit (macos-latest, 2)` 22:05:48Z on 2026-08-18 — the file lands in shard 2
+of the round-robin split on every platform). The suite landed on main via
+PR #2200 at 2026-08-18T06:18Z; every merge-group run since flaked it on
+attempt 1, including silently-retried green runs (e.g. runs 32184127546 and
+32193064942 carry the same retry annotations but concluded success — the
+detection workflow only files an issue when the run overall fails). Reproduced
+locally with a fresh `HOME`: first run fails with `data-dir top-level listing
+changed` and leaves `~/.local/share/opencode-swarm/links` behind; the
+immediate re-run passes. The fix removes the drift; three consecutive
+fresh-`HOME` runs now pass with no residue.
+
+The triage note in issue #2233 considered whether the detector was catching
+the suite's *intentional* guard trips; it was not — the CI retry wrapper keys
+on the whole-file exit code, and the intentional guard throws are
+`expect`-ed (the file exits 0 when behaving as designed). This was a real
+self-inflicted failure of the suite's own store-unchanged bookend.
+
+## Migration steps
+
+None. No source code, quarantine ledger, or workflow changed — the fix is
+confined to the test file's cleanup logic.
+
+## Known caveats
+
+- The proper-fix alternative considered and rejected: quarantining the file in
+  `scripts/ci/quarantined-tests.txt` per the issue's default instruction. That
+  would have suppressed a healthy #2033 safety suite for a 6-line cleanup bug,
+  so the ledger is intentionally left empty.
+- If a future probe in this suite materializes other real-store entries (the
+  tracked set is `links` and `quarantine-backups` in
+  `tests/helpers/prod-store-tripwire.ts`), the same pre/post-existence restore
+  pattern must be applied there too — the afterAll bookend will catch any
+  miss, which is exactly how this bug surfaced.
+- Issues #2233 and #2235 describe the same deterministic flake and should be
+  closed by this fix rather than by quarantine entries.

--- a/tests/helpers/prod-store-tripwire.test.ts
+++ b/tests/helpers/prod-store-tripwire.test.ts
@@ -13,7 +13,13 @@
  */
 
 import { afterAll, describe, expect, test } from 'bun:test';
-import { appendFileSync, mkdirSync, rmdirSync, writeFileSync } from 'node:fs';
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	rmdirSync,
+	writeFileSync,
+} from 'node:fs';
 import * as path from 'node:path';
 import { atomicWriteFile } from '../../src/evidence/task-file.js';
 import { resolveLinkBaseDir } from '../../src/hooks/knowledge-link.js';
@@ -84,6 +90,15 @@ describe('prod-store tripwire (issue #2033)', () => {
 		expect(isRealStoreTarget(realLinkDir)).toBe(true);
 		// mkdir is intentionally unguarded (see helper docs); the file write inside the
 		// real link root must be refused.
+		// Regression (issue #2233): the recursive mkdir below also materializes the
+		// REAL <dataDir>/links root when it does not exist yet (fresh CI runner).
+		// The old cleanup removed only the regression-probe leaf, leaving links/
+		// behind as top-level store drift that failed this file's own afterAll
+		// bookend (verifyRealStoresUnchanged) on the first run against a clean
+		// HOME — a deterministic cross-OS attempt-1 flake that passed on retry
+		// (the leftover links/ dir was already there for attempt 2). Record the
+		// pre-probe existence of the real links root and restore that state.
+		const realLinkRootExisted = existsSync(resolveLinkBaseDir());
 		let mkdirThrew: unknown;
 		try {
 			mkdirSync(realLinkDir, { recursive: true });
@@ -103,6 +118,16 @@ describe('prod-store tripwire (issue #2033)', () => {
 			rmdirSync(realLinkDir);
 		} catch {
 			/* write threw, so the dir may never have been created */
+		}
+		// Restore the pre-probe state of the real links root: if this probe
+		// materialized <dataDir>/links, remove it again so the store's top-level
+		// listing stays byte-identical to process start (the #2233 fix).
+		if (!realLinkRootExisted) {
+			try {
+				rmdirSync(resolveLinkBaseDir());
+			} catch {
+				/* non-empty or already gone — leave whatever is there */
+			}
 		}
 		expect(mkdirThrew).toBeUndefined();
 	});


### PR DESCRIPTION
Closes #2233

## Summary
|**Scope:** Fix the deterministic first-run flake in `tests/helpers/prod-store-tripwire.test.ts` (issue #2233) by restoring the real `links/` store root to its pre-probe state instead of quarantining the suite.
|**Verdict:** APPROVE

### Findings

_No findings — diff is minimal, scoped, and the afterAll bookend exercises the changed cleanup path._

### What I Checked

- Target file present in diff: yes (`tests/helpers/prod-store-tripwire.test.ts`)
- New/updated test exercises the changed code path: yes (`tests/helpers/prod-store-tripwire.test.ts:182-186` — `verifyRealStoresUnchanged()` will fail if the new cleanup leaves `links/` behind)
- Scope creep beyond the issue: no (the issue requested quarantine review; the PR documents why root-cause fix was chosen instead, and the quarantine ledger is intentionally left empty)
- Anti-patterns scanned: silent-except, mock-without-call, off-by-one, signature-break, scope-creep, stale-docs — none found

### Confidence

high — the change is a six-line cleanup fix that matches the root cause described in the release note, the existing afterAll bookend provides a fail-closed guard, and `rmdirSync` is confirmed unguarded in the tripwire helper.

## Invariant audit
- 1 (plugin init):       not touched — diff is test-only; no plugin manifest or init-path changes
- 2 (runtime portability): not touched — no bundle, package export, or plugin-shape changes
- 3 (subprocesses):      touched — the new test code uses unguarded `existsSync`/`mkdirSync`/`rmdirSync` against real platform knowledge-store paths (`<dataDir>/links`). Verification: AGENTS.md invariant 3 governs subprocess + filesystem ops; the tripwire helper at `tests/helpers/prod-store-tripwire.ts:installFsGuards` intentionally leaves these three functions unwrapped so the tripwire can still report guard violations when the test probes materialize the real store. The pre-state snapshot at line 101 captures whether `links/` existed before the probe; the conditional cleanup at lines 125-131 restores the pre-probe state; the in-test `verifyRealStoresUnchanged()` bookend (line 182-186) plus the preload's global afterAll (`tests/preload/prod-store-tripwire.ts`) fail-closed on any residue.
- 4 (.swarm containment): not touched — no `.swarm/` writes, no tool or hook changes
- 5 (plan durability):    not touched — no plan-ledger or projection changes
- 6 (test_runner safety): not touched — no test_runner scope changes; the diff IS a test change, not a tool change
- 7 (test writing):       touched — diff modifies a `bun:test` file (AGENTS.md reading-order table maps "Write or modify any test file" to invariant 7). Verification: bun:test only; no new `mock.module()` (the tripwire's spread-real pattern in `tests/helpers/prod-store-tripwire.ts:315-404` is unchanged); file stays under the 500-line FR-006 cap (current ~200 lines); no hardcoded `/tmp` paths; no `_internals` seam needed for this scope. The new pre-state `existsSync` and conditional `rmdirSync` use Node `node:fs` APIs via static top-level imports, which resolve against the already-mocked registry installed by the preload (mock.module spread does NOT wrap existsSync/rmdirSync, so they pass through as reference-identical pass-throughs — execution-proven by the passing CI).
- 8 (session state):      not touched — no session-scoped state introduced
- 9 (guardrails/retry):   not touched — no retry semantics, scope bindings, or guardrail changes
- 10 (chat/system msg):   not touched — no chat hook or system-message changes
- 11 (tool registration): not touched — no tool, agent, or skill registration changes
- 12 (release/cache):     touched — diff adds `docs/releases/pending/2233-fix-prod-store-tripwire-first-run-flake.md` per AGENTS.md invariant 12 (mandatory fragment for user-visible PR). Verification: fragment follows the established `docs/releases/pending/<unique-slug>.md` shape with What changed / Why / Migration steps / Known caveats sections; release-please owns `package.json#version`, `CHANGELOG.md`, and `.release-please-manifest.json` (no manual edits); no cache-layout changes.

## Test plan
See the linked issue and the change summary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->