### PR TITLE
fix(workflow): /swarm recover + reset-session settlement recovery for wedged coder dispatches (issue #2268)

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -39,6 +39,7 @@ These are invoked as `/swarm <subcommand>`, NOT as bare `/subcommand`. The list 
 - `/swarm rollback` — restore swarm state or project files to a checkpoint
 - `/swarm reset` — clear swarm state files `[--confirm]`
 - `/swarm reset-session` — clear session state, preserve plan/evidence/knowledge
+- `/swarm recover` — settle wedged coder settlements `[task_id] [--force]` (human-only)
 - `/swarm checkpoint` — manage project checkpoints `[save|restore|delete|list] <label>`
 - `/swarm finalize` — finalize the swarm project and archive evidence
 - `/swarm close` — deprecated alias for `/swarm finalize`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -859,7 +859,11 @@ DELETE active swarm state from `.swarm/`, including `plan.md`, `plan.json`, `SWA
 
 ### `/swarm reset-session`
 
-Clear only session state (`.swarm/session/state.json` and related files). Preserves plan, evidence, and knowledge. Use when starting a new model/session but continuing the same project. Before deleting, the session state is auto-backed up to `.swarm/reset-backups/<timestamp>/` (newest 5 kept).
+Clear only session state (`.swarm/session/state.json` and related files). Preserves plan, evidence, and knowledge. Use when starting a new model/session but continuing the same project. Also recovers stale coder settlements (issue #2268): a `DISPATCHED` settlement WAL left behind by a dispatch whose completion never arrived is settled here, so future coder dispatches cannot stay wedged with `CODER_DISPATCH_IN_PROGRESS`. Before deleting, the session state is auto-backed up to `.swarm/reset-backups/<timestamp>/` (newest 5 kept).
+
+### `/swarm recover [task_id] [--force]`
+
+Settle stale coder-settlement WALs in `.swarm/coder-settlements/` — the `CODER_DISPATCH_IN_PROGRESS` / `CODER_SETTLEMENT_IN_PROGRESS` wedge class where a dispatch completed but its settlement never fired (host killed mid-dispatch, cancelled Task, gate denial; issue #2268). Safe mode recovers settlements whose owning process is gone. `--force` additionally releases ownership keys still held by this process — only use it when no coder dispatch is genuinely still running; a still-running dispatch's late completion will then report `CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT` (safe to ignore, the settlement is already durably recovered). Never interrupts a dispatch owned by another live OpenCode process. Human-only: agents self-heal dead-owner settlements via `update_task_status`. `/swarm diagnose` reports non-terminal settlements with the exact remediation.
 
 ### `/swarm checkpoint <save|restore|delete|list> <label>`
 

--- a/docs/releases/pending/issue-2268-coder-settlement-recovery.md
+++ b/docs/releases/pending/issue-2268-coder-settlement-recovery.md
@@ -1,0 +1,22 @@
+# /swarm recover + reset-session settlement recovery: no permanent CODER_DISPATCH_IN_PROGRESS wedge
+
+Issue: #2268
+
+## What changed
+
+- New `/swarm recover [task_id] [--force]` command (human-only) settles stale coder-settlement WALs in `.swarm/coder-settlements/` — the wedge class where a dispatch's completion never arrived (host killed mid-dispatch, cancelled Task, or the pre-#2214 gate-denial path users hit on ≤ 7.141.1) and every retry was refused with `CODER_DISPATCH_IN_PROGRESS` / `CODER_SETTLEMENT_IN_PROGRESS` while `update_task_status` and `/swarm close` were paused by the same guard. Safe mode recovers settlements whose owning process is gone; `--force` additionally releases ownership keys still held by the current process (operator assertion that nothing is genuinely in flight — a still-running dispatch's late completion then reports `CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT`, which is safe to ignore). Settlements owned by another live OpenCode process are reported and never interrupted.
+- `/swarm reset-session` now recovers stale coder settlements (with ownership release) as part of clearing session state, reporting per-task outcomes — previously it cleared in-memory session state but left the durable WAL and in-process ownership key wedged, which is exactly what made the issue reporter's session unfinishable.
+- The dispatch-denial rollback in the `tool.execute.before` chain (`src/index.ts`) no longer skips settlement rollback for throws from the advisory tail after the fail-closed region: any `toolBefore` throw for a Task call now rolls a begun settlement back to `ABORTED`. The old guard contradicted its own adjacent comment ("steps below … can still throw and reject the call"); the catch block only runs on throw, so the widened trigger cannot affect successful dispatches.
+- Wedge error texts now name the real remediation instead of an action with no invoker: "run `/swarm recover <taskId>` (or `/swarm reset-session`)… do not remove the WAL by hand" (previously: "run coder-settlement recovery for this task" — an internal function with no user-facing surface).
+- `/swarm diagnose` gains a "Coder Settlements" health check: enumerates settlement WALs, reports state and owner-process liveness per task, and flags non-terminal settlements with the exact remediation. Warn-level by design so a genuinely in-flight dispatch never fails the check.
+- `coder_settlement` lifecycle audit events gain a `recovered` action (with `forced` / `accepted` extras), recorded for every recovery and forced ownership release.
+- `docs/commands.md` and `docs/troubleshooting/recovery-guide.md` §11 document the new command, the wedge, and why hand-editing settlement WALs is harmful.
+
+## Why
+
+Issue #2268 reported the plugin as unusable: a 2-task hello-world run wedged permanently because a denied coder dispatch left a `DISPATCHED` settlement WAL that no user-reachable action could clear — the error text advised an action that did not exist, and `/swarm reset-session` did not touch the settlement state. On current main the reporter's exact denial path is already fixed (#2214/#2098), but the same wedge remained reachable when a dispatch's completion hook never fires in a still-running host process, and there was still no user-facing recovery command. This PR closes both: every advised action is now wired, and the two natural escape hatches (`/swarm recover`, `/swarm reset-session`) actually clear the wedge.
+
+## Known caveats
+
+- `--force` releasing an ownership key for a genuinely in-flight dispatch means that dispatch's late completion fails settlement with `CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT`; the durable state is already recovered at that point and the conflict is safe to ignore (stated in the command output and docs). This is why the command is human-only — agents keep the safe self-heal path via `update_task_status`.
+- `/swarm close` still surfaces `CODER_DISPATCH_IN_PROGRESS` (rather than recovering past it) when a wedged settlement guards a task it is closing; `/swarm recover` or `/swarm reset-session` unwedge first. Changing close's loop semantics is intentionally out of scope.

--- a/docs/troubleshooting/recovery-guide.md
+++ b/docs/troubleshooting/recovery-guide.md
@@ -290,6 +290,41 @@ operation identity, and observed-file set intact. Resolve the reported recovery
 condition and replay the same trusted completion; never mark the task complete
 from the child transcript alone.
 
+## 11. Wedged Coder Settlement (CODER_DISPATCH_IN_PROGRESS)
+
+Foreground coder dispatches are fenced by a durable write-ahead record at
+`.swarm/coder-settlements/{taskId}.json` (`DISPATCHED` → `PREPARED` →
+`COMMITTED`, or `ABORTED`). When the dispatch completes normally, its
+completion hook settles the record. If that completion never arrives — the
+OpenCode process was killed mid-dispatch, the Task call was cancelled without
+a completion hook, or (on plugin versions ≤ 7.141.1) a gate denied the
+dispatch after the record was written — the record stays `DISPATCHED` and
+every later dispatch for that task is refused with
+`CODER_DISPATCH_IN_PROGRESS` / `CODER_SETTLEMENT_IN_PROGRESS`. On the same
+host process, `update_task_status` and `/swarm close` are paused by the same
+guard, so the session cannot progress on its own.
+
+**Recovery:**
+
+- `/swarm recover [task_id]` — settles stale records whose owning process is
+  gone. Human-only; the swarm's agents already self-heal this case via
+  `update_task_status`.
+- `/swarm recover <task_id> --force` — additionally releases ownership keys
+  still held by the current process. Only use when no coder dispatch is
+  genuinely still running: a still-running dispatch's late completion will
+  report `CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT`, which is safe to ignore.
+- `/swarm reset-session` — recovers all stale coder settlements as part of
+  clearing session state.
+- Settlements owned by another live OpenCode process (a different pid on the
+  same `.swarm/`) are never interrupted: close that instance or run
+  `/swarm recover` there.
+
+**Never delete or hand-edit `.swarm/coder-settlements/*.json`.** The record
+carries the launch baseline that attributes the coder's changes to the task;
+deleting it discards attribution and can strand review debt. `/swarm diagnose`
+reports every non-terminal settlement with its owner liveness and the exact
+remediation.
+
 ---
 
 For architecture details, see `docs/plan-durability.md`.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -93,6 +93,7 @@ export { handlePlanCommand } from './plan';
 export { handlePreflightCommand } from './preflight';
 export { handlePromoteCommand } from './promote';
 export { handleQaGatesCommand } from './qa-gates';
+export { handleRecoverCommand } from './recover';
 export { handleHelpCommand } from './registry';
 export type {
 	CommandContext,

--- a/src/commands/recover.ts
+++ b/src/commands/recover.ts
@@ -1,3 +1,4 @@
+import { sanitizeDiagnosticText } from '../scope/path-identity.js';
 import {
 	listCoderSettlementWalStates,
 	recoverStaleCoderSettlements,
@@ -7,7 +8,10 @@ import {
 /**
  * Renders one recovery outcome as a user-facing report line. Kept as a pure
  * function (no directory access) so tests can pin the exact remediation text
- * for every outcome class.
+ * for every outcome class. WAL-derived free-form fields (transitionId, error
+ * message) are sanitized per the repo's untrusted-diagnostic-field pattern —
+ * they are length-validated only at the schema layer (issue #2268 review,
+ * PRR-001/002).
  */
 function renderOutcome(outcome: StaleSettlementRecoveryOutcome): string {
 	switch (outcome.outcome) {
@@ -20,13 +24,18 @@ function renderOutcome(outcome: StaleSettlementRecoveryOutcome): string {
 		case 'already_terminal':
 			return `⏭️ Task ${outcome.taskId}: settlement already ${outcome.state} (nothing to recover)`;
 		case 'owned_in_process':
-			return `ℹ️ Task ${outcome.taskId}: dispatch ${outcome.transitionId} is still registered as in flight in this process. If no coder is genuinely running, re-run with --force to release it.`;
+			return `ℹ️ Task ${outcome.taskId}: dispatch ${sanitizeDiagnosticText(
+				outcome.transitionId,
+			)} is still registered as in flight in this process. If no coder is genuinely running, re-run with --force to release it.`;
 		case 'owned_by_live_foreign_pid':
 			return `ℹ️ Task ${outcome.taskId}: owned by live process pid ${outcome.processId} (another OpenCode instance). Close that instance or run /swarm recover there; this command never interrupts another live process's dispatch.`;
 		case 'unreadable_wal':
 			return `⚠️ Task ${outcome.taskId}: settlement WAL is unreadable — inspect .swarm/coder-settlements/${outcome.taskId}.json`;
 		case 'error':
-			return `❌ Task ${outcome.taskId}: recovery failed — ${outcome.message}`;
+			return `❌ Task ${outcome.taskId}: recovery failed — ${sanitizeDiagnosticText(
+				outcome.message,
+				512,
+			)}`;
 		default:
 			return `❌ Task ${(outcome as { taskId: string }).taskId}: unknown outcome`;
 	}
@@ -64,12 +73,15 @@ export async function handleRecoverCommand(
 		].join('\n');
 	}
 
-	const listed = await listCoderSettlementWalStates(directory);
+	const { states: listed, truncated: listTruncated } =
+		await listCoderSettlementWalStates(directory);
 	if (listed.length === 0) {
 		return [
 			'## Coder Settlement Recovery',
 			'',
-			'No coder settlement WALs found in .swarm/coder-settlements/ — nothing to recover.',
+			taskId
+				? `❌ No settlement WAL for task ${taskId} (no settlement WALs found in .swarm/coder-settlements/).`
+				: 'No coder settlement WALs found in .swarm/coder-settlements/ — nothing to recover.',
 		].join('\n');
 	}
 
@@ -86,10 +98,11 @@ export async function handleRecoverCommand(
 		}
 	}
 
-	const results = await recoverStaleCoderSettlements(directory, {
-		...(taskId ? { taskIds: [taskId] } : {}),
-		force,
-	});
+	const { results, truncated: recoverTruncated } =
+		await recoverStaleCoderSettlements(directory, {
+			...(taskId ? { taskIds: [taskId] } : {}),
+			force,
+		});
 
 	const lines = results.map((outcome) => renderOutcome(outcome));
 	const recoveredCount = results.filter(
@@ -112,6 +125,12 @@ export async function handleRecoverCommand(
 				: ''
 		}.`,
 	];
+	if (listTruncated || recoverTruncated) {
+		report.push(
+			'',
+			'⚠️ More settlement WALs exist than the recovery scan cap (200) — older settlements were NOT listed or processed. Re-run after the tasks above are settled to reach the rest.',
+		);
+	}
 	if (force && recoveredCount > 0) {
 		report.push(
 			'',

--- a/src/commands/recover.ts
+++ b/src/commands/recover.ts
@@ -1,0 +1,122 @@
+import {
+	listCoderSettlementWalStates,
+	recoverStaleCoderSettlements,
+	type StaleSettlementRecoveryOutcome,
+} from '../workflow/coder-settlement.js';
+
+/**
+ * Renders one recovery outcome as a user-facing report line. Kept as a pure
+ * function (no directory access) so tests can pin the exact remediation text
+ * for every outcome class.
+ */
+function renderOutcome(outcome: StaleSettlementRecoveryOutcome): string {
+	switch (outcome.outcome) {
+		case 'recovered':
+			return `✅ Task ${outcome.taskId}: settlement recovered (${
+				outcome.accepted
+					? 'changes attributed'
+					: 'no workspace change to attribute'
+			}${outcome.forced ? ', in-process ownership released by --force' : ''})`;
+		case 'already_terminal':
+			return `⏭️ Task ${outcome.taskId}: settlement already ${outcome.state} (nothing to recover)`;
+		case 'owned_in_process':
+			return `ℹ️ Task ${outcome.taskId}: dispatch ${outcome.transitionId} is still registered as in flight in this process. If no coder is genuinely running, re-run with --force to release it.`;
+		case 'owned_by_live_foreign_pid':
+			return `ℹ️ Task ${outcome.taskId}: owned by live process pid ${outcome.processId} (another OpenCode instance). Close that instance or run /swarm recover there; this command never interrupts another live process's dispatch.`;
+		case 'unreadable_wal':
+			return `⚠️ Task ${outcome.taskId}: settlement WAL is unreadable — inspect .swarm/coder-settlements/${outcome.taskId}.json`;
+		case 'error':
+			return `❌ Task ${outcome.taskId}: recovery failed — ${outcome.message}`;
+		default:
+			return `❌ Task ${(outcome as { taskId: string }).taskId}: unknown outcome`;
+	}
+}
+
+/**
+ * Handles the /swarm recover command (issue #2268).
+ *
+ * The user-facing invoker for coder-settlement recovery. The wedge class this
+ * exists for: a DISPATCHED settlement WAL whose completion (toolAfter) never
+ * arrived — every dispatch retry is refused with CODER_SETTLEMENT_IN_PROGRESS
+ * / CODER_DISPATCH_IN_PROGRESS and internal sinks (update_task_status, /swarm
+ * close) are paused too. Safe mode recovers settlements whose owning process
+ * is gone; --force additionally releases ownership keys still held by THIS
+ * process (an operator assertion that no dispatch is genuinely in flight —
+ * a still-running dispatch's late completion will then fail settlement with
+ * CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT, which is safe to ignore).
+ *
+ * Human-only by policy: agents already self-heal dead-owner settlements via
+ * update_task_status, and --force must stay an operator decision.
+ */
+export async function handleRecoverCommand(
+	directory: string,
+	args: string[],
+): Promise<string> {
+	const force = args.includes('--force');
+	const positional = args.filter((arg) => !arg.startsWith('--'));
+	const taskId = positional[0];
+	if (positional.length > 1) {
+		return [
+			'## Coder Settlement Recovery',
+			'',
+			`❌ Unexpected arguments: ${positional.join(' ')}`,
+			'Usage: /swarm recover [task_id] [--force]',
+		].join('\n');
+	}
+
+	const listed = await listCoderSettlementWalStates(directory);
+	if (listed.length === 0) {
+		return [
+			'## Coder Settlement Recovery',
+			'',
+			'No coder settlement WALs found in .swarm/coder-settlements/ — nothing to recover.',
+		].join('\n');
+	}
+
+	if (taskId) {
+		const target = listed.find((entry) => entry.taskId === taskId);
+		if (!target) {
+			return [
+				'## Coder Settlement Recovery',
+				'',
+				`❌ No settlement WAL for task ${taskId}. Known tasks: ${listed
+					.map((entry) => entry.taskId)
+					.join(', ')}`,
+			].join('\n');
+		}
+	}
+
+	const results = await recoverStaleCoderSettlements(directory, {
+		...(taskId ? { taskIds: [taskId] } : {}),
+		force,
+	});
+
+	const lines = results.map((outcome) => renderOutcome(outcome));
+	const recoveredCount = results.filter(
+		(r) => r.outcome === 'recovered',
+	).length;
+	const blockedCount = results.filter(
+		(r) =>
+			r.outcome === 'owned_in_process' ||
+			r.outcome === 'owned_by_live_foreign_pid',
+	).length;
+
+	const report = [
+		'## Coder Settlement Recovery',
+		'',
+		...lines,
+		'',
+		`Recovered ${recoveredCount} settlement(s)${
+			blockedCount > 0
+				? `; ${blockedCount} still owned by a live dispatch (see above for the exact remediation)`
+				: ''
+		}.`,
+	];
+	if (force && recoveredCount > 0) {
+		report.push(
+			'',
+			'⚠️ --force released in-process ownership before recovery. If any of these dispatches was genuinely still running, its completion will report CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT — that error is expected and safe to ignore; the settlement is already durably recovered.',
+		);
+	}
+	return report.join('\n');
+}

