### PR TITLE
fix(sast): repair semgrep auto-config gate

### DIFF
--- a/docs/releases/pending/2254-semgrep-auto-config.md
+++ b/docs/releases/pending/2254-semgrep-auto-config.md
@@ -1,0 +1,7 @@
+# Fix Semgrep auto-config scans and SAST gate degradation
+
+`sast_scan` no longer passes Semgrep's pattern-only `--lang` option together with `--config=auto`, fixing fatal CLI exits on Semgrep 1.173.0 and later.
+
+Semgrep failures now carry typed, sanitized diagnostics. A completed nonzero Semgrep process exit with no findings is reported by `pre_check_batch` as explicit `sast_degraded: true` coverage instead of blocking every coder task. Timeouts, cancellation, truncated or malformed output, partial scan errors, zero coverage, and any reported findings remain fail-closed.
+
+`pre_check_batch` now also honors the effective QA profile's `sast_enabled` setting, including session-bound overrides, and does not schedule SAST when that gate is disabled.

--- a/src/hooks/guardrails/pre-check-result.ts
+++ b/src/hooks/guardrails/pre-check-result.ts
@@ -85,11 +85,64 @@ function everyGateFindingIsPreexisting(
 	return true;
 }
 
+function isIntentionalSastSkip(
+	toolResult: Record<string, unknown>,
+	batchResult: Record<string, unknown>,
+): boolean {
+	return (
+		batchResult.sast_skipped === true &&
+		toolResult.ran === false &&
+		toolResult.duration_ms === 0 &&
+		toolResult.passed === undefined &&
+		toolResult.result === undefined &&
+		toolResult.error === undefined &&
+		toolResult.result_omitted === undefined
+	);
+}
+
+function isExpectedSastDegradation(
+	toolResult: Record<string, unknown>,
+	batchResult: Record<string, unknown>,
+): boolean {
+	if (batchResult.sast_degraded !== true || toolResult.ran !== true) {
+		return false;
+	}
+	if (
+		batchResult.output_truncated === true &&
+		toolResult.result_omitted === true &&
+		toolResult.passed === undefined &&
+		toolResult.result === undefined &&
+		toolResult.error === undefined
+	) {
+		return true;
+	}
+	if (
+		toolResult.passed !== undefined ||
+		toolResult.error !== undefined ||
+		toolResult.result_omitted !== undefined
+	) {
+		return false;
+	}
+	const result = toolResult.result;
+	return (
+		isRecord(result) &&
+		result.verdict === 'fail' &&
+		typeof result.error === 'string' &&
+		result.failure_kind === 'semgrep_process_exit' &&
+		Array.isArray(result.findings) &&
+		result.findings.length === 0 &&
+		result.baseline_used !== true
+	);
+}
+
 function hardGateExplicitlyFailed(
 	key: (typeof HARD_GATE_KEYS)[number],
 	toolResult: Record<string, unknown>,
 	batchResult: Record<string, unknown>,
 ): boolean {
+	if (key === 'sast_scan' && isIntentionalSastSkip(toolResult, batchResult)) {
+		return false;
+	}
 	if (toolResult.ran === false || toolResult.passed === false) return true;
 	if (
 		typeof toolResult.error === 'string' &&
@@ -108,6 +161,12 @@ function hardGateExplicitlyFailed(
 		);
 	}
 	if (toolResult.result_omitted !== undefined) return true;
+	if (
+		key === 'sast_scan' &&
+		isExpectedSastDegradation(toolResult, batchResult)
+	) {
+		return false;
+	}
 	if (result.passed === false || typeof result.error === 'string') return true;
 
 	if (key === 'secretscan') {
@@ -177,6 +236,14 @@ export function decodePreCheckResult(output: unknown): PreCheckVerdict {
 	) {
 		return { kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' };
 	}
+	if (
+		(parsed.sast_skipped !== undefined &&
+			typeof parsed.sast_skipped !== 'boolean') ||
+		(parsed.sast_degraded !== undefined &&
+			typeof parsed.sast_degraded !== 'boolean')
+	) {
+		return { kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' };
+	}
 
 	const ranStates: boolean[] = [];
 	for (const key of TOOL_KEYS) {
@@ -200,6 +267,21 @@ export function decodePreCheckResult(output: unknown): PreCheckVerdict {
 	const allSkipped = ranStates.every((ran) => ran === false);
 	const anyRan = ranStates.some((ran) => ran === true);
 	const batchStatus = parsed.batch_status;
+	if (
+		parsed.sast_skipped === true &&
+		!isIntentionalSastSkip(parsed.sast_scan as Record<string, unknown>, parsed)
+	) {
+		return { kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' };
+	}
+	if (
+		parsed.sast_degraded === true &&
+		!isExpectedSastDegradation(
+			parsed.sast_scan as Record<string, unknown>,
+			parsed,
+		)
+	) {
+		return { kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' };
+	}
 	if (
 		batchStatus !== undefined &&
 		batchStatus !== 'completed' &&

--- a/src/sast/semgrep-failure-kind.issue-2254.test.ts
+++ b/src/sast/semgrep-failure-kind.issue-2254.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ExternalToolRunResult } from '../utils/external-tool-runner';
+import { _internals, resetSemgrepCache, runSemgrep } from './semgrep';
+
+const originalResolveExecutableFromPath = _internals.resolveExecutableFromPath;
+const originalRunExternalTool = _internals.runExternalTool;
+
+function completedRun(
+	overrides: Partial<ExternalToolRunResult> = {},
+): ExternalToolRunResult {
+	return {
+		status: 'completed',
+		exitCode: 0,
+		stdout: '',
+		stderr: '',
+		stdoutTruncated: false,
+		stderrTruncated: false,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	resetSemgrepCache();
+	_internals.resolveExecutableFromPath = originalResolveExecutableFromPath;
+	_internals.runExternalTool = originalRunExternalTool;
+});
+
+afterEach(() => {
+	resetSemgrepCache();
+	_internals.resolveExecutableFromPath = originalResolveExecutableFromPath;
+	_internals.runExternalTool = originalRunExternalTool;
+});
+
+describe('Semgrep early failure kinds — issue #2254', () => {
+	test('classifies an unavailable Semgrep probe as a spawn error', async () => {
+		_internals.resolveExecutableFromPath = () => null;
+
+		const result = await runSemgrep({ files: ['test.ts'] });
+
+		expect(result.available).toBe(false);
+		expect(result.failure_kind).toBe('spawn_error');
+	});
+
+	test('classifies an aborted availability check as cancellation', async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		const result = await runSemgrep({
+			files: ['test.ts'],
+			abortSignal: controller.signal,
+		});
+
+		expect(result.available).toBe(true);
+		expect(result.failure_kind).toBe('cancelled');
+	});
+
+	test('classifies a binary disappearing after the availability probe as a spawn error', async () => {
+		let resolutions = 0;
+		_internals.resolveExecutableFromPath = () => {
+			resolutions++;
+			return resolutions === 1 ? '/fake/semgrep' : null;
+		};
+		_internals.runExternalTool = async () => completedRun({ stdout: '1.0.0' });
+
+		const result = await runSemgrep({ files: ['test.ts'] });
+
+		expect(result.available).toBe(false);
+		expect(result.failure_kind).toBe('spawn_error');
+	});
+});

--- a/src/sast/semgrep.test.ts
+++ b/src/sast/semgrep.test.ts
@@ -211,7 +211,6 @@ describe('Semgrep Integration', () => {
 				files: ['./src/test.ts'],
 				cwd,
 				useAutoConfig: true,
-				lang: 'ts',
 			});
 
 			expect(result.available).toBe(true);
@@ -231,7 +230,6 @@ describe('Semgrep Integration', () => {
 				'--config=auto',
 				'--json',
 				'--quiet',
-				'--lang=ts',
 				'./src/test.ts',
 			]);
 		});
@@ -297,7 +295,10 @@ describe('Semgrep Integration', () => {
 			// exposing scanner output to tool responses and durable evidence.
 			const result = await runSemgrep({ files: ['src/f.ts'] });
 
-			expect(result.error).toBe('Semgrep exited with code 2');
+			expect(result.error).toBe(
+				'Semgrep exited with code 2; run Semgrep directly in the project to diagnose',
+			);
+			expect(result.failure_kind).toBe('process_exit');
 			expect(result.error).not.toContain(sensitiveStderr);
 		});
 

--- a/src/sast/semgrep.ts
+++ b/src/sast/semgrep.ts
@@ -434,6 +434,7 @@ export async function runSemgrep(
 				available: true,
 				findings: [],
 				error: 'Semgrep execution cancelled',
+				failure_kind: 'cancelled',
 				engine: 'tier_a',
 			};
 		}
@@ -441,6 +442,7 @@ export async function runSemgrep(
 			available: false,
 			findings: [],
 			error: 'Semgrep is not installed or not available on PATH',
+			failure_kind: 'spawn_error',
 			engine: 'tier_a',
 		};
 	}
@@ -451,6 +453,7 @@ export async function runSemgrep(
 			available: false,
 			findings: [],
 			error: 'Semgrep is not installed or not available on PATH',
+			failure_kind: 'spawn_error',
 			engine: 'tier_a',
 		};
 	}

--- a/src/sast/semgrep.ts
+++ b/src/sast/semgrep.ts
@@ -23,13 +23,21 @@ export interface SemgrepOptions {
 	timeoutMs?: number;
 	/** Working directory for Semgrep execution */
 	cwd?: string;
-	/** Language identifier for --lang flag (used with useAutoConfig) */
-	lang?: string;
 	/** When true, use --config auto instead of local rulesDir (for profile-driven languages) */
 	useAutoConfig?: boolean;
 	/** Host/tool cancellation propagated to the shared subprocess runner. */
 	abortSignal?: AbortSignal;
 }
+
+export type SemgrepFailureKind =
+	| 'process_exit'
+	| 'timeout'
+	| 'cancelled'
+	| 'output_limit'
+	| 'spawn_error'
+	| 'invalid_output'
+	| 'scan_error'
+	| 'unexpected';
 
 /**
  * Result from Semgrep execution
@@ -41,6 +49,8 @@ export interface SemgrepResult {
 	findings: SastFinding[];
 	/** Error message if Semgrep failed */
 	error?: string;
+	/** Machine-readable category for an available scanner failure. */
+	failure_kind?: SemgrepFailureKind;
 	/** Engine label for the findings */
 	engine: 'tier_a' | 'tier_a+tier_b';
 }
@@ -151,6 +161,19 @@ function describeExternalToolFailure(
 		case 'spawn-error':
 			return 'Semgrep process failed to start or terminate safely';
 	}
+}
+
+const LANG_WITHOUT_PATTERN_DIAGNOSTIC =
+	'-e/--pattern and -l/--lang must both be specified';
+
+function describeSemgrepProcessExit(
+	exitCode: number | null,
+	stderr: string,
+): string {
+	if (stderr.includes(LANG_WITHOUT_PATTERN_DIAGNOSTIC)) {
+		return `Semgrep exited with code ${exitCode}: incompatible --lang option in config mode`;
+	}
+	return `Semgrep exited with code ${exitCode}; run Semgrep directly in the project to diagnose`;
 }
 
 export const _internals: {
@@ -437,9 +460,6 @@ export async function runSemgrep(
 		'--json',
 		'--quiet',
 	];
-	if (options.lang) {
-		args.push(`--lang=${options.lang}`);
-	}
 	args.push(...files);
 
 	try {
@@ -458,6 +478,7 @@ export async function runSemgrep(
 				available: true,
 				findings: [],
 				error: `Semgrep output exceeded ${MAX_OUTPUT_BYTES} bytes and was truncated; results incomplete`,
+				failure_kind: 'output_limit',
 				engine: 'tier_a',
 			};
 		}
@@ -466,6 +487,8 @@ export async function runSemgrep(
 				available: true,
 				findings: [],
 				error: describeExternalToolFailure(result.status),
+				failure_kind:
+					result.status === 'spawn-error' ? 'spawn_error' : result.status,
 				engine: 'tier_a',
 			};
 		}