--- a/src/commands/registration-parity-baselines.test.ts
+++ b/src/commands/registration-parity-baselines.test.ts
@@ -155,6 +155,9 @@ describe('Command registration parity — classification baselines', () => {
 				'skill-opt approve',
 				'skill-opt reject',
 				'skill-opt rollback',
+				// #2268: settlement recovery escape hatch — --force releases
+				// in-process dispatch ownership, an operator-only assertion.
+				'recover',
 			]),
 			toolCommands: new Set([
 				'pr subscribe',
@@ -174,6 +177,9 @@ describe('Command registration parity — classification baselines', () => {
 				'skill-opt approve',
 				'skill-opt reject',
 				'skill-opt rollback',
+				// #2268: human-only commands stay in the swarm_command z.enum —
+				// agent attempts are refused with a surface-to-user message.
+				'recover',
 			]),
 			noArgs: new Set(['pr status', 'lanes', 'context-map stats']),
 		};

--- a/src/commands/registry.tool-policy.test.ts
+++ b/src/commands/registry.tool-policy.test.ts
@@ -86,19 +86,6 @@ describe('toolPolicy classification snapshot — no regression', () => {
 		'skill-opt history',
 	]);
 
-	const EXPECTED_HUMAN_ONLY = new Set<string>([
-		'review',
-		'memory compact',
-		'memory import',
-		'memory migrate',
-		'knowledge hive-quarantine',
-		// #1822: governed skill optimizer — mutating commands (human-gated)
-		'skill-opt run',
-		'skill-opt approve',
-		'skill-opt reject',
-		'skill-opt rollback',
-	]);
-
 	const EXPECTED_RESTRICTED = new Set<string>([
 		'abort-pr-workflow',
 		'acknowledge-spec-drift',
@@ -157,22 +144,6 @@ describe('toolPolicy classification snapshot — no regression', () => {
 		}
 		for (const name of actual) {
 			expect(EXPECTED_AGENT.has(name)).toBe(true);
-		}
-	});
-
-	test("'human-only' bucket contains exactly the expected 9 commands", () => {
-		const actual = new Set<string>();
-		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {
-			if ((entry as CommandEntry).toolPolicy === 'human-only') {
-				actual.add(name);
-			}
-		}
-		expect(actual.size).toBe(9);
-		for (const name of EXPECTED_HUMAN_ONLY) {
-			expect(actual.has(name)).toBe(true);
-		}
-		for (const name of actual) {
-			expect(EXPECTED_HUMAN_ONLY.has(name)).toBe(true);
 		}
 	});
 

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -98,6 +98,7 @@ import { handlePrUnsubscribeCommand } from './pr-unsubscribe.js';
 import { handlePreflightCommand } from './preflight.js';
 import { handlePromoteCommand } from './promote.js';
 import { handleQaGatesCommand } from './qa-gates.js';
+import { handleRecoverCommand } from './recover.js';
 import { handleResetCommand } from './reset.js';
 import { handleResetSessionCommand } from './reset-session.js';
 import { handleRetrieveCommand } from './retrieve.js';
@@ -1409,10 +1410,19 @@ export const COMMAND_REGISTRY = {
 		description:
 			'Clear session state while preserving plan, evidence, and knowledge',
 		details:
-			'Deletes only .swarm/session/state.json and any other session files. Clears in-memory agent sessions, delegation chains, and active-agent mappings. Preserves plan, evidence, and knowledge for cross-session continuity. Before deleting, auto-backs up the session files it removes to .swarm/reset-backups/<timestamp>/ (newest 5 kept).',
+			'Deletes only .swarm/session/state.json and any other session files. Clears in-memory agent sessions, delegation chains, and active-agent mappings. Preserves plan, evidence, and knowledge for cross-session continuity. Also recovers stale coder settlements, releasing in-flight ownership held by this process, so dispatches cannot stay wedged on CODER_DISPATCH_IN_PROGRESS (issue #2268). Before deleting, auto-backs up the session files it removes to .swarm/reset-backups/<timestamp>/ (newest 5 kept).',
 		args: '',
 		category: 'utility',
 		toolPolicy: 'restricted',
+	},
+	recover: {
+		handler: (ctx) => handleRecoverCommand(ctx.directory, ctx.args),
+		description: 'Recover wedged coder settlements [task_id] [--force]',
+		details:
+			"Settles stale coder-settlement WALs in .swarm/coder-settlements/ — the CODER_DISPATCH_IN_PROGRESS wedge where a dispatch's completion never fired (issue #2268). Safe mode recovers settlements whose owner process is gone. --force also releases ownership keys held by this process: use only when no dispatch is genuinely running (a late completion then reports CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT, safe to ignore). Never interrupts another live OpenCode process. Human-only.",
+		args: '[task_id] [--force]',
+		category: 'utility',
+		toolPolicy: 'human-only',
 	},
 	rollback: {
 		handler: (ctx) => handleRollbackCommand(ctx.directory, ctx.args),

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -5,6 +5,7 @@ import { clearTrajectoryStep } from '../hooks/trajectory-logger';
 import { validateSwarmPath } from '../hooks/utils';
 import { resetPrmSessionState } from '../prm';
 import { swarmState } from '../state';
+import { recoverStaleCoderSettlements } from '../workflow/coder-settlement.js';
 import {
 	cleanupOrphanedBranches,
 	type OrphanCleanupResult,
@@ -148,6 +149,82 @@ export async function handleResetSessionCommand(
 	const activeAgentCount = swarmState.activeAgent.size;
 	swarmState.activeAgent.clear();
 	results.push(`✅ Cleared ${activeAgentCount} active-agent mapping(s)`);
+
+	// Issue #2268: recover stale coder settlements. reset-session already
+	// clears every session's in-process state process-wide, so it is the
+	// operator's quiescence assertion: a DISPATCHED settlement WAL whose
+	// completion never arrived (host killed mid-dispatch, cancelled Task,
+	// gate denial on the reporter's pre-#2214 build) is settled here instead
+	// of wedging every future dispatch with CODER_DISPATCH_IN_PROGRESS.
+	// Runs BEFORE the .swarm-worktrees removal below so worktree-carrying
+	// settlements can still reconcile their merges. Fail-open per task.
+	try {
+		const settlementResults = await recoverStaleCoderSettlements(directory, {
+			force: true,
+		});
+		if (settlementResults.length === 0) {
+			results.push('⏭️ No coder settlements to recover');
+		}
+		for (const outcome of settlementResults) {
+			switch (outcome.outcome) {
+				case 'recovered':
+					results.push(
+						`✅ Recovered coder settlement ${outcome.taskId} (${
+							outcome.accepted
+								? 'changes attributed'
+								: 'no workspace change to attribute'
+						})`,
+					);
+					break;
+				case 'already_terminal':
+					results.push(
+						`⏭️ Coder settlement ${outcome.taskId} already ${outcome.state}`,
+					);
+					break;
+				case 'owned_in_process':
+					results.push(
+						`ℹ️ Coder settlement ${outcome.taskId} still registered in flight (${outcome.transitionId}) — its dispatch may be genuinely running; not force-recovered`,
+					);
+					break;
+				case 'owned_by_live_foreign_pid':
+					results.push(
+						`ℹ️ Coder settlement ${outcome.taskId} owned by live process pid ${outcome.processId} (another OpenCode instance) — not touched; run /swarm recover there after closing it`,
+					);
+					break;
+				case 'unreadable_wal':
+					results.push(
+						`⚠️ Coder settlement WAL ${outcome.taskId} is unreadable — inspect .swarm/coder-settlements/${outcome.taskId}.json`,
+					);
+					break;
+				case 'error':
+					results.push(
+						`⚠️ Coder settlement ${outcome.taskId} recovery failed: ${outcome.message}`,
+					);
+					break;
+				default:
+					results.push(
+						`⚠️ Coder settlement ${(outcome as { taskId: string }).taskId}: unknown outcome`,
+					);
+					break;
+			}
+		}
+		// reset-session always recovers with force, so mirror /swarm recover
+		// --force's heads-up when any in-process ownership key had to be
+		// released: a genuinely still-running dispatch's late completion will
+		// fail settlement with CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT.
+		const forcedRecovered = settlementResults.filter(
+			(outcome) => outcome.outcome === 'recovered' && outcome.forced,
+		).length;
+		if (forcedRecovered > 0) {
+			results.push(
+				`⚠️ Released in-process ownership for ${forcedRecovered} dispatch(es) before recovery — if any was genuinely still running, its completion will report CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT (safe to ignore; the settlement is already recovered).`,
+			);
+		}
+	} catch (err) {
+		results.push(
+			`⚠️ Coder settlement recovery failed (continuing with reset): ${errorMessage(err)}`,
+		);
+	}
 
 	// Best-effort: clean stale worktree directories and orphan branches
 	const worktreesDir = path.resolve(

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -4,6 +4,7 @@ import { SWARM_WORKTREE_DIR_NAME } from '../config/constants';
 import { clearTrajectoryStep } from '../hooks/trajectory-logger';
 import { validateSwarmPath } from '../hooks/utils';
 import { resetPrmSessionState } from '../prm';
+import { sanitizeDiagnosticText } from '../scope/path-identity.js';
 import { swarmState } from '../state';
 import { recoverStaleCoderSettlements } from '../workflow/coder-settlement.js';
 import {
@@ -31,9 +32,11 @@ export const _internals: {
 		kind: 'reset' | 'reset-session',
 		relEntries: string[],
 	) => ResetBackupResult;
+	recoverStaleCoderSettlements: typeof recoverStaleCoderSettlements;
 } = {
 	cleanupOrphanedBranches,
 	backupSwarmStateBeforeReset,
+	recoverStaleCoderSettlements,
 };
 
 function errorMessage(err: unknown): string {
@@ -158,10 +161,12 @@ export async function handleResetSessionCommand(
 	// of wedging every future dispatch with CODER_DISPATCH_IN_PROGRESS.
 	// Runs BEFORE the .swarm-worktrees removal below so worktree-carrying
 	// settlements can still reconcile their merges. Fail-open per task.
+	let preserveWorktrees = false;
 	try {
-		const settlementResults = await recoverStaleCoderSettlements(directory, {
-			force: true,
-		});
+		const { results: settlementResults, truncated } =
+			await _internals.recoverStaleCoderSettlements(directory, {
+				force: true,
+			});
 		if (settlementResults.length === 0) {
 			results.push('⏭️ No coder settlements to recover');
 		}
@@ -183,7 +188,9 @@ export async function handleResetSessionCommand(
 					break;
 				case 'owned_in_process':
 					results.push(
-						`ℹ️ Coder settlement ${outcome.taskId} still registered in flight (${outcome.transitionId}) — its dispatch may be genuinely running; not force-recovered`,
+						`ℹ️ Coder settlement ${outcome.taskId} still registered in flight (${sanitizeDiagnosticText(
+							outcome.transitionId,
+						)}) — its dispatch may be genuinely running; not force-recovered`,
 					);
 					break;
 				case 'owned_by_live_foreign_pid':
@@ -198,7 +205,10 @@ export async function handleResetSessionCommand(
 					break;
 				case 'error':
 					results.push(
-						`⚠️ Coder settlement ${outcome.taskId} recovery failed: ${outcome.message}`,
+						`⚠️ Coder settlement ${outcome.taskId} recovery failed: ${sanitizeDiagnosticText(
+							outcome.message,
+							512,
+						)}`,
 					);
 					break;
 				default:
@@ -207,6 +217,11 @@ export async function handleResetSessionCommand(
 					);
 					break;
 			}
+		}
+		if (truncated) {
+			results.push(
+				'⚠️ More settlement WALs exist than the recovery scan cap (200) — older settlements were NOT recovered. Re-run /swarm reset-session after the tasks above are settled.',
+			);
 		}
 		// reset-session always recovers with force, so mirror /swarm recover
 		// --force's heads-up when any in-process ownership key had to be
@@ -220,7 +235,28 @@ export async function handleResetSessionCommand(
 				`⚠️ Released in-process ownership for ${forcedRecovered} dispatch(es) before recovery — if any was genuinely still running, its completion will report CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT (safe to ignore; the settlement is already recovered).`,
 			);
 		}
+		// PR review PRR-012: a worktree-carrying settlement whose recovery
+		// errored still references its worktree — deleting .swarm-worktrees/
+		// now would strand the WAL (scopedObservedFiles would read null from
+		// the deleted worktree and every later recovery throws
+		// CODER_SETTLEMENT_RECOVERY_UNCERTAIN). 'unreadable_wal' also
+		// triggers preservation: an unparseable WAL may reference a worktree,
+		// which cannot be known without parsing it. Preserve the worktrees
+		// and tell the operator; branch cleanup below still runs.
+		preserveWorktrees = settlementResults.some(
+			(outcome) =>
+				outcome.outcome === 'error' || outcome.outcome === 'unreadable_wal',
+		);
+		if (preserveWorktrees) {
+			results.push(
+				'⚠️ Preserved .swarm-worktrees/ because at least one settlement recovery failed — a worktree referenced by an unsettled WAL would become unrecoverable if deleted. Resolve the failures above (re-run /swarm reset-session or /swarm recover) before clearing worktrees.',
+			);
+		}
 	} catch (err) {
+		// Reviewer round: the whole recovery call throwing leaves the
+		// settlement state unknown — same stranding risk as a per-task error,
+		// so preserve the worktrees here too.
+		preserveWorktrees = true;
 		results.push(
 			`⚠️ Coder settlement recovery failed (continuing with reset): ${errorMessage(err)}`,
 		);
@@ -233,8 +269,12 @@ export async function handleResetSessionCommand(
 	);
 	try {
 		if (fs.existsSync(worktreesDir)) {
-			fs.rmSync(worktreesDir, { recursive: true, force: true });
-			results.push('✅ Removed .swarm-worktrees/ directory');
+			if (preserveWorktrees) {
+				results.push('⏭️ Skipped .swarm-worktrees/ removal (see above)');
+			} else {
+				fs.rmSync(worktreesDir, { recursive: true, force: true });
+				results.push('✅ Removed .swarm-worktrees/ directory');
+			}
 		}
 	} catch (err) {
 		results.push(`⚠️ Failed to remove .swarm-worktrees/: ${errorMessage(err)}`);

--- a/src/commands/tool-policy.human-only.test.ts
+++ b/src/commands/tool-policy.human-only.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { COMMAND_REGISTRY, resolveCommand } from './registry';
 import type { CommandEntry } from './registry';
+import { COMMAND_REGISTRY, resolveCommand } from './registry';
 import {
 	classifySwarmCommandChatFallbackUse,
 	classifySwarmCommandToolUse,

--- a/src/commands/tool-policy.human-only.test.ts
+++ b/src/commands/tool-policy.human-only.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveCommand } from './registry';
+import { COMMAND_REGISTRY, resolveCommand } from './registry';
+import type { CommandEntry } from './registry';
 import {
 	classifySwarmCommandChatFallbackUse,
 	classifySwarmCommandToolUse,
@@ -29,6 +30,51 @@ describe('tool-policy — human-only command refusal (issue #890)', () => {
 		expect(HUMAN_ONLY_SWARM_COMMANDS.has('memory compact')).toBe(true);
 		// FR-004: sdd project is now agent-invocable (overwrite gated by --overwrite)
 		expect(HUMAN_ONLY_SWARM_COMMANDS.has('sdd project')).toBe(false);
+	});
+
+	// Moved from registry.tool-policy.test.ts (FR-006 ratchet: that file is
+	// over the 500-line cap and must not grow). #2268 added 'recover'.
+	test("'human-only' registry bucket contains exactly the expected 10 commands", () => {
+		const expectedHumanOnly = new Set<string>([
+			'review',
+			'memory compact',
+			'memory import',
+			'memory migrate',
+			'knowledge hive-quarantine',
+			// #1822: governed skill optimizer — mutating commands (human-gated)
+			'skill-opt run',
+			'skill-opt approve',
+			'skill-opt reject',
+			'skill-opt rollback',
+			// #2268: settlement recovery escape hatch — --force releases
+			// in-process dispatch ownership, an operator-only assertion.
+			'recover',
+		]);
+		const actual = new Set<string>();
+		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {
+			if ((entry as CommandEntry).toolPolicy === 'human-only') {
+				actual.add(name);
+			}
+		}
+		expect(actual.size).toBe(10);
+		for (const name of expectedHumanOnly) {
+			expect(actual.has(name)).toBe(true);
+		}
+		for (const name of actual) {
+			expect(expectedHumanOnly.has(name)).toBe(true);
+		}
+	});
+
+	test('recover is refused for agents but allowed for the user (issue #2268)', () => {
+		expect(HUMAN_ONLY_SWARM_COMMANDS.has('recover')).toBe(true);
+		const toolResult = classifySwarmCommandToolUse(resolve(['recover']));
+		expect(toolResult.allowed).toBe(false);
+		if (toolResult.allowed === false) {
+			expect(toolResult.message).toContain('human-only');
+		}
+		expect(
+			classifySwarmCommandChatFallbackUse(resolve(['recover'])).allowed,
+		).toBe(true);
 	});
 
 	describe('classifySwarmCommandToolUse — chat-tool path', () => {

--- a/src/gate-evidence.ts
+++ b/src/gate-evidence.ts
@@ -140,7 +140,7 @@ export function assertTaskEvidenceWriteAllowed(
 		)
 	) {
 		throw new Error(
-			`CODER_SETTLEMENT_IN_PROGRESS: transition ${String(coderWal.transitionId)} owns evidence for task ${taskId}`,
+			`CODER_SETTLEMENT_IN_PROGRESS: transition ${String(coderWal.transitionId)} owns evidence for task ${taskId}. Wait for the owning transition to settle or run /swarm recover ${taskId} (or /swarm reset-session), then retry; do not remove the WAL by hand.`,
 		);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2462,6 +2462,11 @@ async function initializeOpenCodeSwarm(
 					description:
 						'Use /swarm reset-session to clear session state and delegation chains',
 				},
+				'swarm-recover': {
+					template: '/swarm recover $ARGUMENTS',
+					description:
+						'Use /swarm recover to settle wedged coder settlements [task_id] [--force]',
+				},
 				'swarm-simulate': {
 					template: '/swarm simulate $ARGUMENTS',
 					description: 'Use /swarm simulate to run a simulated agent session',
@@ -3133,25 +3138,25 @@ async function initializeOpenCodeSwarm(
 				}
 				// Issue #2214: a denied Task call never fires toolAfter. If the
 				// delegation gate (step 4) already durably began a coder
-				// settlement for this callID before a later fail-closed gate
-				// (steps 5-8) rejected it, roll the DISPATCHED WAL back to
-				// ABORTED so the task is not wedged until a process restart.
-				// Never throws — the original denial propagates unchanged.
+				// settlement for this callID before ANY later step in this
+				// handler rejected it — fail-closed gates 5-8 OR the advisory
+				// tail above the flag (issue #2268) — roll the DISPATCHED WAL
+				// back to ABORTED so the task is not wedged until a process
+				// restart. Never throws — the original denial propagates
+				// unchanged.
 				//
-				// INVARIANT (PR #2223 review, advisory): rollback ELIGIBILITY reuses
-				// `failClosedRegionCompleted`, so this block only fires when the
-				// denial came from the fail-closed region. That is correct today
-				// because no uncaught await exists in the advisory tail below the
-				// flag set (verified empirically by review fault injection). Any
-				// future raw-awaited call added to that tail must either set the
-				// flag first or throw only after this rollback — otherwise an
-				// advisory-tail throw would reject the call WITHOUT rolling back a
-				// begun settlement, reopening the #2214 wedge class. The
-				// gate-denial-wiring static guard pins this contract.
+				// INVARIANT (issue #2268): rollback eligibility deliberately does
+				// NOT consult `failClosedRegionCompleted`. This catch only runs
+				// when toolBefore THREW, so the Task tool never executes and any
+				// begun settlement is orphaned regardless of which region threw.
+				// abortDeniedSettlementForCall is a callID-keyed no-op when no
+				// settlement was begun for this call, so firing it
+				// unconditionally is safe for non-settlement throws (reviewer/
+				// docs/other tools). The gate-denial-wiring static guard pins
+				// this contract.
 				if (
-					!failClosedRegionCompleted &&
-					(normalizeToolName(input.tool) === 'Task' ||
-						normalizeToolName(input.tool) === 'task')
+					normalizeToolName(input.tool) === 'Task' ||
+					normalizeToolName(input.tool) === 'task'
 				) {
 					try {
 						await delegationGateHooks.abortDeniedSettlementForCall(

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -13,6 +13,7 @@ import { loadPlanJsonOnly } from '../plan/manager';
 import { SandboxCapabilityProbe } from '../sandbox/capability-probe.js';
 import { getExecutor } from '../sandbox/executor.js';
 import { readEffectiveSpecSync } from '../sdd/effective-spec';
+import { listCoderSettlementWalStates } from '../workflow/coder-settlement.js';
 import { checkKnowledgeHealth } from './knowledge-diagnostics.js';
 import { compareVersions, readVersionCache } from './version-check.js';
 import { getDeferredWarnings } from './warning-buffer.js';
@@ -991,6 +992,63 @@ export async function getDiagnoseData(
 				detail: 'Not found',
 			});
 		}
+	}
+
+	// Check: Coder settlements (issue #2268) — surface the
+	// CODER_DISPATCH_IN_PROGRESS wedge class that used to be invisible to
+	// diagnose: a non-terminal settlement WAL whose dispatch completion never
+	// arrived. Warn-level by design: a genuinely in-flight dispatch also shows
+	// up as non-terminal here and must not fail the health check. Fail-open:
+	// an inspection failure downgrades to a warning, never breaks diagnose.
+	try {
+		const settlementStates = await listCoderSettlementWalStates(directory);
+		if (settlementStates.length === 0) {
+			checks.push({
+				name: 'Coder Settlements',
+				status: '✅',
+				detail: 'No coder settlement WALs',
+			});
+		} else {
+			const nonTerminal = settlementStates.filter(
+				(entry) =>
+					entry.state === 'DISPATCHED' ||
+					entry.state === 'PREPARED' ||
+					entry.state === 'unreadable',
+			);
+			if (nonTerminal.length === 0) {
+				checks.push({
+					name: 'Coder Settlements',
+					status: '✅',
+					detail: `${settlementStates.length} settlement(s) all in terminal state`,
+				});
+			} else {
+				const details = nonTerminal.map((entry) => {
+					if (entry.state === 'unreadable') {
+						return `task ${entry.taskId}: WAL unreadable`;
+					}
+					const owner =
+						entry.ownedInProcess || entry.ownedByLiveForeignPid
+							? `owner pid ${entry.processId ?? '?'} still alive — in flight or wedged`
+							: 'owner process is gone — stale';
+					return `task ${entry.taskId} (${entry.state}, ${owner})`;
+				});
+				checks.push({
+					name: 'Coder Settlements',
+					status: '⚠️',
+					detail: `${nonTerminal.length} non-terminal settlement(s): ${details.join(
+						'; ',
+					)}. Stale settlements block dispatches with CODER_DISPATCH_IN_PROGRESS — run /swarm recover [task_id] (--force if no dispatch is genuinely running) or /swarm reset-session.`,
+				});
+			}
+		}
+	} catch (error) {
+		checks.push({
+			name: 'Coder Settlements',
+			status: '⚠️',
+			detail: `could not inspect coder settlements: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		});
 	}
 
 	// Check: context.md exists

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -1001,12 +1001,18 @@ export async function getDiagnoseData(
 	// up as non-terminal here and must not fail the health check. Fail-open:
 	// an inspection failure downgrades to a warning, never breaks diagnose.
 	try {
-		const settlementStates = await listCoderSettlementWalStates(directory);
+		const { states: settlementStates, truncated } =
+			await listCoderSettlementWalStates(directory);
+		const truncationNote = truncated
+			? ' MORE settlement WALs exist than the scan cap (200) — older ones are not shown.'
+			: '';
 		if (settlementStates.length === 0) {
 			checks.push({
 				name: 'Coder Settlements',
-				status: '✅',
-				detail: 'No coder settlement WALs',
+				status: truncated ? '⚠️' : '✅',
+				detail: truncated
+					? `Settlement WAL scan truncated at 200 — additional settlements exist but are not shown.${truncationNote}`
+					: 'No coder settlement WALs',
 			});
 		} else {
 			const nonTerminal = settlementStates.filter(
@@ -1015,7 +1021,7 @@ export async function getDiagnoseData(
 					entry.state === 'PREPARED' ||
 					entry.state === 'unreadable',
 			);
-			if (nonTerminal.length === 0) {
+			if (nonTerminal.length === 0 && !truncated) {
 				checks.push({
 					name: 'Coder Settlements',
 					status: '✅',
@@ -1035,9 +1041,13 @@ export async function getDiagnoseData(
 				checks.push({
 					name: 'Coder Settlements',
 					status: '⚠️',
-					detail: `${nonTerminal.length} non-terminal settlement(s): ${details.join(
-						'; ',
-					)}. Stale settlements block dispatches with CODER_DISPATCH_IN_PROGRESS — run /swarm recover [task_id] (--force if no dispatch is genuinely running) or /swarm reset-session.`,
+					detail: `${
+						nonTerminal.length > 0
+							? `${nonTerminal.length} non-terminal settlement(s): ${details.join(
+									'; ',
+								)}.`
+							: 'All shown settlements are terminal, but the scan was truncated.'
+					} Stale settlements block dispatches with CODER_DISPATCH_IN_PROGRESS — run /swarm recover [task_id] (--force if no dispatch is genuinely running) or /swarm reset-session.${truncationNote}`,
 				});
 			}
 		}

--- a/src/workflow/coder-settlement.ts
+++ b/src/workflow/coder-settlement.ts
@@ -1005,21 +1005,27 @@ export interface CoderSettlementWalState {
  * `ownedInProcess` means this process's liveDispatches registry holds the
  * dispatch (its completion may still be pending or was lost); a foreign live
  * pid can never be released from this process by construction.
+ *
+ * `truncated` is true when the directory held more matching files than
+ * MAX_SETTLEMENT_WAL_SCAN — consumers MUST surface that so a wedge sorted
+ * past the cap is not silently invisible (issue #2268 review, PRR-011).
  */
 export async function listCoderSettlementWalStates(
 	directory: string,
-): Promise<CoderSettlementWalState[]> {
+): Promise<{ states: CoderSettlementWalState[]; truncated: boolean }> {
 	let entries: string[];
 	try {
 		const dirPath = validateSwarmPath(directory, 'coder-settlements');
 		entries = await readdir(dirPath);
 	} catch {
 		// Missing directory or unreadable path: no settlements to report.
-		return [];
+		return { states: [], truncated: false };
 	}
+	const matching = entries.filter((entry) =>
+		SETTLEMENT_WAL_FILE_PATTERN.test(entry),
+	);
 	const states: CoderSettlementWalState[] = [];
-	for (const entry of entries.sort().slice(0, MAX_SETTLEMENT_WAL_SCAN)) {
-		if (!SETTLEMENT_WAL_FILE_PATTERN.test(entry)) continue;
+	for (const entry of matching.sort().slice(0, MAX_SETTLEMENT_WAL_SCAN)) {
 		const taskId = entry.slice(0, -'.json'.length);
 		try {
 			const wal = await readWal(walPath(directory, taskId), taskId);
@@ -1045,7 +1051,7 @@ export async function listCoderSettlementWalStates(
 			});
 		}
 	}
-	return states;
+	return { states, truncated: matching.length > MAX_SETTLEMENT_WAL_SCAN };
 }
 
 export type StaleSettlementRecoveryOutcome =
@@ -1084,8 +1090,12 @@ export type StaleSettlementRecoveryOutcome =
 export async function recoverStaleCoderSettlements(
 	directory: string,
 	options?: { taskIds?: string[]; force?: boolean },
-): Promise<StaleSettlementRecoveryOutcome[]> {
-	const listed = await listCoderSettlementWalStates(directory);
+): Promise<{
+	results: StaleSettlementRecoveryOutcome[];
+	truncated: boolean;
+}> {
+	const { states: listed, truncated } =
+		await listCoderSettlementWalStates(directory);
 	const filter = options?.taskIds ? new Set(options.taskIds) : undefined;
 	const results: StaleSettlementRecoveryOutcome[] = [];
 	for (const entry of listed) {
@@ -1228,7 +1238,7 @@ export async function recoverStaleCoderSettlements(
 			});
 		}
 	}
-	return results;
+	return { results, truncated };
 }
 
 export const _internals = {

--- a/src/workflow/coder-settlement.ts
+++ b/src/workflow/coder-settlement.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { appendFile, mkdir } from 'node:fs/promises';
+import { appendFile, mkdir, readdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type {
 	BackgroundTaskChangeContext,
@@ -106,7 +106,12 @@ async function writeWal(
  */
 async function appendSettlementEvent(
 	directory: string,
-	action: 'dispatched' | 'settled' | 'aborted',
+	action:
+		| 'dispatched'
+		| 'settled'
+		| 'aborted'
+		| 'recovered'
+		| 'recovery-failed',
 	wal: Pick<CoderSettlementWal, 'taskId' | 'transitionId' | 'actor'>,
 	extra?: Record<string, unknown>,
 ): Promise<void> {
@@ -324,7 +329,7 @@ export async function beginCoderSettlement(options: {
 							existing.transitionId !== options.transitionId
 						) {
 							throw new Error(
-								`CODER_SETTLEMENT_IN_PROGRESS: transition ${existing.transitionId} owns task ${options.taskId}, so transition ${options.transitionId} cannot dispatch it (${filePath}, state ${existing.state}). Wait for the owning transition to settle or run coder-settlement recovery for this task, then retry; do not remove the WAL by hand.`,
+								`CODER_SETTLEMENT_IN_PROGRESS: transition ${existing.transitionId} owns task ${options.taskId}, so transition ${options.transitionId} cannot dispatch it (${filePath}, state ${existing.state}). Wait for the owning transition to settle or run /swarm recover ${options.taskId} (or /swarm reset-session), then retry; do not remove the WAL by hand.`,
 							);
 						}
 						if (existing.transitionId === options.transitionId) {
@@ -738,7 +743,7 @@ export async function recoverCoderSettlement(
 			(wal.processId !== process.pid && isProcessAlive(wal.processId))
 		) {
 			throw new Error(
-				`CODER_DISPATCH_IN_PROGRESS: transition ${wal.transitionId} still owns task ${taskId} (${filePath}, state ${wal.state}, pid ${wal.processId}). Wait for that dispatch to settle or recover it before retrying; do not remove the WAL by hand.`,
+				`CODER_DISPATCH_IN_PROGRESS: transition ${wal.transitionId} still owns task ${taskId} (${filePath}, state ${wal.state}, pid ${wal.processId}). Wait for that dispatch to settle or run /swarm recover ${taskId} (or /swarm reset-session) to unwedge it; do not remove the WAL by hand.`,
 			);
 		}
 		if (wal.state === 'DISPATCHED') {
@@ -973,11 +978,264 @@ export async function assertNoUnsettledCoderDispatch(
 	if (wal === null) return;
 	if (wal.state === 'DISPATCHED' || wal.state === 'PREPARED') {
 		throw new Error(
-			`CODER_SETTLEMENT_RECOVERY_REQUIRED: transition ${wal.transitionId} must settle before task ${taskId} can change plan status (${filePath}, state ${wal.state}). Run coder-settlement recovery for this task, then retry.`,
+			`CODER_SETTLEMENT_RECOVERY_REQUIRED: transition ${wal.transitionId} must settle before task ${taskId} can change plan status (${filePath}, state ${wal.state}). Run /swarm recover ${taskId} (or /swarm reset-session), then retry.`,
 		);
 	}
 }
 
+const MAX_SETTLEMENT_WAL_SCAN = 200;
+const SETTLEMENT_WAL_FILE_PATTERN = /^[\w.\-:]+\.json$/;
+
+export interface CoderSettlementWalState {
+	taskId: string;
+	state: CoderSettlementWal['state'] | 'unreadable';
+	transitionId?: string;
+	processId?: number;
+	recordedAt?: string;
+	/** The in-process ownership registry still holds this dispatch (toolAfter never drained it). */
+	ownedInProcess: boolean;
+	/** A different, still-alive host process owns the dispatch. Never force-releasable from here. */
+	ownedByLiveForeignPid: boolean;
+}
+
+/**
+ * Bounded inventory of durable coder-settlement WALs for diagnostics and
+ * recovery surfaces (/swarm diagnose, /swarm recover, /swarm reset-session).
+ * Ownership predicates mirror recoverCoderSettlement's refusal guard exactly:
+ * `ownedInProcess` means this process's liveDispatches registry holds the
+ * dispatch (its completion may still be pending or was lost); a foreign live
+ * pid can never be released from this process by construction.
+ */
+export async function listCoderSettlementWalStates(
+	directory: string,
+): Promise<CoderSettlementWalState[]> {
+	let entries: string[];
+	try {
+		const dirPath = validateSwarmPath(directory, 'coder-settlements');
+		entries = await readdir(dirPath);
+	} catch {
+		// Missing directory or unreadable path: no settlements to report.
+		return [];
+	}
+	const states: CoderSettlementWalState[] = [];
+	for (const entry of entries.sort().slice(0, MAX_SETTLEMENT_WAL_SCAN)) {
+		if (!SETTLEMENT_WAL_FILE_PATTERN.test(entry)) continue;
+		const taskId = entry.slice(0, -'.json'.length);
+		try {
+			const wal = await readWal(walPath(directory, taskId), taskId);
+			if (wal === null) continue;
+			states.push({
+				taskId,
+				state: wal.state,
+				transitionId: wal.transitionId,
+				processId: wal.processId,
+				recordedAt: wal.recordedAt,
+				ownedInProcess: liveDispatches.has(
+					dispatchKey(directory, taskId, wal.transitionId),
+				),
+				ownedByLiveForeignPid:
+					wal.processId !== process.pid && isProcessAlive(wal.processId),
+			});
+		} catch {
+			states.push({
+				taskId,
+				state: 'unreadable',
+				ownedInProcess: false,
+				ownedByLiveForeignPid: false,
+			});
+		}
+	}
+	return states;
+}
+
+export type StaleSettlementRecoveryOutcome =
+	| { taskId: string; outcome: 'recovered'; accepted: boolean; forced: boolean }
+	| {
+			taskId: string;
+			outcome: 'already_terminal';
+			state: 'ABORTED' | 'COMMITTED';
+	  }
+	| {
+			taskId: string;
+			outcome: 'owned_in_process';
+			transitionId: string;
+	  }
+	| {
+			taskId: string;
+			outcome: 'owned_by_live_foreign_pid';
+			processId: number;
+	  }
+	| { taskId: string; outcome: 'unreadable_wal' }
+	| { taskId: string; outcome: 'error'; message: string };
+
+/**
+ * Issue #2268: the user-facing settlement recovery entry point. Settles every
+ * non-terminal coder-settlement WAL via the same recoverCoderSettlement
+ * transition the internal sinks (update_task_status, /swarm close preflight,
+ * Stage-B ingestion) already use — no new states, no schema change.
+ *
+ * `force` releases THIS process's ownership registry keys before recovery.
+ * That is safe only as an explicit operator assertion (human-only /swarm
+ * recover --force, /swarm reset-session): if the dispatch was genuinely still
+ * in flight, its late completion will fail settlement with
+ * CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT against the already-recovered WAL.
+ * A foreign live pid is NEVER forced — its dispatch lives in another process.
+ */
+export async function recoverStaleCoderSettlements(
+	directory: string,
+	options?: { taskIds?: string[]; force?: boolean },
+): Promise<StaleSettlementRecoveryOutcome[]> {
+	const listed = await listCoderSettlementWalStates(directory);
+	const filter = options?.taskIds ? new Set(options.taskIds) : undefined;
+	const results: StaleSettlementRecoveryOutcome[] = [];
+	for (const entry of listed) {
+		if (filter && !filter.has(entry.taskId)) continue;
+		if (entry.state === 'unreadable') {
+			results.push({ taskId: entry.taskId, outcome: 'unreadable_wal' });
+			continue;
+		}
+		if (entry.state === 'ABORTED' || entry.state === 'COMMITTED') {
+			// Idempotent: completes pending COMMITTED worktree cleanup, else no-op.
+			try {
+				await _internals.recoverCoderSettlement(directory, entry.taskId);
+				results.push({
+					taskId: entry.taskId,
+					outcome: 'already_terminal',
+					state: entry.state,
+				});
+			} catch (error) {
+				results.push({
+					taskId: entry.taskId,
+					outcome: 'error',
+					message: error instanceof Error ? error.message : String(error),
+				});
+			}
+			continue;
+		}
+		// Non-terminal (DISPATCHED/PREPARED).
+		if (entry.ownedInProcess && options?.force !== true) {
+			results.push({
+				taskId: entry.taskId,
+				outcome: 'owned_in_process',
+				transitionId: entry.transitionId ?? '',
+			});
+			continue;
+		}
+		if (entry.ownedByLiveForeignPid) {
+			results.push({
+				taskId: entry.taskId,
+				outcome: 'owned_by_live_foreign_pid',
+				processId: entry.processId ?? -1,
+			});
+			continue;
+		}
+		const forced = entry.ownedInProcess && options?.force === true;
+		// `force` is established at this ownership-release layer only —
+		// recoverCoderSettlement below is the normal recovery path; `forced`
+		// in the result reports that a release was necessary, not that the
+		// caller passed --force.
+		if (forced && entry.transitionId) {
+			releaseCoderDispatchOwnership(
+				directory,
+				entry.taskId,
+				entry.transitionId,
+			);
+			await appendSettlementEvent(
+				directory,
+				'recovered',
+				{
+					taskId: entry.taskId,
+					transitionId: entry.transitionId,
+					actor: 'swarm-recovery',
+				},
+				{ forced: true, stage: 'ownership-release' },
+			);
+		}
+		try {
+			const recovered = await _internals.recoverCoderSettlement(
+				directory,
+				entry.taskId,
+			);
+			if (recovered === null) {
+				// A concurrent completion may have settled the WAL between our
+				// listing and the recovery attempt — that is success, not an
+				// error. Only a genuinely missing (or newly unreadable) WAL
+				// stays an error.
+				let current: CoderSettlementWal | null = null;
+				try {
+					current = await readWal(
+						walPath(directory, entry.taskId),
+						entry.taskId,
+					);
+				} catch {
+					current = null;
+				}
+				if (
+					current &&
+					(current.state === 'COMMITTED' || current.state === 'ABORTED')
+				) {
+					results.push({
+						taskId: entry.taskId,
+						outcome: 'already_terminal',
+						state: current.state,
+					});
+					continue;
+				}
+				results.push({
+					taskId: entry.taskId,
+					outcome: 'error',
+					message: 'settlement WAL disappeared during recovery',
+				});
+				continue;
+			}
+			await appendSettlementEvent(
+				directory,
+				'recovered',
+				{
+					taskId: entry.taskId,
+					transitionId: entry.transitionId ?? '',
+					actor: 'swarm-recovery',
+				},
+				{ forced, accepted: recovered.accepted },
+			);
+			results.push({
+				taskId: entry.taskId,
+				outcome: 'recovered',
+				accepted: recovered.accepted,
+				forced,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			// Reviewer finding: a forced ownership-release event without a
+			// matching outcome leaves the audit trail inconsistent — record the
+			// failure so events.jsonl explains a still-non-terminal WAL. The
+			// failure carries its own top-level action so analytics can filter
+			// it without inspecting the extras.
+			await appendSettlementEvent(
+				directory,
+				'recovery-failed',
+				{
+					taskId: entry.taskId,
+					transitionId: entry.transitionId ?? '',
+					actor: 'swarm-recovery',
+				},
+				{ forced, error: message },
+			);
+			results.push({
+				taskId: entry.taskId,
+				outcome: 'error',
+				message,
+			});
+		}
+	}
+	return results;
+}
+
 export const _internals = {
 	liveDispatches,
+	// Test seam: recoverStaleCoderSettlements routes its per-task recovery
+	// through here so tests can deterministically simulate the
+	// listed-non-terminal → recovered-atomically race window (a concurrent
+	// completion) and recovery failures without real interleaving.
+	recoverCoderSettlement,
 };

--- a/tests/unit/commands/hive-quarantine-policy.test.ts
+++ b/tests/unit/commands/hive-quarantine-policy.test.ts
@@ -76,9 +76,10 @@ describe('knowledge hive-quarantine policy (issue #2033)', () => {
 		expect(r.remainingArgs).toEqual(['preview', 'id-1']);
 	});
 
-	test('registry human-only bucket still contains exactly the expected 9 commands', () => {
-		// Mirrors the no-regression bucket snapshot in registry.tool-policy.test.ts
-		// (which cannot grow: FR-006 over-cap ratchet) — #2033's entry made it 9.
+	test('registry human-only bucket still contains exactly the expected 10 commands', () => {
+		// Mirrors the no-regression bucket snapshot in tool-policy.human-only.test.ts
+		// (moved out of the FR-006 over-capped registry.tool-policy.test.ts) —
+		// #2033's entry made it 9; #2268's /swarm recover made it 10.
 		const actual = new Set<string>();
 		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {
 			if ((entry as { toolPolicy?: string }).toolPolicy === 'human-only') {
@@ -96,6 +97,7 @@ describe('knowledge hive-quarantine policy (issue #2033)', () => {
 				'skill-opt reject',
 				'skill-opt rollback',
 				'knowledge hive-quarantine',
+				'recover',
 			].sort(),
 		);
 	});

--- a/tests/unit/commands/recover.test.ts
+++ b/tests/unit/commands/recover.test.ts
@@ -171,6 +171,38 @@ describe('issue #2268 — /swarm recover command', () => {
 		expect(out).toContain('Known tasks: 1.1');
 	});
 
+	test('empty project with an explicit task_id reports the task-specific miss (PRR-014)', async () => {
+		const out = await handleRecoverCommand(directory, ['2.2']);
+		expect(out).toContain('No settlement WAL for task 2.2');
+		expect(out).toContain(
+			'no settlement WALs found in .swarm/coder-settlements/',
+		);
+	});
+
+	test('hostile WAL transitionId is sanitized in rendered output (PRR-001)', async () => {
+		await beginRealDispatch('evil\u0000inject\nline2');
+		const out = await handleRecoverCommand(directory, []);
+		expect(out).toContain('still registered as in flight');
+		// The raw NUL/newline payload must never reach the chat surface; the
+		// sanitizer collapses control characters to '?'.
+		expect(out).not.toContain('evil\u0000');
+		expect(out).toContain('coder:evil?inject?line2');
+	});
+
+	test('scan-cap truncation is surfaced to the operator (PRR-011)', async () => {
+		const settlementsDir = path.join(directory, '.swarm', 'coder-settlements');
+		fs.mkdirSync(settlementsDir, { recursive: true });
+		// Pattern-matching but unparseable files still count toward the cap and
+		// surface as unreadable entries — the cheapest realistic >200 fixture.
+		for (let i = 0; i < 201; i++) {
+			fs.writeFileSync(path.join(settlementsDir, `9${i}.json`), 'not json');
+		}
+		const out = await handleRecoverCommand(directory, []);
+		expect(out).toContain('WAL is unreadable');
+		expect(out).toContain('scan cap (200)');
+		expect(out).toContain('NOT listed or processed');
+	});
+
 	test('extra positional arguments print usage', async () => {
 		const out = await handleRecoverCommand(directory, ['1.1', '2.2']);
 		expect(out).toContain('Unexpected arguments');

--- a/tests/unit/commands/recover.test.ts
+++ b/tests/unit/commands/recover.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { handleRecoverCommand } from '../../../src/commands/recover';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { _internals as settlementInternals } from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function walPath(directory: string, taskId: string): string {
+	return path.join(directory, '.swarm', 'coder-settlements', `${taskId}.json`);
+}
+
+function readWalState(directory: string, taskId: string): string {
+	return (
+		JSON.parse(fs.readFileSync(walPath(directory, taskId), 'utf8')) as {
+			state: string;
+		}
+	).state;
+}
+
+function rewriteWalProcessId(
+	directory: string,
+	taskId: string,
+	processId: number,
+): void {
+	const walPathFor = walPath(directory, taskId);
+	const wal = JSON.parse(fs.readFileSync(walPathFor, 'utf8')) as {
+		processId: number;
+	};
+	wal.processId = processId;
+	fs.writeFileSync(walPathFor, JSON.stringify(wal));
+}
+
+function deadProcessId(): number {
+	const result = spawnSync(process.execPath, ['--version'], {
+		stdin: 'ignore',
+		encoding: 'utf8',
+		timeout: 15_000,
+		windowsHide: true,
+	});
+	if (result.pid === undefined) throw new Error('no pid from helper child');
+	return result.pid;
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+describe('issue #2268 — /swarm recover command', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		({ dir: directory, cleanup } = createSafeTestDir('recover-cmd-2268-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		cleanup();
+	});
+
+	async function beginRealDispatch(callID: string): Promise<void> {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID },
+			{ args: { ...CODER_ARGS } },
+		);
+	}
+
+	test('clean project reports nothing to recover', async () => {
+		const out = await handleRecoverCommand(directory, []);
+		expect(out).toContain('## Coder Settlement Recovery');
+		expect(out).toContain('No coder settlement WALs found');
+	});
+
+	test('same-process wedge: default reports the in-flight registration and remediation', async () => {
+		await beginRealDispatch('cmd-inproc');
+		const out = await handleRecoverCommand(directory, []);
+		expect(out).toContain('still registered as in flight');
+		expect(out).toContain('re-run with --force');
+		expect(out).toContain('coder:cmd-inproc');
+		expect(readWalState(directory, '1.1')).toBe('DISPATCHED');
+	});
+
+	test('same-process wedge: --force recovers and prints the late-completion warning', async () => {
+		await beginRealDispatch('cmd-force');
+		const out = await handleRecoverCommand(directory, ['--force']);
+		expect(out).toContain('Task 1.1: settlement recovered');
+		expect(out).toContain('in-process ownership released by --force');
+		expect(out).toContain('CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT');
+		expect(readWalState(directory, '1.1')).toBe('COMMITTED');
+	});
+
+	test('host-crash wedge (dead pid) recovers in safe mode', async () => {
+		await beginRealDispatch('cmd-crash');
+		rewriteWalProcessId(directory, '1.1', deadProcessId());
+		settlementInternals.liveDispatches.clear();
+		const out = await handleRecoverCommand(directory, []);
+		expect(out).toContain('Task 1.1: settlement recovered');
+		expect(readWalState(directory, '1.1')).toBe('COMMITTED');
+	});
+
+	test('foreign live pid is reported, never interrupted, even with --force', async () => {
+		await beginRealDispatch('cmd-foreign');
+		rewriteWalProcessId(directory, '1.1', process.ppid);
+		settlementInternals.liveDispatches.clear();
+		for (const args of [[], ['--force']]) {
+			const out = await handleRecoverCommand(directory, args);
+			expect(out).toContain('owned by live process pid');
+			expect(out).toContain('another OpenCode instance');
+		}
+		expect(readWalState(directory, '1.1')).toBe('DISPATCHED');
+	});
+
+	test('unknown task id lists known tasks', async () => {
+		await beginRealDispatch('cmd-known');
+		const out = await handleRecoverCommand(directory, ['2.2']);
+		expect(out).toContain('No settlement WAL for task 2.2');
+		expect(out).toContain('Known tasks: 1.1');
+	});
+
+	test('extra positional arguments print usage', async () => {
+		const out = await handleRecoverCommand(directory, ['1.1', '2.2']);
+		expect(out).toContain('Unexpected arguments');
+		expect(out).toContain('Usage: /swarm recover [task_id] [--force]');
+	});
+
+	test('single task_id scope recovers only that task', async () => {
+		await beginRealDispatch('cmd-scope');
+		const out = await handleRecoverCommand(directory, ['1.1', '--force']);
+		expect(out).toContain('Task 1.1: settlement recovered');
+		expect(out).not.toContain('Task 2.2');
+	});
+});

--- a/tests/unit/commands/reset-session-settlement-recovery.test.ts
+++ b/tests/unit/commands/reset-session-settlement-recovery.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { handleResetSessionCommand } from '../../../src/commands/reset-session';
+import {
+	_internals,
+	handleResetSessionCommand,
+} from '../../../src/commands/reset-session';
 import type { PluginConfig } from '../../../src/config';
 import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
 import { ensureAgentSession, resetSwarmState } from '../../../src/state';
@@ -44,6 +47,8 @@ function readWalState(directory: string, taskId: string): string {
 		}
 	).state;
 }
+
+const realRecoverStale = _internals.recoverStaleCoderSettlements;
 
 const CODER_ARGS = {
 	subagent_type: 'coder',
@@ -96,6 +101,7 @@ describe('issue #2268 — reset-session recovers stale coder settlements', () =>
 	});
 
 	afterEach(() => {
+		_internals.recoverStaleCoderSettlements = realRecoverStale;
 		resetSwarmState();
 		settlementInternals.liveDispatches.clear();
 		cleanup();
@@ -141,6 +147,64 @@ describe('issue #2268 — reset-session recovers stale coder settlements', () =>
 		const out = await handleResetSessionCommand(directory, []);
 		expect(out).toContain('WAL 7.7 is unreadable');
 		expect(out).toContain('Deleted .swarm/session/state.json');
+	});
+
+	test('failed recovery preserves .swarm-worktrees/ and sanitizes hostile messages (PRR-012/001)', async () => {
+		const worktreesDir = path.resolve(
+			path.dirname(directory),
+			'.swarm-worktrees',
+		);
+		fs.mkdirSync(worktreesDir, { recursive: true });
+		fs.writeFileSync(path.join(worktreesDir, 'lane-marker'), 'keep');
+		_internals.recoverStaleCoderSettlements = (async () => ({
+			results: [
+				{
+					taskId: '1.1',
+					outcome: 'error',
+					message:
+						'CODER_SETTLEMENT_RECOVERY_UNCERTAIN: evil\u0007inject\nline2',
+				},
+			],
+			truncated: false,
+		})) as typeof realRecoverStale;
+
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain(
+			'recovery failed: CODER_SETTLEMENT_RECOVERY_UNCERTAIN: evil?inject?line2',
+		);
+		expect(out).not.toContain('evil\u0007');
+		expect(out).toContain('Preserved .swarm-worktrees/');
+		expect(out).toContain('Skipped .swarm-worktrees/ removal');
+		expect(fs.existsSync(path.join(worktreesDir, 'lane-marker'))).toBe(true);
+	});
+
+	test('scan-cap truncation is surfaced by reset-session (PRR-011)', async () => {
+		_internals.recoverStaleCoderSettlements = (async () => ({
+			results: [],
+			truncated: true,
+		})) as typeof realRecoverStale;
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain('scan cap (200)');
+		expect(out).toContain('NOT recovered');
+	});
+
+	test('a thrown recovery call also preserves .swarm-worktrees/ (reviewer round)', async () => {
+		const worktreesDir = path.resolve(
+			path.dirname(directory),
+			'.swarm-worktrees',
+		);
+		fs.mkdirSync(worktreesDir, { recursive: true });
+		fs.writeFileSync(path.join(worktreesDir, 'lane-marker'), 'keep');
+		_internals.recoverStaleCoderSettlements = (async () => {
+			throw new Error('CODER_SETTLEMENT_LOCKED: task 1.1');
+		}) as typeof realRecoverStale;
+
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain(
+			'Coder settlement recovery failed (continuing with reset)',
+		);
+		expect(out).toContain('Skipped .swarm-worktrees/ removal');
+		expect(fs.existsSync(path.join(worktreesDir, 'lane-marker'))).toBe(true);
 	});
 
 	test('a foreign-live-pid settlement is reported, not touched', async () => {

--- a/tests/unit/commands/reset-session-settlement-recovery.test.ts
+++ b/tests/unit/commands/reset-session-settlement-recovery.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { handleResetSessionCommand } from '../../../src/commands/reset-session';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { _internals as settlementInternals } from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function walPath(directory: string, taskId: string): string {
+	return path.join(directory, '.swarm', 'coder-settlements', `${taskId}.json`);
+}
+
+function readWalState(directory: string, taskId: string): string {
+	return (
+		JSON.parse(fs.readFileSync(walPath(directory, taskId), 'utf8')) as {
+			state: string;
+		}
+	).state;
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+/**
+ * Issue #2268 regression: the reporter's session was permanently wedged
+ * because /swarm reset-session cleared in-memory session state but left the
+ * durable DISPATCHED settlement WAL and the in-process ownership key in
+ * place, so every coder dispatch retry was refused with
+ * CODER_DISPATCH_IN_PROGRESS and even update_task_status stayed paused.
+ */
+describe('issue #2268 — reset-session recovers stale coder settlements', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		({ dir: directory, cleanup } = createSafeTestDir('reset-settle-2268-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		fs.mkdirSync(path.join(directory, '.swarm', 'session'), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'session', 'state.json'),
+			JSON.stringify({ task: '1.1' }),
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		cleanup();
+	});
+
+	async function wedgeTaskWithRealDispatch(callID: string): Promise<void> {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID },
+			{ args: { ...CODER_ARGS } },
+		);
+		expect(readWalState(directory, '1.1')).toBe('DISPATCHED');
+	}
+
+	test('regression (#2268): a wedged DISPATCHED WAL + live ownership key is recovered by reset-session', async () => {
+		await wedgeTaskWithRealDispatch('wedge-2268');
+		// Pre-fix failure shape: both survive a session reset.
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain('Recovered coder settlement 1.1');
+		// Reviewer round-3 pin: the forced-recovery heads-up must surface the
+		// idempotency-conflict caveat, mirroring /swarm recover --force.
+		expect(out).toContain('Released in-process ownership for 1 dispatch');
+		expect(out).toContain('CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT');
+		expect(readWalState(directory, '1.1')).toBe('COMMITTED');
+		expect(
+			settlementInternals.liveDispatches.has(
+				`${directory}\u00001.1\u0000coder:wedge-2268`,
+			),
+		).toBe(false);
+	});
+
+	test('clean project keeps the fast zero-settlement path', async () => {
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain('No coder settlements to recover');
+		expect(out).toContain('Deleted .swarm/session/state.json');
+	});
+
+	test('an unreadable settlement WAL warns but never breaks the reset', async () => {
+		fs.mkdirSync(path.dirname(walPath(directory, '7.7')), {
+			recursive: true,
+		});
+		fs.writeFileSync(walPath(directory, '7.7'), 'not json');
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain('WAL 7.7 is unreadable');
+		expect(out).toContain('Deleted .swarm/session/state.json');
+	});
+
+	test('a foreign-live-pid settlement is reported, not touched', async () => {
+		await wedgeTaskWithRealDispatch('foreign-2268');
+		const wal = JSON.parse(
+			fs.readFileSync(walPath(directory, '1.1'), 'utf8'),
+		) as { processId: number };
+		wal.processId = process.ppid;
+		fs.writeFileSync(walPath(directory, '1.1'), JSON.stringify(wal));
+		settlementInternals.liveDispatches.clear();
+
+		const out = await handleResetSessionCommand(directory, []);
+		expect(out).toContain('owned by live process pid');
+		expect(readWalState(directory, '1.1')).toBe('DISPATCHED');
+	});
+});

--- a/tests/unit/commands/swarm-subcommand-parity.test.ts
+++ b/tests/unit/commands/swarm-subcommand-parity.test.ts
@@ -358,7 +358,9 @@ describe('swarm-subcommand-parity', () => {
 		// Pin the expected command count to prevent silent shrinkage.
 		// If commands are added to or removed from COMMAND_REGISTRY, update this number
 		// after verifying the skill's subcommand list is updated to match.
-		expect(expectedCommands.size).toBe(102);
+		// 102 → 103: /swarm recover added (issue #2268), documented in
+		// .claude/skills/swarm/SKILL.md.
+		expect(expectedCommands.size).toBe(103);
 
 		console.info(
 			`[swarm-subcommand-parity] skill documented commands (raw): ${skillRawCommands.length}`,

--- a/tests/unit/hooks/gate-denial-wiring.test.ts
+++ b/tests/unit/hooks/gate-denial-wiring.test.ts
@@ -134,15 +134,40 @@ describe('gate-denial tracker wiring in src/index.ts', () => {
 	// way the tracker assertions above do — the runtime behavior is covered by
 	// tests/unit/workflow/coder-settlement-2214*.test.ts against the hook
 	// object; this guard proves src/index.ts actually calls it.
+	// Issue #2268 widened the trigger: rollback must fire for ANY throw in the
+	// tool.execute.before handler, including the advisory tail after
+	// failClosedRegionCompleted = true — that catch only runs when the handler
+	// threw, so the Task tool never executes and a begun settlement is
+	// orphaned regardless of which region threw. Gating on the flag reopens
+	// the #2214 wedge class for any future raw-awaited tail step.
 	test('the denial catch rolls back a begun settlement for denied Task calls', () => {
 		const catchIdx = toolBeforeBlock.search(/\}\s*catch\s*\(err\)\s*\{/);
 		const catchBody = toolBeforeBlock.slice(catchIdx);
 
-		// The rollback must fire only for the fail-closed region's denials and
-		// only for Task calls...
+		// The rollback must fire for EVERY Task-call throw — the eligibility
+		// condition must NOT consult failClosedRegionCompleted...
 		expect(catchBody).toMatch(
-			/if\s*\(\s*!failClosedRegionCompleted\s*&&\s*\(\s*normalizeToolName\(input\.tool\) === 'Task'\s*\|\|\s*normalizeToolName\(input\.tool\) === 'task'\s*\)\s*\)\s*\{/,
+			/if\s*\(\s*normalizeToolName\(input\.tool\) === 'Task'\s*\|\|\s*normalizeToolName\(input\.tool\) === 'task'\s*\)\s*\{/,
 		);
+		const rollbackIfMatch = catchBody.match(
+			/if\s*\(\s*normalizeToolName\(input\.tool\) === 'Task'/,
+		);
+		expect(rollbackIfMatch).not.toBeNull();
+		// ...the flag gate must not appear between the catch keyword and the
+		// rollback call (a re-narrowed trigger is the exact #2268 regression).
+		const rollbackCallIdx = catchBody.indexOf(
+			'delegationGateHooks.abortDeniedSettlementForCall(',
+		);
+		expect(rollbackCallIdx).toBeGreaterThan(0);
+		const rollbackConditionStart = catchBody.lastIndexOf(
+			'if (',
+			rollbackCallIdx,
+		);
+		const rollbackCondition = catchBody.slice(
+			rollbackConditionStart,
+			rollbackCallIdx,
+		);
+		expect(rollbackCondition).not.toContain('failClosedRegionCompleted');
 		// ...and must call the delegation gate's rollback entry point from
 		// inside its own try/catch so the original denial still propagates, with
 		// the rethrow landing AFTER the rollback attempt.

--- a/tests/unit/index-commands.test.ts
+++ b/tests/unit/index-commands.test.ts
@@ -56,8 +56,9 @@ describe('Swarm subcommand registration', () => {
 
 		// Catch-all plus the current command registry entries. This includes the
 		// evaluation gate commands, main's CI-monitor command, the context-map
-		// stats command (issue #1672), and the swarm-skill-opt shortcut (issue #1822).
-		expect(commandKeys.length).toBe(83);
+		// stats command (issue #1672), the swarm-skill-opt shortcut (issue #1822),
+		// and the swarm-recover shortcut (issue #2268).
+		expect(commandKeys.length).toBe(84);
 
 		expect(commands.swarm).toBeDefined();
 	});
@@ -170,6 +171,7 @@ describe('Swarm subcommand registration', () => {
 			'swarm-auto-proceed',
 			'swarm-write-retro',
 			'swarm-reset-session',
+			'swarm-recover',
 			'swarm-simulate',
 			'swarm-promote',
 			'swarm-checkpoint',

--- a/tests/unit/services/diagnose-service-new-checks.test.ts
+++ b/tests/unit/services/diagnose-service-new-checks.test.ts
@@ -13,6 +13,8 @@ vi.mock('../../../src/evidence/manager.js', () => ({
 }));
 vi.mock('../../../src/hooks/utils.js', () => ({
 	readSwarmFileAsync: vi.fn(),
+	// #2268: diagnose's Coder Settlements check resolves paths via this stub.
+	validateSwarmPath: (dir: string, file: string) => `${dir}/${file}`,
 }));
 vi.mock('../../../src/config/loader.js', () => ({
 	loadPluginConfig: vi.fn(),
@@ -35,7 +37,6 @@ import { readSwarmFileAsync } from '../../../src/hooks/utils.js';
 // Import mocked modules
 import { loadPlanJsonOnly } from '../../../src/plan/manager.js';
 
-// Type assertions for mocks
 const mockLoadPlanJsonOnly = loadPlanJsonOnly as ReturnType<typeof vi.fn>;
 const mockListEvidenceTaskIds = listEvidenceTaskIds as ReturnType<typeof vi.fn>;
 const mockReadSwarmFileAsync = readSwarmFileAsync as ReturnType<typeof vi.fn>;
@@ -46,7 +47,6 @@ const mockStatSync = statSync as ReturnType<typeof vi.fn>;
 const mockExecSync = execSync as ReturnType<typeof vi.fn>;
 const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
 
-// Helper to find a check by name
 function findCheck(checks: any[], name: string) {
 	return checks.find((c) => c.name === name);
 }

--- a/tests/unit/services/diagnose-settlement-check.test.ts
+++ b/tests/unit/services/diagnose-settlement-check.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Issue #2268 — the "Coder Settlements" diagnose health check.
+ *
+ * The wedge class (a non-terminal settlement WAL whose dispatch completion
+ * never arrived) used to be invisible to /swarm diagnose. These tests run
+ * getDiagnoseData against a REAL temp git repo so the check is exercised
+ * with genuine WAL files produced by the real delegation gate.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { getDiagnoseData } from '../../../src/services/diagnose-service';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { _internals as settlementInternals } from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function walPath(directory: string, taskId: string): string {
+	return path.join(directory, '.swarm', 'coder-settlements', `${taskId}.json`);
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+describe('diagnose — Coder Settlements check (issue #2268)', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		({ dir: directory, cleanup } = createSafeTestDir('diagnose-settle-2268-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		cleanup();
+	});
+
+	function findCheck(
+		checks: Array<{ name: string; status: string; detail: string }>,
+		name: string,
+	) {
+		return checks.find((entry) => entry.name === name);
+	}
+
+	test('passes with no settlement WALs', async () => {
+		const data = await getDiagnoseData(directory);
+		const check = findCheck(data.checks, 'Coder Settlements');
+		expect(check).toBeDefined();
+		expect(check?.status).toBe('✅');
+		expect(check?.detail).toContain('No coder settlement WALs');
+	});
+
+	test('warns on an in-flight (or wedged) in-process settlement with remediation', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'diagnose-wedge' },
+			{ args: { ...CODER_ARGS } },
+		);
+		const data = await getDiagnoseData(directory);
+		const check = findCheck(data.checks, 'Coder Settlements');
+		expect(check?.status).toBe('⚠️');
+		expect(check?.detail).toContain('task 1.1');
+		expect(check?.detail).toContain('in flight or wedged');
+		expect(check?.detail).toContain('/swarm recover');
+		// Warn-level: a genuinely in-flight dispatch must not fail diagnose.
+		expect(check?.status).not.toBe('❌');
+	});
+
+	test('warns on a stale dead-owner settlement', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'diagnose-stale' },
+			{ args: { ...CODER_ARGS } },
+		);
+		const deadChild = spawnSync(process.execPath, ['--version'], {
+			stdin: 'ignore',
+			encoding: 'utf8',
+			timeout: 15_000,
+			windowsHide: true,
+		});
+		const walPathFor = walPath(directory, '1.1');
+		const wal = JSON.parse(fs.readFileSync(walPathFor, 'utf8')) as {
+			processId: number;
+		};
+		wal.processId = deadChild.pid as number;
+		fs.writeFileSync(walPathFor, JSON.stringify(wal));
+		settlementInternals.liveDispatches.clear();
+
+		const data = await getDiagnoseData(directory);
+		const check = findCheck(data.checks, 'Coder Settlements');
+		expect(check?.status).toBe('⚠️');
+		expect(check?.detail).toContain('owner process is gone — stale');
+		expect(check?.detail).toContain('/swarm recover');
+	});
+
+	test('passes when every settlement is terminal', async () => {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID: 'diagnose-terminal' },
+			{ args: { ...CODER_ARGS } },
+		);
+		const { setStoredInputArgs } = await import(
+			'../../../src/hooks/guardrails/stored-input-args'
+		);
+		setStoredInputArgs('diagnose-terminal', { ...CODER_ARGS });
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent', callID: 'diagnose-terminal' },
+			{ state: 'completed', output: 'no changes required' },
+		);
+		const data = await getDiagnoseData(directory);
+		const check = findCheck(data.checks, 'Coder Settlements');
+		expect(check?.status).toBe('✅');
+		expect(check?.detail).toContain('all in terminal state');
+	});
+});

--- a/tests/unit/services/diagnose-settlement-check.test.ts
+++ b/tests/unit/services/diagnose-settlement-check.test.ts
@@ -193,7 +193,7 @@ describe('diagnose — Coder Settlements check (issue #2268)', () => {
 					changedFiles: [],
 				},
 			},
-			recordedAt: new Date().toISOString(),
+			recordedAt: '2026-08-21T00:00:00.000Z',
 		};
 		for (let i = 0; i < 201; i++) {
 			const taskId = `9${i}`;

--- a/tests/unit/services/diagnose-settlement-check.test.ts
+++ b/tests/unit/services/diagnose-settlement-check.test.ts
@@ -164,4 +164,50 @@ describe('diagnose — Coder Settlements check (issue #2268)', () => {
 		expect(check?.status).toBe('✅');
 		expect(check?.detail).toContain('all in terminal state');
 	});
+
+	test('warns with remediation when all shown settlements are terminal but the scan truncated (critic round)', async () => {
+		// 201 hand-written schema-valid COMMITTED WALs: every SHOWN entry is
+		// terminal, so only the truncation flag stands between this check and
+		// a green ✅ that hides settlements beyond the cap.
+		const settlementsDir = path.join(directory, '.swarm', 'coder-settlements');
+		fs.mkdirSync(settlementsDir, { recursive: true });
+		const template = {
+			version: 1,
+			state: 'COMMITTED',
+			taskId: 'x',
+			transitionId: 'coder:diagnose-cap',
+			actor: 'architect',
+			processId: process.pid,
+			runtimeId: 'runtime-diagnose-cap',
+			expectedGeneration: 0,
+			accepted: false,
+			testEngineerExempt: false,
+			context: {
+				declaredFiles: [],
+				baseline: {
+					directory,
+					gitHead: null,
+					dirtyHash: null,
+					prHeadSha: null,
+					scope: null,
+					changedFiles: [],
+				},
+			},
+			recordedAt: new Date().toISOString(),
+		};
+		for (let i = 0; i < 201; i++) {
+			const taskId = `9${i}`;
+			fs.writeFileSync(
+				path.join(settlementsDir, `${taskId}.json`),
+				JSON.stringify({ ...template, taskId }),
+			);
+		}
+		const data = await getDiagnoseData(directory);
+		const check = findCheck(data.checks, 'Coder Settlements');
+		expect(check?.status).toBe('⚠️');
+		expect(check?.detail).toContain(
+			'All shown settlements are terminal, but the scan was truncated.',
+		);
+		expect(check?.detail).toContain('/swarm recover');
+	});
 });

--- a/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
+++ b/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
@@ -266,7 +266,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 					changedFiles: [],
 				},
 			},
-			recordedAt: new Date().toISOString(),
+			recordedAt: '2026-08-21T00:00:00.000Z',
 		};
 		for (let i = 0; i < 201; i++) {
 			const taskId = `9${i}`;

--- a/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
+++ b/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
@@ -134,12 +134,15 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 	}
 
 	test('listCoderSettlementWalStates: empty project lists nothing', async () => {
-		expect(await listCoderSettlementWalStates(directory)).toEqual([]);
+		expect(await listCoderSettlementWalStates(directory)).toEqual({
+			states: [],
+			truncated: false,
+		});
 	});
 
 	test('listCoderSettlementWalStates: in-flight dispatch reports ownedInProcess', async () => {
 		await beginRealDispatch('list-owned');
-		const states = await listCoderSettlementWalStates(directory);
+		const { states } = await listCoderSettlementWalStates(directory);
 		expect(states).toHaveLength(1);
 		expect(states[0]).toMatchObject({
 			taskId: '1.1',
@@ -154,7 +157,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 		rewriteWalProcessId(directory, '1.1', deadProcessId());
 		settlementInternals.liveDispatches.clear();
 
-		const results = await recoverStaleCoderSettlements(directory);
+		const { results } = await recoverStaleCoderSettlements(directory);
 		expect(results).toEqual([
 			{ taskId: '1.1', outcome: 'recovered', accepted: false, forced: false },
 		]);
@@ -163,7 +166,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 
 	test('same-process wedge: no --force reports owned_in_process and leaves the WAL untouched', async () => {
 		await beginRealDispatch('in-process');
-		const results = await recoverStaleCoderSettlements(directory);
+		const { results } = await recoverStaleCoderSettlements(directory);
 		expect(results).toEqual([
 			{
 				taskId: '1.1',
@@ -178,7 +181,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 		await beginRealDispatch('force-me');
 		expect(readWalJson(directory, '1.1').state).toBe('DISPATCHED');
 
-		const results = await recoverStaleCoderSettlements(directory, {
+		const { results } = await recoverStaleCoderSettlements(directory, {
 			force: true,
 		});
 		expect(results).toEqual([
@@ -207,7 +210,9 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 		settlementInternals.liveDispatches.clear();
 
 		for (const force of [false, true]) {
-			const results = await recoverStaleCoderSettlements(directory, { force });
+			const { results } = await recoverStaleCoderSettlements(directory, {
+				force,
+			});
 			expect(results).toEqual([
 				{
 					taskId: '1.1',
@@ -229,13 +234,55 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 		});
 		expect(readWalJson(directory, '1.1').state).toBe('ABORTED');
 
-		const results = await recoverStaleCoderSettlements(directory, {
+		const { results } = await recoverStaleCoderSettlements(directory, {
 			force: true,
 		});
 		expect(results).toEqual([
 			{ taskId: '1.1', outcome: 'already_terminal', state: 'ABORTED' },
 		]);
 		expect(readWalJson(directory, '1.1').state).toBe('ABORTED');
+	});
+
+	test('scan cap: >200 WALs truncates the listing with truncated=true (PRR-011)', async () => {
+		const settlementsDir = path.join(directory, '.swarm', 'coder-settlements');
+		fs.mkdirSync(settlementsDir, { recursive: true });
+		const template = {
+			version: 1,
+			state: 'COMMITTED',
+			taskId: 'x',
+			transitionId: 'coder:cap',
+			actor: 'architect',
+			processId: process.pid,
+			runtimeId: 'runtime-cap',
+			expectedGeneration: 0,
+			context: {
+				declaredFiles: [],
+				baseline: {
+					directory,
+					gitHead: null,
+					dirtyHash: null,
+					prHeadSha: null,
+					scope: null,
+					changedFiles: [],
+				},
+			},
+			recordedAt: new Date().toISOString(),
+		};
+		for (let i = 0; i < 201; i++) {
+			const taskId = `9${i}`;
+			fs.writeFileSync(
+				path.join(settlementsDir, `${taskId}.json`),
+				JSON.stringify({ ...template, taskId }),
+			);
+		}
+		const { states, truncated } = await listCoderSettlementWalStates(directory);
+		expect(truncated).toBe(true);
+		expect(states).toHaveLength(200);
+		const { results, truncated: recoverTruncated } =
+			await recoverStaleCoderSettlements(directory);
+		expect(recoverTruncated).toBe(true);
+		expect(results).toHaveLength(200);
+		expect(results.every((r) => r.outcome === 'already_terminal')).toBe(true);
 	});
 
 	test('a settlement completed concurrently with recovery is already_terminal, not error (reviewer delta)', async () => {
@@ -258,7 +305,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 			return null;
 		};
 		try {
-			const results = await recoverStaleCoderSettlements(directory);
+			const { results } = await recoverStaleCoderSettlements(directory);
 			expect(results).toEqual([
 				{ taskId: '1.1', outcome: 'already_terminal', state: 'COMMITTED' },
 			]);
@@ -275,7 +322,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 			throw new Error('CODER_SETTLEMENT_RECOVERY_UNCERTAIN: simulated');
 		};
 		try {
-			const results = await recoverStaleCoderSettlements(directory);
+			const { results } = await recoverStaleCoderSettlements(directory);
 			expect(results).toEqual([
 				{
 					taskId: '1.1',
@@ -304,7 +351,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 			recursive: true,
 		});
 		fs.writeFileSync(walPath(directory, '9.9'), 'not json at all');
-		const results = await recoverStaleCoderSettlements(directory);
+		const { results } = await recoverStaleCoderSettlements(directory);
 		expect(results).toEqual([{ taskId: '9.9', outcome: 'unreadable_wal' }]);
 	});
 
@@ -317,7 +364,7 @@ describe('issue #2268 — stale settlement recovery helpers', () => {
 		});
 		fs.writeFileSync(walPath(directory, '9.9'), 'not json at all');
 
-		const results = await recoverStaleCoderSettlements(directory, {
+		const { results } = await recoverStaleCoderSettlements(directory, {
 			taskIds: ['1.1'],
 			force: true,
 		});

--- a/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
+++ b/tests/unit/workflow/coder-settlement-recovery-helpers.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import {
+	abortCoderSettlement,
+	listCoderSettlementWalStates,
+	recoverStaleCoderSettlements,
+	_internals as settlementInternals,
+} from '../../../src/workflow/coder-settlement';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 10_000,
+		maxBuffer: 1024 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0)
+		throw new Error(`git ${args.join(' ')}: ${result.stderr || result.stdout}`);
+}
+
+function writeFile(directory: string, file: string, content: string): void {
+	const absolute = path.join(directory, file);
+	fs.mkdirSync(path.dirname(absolute), { recursive: true });
+	fs.writeFileSync(absolute, content);
+}
+
+function walPath(directory: string, taskId: string): string {
+	return path.join(directory, '.swarm', 'coder-settlements', `${taskId}.json`);
+}
+
+function readWalJson(
+	directory: string,
+	taskId: string,
+): Record<string, unknown> {
+	return JSON.parse(
+		fs.readFileSync(walPath(directory, taskId), 'utf8'),
+	) as Record<string, unknown>;
+}
+
+function rewriteWalProcessId(
+	directory: string,
+	taskId: string,
+	processId: number,
+): void {
+	const wal = readWalJson(directory, taskId);
+	wal.processId = processId;
+	fs.writeFileSync(walPath(directory, taskId), JSON.stringify(wal));
+}
+
+/** A pid that exited, so isProcessAlive() reports it dead (host-crash wedge). */
+function deadProcessId(): number {
+	const result = spawnSync(process.execPath, ['--version'], {
+		stdin: 'ignore',
+		encoding: 'utf8',
+		timeout: 15_000,
+		windowsHide: true,
+	});
+	if (result.pid === undefined) throw new Error('no pid from helper child');
+	return result.pid;
+}
+
+const CODER_ARGS = {
+	subagent_type: 'coder',
+	task_id: '1.1',
+	prompt:
+		'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+};
+
+const realRecoverCoderSettlement = settlementInternals.recoverCoderSettlement;
+
+/**
+ * Issue #2268: the /swarm recover + /swarm reset-session recovery matrix.
+ * The wedge class: a DISPATCHED settlement WAL whose completion (toolAfter)
+ * never arrived, plus the in-process ownership key when the host survived.
+ */
+describe('issue #2268 — stale settlement recovery helpers', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(async () => {
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		settlementInternals.recoverCoderSettlement = realRecoverCoderSettlement;
+		({ dir: directory, cleanup } = createSafeTestDir('coder-recover-2268-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		writeFile(directory, 'src/feature.ts', 'export const feature = 1;\n');
+		git(directory, ['add', '.']);
+		git(directory, ['commit', '-m', 'seed']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+		const session = ensureAgentSession('parent', 'architect', directory);
+		session.currentTaskId = '1.1';
+	});
+
+	afterEach(() => {
+		settlementInternals.recoverCoderSettlement = realRecoverCoderSettlement;
+		resetSwarmState();
+		settlementInternals.liveDispatches.clear();
+		cleanup();
+	});
+
+	async function beginRealDispatch(callID: string): Promise<void> {
+		const hook = createDelegationGateHook(config, directory);
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent', callID },
+			{ args: { ...CODER_ARGS } },
+		);
+	}
+
+	test('listCoderSettlementWalStates: empty project lists nothing', async () => {
+		expect(await listCoderSettlementWalStates(directory)).toEqual([]);
+	});
+
+	test('listCoderSettlementWalStates: in-flight dispatch reports ownedInProcess', async () => {
+		await beginRealDispatch('list-owned');
+		const states = await listCoderSettlementWalStates(directory);
+		expect(states).toHaveLength(1);
+		expect(states[0]).toMatchObject({
+			taskId: '1.1',
+			state: 'DISPATCHED',
+			ownedInProcess: true,
+			ownedByLiveForeignPid: false,
+		});
+	});
+
+	test('host-crash wedge (dead foreign pid, no in-process key) recovers WITHOUT --force', async () => {
+		await beginRealDispatch('host-crash');
+		rewriteWalProcessId(directory, '1.1', deadProcessId());
+		settlementInternals.liveDispatches.clear();
+
+		const results = await recoverStaleCoderSettlements(directory);
+		expect(results).toEqual([
+			{ taskId: '1.1', outcome: 'recovered', accepted: false, forced: false },
+		]);
+		expect(readWalJson(directory, '1.1').state).toBe('COMMITTED');
+	});
+
+	test('same-process wedge: no --force reports owned_in_process and leaves the WAL untouched', async () => {
+		await beginRealDispatch('in-process');
+		const results = await recoverStaleCoderSettlements(directory);
+		expect(results).toEqual([
+			{
+				taskId: '1.1',
+				outcome: 'owned_in_process',
+				transitionId: 'coder:in-process',
+			},
+		]);
+		expect(readWalJson(directory, '1.1').state).toBe('DISPATCHED');
+	});
+
+	test('same-process wedge: --force releases ownership and recovers, recording the audit event', async () => {
+		await beginRealDispatch('force-me');
+		expect(readWalJson(directory, '1.1').state).toBe('DISPATCHED');
+
+		const results = await recoverStaleCoderSettlements(directory, {
+			force: true,
+		});
+		expect(results).toEqual([
+			{ taskId: '1.1', outcome: 'recovered', accepted: false, forced: true },
+		]);
+		expect(readWalJson(directory, '1.1').state).toBe('COMMITTED');
+		expect(
+			settlementInternals.liveDispatches.has(
+				`${directory}\u00001.1\u0000coder:force-me`,
+			),
+		).toBe(false);
+
+		const events = fs.readFileSync(
+			path.join(directory, '.swarm', 'events.jsonl'),
+			'utf8',
+		);
+		expect(events).toContain('"type":"coder_settlement"');
+		expect(events).toContain('"action":"recovered"');
+		expect(events).toContain('"forced":true');
+	});
+
+	test('foreign live pid is NEVER forced, even with --force', async () => {
+		await beginRealDispatch('foreign-live');
+		// process.ppid is alive for the whole test run and is not this process.
+		rewriteWalProcessId(directory, '1.1', process.ppid);
+		settlementInternals.liveDispatches.clear();
+
+		for (const force of [false, true]) {
+			const results = await recoverStaleCoderSettlements(directory, { force });
+			expect(results).toEqual([
+				{
+					taskId: '1.1',
+					outcome: 'owned_by_live_foreign_pid',
+					processId: process.ppid,
+				},
+			]);
+		}
+		expect(readWalJson(directory, '1.1').state).toBe('DISPATCHED');
+	});
+
+	test('terminal settlements are reported and left untouched', async () => {
+		await beginRealDispatch('abort-me');
+		await abortCoderSettlement({
+			directory,
+			taskId: '1.1',
+			transitionId: 'coder:abort-me',
+			reason: 'test abort',
+		});
+		expect(readWalJson(directory, '1.1').state).toBe('ABORTED');
+
+		const results = await recoverStaleCoderSettlements(directory, {
+			force: true,
+		});
+		expect(results).toEqual([
+			{ taskId: '1.1', outcome: 'already_terminal', state: 'ABORTED' },
+		]);
+		expect(readWalJson(directory, '1.1').state).toBe('ABORTED');
+	});
+
+	test('a settlement completed concurrently with recovery is already_terminal, not error (reviewer delta)', async () => {
+		await beginRealDispatch('race-settle');
+		settlementInternals.liveDispatches.clear();
+		const realRecover = settlementInternals.recoverCoderSettlement;
+		settlementInternals.recoverCoderSettlement = async () => {
+			// Simulate the concurrent completion settling the WAL between the
+			// listing and the recovery attempt, then returning null (terminal).
+			const wal = readWalJson(directory, '1.1');
+			fs.writeFileSync(
+				walPath(directory, '1.1'),
+				JSON.stringify({
+					...wal,
+					state: 'COMMITTED',
+					accepted: false,
+					testEngineerExempt: false,
+				}),
+			);
+			return null;
+		};
+		try {
+			const results = await recoverStaleCoderSettlements(directory);
+			expect(results).toEqual([
+				{ taskId: '1.1', outcome: 'already_terminal', state: 'COMMITTED' },
+			]);
+		} finally {
+			settlementInternals.recoverCoderSettlement = realRecover;
+		}
+	});
+
+	test('a failed recovery emits a recovery-failed audit event (reviewer delta)', async () => {
+		await beginRealDispatch('fail-settle');
+		settlementInternals.liveDispatches.clear();
+		const realRecover = settlementInternals.recoverCoderSettlement;
+		settlementInternals.recoverCoderSettlement = async () => {
+			throw new Error('CODER_SETTLEMENT_RECOVERY_UNCERTAIN: simulated');
+		};
+		try {
+			const results = await recoverStaleCoderSettlements(directory);
+			expect(results).toEqual([
+				{
+					taskId: '1.1',
+					outcome: 'error',
+					message: 'CODER_SETTLEMENT_RECOVERY_UNCERTAIN: simulated',
+				},
+			]);
+			const events = fs.readFileSync(
+				path.join(directory, '.swarm', 'events.jsonl'),
+				'utf8',
+			);
+			expect(events).toContain('"action":"recovery-failed"');
+			expect(events).toContain(
+				'CODER_SETTLEMENT_RECOVERY_UNCERTAIN: simulated',
+			);
+			// The WAL is untouched — a retry after fixing the underlying cause
+			// remains possible.
+			expect(readWalJson(directory, '1.1').state).toBe('DISPATCHED');
+		} finally {
+			settlementInternals.recoverCoderSettlement = realRecover;
+		}
+	});
+
+	test('an unparseable WAL is reported as unreadable_wal, not a crash', async () => {
+		fs.mkdirSync(path.dirname(walPath(directory, '9.9')), {
+			recursive: true,
+		});
+		fs.writeFileSync(walPath(directory, '9.9'), 'not json at all');
+		const results = await recoverStaleCoderSettlements(directory);
+		expect(results).toEqual([{ taskId: '9.9', outcome: 'unreadable_wal' }]);
+	});
+
+	test('taskIds filter recovers only the requested task', async () => {
+		// Plan already contains only task 1.1 for this suite; add a second
+		// settlement WAL for 9.9 by hand so the filter has two candidates.
+		await beginRealDispatch('filter-a');
+		fs.mkdirSync(path.dirname(walPath(directory, '9.9')), {
+			recursive: true,
+		});
+		fs.writeFileSync(walPath(directory, '9.9'), 'not json at all');
+
+		const results = await recoverStaleCoderSettlements(directory, {
+			taskIds: ['1.1'],
+			force: true,
+		});
+		// Only 1.1 is in scope: recovered. 9.9 (unreadable) is untouched.
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({ taskId: '1.1', outcome: 'recovered' });
+	});
+});

--- a/tests/unit/workflow/workflow-state-conflict-diagnostics.test.ts
+++ b/tests/unit/workflow/workflow-state-conflict-diagnostics.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { captureWorkspaceSnapshot } from '../../../src/background/workspace-snapshot';
+import { assertTaskEvidenceWriteAllowed } from '../../../src/gate-evidence';
 import {
 	assertNoUnsettledCoderDispatch,
 	beginCoderSettlement,
@@ -106,6 +107,61 @@ describe('workflow state-conflict error diagnostics', () => {
 		expect(error.message).toContain('do not remove the WAL by hand');
 	});
 
+	test('gate-evidence CODER_SETTLEMENT_IN_PROGRESS names the recovery commands (issue #2268 sweep)', async () => {
+		// The evidence fence emits the same wedge token from a fourth site
+		// (assertTaskEvidenceWriteAllowed); the #2268 sweep must keep its
+		// remediation wired, not just the three coder-settlement.ts sites.
+		const git = (args: string[]): void => {
+			const result = spawnSync('git', ['-C', directory, ...args], {
+				cwd: directory,
+				stdin: 'ignore',
+				stdout: 'pipe',
+				stderr: 'pipe',
+				encoding: 'utf8',
+				timeout: 10_000,
+				maxBuffer: 128 * 1024,
+				windowsHide: true,
+			});
+			if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+		};
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(['init']);
+		git(['config', 'user.email', 'tests@example.com']);
+		git(['config', 'user.name', 'Tests']);
+		git(['add', 'src/feature.ts']);
+		git(['commit', '-m', 'test: seed']);
+
+		await beginCoderSettlement({
+			directory,
+			taskId: '8.2',
+			transitionId: 'coder:8.2:owning',
+			actor: 'architect',
+			expectedGeneration: 0,
+			context: {
+				declaredFiles: ['src/feature.ts'],
+				baseline: captureWorkspaceSnapshot(directory),
+				workflowGeneration: 0,
+			},
+		});
+
+		let error: Error = new Error('no throw');
+		try {
+			assertTaskEvidenceWriteAllowed(directory, '8.2');
+		} catch (caught) {
+			error = caught as Error;
+		}
+		expect(error.message).toContain('CODER_SETTLEMENT_IN_PROGRESS');
+		expect(error.message).toContain('coder:8.2:owning');
+		expect(error.message).toContain('task 8.2');
+		expect(error.message).toContain('/swarm recover 8.2');
+		expect(error.message).toContain('/swarm reset-session');
+		expect(error.message).toContain('do not remove the WAL by hand');
+	});
+
 	test('CODER_SETTLEMENT_RECOVERY_REQUIRED names the task, transition, WAL path and next action', async () => {
 		const walPath = writeWal('coder-settlements', '1.1', {
 			version: 1,
@@ -139,7 +195,10 @@ describe('workflow state-conflict error diagnostics', () => {
 		expect(error.message).toContain('task 1.1');
 		expect(error.message).toContain(walPath);
 		expect(error.message).toContain('state DISPATCHED');
-		expect(error.message).toContain('Run coder-settlement recovery');
+		// Issue #2268: the advised action must name the real command, not an
+		// internal function with no user-facing invoker.
+		expect(error.message).toContain('Run /swarm recover 1.1');
+		expect(error.message).toContain('/swarm reset-session');
 	});
 
 	test('CODER_DISPATCH_IN_PROGRESS names the owning transition, WAL path, state and pid', async () => {


### PR DESCRIPTION
Closes #2268

## Summary

On plugin ≤ 7.141.1, a coder Task dispatch denied with `SCOPE_NOT_DECLARED` had already written a `DISPATCHED` settlement WAL plus an in-process ownership key; every retry was refused with `CODER_DISPATCH_IN_PROGRESS`, `/swarm reset-session` cleared neither, and the error text advised an action with no invoker. That exact denial path was already fixed on main (#2214 ordering + abort-on-denial, #2098 transactional recovery) — this PR closes the remaining wedge class (a dispatch whose completion never arrives in a still-running host process) and wires every advised action:

1. **Recovery helpers** (`src/workflow/coder-settlement.ts`): `listCoderSettlementWalStates` (bounded inventory with an explicit `truncated` flag when the 200-WAL scan cap is hit) and `recoverStaleCoderSettlements({taskIds?, force?})` — settles non-terminal WALs via the same `recoverCoderSettlement` the internal sinks use (no state-machine or schema change). Foreign live pids are never interrupted; forced releases emit `coder_settlement` `recovered` audit events and failures emit a top-level `recovery-failed` event; a WAL settled by a concurrent completion between listing and recovery is classified `already_terminal`, not `error`.
2. **New human-only `/swarm recover [task_id] [--force]`** command: safe mode recovers dead-owner settlements; `--force` releases this-process ownership keys (operator assertion; output warns a still-running dispatch's late completion will report `CODER_SETTLEMENT_IDEMPOTENCY_CONFLICT`, safe to ignore). WAL-derived free-form fields are sanitized at render per the repo's untrusted-diagnostic pattern. Agent attempts are refused with a surface-to-user message; agents keep the safe self-heal via `update_task_status`.
3. **`/swarm reset-session`** force-recovers stale settlements (per-task fail-open reporting, idempotency-conflict heads-up, scan-cap warning) before `.swarm-worktrees/` removal — and **defers worktree removal when any recovery errored**, so an unsettled worktree-carrying WAL cannot be stranded by a deleted worktree.
4. **Rollback gap closed** (`src/index.ts`): the #2214 denied-dispatch rollback no longer skips throws from the advisory tail after `failClosedRegionCompleted = true` (the catch only runs when `toolBefore` threw, so the Task never executes; `abortDeniedSettlementForCall` is a callID-keyed no-op when nothing was begun).
5. **Wired advisories**: all four `CODER_SETTLEMENT_IN_PROGRESS` / `CODER_DISPATCH_IN_PROGRESS` / `CODER_SETTLEMENT_RECOVERY_REQUIRED` emitters (three in `coder-settlement.ts`, one in `gate-evidence.ts`) name `/swarm recover <taskId>` / `/swarm reset-session` (leading code tokens byte-identical).
6. **`/swarm diagnose`** gains a warn-level "Coder Settlements" check (state + owner liveness + remediation + truncation note; never fails on a genuinely in-flight dispatch; fail-open).
7. Docs: `docs/commands.md`, `docs/troubleshooting/recovery-guide.md` §11 (incl. why hand-editing settlement WALs is harmful), release fragment.

**Not changed (deliberate):** settlement state machine / WAL schema / attribution semantics (#2098/#2214 reused); `/swarm close`'s per-task recovery loop (recover/reset-session are the sanctioned unwedge paths); no init-time auto-recovery (init-path boundedness); no timestamp staleness heuristics (explicit operator action instead).

### abortDeniedSettlementForCall finally-guarantee
The rollback entry point releases the in-process ownership key and drains callID bookkeeping in a `finally` even when the abort write itself fails (`delegation-gate.ts` finally block) — an abort failure degrades to the self-healing dead-owner path, never a same-process wedge.

## Invariant audit
- 1 (plugin init):       not touched — src/index.ts changes are inside the tool.execute.before hook, off the init path; no new init work.
- 2 (runtime portability): not touched — no bun: imports, no Bun.* calls; build + Node ESM import verified on the final diff.
- 3 (subprocesses):       not touched — no new spawns; recovery drives pre-existing compliant git helpers; test spawns use array form, cwd, stdin ignore, timeouts.
- 4 (.swarm containment): touched — all new paths route through validateSwarmPath; no new roots, no process.cwd().
- 5 (plan durability):    not touched — no ledger/schema changes.
- 6 (test_runner safety): not touched.
- 7 (test writing):       touched — bun:test only, `_internals` DI seams (no new mock.module), real-I/O fixtures via createSafeTestDir/writeApprovedPlan; FR-006 ratchet 0 violations (over-cap files shrank/net-zero).
- 8 (session state):      touched (reviewed) — reuses the existing process-global liveDispatches registry via releaseCoderDispatchOwnership/dispatchKey; no new unkeyed globals; scan capped.
- 9 (guardrails/retry):   touched (narrowly) — rollback trigger widened to all toolBefore throws for Task calls; denial counting/streak semantics unchanged; wiring test pins the contract.
- 10 (chat/system msg):   not touched.
- 11 (tool registration): touched — new command fully registered (handler, registry entry, export, TUI shortcut swarm-recover, toolPolicy human-only surfaces, baselines/snapshots updated); check-tool-registration + drift:check + parity/help/shortcut suites green.
- 12 (release/cache):     touched — pending release fragment added; no version/CHANGELOG edits.

## Test plan
All observed locally per-file (`bun --smol test <file>`), plus full gates:

- New suites: `coder-settlement-recovery-helpers.test.ts` 12 pass (recovery matrix incl. host-crash dead-pid, owned_in_process, force+audit events, foreign-live-pid never forced, terminal untouched, unreadable, taskIds filter, concurrent-completion race → already_terminal, failed recovery → recovery-failed event, **201-WAL scan cap → 200 states + truncated at both layers**) · `commands/recover.test.ts` 11 pass (**task-specific miss on empty project, hostile-transitionId sanitization via real dispatch, scan-cap truncation warning**) · `commands/reset-session-settlement-recovery.test.ts` 7 pass (**the #2268 regression**: wedged DISPATCHED WAL + live key recovered; **failed-recovery AND thrown-recovery both preserve .swarm-worktrees/** with marker-file survival + hostile-message sanitization; truncation warning) · `services/diagnose-settlement-check.test.ts` 5 pass (incl. **all-terminal+truncated → ⚠️ with remediation**, mutation-falsified).
- Updated: `gate-denial-wiring.test.ts` 11 pass (unconditional rollback contract pinned) · `workflow-state-conflict-diagnostics.test.ts` 10 pass (command-naming + fourth-emitter pin) · `index-commands.test.ts` 13 pass · `tool-policy.human-only.test.ts` 20 pass · registration-parity/registry suites green · `update-task-status-terminal-wal-2098.test.ts` 6 pass.
- Behavior preserved: 2214 11 pass, 2214-hardening 6 pass, 2098 5 pass, worktree-recovery 6 pass, coder-transactions 4 pass, close-terminal-preflight 2 pass, reset-session 13 + enoent 4 pass, close 76 pass, all 7 diagnose suites pass, `tests/unit/config` batch 2031 pass.
- Gates: typecheck clean · `biome check .` clean (import-sort fixed) · build OK + `node --input-type=module` dist import OK · `check-tool-registration` 121 tools coherent · `drift:check` clean · `check:test-file-cap` 0 violations · invariants/mock-cleanup/test-tmpdir/test-clock gates pass.
- Falsifiability: regression tests verified failing with fixes reverted (stash/mutation runs recorded in the trace); each new feedback test targets the exact pre-fix behavior.

## Review history
Implemented under the issue-tracer/swarm lifecycle (plan critic + implementation reviewer rounds + final critic all APPROVE), then reviewed by a full swarm-pr-review run (6 base lanes, 11-family micro coverage, 4 reviewer shards, 2 critic passes): verdict REQUEST_CHANGES with 6 actionable findings; all fixed in the feedback commit — import-sort (CI quality), WAL-field render sanitization, scan-cap truncation surfacing, worktree-preservation on failed recovery, task-specific miss message; the PR-body contract is fixed in this description. Disproved findings (agent human-only bypass — execution-probed; missing try/catch — framework already wraps; file-cap claims — ratchet semantics) are recorded in the review ledger with evidence.