@@ -485,7 +508,8 @@ export async function runSemgrep(
 				findings: [],
 				// Never expose raw stderr: scanners and wrappers may echo source,
 				// environment values, credentials, or host paths into diagnostics.
-				error: `Semgrep exited with code ${result.exitCode}`,
+				error: describeSemgrepProcessExit(result.exitCode, result.stderr),
+				failure_kind: 'process_exit',
 				engine: 'tier_a',
 			};
 		}
@@ -508,6 +532,13 @@ export async function runSemgrep(
 			available: true,
 			findings: [],
 			error: safeError,
+			failure_kind:
+				error instanceof SemgrepScanError
+					? 'scan_error'
+					: error instanceof Error &&
+							error.message === 'Semgrep returned invalid JSON output'
+						? 'invalid_output'
+						: 'unexpected',
 			engine: 'tier_a',
 		};
 	}

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -228,6 +228,8 @@ export interface PreCheckBatchResult {
 	sast_preexisting_findings?: SastScanFinding[];
 	/** Optional Semgrep exited nonzero with no findings; SAST coverage is incomplete. */
 	sast_degraded?: boolean;
+	/** SAST was intentionally disabled by the effective QA profile. */
+	sast_skipped?: boolean;
 }
 
 function truncateUtf8(value: string, maxBytes: number): string {
@@ -273,6 +275,9 @@ function serializePreCheckResult(result: PreCheckBatchResult): string {
 		gates_passed: result.gates_passed,
 		...(result.sast_degraded !== undefined && {
 			sast_degraded: result.sast_degraded,
+		}),
+		...(result.sast_skipped !== undefined && {
+			sast_skipped: result.sast_skipped,
 		}),
 		lint: compactToolResult(result.lint),
 		secretscan: compactToolResult(result.secretscan),
@@ -1618,6 +1623,7 @@ export async function runPreCheckBatch(
 		quality_budget: qualityBudgetResult,
 		total_duration_ms: Math.round(totalDuration),
 		...(sastDegraded && { sast_degraded: true }),
+		...(!sast_enabled && { sast_skipped: true }),
 		...(sastPreexistingFindings &&
 			sastPreexistingFindings.length > 0 && {
 				sast_preexisting_findings: sastPreexistingFindings,

--- a/src/tools/pre-check-batch.ts
+++ b/src/tools/pre-check-batch.ts
@@ -25,6 +25,7 @@ import type {
 	ResolvedLinterCommand,
 } from './lint';
 import { detectResolvedLinter, _internals as lintInternals } from './lint';
+import { resolveGatePreamble } from './phase-complete/gates/gate-helpers';
 import type { QualityBudgetResult } from './quality-budget';
 import { qualityBudget } from './quality-budget';
 import type { SastScanFinding, SastScanResult } from './sast-scan';
@@ -58,6 +59,8 @@ export const _internals: {
 	runLintOnFiles: typeof runLintOnFiles;
 	platform: () => NodeJS.Platform;
 	serializePreCheckResult: typeof serializePreCheckResult;
+	resolveGatePreamble: typeof resolveGatePreamble;
+	runPreCheckBatch: typeof runPreCheckBatch;
 	MAX_COMBINED_BYTES: number;
 } = {
 	qualityBudget,
@@ -73,6 +76,8 @@ export const _internals: {
 	runLintOnFiles,
 	platform: () => process.platform,
 	serializePreCheckResult,
+	resolveGatePreamble,
+	runPreCheckBatch,
 	MAX_COMBINED_BYTES,
 };
 
@@ -94,6 +99,8 @@ export interface PreCheckBatchInput {
 	 * with capture_baseline:true.
 	 */
 	phase?: number;
+	/** Effective QA-profile value derived internally by the public tool boundary. */
+	sast_enabled?: boolean;
 }
 
 export interface ToolResult<T> {
@@ -219,6 +226,8 @@ export interface PreCheckBatchResult {
 	total_duration_ms: number;
 	/** Pre-existing SAST findings on unchanged lines, requiring reviewer triage */
 	sast_preexisting_findings?: SastScanFinding[];
+	/** Optional Semgrep exited nonzero with no findings; SAST coverage is incomplete. */
+	sast_degraded?: boolean;
 }
 
 function truncateUtf8(value: string, maxBytes: number): string {
@@ -262,6 +271,9 @@ function serializePreCheckResult(result: PreCheckBatchResult): string {
 	const compact = {
 		batch_status: result.batch_status,
 		gates_passed: result.gates_passed,
+		...(result.sast_degraded !== undefined && {
+			sast_degraded: result.sast_degraded,
+		}),
 		lint: compactToolResult(result.lint),
 		secretscan: compactToolResult(result.secretscan),
 		sast_scan: compactToolResult(result.sast_scan),
@@ -1243,7 +1255,14 @@ export async function runPreCheckBatch(
 	const effectiveWorkspaceDir = (workspaceDir ||
 		input.directory ||
 		contextDir) as string;
-	const { files, directory, sast_threshold = 'medium', config, phase } = input;
+	const {
+		files,
+		directory,
+		sast_threshold = 'medium',
+		config,
+		phase,
+		sast_enabled = true,
+	} = input;
 
 	// Validate directory
 	const dirError = validateDirectory(directory, effectiveWorkspaceDir);
@@ -1372,16 +1391,21 @@ export async function runPreCheckBatch(
 					abortSignal,
 				),
 			),
-			limit(() =>
-				_internals.runSastScanWrapped(
-					changedFiles,
-					directory,
-					sast_threshold,
-					config,
-					phase,
-					abortSignal,
-				),
-			),
+			sast_enabled
+				? limit(() =>
+						_internals.runSastScanWrapped(
+							changedFiles,
+							directory,
+							sast_threshold,
+							config,
+							phase,
+							abortSignal,
+						),
+					)
+				: Promise.resolve<ToolResult<SastScanResult>>({
+						ran: false,
+						duration_ms: 0,
+					}),
 			limit(() =>
 				_internals.runQualityBudgetWrapped(
 					changedFiles,
@@ -1470,14 +1494,25 @@ export async function runPreCheckBatch(
 
 	// Check SAST scan (hard gate with pre-existing finding classification)
 	let sastPreexistingFindings: SastScanFinding[] | undefined;
+	let sastDegraded = false;
 	if (sastScanResult.ran && sastScanResult.result) {
 		const sastResult = sastScanResult.result;
 
 		if (sastResult.error) {
-			gatesPassed = false;
-			warn(
-				`pre_check_batch: SAST scan error (${sastResult.error}) - GATE FAILED`,
-			);
+			if (
+				sastResult.failure_kind === 'semgrep_process_exit' &&
+				sastResult.findings.length === 0
+			) {
+				sastDegraded = true;
+				warn(
+					`pre_check_batch: SAST coverage degraded (${sastResult.error}) - continuing without a gate failure`,
+				);
+			} else {
+				gatesPassed = false;
+				warn(
+					`pre_check_batch: SAST scan error (${sastResult.error}) - GATE FAILED`,
+				);
+			}
 		} else if (sastResult.baseline_used) {
 			// Baseline diff mode: verdict is driven ONLY by new_findings in sastScan.
 			// Populate reviewer triage with pre_existing_findings (if any), regardless of verdict.
@@ -1582,6 +1617,7 @@ export async function runPreCheckBatch(
 		sast_scan: sastScanResult,
 		quality_budget: qualityBudgetResult,
 		total_duration_ms: Math.round(totalDuration),
+		...(sastDegraded && { sast_degraded: true }),
 		...(sastPreexistingFindings &&
 			sastPreexistingFindings.length > 0 && {
 				sast_preexisting_findings: sastPreexistingFindings,
@@ -1600,7 +1636,7 @@ export async function runPreCheckBatch(
 export const pre_check_batch: ReturnType<typeof tool> = createSwarmTool({
 	allowWorkingDirectoryOverride: true,
 	description:
-		'Run multiple verification tools in parallel: lint, secretscan, SAST scan, and quality budget. Returns unified result with gates_passed status. Security tools (secretscan, sast_scan) are HARD GATES - failures block merging.',
+		'Run multiple verification tools in parallel: lint, secretscan, SAST scan, and quality budget. Returns unified result with gates_passed status. Security findings and incomplete SAST runs are hard failures; a Semgrep nonzero process exit with zero findings is returned as explicit sast_degraded coverage and does not block.',
 	args: {
 		files: z
 			.array(z.string())
@@ -1750,6 +1786,20 @@ export const pre_check_batch: ReturnType<typeof tool> = createSwarmTool({
 
 		// Run pre-check batch
 		try {
+			let sastEnabled = true;
+			try {
+				const preamble = await _internals.resolveGatePreamble(
+					resolvedDirectory,
+					ctx?.sessionID,
+				);
+				if (preamble.resolved && preamble.effectiveGates) {
+					sastEnabled = preamble.effectiveGates.sast_enabled;
+				}
+			} catch {
+				warn(
+					'pre_check_batch: QA-gate profile resolution failed; keeping SAST enabled',
+				);
+			}
 			const rawPhase = (typedArgs as unknown as Record<string, unknown>).phase;
 			const safePhase =
 				typeof rawPhase === 'number' &&
@@ -1758,13 +1808,14 @@ export const pre_check_batch: ReturnType<typeof tool> = createSwarmTool({
 					? rawPhase
 					: undefined;
 
-			const result = await runPreCheckBatch(
+			const result = await _internals.runPreCheckBatch(
 				{
 					files: typedArgs.files,
 					directory: resolvedDirectory,
 					sast_threshold: typedArgs.sast_threshold,
 					config: typedArgs.config,
 					phase: safePhase,
+					sast_enabled: sastEnabled,
 				},
 				workspaceAnchor,
 				directory,

--- a/src/tools/sast-scan.ts
+++ b/src/tools/sast-scan.ts
@@ -18,6 +18,7 @@ import {
 	checkSemgrepAvailable,
 	isSemgrepAvailable,
 	runSemgrep,
+	type SemgrepFailureKind,
 } from '../sast/semgrep';
 import { warn } from '../utils';
 import { createSwarmTool } from './create-tool';
@@ -66,6 +67,8 @@ export interface SastScanResult {
 	verdict: EvidenceVerdict;
 	/** Validation error when the requested scan cannot safely run */
 	error?: string;
+	/** Machine-readable failure category for gate consumers. */
+	failure_kind?: SastFailureKind;
 	/** Array of security findings */
 	findings: SastScanFinding[];
 	/** Summary information */
@@ -98,6 +101,20 @@ export interface SastScanResult {
 	/** True when pre_existing_findings were truncated to fit result limits */
 	truncated_pre_existing?: boolean;
 }
+
+export type SastFailureKind =
+	| 'semgrep_process_exit'
+	| 'semgrep_timeout'
+	| 'semgrep_cancelled'
+	| 'semgrep_output_limit'
+	| 'semgrep_spawn_error'
+	| 'semgrep_invalid_output'
+	| 'semgrep_scan_error'
+	| 'semgrep_unexpected'
+	| 'semgrep_unclassified'
+	| 'coverage'
+	| 'cancelled'
+	| 'invalid_input';
 
 export interface SastScanFinding {
 	rule_id: string;
@@ -223,6 +240,20 @@ function safeSemgrepDiagnostic(message: string): string {
 	if (/^Semgrep exited with code -?\d+$/.test(diagnostic)) {
 		return diagnostic;
 	}
+	if (
+		/^Semgrep exited with code -?\d+; run Semgrep directly in the project to diagnose$/.test(
+			diagnostic,
+		)
+	) {
+		return diagnostic;
+	}
+	if (
+		/^Semgrep exited with code -?\d+: incompatible --lang option in config mode$/.test(
+			diagnostic,
+		)
+	) {
+		return diagnostic;
+	}
 	if (/^Semgrep reported \d+ scan errors?$/.test(diagnostic)) {
 		return diagnostic;
 	}
@@ -240,6 +271,7 @@ function cancelledScanResult(
 	return {
 		verdict: 'fail',
 		error: 'SAST scan cancelled',
+		failure_kind: 'cancelled',
 		findings: finalFindings,
 		summary: {
 			engine: 'tier_a',
@@ -248,6 +280,12 @@ function cancelledScanResult(
 			findings_by_severity: countBySeverity(finalFindings),
 		},
 	};
+}
+
+function mapSemgrepFailureKind(
+	failureKind: SemgrepFailureKind | undefined,
+): SastFailureKind {
+	return failureKind ? `semgrep_${failureKind}` : 'semgrep_unclassified';
 }
 
 /**
@@ -342,6 +380,7 @@ export async function sastScan(
 	let semgrepError: string | undefined = abort_signal?.aborted
 		? 'SAST scan cancelled'
 		: undefined;
+	let semgrepFailureKind: SastFailureKind | undefined;
 
 	// Process each file
 	for (const filePath of changed_files) {
@@ -460,11 +499,9 @@ export async function sastScan(
 				let semgrepResult: Awaited<ReturnType<typeof runSemgrep>>;
 
 				if (bucketKey.startsWith('auto:')) {
-					// Profile-driven auto mode: --config auto --lang <lang>
-					const lang = bucketKey.slice('auto:'.length);
+					// Profile-driven auto mode: Semgrep infers language from the files.
 					semgrepResult = await _internals.runSemgrep({
 						files: bucketFiles,
-						lang,
 						useAutoConfig: true,
 						cwd: directory,
 						abortSignal: abort_signal,
@@ -479,6 +516,9 @@ export async function sastScan(
 				}
 				if (semgrepResult.error) {
 					semgrepError = safeSemgrepDiagnostic(semgrepResult.error);
+					semgrepFailureKind = mapSemgrepFailureKind(
+						semgrepResult.failure_kind,
+					);
 					break;
 				}
 
@@ -515,6 +555,7 @@ export async function sastScan(
 			}
 		} catch {
 			semgrepError = 'Semgrep execution failed';
+			semgrepFailureKind = 'semgrep_unexpected';
 		}
 	}
 	if (abort_signal?.aborted) {
@@ -552,6 +593,7 @@ export async function sastScan(
 		return {
 			verdict: 'fail',
 			error: `Semgrep execution failed: ${semgrepError}`,
+			failure_kind: semgrepFailureKind ?? 'semgrep_unclassified',
 			findings: finalFindings,
 			summary,
 		};
@@ -584,6 +626,7 @@ export async function sastScan(
 				verdict: 'fail',
 				error:
 					'capture_baseline requires changed_files to produce a non-empty baseline',
+				failure_kind: 'invalid_input',
 				findings: finalFindings,
 				summary: {
 					engine,
@@ -792,6 +835,7 @@ export async function sastScan(
 		// #2210: surface the zero-coverage reason (mirrors the capture_baseline
 		// path's explicit error contract).
 		...(zeroCoverageError ? { error: zeroCoverageError } : {}),
+		...(zeroCoverageError ? { failure_kind: 'coverage' as const } : {}),
 	};
 
 	if (baselineUsed) {

--- a/tests/unit/hooks/pre-check-result.test.ts
+++ b/tests/unit/hooks/pre-check-result.test.ts
@@ -130,6 +130,76 @@ describe('decodePreCheckResult', () => {
 		).toEqual({ kind: 'pass' });
 	});
 
+	test('accepts only explicit producer states for disabled and degraded SAST', () => {
+		expect(
+			decodePreCheckResult(
+				result(true, {
+					sast_skipped: true,
+					sast_scan: {
+						ran: false,
+						duration_ms: 0,
+					},
+				}),
+			),
+		).toEqual({ kind: 'pass' });
+		expect(
+			decodePreCheckResult(
+				result(true, {
+					sast_degraded: true,
+					sast_scan: toolResult(true, {
+						result: {
+							verdict: 'fail',
+							error: 'Semgrep exited with code 7',
+							failure_kind: 'semgrep_process_exit',
+							findings: [],
+						},
+					}),
+				}),
+			),
+		).toEqual({ kind: 'pass' });
+		expect(
+			decodePreCheckResult(
+				result(true, {
+					sast_degraded: true,
+					sast_scan: toolResult(true, {
+						result: {
+							verdict: 'fail',
+							error: 'Semgrep exited with code 7',
+							failure_kind: 'semgrep_process_exit',
+							findings: [{}],
+						},
+					}),
+				}),
+			),
+		).toEqual({ kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' });
+		expect(
+			decodePreCheckResult(
+				result(true, {
+					sast_skipped: true,
+					sast_scan: {
+						ran: false,
+						duration_ms: 0,
+						passed: false,
+					},
+				}),
+			),
+		).toEqual({ kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' });
+		expect(
+			decodePreCheckResult(
+				result(true, {
+					sast_degraded: true,
+					output_truncated: true,
+					sast_scan: {
+						ran: true,
+						duration_ms: 0,
+						passed: false,
+						result_omitted: true,
+					},
+				}),
+			),
+		).toEqual({ kind: 'invalid', code: 'PRE_CHECK_RESULT_INVALID' });
+	});
+
 	test('F-001 rejects unrelated pre-existing evidence for a new SAST finding', () => {
 		const finding = (rule_id: string, file: string) => ({
 			rule_id,

--- a/tests/unit/sast/semgrep-failure-kinds.issue-2254.test.ts
+++ b/tests/unit/sast/semgrep-failure-kinds.issue-2254.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	_internals,
+	runSemgrep,
+	type SemgrepFailureKind,
+} from '../../../src/sast/semgrep';
+
+const originals = {
+	resolveExecutableFromPath: _internals.resolveExecutableFromPath,
+	runExternalTool: _internals.runExternalTool,
+};
+
+type RunResult = Awaited<ReturnType<typeof _internals.runExternalTool>>;
+
+function completedRun(overrides: Partial<RunResult> = {}): RunResult {
+	return {
+		status: 'completed',
+		exitCode: 0,
+		stdout: '',
+		stderr: '',
+		stdoutTruncated: false,
+		stderrTruncated: false,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	_internals.resetSemgrepCache();
+	_internals.resolveExecutableFromPath = () => '/fake/semgrep';
+});
+
+afterEach(() => {
+	_internals.resolveExecutableFromPath = originals.resolveExecutableFromPath;
+	_internals.runExternalTool = originals.runExternalTool;
+	_internals.resetSemgrepCache();
+});
+
+async function runWithScanResult(scanResult: RunResult) {
+	_internals.runExternalTool = async (options) =>
+		options.args[0] === '--version'
+			? completedRun({ stdout: '1.173.0' })
+			: scanResult;
+	return runSemgrep({ files: ['safe.ts'], useAutoConfig: true });
+}
+
+describe('Semgrep typed failures — issue #2254', () => {
+	test.each([
+		['timeout', 'timeout', 'Semgrep process timed out'],
+		['cancelled', 'cancelled', 'Semgrep execution cancelled'],
+		[
+			'spawn-error',
+			'spawn_error',
+			'Semgrep process failed to start or terminate safely',
+		],
+	] as const)('classifies external-runner %s separately', async (status, failureKind, message) => {
+		const result = await runWithScanResult(
+			completedRun({ status, exitCode: null }),
+		);
+
+		expect(result).toMatchObject({
+			findings: [],
+			error: message,
+			failure_kind: failureKind,
+		});
+	});
+
+	test('classifies bounded-output overflow without exposing output', async () => {
+		const secret = 'Authorization: Bearer hidden-marker';
+		const result = await runWithScanResult(
+			completedRun({
+				stdout: secret,
+				stderr: 'C:\\private\\source.ts',
+				stdoutTruncated: true,
+			}),
+		);
+
+		expect(result.failure_kind).toBe('output_limit');
+		expect(result.error).toContain('truncated');
+		expect(result.error).not.toContain('hidden-marker');
+		expect(result.error).not.toContain('private');
+	});
+
+	test('classifies invalid JSON separately', async () => {
+		const result = await runWithScanResult(
+			completedRun({ stdout: '{not-json' }),
+		);
+
+		expect(result).toMatchObject({
+			failure_kind: 'invalid_output',
+			error: 'Semgrep returned invalid JSON output',
+		});
+	});
+
+	test('classifies structured partial-scan errors separately', async () => {
+		const result = await runWithScanResult(
+			completedRun({
+				stdout: JSON.stringify({
+					results: [],
+					errors: [{ type: 'ParseError', message: 'incomplete' }],
+				}),
+			}),
+		);
+
+		expect(result).toMatchObject({
+			failure_kind: 'scan_error',
+			error: 'Semgrep reported 1 scan error',
+		});
+	});
+
+	test('classifies unexpected wrapper exceptions separately', async () => {
+		_internals.runExternalTool = async (options) => {
+			if (options.args[0] === '--version') {
+				return completedRun({ stdout: '1.173.0' });
+			}
+			throw new Error('C:\\secret\\source.ts bearer hidden-marker');
+		};
+
+		const result = await runSemgrep({ files: ['safe.ts'] });
+
+		expect(result).toMatchObject({
+			failure_kind: 'unexpected',
+			error: 'Semgrep execution failed unexpectedly',
+		});
+		expect(result.error).not.toContain('hidden-marker');
+	});
+
+	test('only a completed nonzero exit receives process_exit guidance', async () => {
+		const secret = 'Bearer hidden-marker C:\\private\\source.ts';
+		const result = await runWithScanResult(
+			completedRun({ exitCode: 7, stderr: secret }),
+		);
+
+		expect(result.failure_kind satisfies SemgrepFailureKind).toBe(
+			'process_exit',
+		);
+		expect(result.error).toBe(
+			'Semgrep exited with code 7; run Semgrep directly in the project to diagnose',
+		);
+		expect(result.error).not.toContain('hidden-marker');
+		expect(result.error).not.toContain('private');
+	});
+
+	test('maps the reporter-confirmed stderr to a fixed safe explanation', async () => {
+		const result = await runWithScanResult(
+			completedRun({
+				exitCode: 7,
+				stderr:
+					'[00.13][ERROR]: -e/--pattern and -l/--lang must both be specified',
+			}),
+		);
+
+		expect(result).toMatchObject({
+			failure_kind: 'process_exit',
+			error:
+				'Semgrep exited with code 7: incompatible --lang option in config mode',
+		});
+	});
+});

--- a/tests/unit/tools/pre-check-batch-sast-degraded.issue-2254.test.ts
+++ b/tests/unit/tools/pre-check-batch-sast-degraded.issue-2254.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals as batchInternals,
+	runPreCheckBatch,
+} from '../../../src/tools/pre-check-batch';
+import {
+	type SastScanResult,
+	_internals as sastInternals,
+	sastScan,
+} from '../../../src/tools/sast-scan';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const originals = {
+	runLintWrapped: batchInternals.runLintWrapped,
+	runSecretscanWrapped: batchInternals.runSecretscanWrapped,
+	runSastScanWrapped: batchInternals.runSastScanWrapped,
+	runQualityBudgetWrapped: batchInternals.runQualityBudgetWrapped,
+	saveEvidence: batchInternals.saveEvidence,
+	checkSemgrepAvailable: sastInternals.checkSemgrepAvailable,
+	runSemgrep: sastInternals.runSemgrep,
+};
+
+let directory = '';
+let sastResult: SastScanResult;
+
+function cleanSastResult(): SastScanResult {
+	return {
+		verdict: 'pass',
+		findings: [],
+		summary: {
+			engine: 'tier_a',
+			files_scanned: 1,
+			findings_count: 0,
+			findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0 },
+		},
+	};
+}
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('pre-check-sast-degraded-');
+	fs.writeFileSync(
+		path.join(directory, 'safe.ts'),
+		'export const safe = true;\n',
+	);
+	sastResult = cleanSastResult();
+
+	batchInternals.runLintWrapped = async () => ({
+		ran: false,
+		error: 'lint unavailable',
+		duration_ms: 0,
+	});
+	batchInternals.runSecretscanWrapped = async () => ({
+		ran: true,
+		result: {
+			scan_dir: directory,
+			findings: [],
+			count: 0,
+			files_scanned: 1,
+			skipped_files: 0,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		},
+		duration_ms: 0,
+	});
+	batchInternals.runSastScanWrapped = async () => ({
+		ran: true,
+		result: sastResult,
+		duration_ms: 0,
+	});
+	batchInternals.runQualityBudgetWrapped = async () => ({
+		ran: false,
+		error: 'quality budget unavailable',
+		duration_ms: 0,
+	});
+	batchInternals.saveEvidence = async () => undefined;
+});
+
+afterEach(() => {
+	batchInternals.runLintWrapped = originals.runLintWrapped;
+	batchInternals.runSecretscanWrapped = originals.runSecretscanWrapped;
+	batchInternals.runSastScanWrapped = originals.runSastScanWrapped;
+	batchInternals.runQualityBudgetWrapped = originals.runQualityBudgetWrapped;
+	batchInternals.saveEvidence = originals.saveEvidence;
+	sastInternals.checkSemgrepAvailable = originals.checkSemgrepAvailable;
+	sastInternals.runSemgrep = originals.runSemgrep;
+	fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe('pre_check_batch degraded SAST contract — issue #2254', () => {
+	test('derived sast_enabled false never schedules the SAST wrapper', async () => {
+		let calls = 0;
+		batchInternals.runSastScanWrapped = async () => {
+			calls++;
+			throw new Error('SAST must not run');
+		};
+
+		const result = await runPreCheckBatch({
+			files: ['safe.ts'],
+			directory,
+			sast_enabled: false,
+		});
+
+		expect(calls).toBe(0);
+		expect(result.gates_passed).toBe(true);
+		expect(result.sast_scan).toEqual({ ran: false, duration_ms: 0 });
+	});
+
+	test('a Semgrep process exit with zero findings is an explicit nonblocking degradation', async () => {
+		sastResult = {
+			...cleanSastResult(),
+			verdict: 'fail',
+			error:
+				'Semgrep execution failed: Semgrep exited with code 7; run Semgrep directly in the project to diagnose',
+			failure_kind: 'semgrep_process_exit',
+		};
+
+		const result = await runPreCheckBatch({
+			files: ['safe.ts'],
+			directory,
+		});
+
+		expect(result.gates_passed).toBe(true);
+		expect(result.sast_degraded).toBe(true);
+		expect(result.sast_scan.result?.error).toContain('code 7');
+	});
+
+	test('a Semgrep process exit with any finding remains blocking', async () => {
+		sastResult = {
+			...cleanSastResult(),
+			verdict: 'fail',
+			error: 'Semgrep execution failed: Semgrep exited with code 7',
+			failure_kind: 'semgrep_process_exit',
+			findings: [
+				{
+					rule_id: 'unsafe-eval',
+					severity: 'high',
+					message: 'Unsafe eval',
+					location: { file: 'safe.ts', line: 1 },
+				},
+			],
+		};
+
+		const result = await runPreCheckBatch({
+			files: ['safe.ts'],
+			directory,
+		});
+
+		expect(result.gates_passed).toBe(false);
+		expect(result.sast_degraded).not.toBe(true);
+	});
+
+	test.each([
+		'coverage',
+		'cancelled',
+		'invalid_input',
+		'semgrep_timeout',
+		'semgrep_cancelled',
+		'semgrep_output_limit',
+		'semgrep_spawn_error',
+		'semgrep_invalid_output',
+		'semgrep_scan_error',
+		'semgrep_unexpected',
+	] as const)('%s remains fail-closed', async (failureKind) => {
+		sastResult = {
+			...cleanSastResult(),
+			verdict: 'fail',
+			error: 'SAST could not complete safely',
+			failure_kind: failureKind,
+		};
+
+		const result = await runPreCheckBatch({
+			files: ['safe.ts'],
+			directory,
+		});
+
+		expect(result.gates_passed).toBe(false);
+		expect(result.sast_degraded).not.toBe(true);
+	});
+
+	test('a no-native-rules Kotlin scan can degrade, but never silently passes', async () => {
+		fs.writeFileSync(path.join(directory, 'safe.kt'), 'fun main() {}\n');
+		sastInternals.checkSemgrepAvailable = async () => true;
+		sastInternals.runSemgrep = async () => ({
+			available: true,
+			findings: [],
+			error:
+				'Semgrep exited with code 7; run Semgrep directly in the project to diagnose',
+			failure_kind: 'process_exit',
+			engine: 'tier_a',
+		});
+		batchInternals.runSastScanWrapped = async (files, root) => ({
+			ran: true,
+			result: await sastScan({ changed_files: files }, root),
+			duration_ms: 0,
+		});
+
+		const result = await runPreCheckBatch({
+			files: ['safe.kt'],
+			directory,
+		});
+
+		expect(result.gates_passed).toBe(true);
+		expect(result.sast_degraded).toBe(true);
+		expect(result.sast_scan.result).toMatchObject({
+			failure_kind: 'semgrep_process_exit',
+			summary: { files_scanned: 1 },
+		});
+	});
+});

--- a/tests/unit/tools/pre-check-batch-sast-degraded.issue-2254.test.ts
+++ b/tests/unit/tools/pre-check-batch-sast-degraded.issue-2254.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { decodePreCheckResult } from '../../../src/hooks/guardrails/pre-check-result';
 import {
 	_internals as batchInternals,
 	runPreCheckBatch,
@@ -105,6 +106,10 @@ describe('pre_check_batch degraded SAST contract — issue #2254', () => {
 		expect(calls).toBe(0);
 		expect(result.gates_passed).toBe(true);
 		expect(result.sast_scan).toEqual({ ran: false, duration_ms: 0 });
+		expect(result.sast_skipped).toBe(true);
+		expect(
+			decodePreCheckResult(batchInternals.serializePreCheckResult(result)),
+		).toEqual({ kind: 'pass' });
 	});
 
 	test('a Semgrep process exit with zero findings is an explicit nonblocking degradation', async () => {
@@ -124,6 +129,9 @@ describe('pre_check_batch degraded SAST contract — issue #2254', () => {
 		expect(result.gates_passed).toBe(true);
 		expect(result.sast_degraded).toBe(true);
 		expect(result.sast_scan.result?.error).toContain('code 7');
+		expect(
+			decodePreCheckResult(batchInternals.serializePreCheckResult(result)),
+		).toEqual({ kind: 'pass' });
 	});
 
 	test('a Semgrep process exit with any finding remains blocking', async () => {
@@ -162,6 +170,7 @@ describe('pre_check_batch degraded SAST contract — issue #2254', () => {
 		'semgrep_invalid_output',
 		'semgrep_scan_error',
 		'semgrep_unexpected',
+		'semgrep_unclassified',
 	] as const)('%s remains fail-closed', async (failureKind) => {
 		sastResult = {
 			...cleanSastResult(),

--- a/tests/unit/tools/pre-check-batch-sast-profile.issue-2254.test.ts
+++ b/tests/unit/tools/pre-check-batch-sast-profile.issue-2254.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ToolContext } from '@opencode-ai/plugin';
+import {
+	_internals,
+	type PreCheckBatchInput,
+	type PreCheckBatchResult,
+	pre_check_batch,
+} from '../../../src/tools/pre-check-batch';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const originals = {
+	resolveGatePreamble: _internals.resolveGatePreamble,
+	runPreCheckBatch: _internals.runPreCheckBatch,
+};
+
+let directory = '';
+let capturedInput: PreCheckBatchInput | undefined;
+let capturedSessionID: string | undefined;
+
+function completedResult(): PreCheckBatchResult {
+	const skipped = { ran: false, duration_ms: 0 };
+	return {
+		batch_status: 'completed',
+		gates_passed: true,
+		lint: skipped,
+		secretscan: skipped,
+		sast_scan: skipped,
+		quality_budget: skipped,
+		total_duration_ms: 0,
+	};
+}
+
+function context(): ToolContext {
+	return {
+		sessionID: 'issue-2254-session',
+		messageID: 'message',
+		agent: 'architect',
+		directory,
+		worktree: directory,
+		abort: new AbortController().signal,
+		metadata: () => undefined,
+		ask: async () => undefined,
+	} as unknown as ToolContext;
+}
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('pre-check-sast-profile-');
+	fs.mkdirSync(path.join(directory, '.git'));
+	fs.writeFileSync(
+		path.join(directory, 'safe.ts'),
+		'export const safe = true;\n',
+	);
+	capturedInput = undefined;
+	capturedSessionID = undefined;
+	_internals.runPreCheckBatch = async (input) => {
+		capturedInput = input;
+		return completedResult();
+	};
+});
+
+afterEach(() => {
+	_internals.resolveGatePreamble = originals.resolveGatePreamble;
+	_internals.runPreCheckBatch = originals.runPreCheckBatch;
+	fs.rmSync(directory, { recursive: true, force: true });
+});
+
+async function execute() {
+	const raw = await pre_check_batch.execute(
+		{ files: ['safe.ts'], directory },
+		context() as never,
+	);
+	return JSON.parse(raw);
+}
+
+describe('pre_check_batch QA-profile SAST wiring — issue #2254', () => {
+	test('effective sast_enabled false is derived internally and receives session identity', async () => {
+		_internals.resolveGatePreamble = async (_dir, sessionID) => {
+			capturedSessionID = sessionID;
+			return {
+				resolved: true,
+				effectiveGates: { sast_enabled: false },
+			} as never;
+		};
+
+		await execute();
+
+		expect(capturedSessionID).toBe('issue-2254-session');
+		expect(capturedInput?.sast_enabled).toBe(false);
+	});
+
+	test('effective sast_enabled true schedules the gate', async () => {
+		_internals.resolveGatePreamble = async () =>
+			({
+				resolved: true,
+				effectiveGates: { sast_enabled: true },
+			}) as never;
+
+		await execute();
+
+		expect(capturedInput?.sast_enabled).toBe(true);
+	});
+
+	test('missing plan or profile defaults SAST to enabled', async () => {
+		_internals.resolveGatePreamble = async () => ({ resolved: false });
+
+		await execute();
+
+		expect(capturedInput?.sast_enabled).toBe(true);
+	});
+
+	test('profile resolution exceptions fail safe by keeping SAST enabled', async () => {
+		_internals.resolveGatePreamble = async () => {
+			throw new Error('profile database unavailable');
+		};
+
+		const result = await execute();
+
+		expect(result.gates_passed).toBe(true);
+		expect(capturedInput?.sast_enabled).toBe(true);
+	});
+});

--- a/tests/unit/tools/pre-check-batch-status.test.ts
+++ b/tests/unit/tools/pre-check-batch-status.test.ts
@@ -12,6 +12,7 @@ import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 function oversizedResult(
 	gatesPassed: boolean,
 	detail: string,
+	sastDegraded = false,
 ): PreCheckBatchResult {
 	const toolResult = {
 		ran: true,
@@ -21,6 +22,7 @@ function oversizedResult(
 	return {
 		batch_status: 'completed',
 		gates_passed: gatesPassed,
+		sast_degraded: sastDegraded,
 		lint: toolResult,
 		secretscan: toolResult,
 		sast_scan: toolResult,
@@ -102,7 +104,7 @@ test('serializer measures multibyte diagnostics in UTF-8 bytes and preserves a p
 		Math.floor(_internals.MAX_COMBINED_BYTES / 4),
 	);
 	const serialized = _internals.serializePreCheckResult(
-		oversizedResult(true, multibyteDetail),
+		oversizedResult(true, multibyteDetail, true),
 	);
 	const parsed = JSON.parse(serialized) as Record<string, unknown>;
 
@@ -114,6 +116,7 @@ test('serializer measures multibyte diagnostics in UTF-8 bytes and preserves a p
 		_internals.MAX_COMBINED_BYTES,
 	);
 	expect(parsed.output_truncated).toBe(true);
+	expect(parsed.sast_degraded).toBe(true);
 	const secretscan = parsed.secretscan as Record<string, unknown>;
 	// F-010 prior behavior mislabeled a successful omitted result as an error.
 	expect(secretscan.error).toBeUndefined();

--- a/tests/unit/tools/sast-scan-profiles-adversarial.test.ts
+++ b/tests/unit/tools/sast-scan-profiles-adversarial.test.ts
@@ -175,7 +175,7 @@ describe('SAST Scan - Adversarial Tests', () => {
 		expect(mockExecuteRulesSyncCalls.length).toBe(0); // Tier A NOT called (nativeRuleSet === null)
 		expect(mockRunSemgrepCalls.length).toBe(1);
 		expect(mockRunSemgrepCalls[0].useAutoConfig).toBe(true); // Auto mode used
-		expect(mockRunSemgrepCalls[0].lang).toBe('kotlin');
+		expect(mockRunSemgrepCalls[0].lang).toBeUndefined();
 	});
 
 	it('Adversarial 5: runSemgrep returns malformed findings → must not crash', async () => {
@@ -309,7 +309,7 @@ describe('SAST Scan - Adversarial Tests', () => {
 		expect(result2.summary.files_scanned).toBe(1);
 		expect(mockRunSemgrepCalls.length).toBe(1);
 		expect(mockRunSemgrepCalls[0].useAutoConfig).toBe(true); // Auto mode
-		expect(mockRunSemgrepCalls[0].lang).toBe('kotlin');
+		expect(mockRunSemgrepCalls[0].lang).toBeUndefined();
 		expect(mockRunSemgrepCalls[0].files).toContain(kotlinFile);
 
 		// Combined: Both buckets work correctly

--- a/tests/unit/tools/sast-scan-profiles.test.ts
+++ b/tests/unit/tools/sast-scan-profiles.test.ts
@@ -127,7 +127,7 @@ describe('SAST Scan - Profile-Driven Behavior', () => {
 		expect(mockExecuteRulesSyncCalls.length).toBe(0); // Tier A NOT called
 		expect(mockRunSemgrepCalls.length).toBe(1);
 		expect(mockRunSemgrepCalls[0].useAutoConfig).toBe(true);
-		expect(mockRunSemgrepCalls[0].lang).toBe('kotlin');
+		expect(mockRunSemgrepCalls[0].lang).toBeUndefined();
 		expect(mockRunSemgrepCalls[0].files).toContain(testFile);
 	});
 


### PR DESCRIPTION
Closes #2254

## Summary

- remove the incompatible `--lang` argument from Semgrep auto-config scans while preserving the explicit profile as a separate configuration path
- classify Semgrep execution failures and only degrade an empty-result process exit; timeouts, cancellation, truncation, spawn/parse failures, partial scans, and every scan with findings remain blocking
- honor the active session's QA profile before scheduling batch SAST and preserve `sast_degraded` in compact output
- add focused regression, adversarial, profile-gating, real-Semgrep, and release-note coverage for the reported Semgrep 1.173.0 failure

## Invariant audit

- 1 (plugin init): touched — `pre-check-batch` imports the session-bound gate resolver; `bun run build` and `node scripts/repro-704.mjs` passed, including 326.7 ms plugin initialization under the 400 ms limit.
- 2 (runtime portability): touched — `bun run build`, the Node ESM import of `dist/index.js`, portability gates, and the 10-case smoke suite passed.
- 3 (subprocesses): touched — Semgrep argument/result handling changed without adding a spawn site; the diff spawn-pattern audit was empty, real Semgrep 1.173.0 completed successfully, and timeout/cancellation/output-limit cases are covered.
- 4 (.swarm containment): not touched — no runtime path or storage behavior changed.
- 5 (plan durability): not touched — no plan schema, ledger, projection, or checkpoint behavior changed.
- 6 (test_runner safety): not touched — validation used focused shell test commands and repository scripts, not broad `test_runner` scope.
- 7 (test writing): touched — the writing-tests protocol was loaded; new tests use `bun:test`, restore `_internals` seams, remain below 500 lines, and `bun run check:test-file-cap` passed with zero violations.
- 8 (session state): touched — batch SAST now resolves `sast_enabled` from the exact active session/task QA profile; focused tests prove enabled, disabled, unbound, and profile-load-failure behavior.
- 9 (guardrails/retry): touched — the SAST gate now distinguishes one narrow fail-open process-exit condition from fail-closed unsafe categories; the regression matrix covers findings plus every classified and unclassified failure path.
- 10 (chat/system msg): not touched — no chat hook or message-shape behavior changed.
- 11 (tool registration): not touched — no tool was added or renamed; tool-registration validation passed (121 assertions).
- 12 (release/cache): touched — added `docs/releases/pending/2254-semgrep-auto-config.md`; build and npm package smoke passed (1088-file tarball).

## Test plan

- [x] Focused Semgrep/SAST/pre-check regression suites: 72 assertions passed
- [x] Real Semgrep 1.173.0 Kotlin auto-config reproduction: corrected scan exited successfully
- [x] `bun run typecheck`, `bun run lint:ci`, `bun run build`, and Node ESM bundle import
- [x] `node scripts/repro-704.mjs`, smoke suite (10/10), and `bun run package:smoke`
- [x] Security suite (168 pass, 4 skip) and adversarial suite (846 pass)
- [x] Tool registration, runtime source references, events, portability, drift, test-file-cap, invariant, mock-cleanup, clock, tmpdir, cross-contamination, and Bash portability gates
- [x] Full unit run: every changed-path test passed; three unrelated failures reproduced identically on clean `origin/main` (production-store sandbox access, skill consolidation, architecture-supervisor evidence)
- [x] Aggregate integration run: branch was no worse than clean `origin/main` (720 pass/251 fail versus 719 pass/252 fail); the failures are pre-existing shared-state contamination outside this patch
- [x] Independent implementation review and final critic review: approved


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

