### PR TITLE
fix(pr-review): inject per-lane-kind output budgets and pre-seed shell rules (#2276)

### DIFF
--- a/.opencode/skills/swarm-pr-review/references/prompt-templates.md
+++ b/.opencode/skills/swarm-pr-review/references/prompt-templates.md
@@ -65,7 +65,7 @@ Use this template when dispatching a base explorer:
 ```text
 You are a base explorer. Optimize for recall, not final judgment.
 Return candidates only. Do not use CONFIRMED, DISPROVED, or PRE_EXISTING.
-Do not narrate progress or repeat the prompt. Keep the complete final response at or below 12,000 characters; spend that budget on evidence-bearing rows and the minimum prose needed to make them auditable.
+Do not narrate progress or repeat the prompt. Keep the complete final response at or below 12,000 characters; spend that budget on evidence-bearing rows and the minimum prose needed to make them auditable. When the controller-appended contract declares a per-lane final_response_char_budget, that number is authoritative over this template default.
 
 Lane:
 Scope:
@@ -106,7 +106,7 @@ Use this template when dispatching a micro-lane or council explorer:
 ```text
 You are a micro-lane or council explorer. Optimize for recall, not final judgment.
 Return candidates only. Do not use CONFIRMED, DISPROVED, or PRE_EXISTING.
-Do not narrate progress or repeat the prompt. Keep the complete final response at or below 12,000 characters; spend that budget on evidence-bearing rows and the minimum prose needed to make them auditable.
+Do not narrate progress or repeat the prompt. Keep the complete final response at or below 12,000 characters; spend that budget on evidence-bearing rows and the minimum prose needed to make them auditable. When the controller-appended contract declares a per-lane final_response_char_budget, that number is authoritative over this template default.
 
 Micro/council lane:
 Scope:

--- a/docs/releases/pending/2276-lane-delivery-budgets-shell-rules.md
+++ b/docs/releases/pending/2276-lane-delivery-budgets-shell-rules.md
@@ -1,0 +1,17 @@
+# Dynamic PR-review lane budgets and pre-seeded shell rules
+
+## What changed
+
+`/swarm pr-review` lanes now receive an explicit, workload-derived final-response budget and the read-only shell rules up front, in the controller-appended `[CONTROLLER-BOUND PR WORKFLOW CONTRACT]` block (issue #2276; stacks on the #2258/#2272 recovery work).
+
+- **Per-lane-kind budgets** replace the one-size-fits-all 12,000-character cap for `swarm-pr-review:*` lanes: base dimension lanes get 18,000 chars, micro family lanes 12,000 (a consolidated micro lane owning several workflow lanes at depth tiers S/M scales up 2,000 per additional owned lane, capped at 18,000; council lanes are flat 12,000 because the dispatch gate forbids multi-lane ownership on them), and reviewer/critic lanes 6,000 plus 1,500 per assigned review item — all capped at 18,000, every value safely under the 20,000-character inline preview window. `swarm-pr-feedback:*` lanes keep the previous flat 12,000-character guidance.
+- **Budget discipline is stated, not implied**: only the final response is bounded — investigation and tool-call volume are explicitly uncapped; terminal machine-readable rows are spent first and must always fit with room to spare; verify each target exactly once; never restate a verification; emit rows the moment analysis is complete. This is the instruction whose caller-side equivalent succeeded 5/5 in the observed tier-L run where budget-less lanes lost 7 of 13 dispatches to overshoot loops.
+- **Read-only shell rules are pre-seeded** into every appended contract block (PR-review and PR-feedback modes alike): one standalone command per shell call — no pipes, no `&&`/`||`/`;`, no redirects or command substitution — with the three tolerated forms and the "prefer Read/Glob/Grep" guidance. Previously each lane rediscovered these rules through 2–4 rejected tool calls.
+- The `swarm-pr-review` prompt templates now defer to the controller-declared budget when one is present.
+- New regression coverage pins the budget derivation (five distinct sizes, item-count and owned-lane scaling with the ceiling), the budget/shell paragraph content in every mode, and re-confirms #2272's end-to-end projection pin (the ledger-to-collect-receipt `truncated-preview-durable-artifact` disclosure in `dispatch-lanes-pr-review-verdict-transport-recovery`) stays green alongside the new guidance.
+
+## Why
+
+The tier-L review postmortem (#2276) showed lower-tier orchestrator lanes overshoot without an explicit budget (147k–162k characters of restated verification) and waste calls on rejected compound commands. With #2272 already trusting digest-verified artifacts over preview truncation, the remaining fix is to tell lanes the delivery contract up front so conformance does not depend on trial and error.
+
+Closes #2276.

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -90,6 +90,32 @@ const MAX_COLLECT_TIMEOUT_MS = 60 * 60_000;
 const COLLECT_POLL_INTERVAL_MS = 500;
 const MAX_COLLECT_POLL_INTERVAL_MS = 10_000;
 const MAX_STATUS_CALL_BUDGET_MS = 2_000;
+// #2276: per-lane-kind final-response budgets for swarm-pr-review lanes. All
+// derive from the 20_000-char inline preview window (MAX_LANE_OUTPUT_CHARS):
+// every budget stays ≥2_000 under it, so a conforming lane's preview is never
+// truncated and its terminal machine-readable rows always ride inside the
+// preview. These bound ONLY the final response — never investigation volume.
+const PR_REVIEW_RESPONSE_BUDGET_CEILING_CHARS = 18_000;
+// A base lane owns one of the six full dimensions with multi-file analysis —
+// the largest sustainable budget (observed runs need ~18k of row-bearing text).
+const PR_REVIEW_BASE_LANE_RESPONSE_BUDGET_CHARS = 18_000;
+// A micro family lane owns a narrow scope; 12k matched every successful
+// caller-side budget instruction in the observed tier-L run. A consolidated
+// micro lane (owned_workflow_lanes, allowed at depth tiers S/M — see the
+// dispatch gate that rejects consolidation only at tier L) settles one
+// attestation per owned lane, so its budget scales with the owned count.
+const PR_REVIEW_MICRO_LANE_RESPONSE_BUDGET_CHARS = 12_000;
+const PR_REVIEW_MICRO_PER_OWNED_LANE_CHARS = 2_000;
+// A council lane settles a single attestation: the dispatch gate forbids
+// owned_workflow_lanes on council/reviewer/critic lanes outright (consolidation
+// applies only to base and micro discovery lanes), so its budget is flat.
+const PR_REVIEW_COUNCIL_LANE_RESPONSE_BUDGET_CHARS = 12_000;
+// Reviewer/critic verdict rows scale with the assigned item count: a floor
+// plus a per-item increment, capped at the ceiling.
+const PR_REVIEW_VERDICT_RESPONSE_FLOOR_CHARS = 6_000;
+const PR_REVIEW_VERDICT_RESPONSE_PER_ITEM_CHARS = 1_500;
+// Terminal-output guidance for lanes without a derived budget (the
+// swarm-pr-feedback modes, which #2276 leaves on the pre-existing flat cap).
 const PR_WORKFLOW_PROTOCOL_OUTPUT_MAX_CHARS = 12_000;
 const MAX_ZOD_ISSUES_LISTED = 20;
 const MAX_SESSION_CREATE_GENERATIONS = 2;
@@ -823,6 +849,10 @@ export const _test_exports = {
 	// without round-tripping through the durable delegation store or a
 	// SessionOps mock.
 	recordToLaneResult,
+	// #2276: pure per-lane-kind budget derivation, exported beside the prompt
+	// contract builder so budget scaling can be asserted without prompt-text
+	// parsing (file precedent: prompt-construction internals live here).
+	prReviewLaneResponseBudgetChars,
 };
 
 type ReadOnlyToolPermissions = Record<string, false> & {
@@ -3311,6 +3341,46 @@ ${controllerIdentity}${formatSuffix}`;
 		: { ok: true, lanes: formatted };
 }
 
+/**
+ * #2276: derive the final-response character budget for a PR-review lane from
+ * the lane's owned workload. Returns `undefined` for modes without a derived
+ * budget (the swarm-pr-feedback modes keep their flat
+ * {@link PR_WORKFLOW_PROTOCOL_OUTPUT_MAX_CHARS} guidance).
+ */
+function prReviewLaneResponseBudgetChars(
+	mode: string,
+	lane: DispatchLaneSpec,
+): number | undefined {
+	if (mode === 'swarm-pr-review:base') {
+		return PR_REVIEW_BASE_LANE_RESPONSE_BUDGET_CHARS;
+	}
+	if (mode === 'swarm-pr-review:micro') {
+		// Consolidated micro lanes (depth tiers S/M) settle one attestation per
+		// owned workflow lane; a single-family micro lane (tier L) owns one.
+		const owned = Math.max(1, lane.owned_workflow_lanes?.length ?? 1);
+		return Math.min(
+			PR_REVIEW_RESPONSE_BUDGET_CEILING_CHARS,
+			PR_REVIEW_MICRO_LANE_RESPONSE_BUDGET_CHARS +
+				(owned - 1) * PR_REVIEW_MICRO_PER_OWNED_LANE_CHARS,
+		);
+	}
+	if (mode === 'swarm-pr-review:council') {
+		return PR_REVIEW_COUNCIL_LANE_RESPONSE_BUDGET_CHARS;
+	}
+	if (
+		mode === 'swarm-pr-review:reviewer' ||
+		mode === 'swarm-pr-review:critic'
+	) {
+		const items = Math.max(0, lane.review_item_ids?.length ?? 0);
+		return Math.min(
+			PR_REVIEW_RESPONSE_BUDGET_CEILING_CHARS,
+			PR_REVIEW_VERDICT_RESPONSE_FLOOR_CHARS +
+				items * PR_REVIEW_VERDICT_RESPONSE_PER_ITEM_CHARS,
+		);
+	}
+	return undefined;
+}
+
 function applyPrWorkflowPromptContract(
 	lanes: DispatchLaneSpec[],
 	options: {
@@ -3359,6 +3429,21 @@ function applyPrWorkflowPromptContract(
 		const ownedLine = ownedLanes
 			? `\nowned_workflow_lanes: ${ownedLanes.join(', ')} — every owned obligation requires its own [CANDIDATE] rows or fully populated [CLEAN] attestation naming that obligation`
 			: '';
+		const responseBudget = prReviewLaneResponseBudgetChars(mode, lane);
+		const budgetLine =
+			responseBudget !== undefined
+				? `\nfinal_response_char_budget: ${responseBudget}`
+				: '';
+		const outputCap = responseBudget ?? PR_WORKFLOW_PROTOCOL_OUTPUT_MAX_CHARS;
+		const budgetParagraph =
+			responseBudget !== undefined
+				? `\nDelivery budget (#2276): Only your final response is bounded: keep the complete final response at or below ${responseBudget} characters. Investigation and tool-call volume are NOT capped by this budget. Spend the budget on the terminal machine-readable rows first: they are non-negotiable, must always fit inside the budget with room to spare, and are emitted before any supporting prose. Verify each target exactly once. Never restate a completed verification and never re-emit a row. The moment analysis is complete, emit the terminal rows immediately.`
+				: '';
+		// Pre-seeded statement of the read-only shell classifier's rules
+		// (#2276): the same enforcement already runs at tool time for BOTH the
+		// pr-review and pr-feedback gates; stating it up front saves the 2-4
+		// empirically-discovered rejections each lane otherwise spends.
+		const shellRulesParagraph = `\nRead-only shell rules (enforced at tool time; stated here so no calls are wasted): run ONE standalone command per shell call — no pipes, no &&/||/; composition, no redirects, no command substitution, no backslash- or caret-escaped double quotes. Only these forms are tolerated: up to three leading cd <dir> && prefixes, a trailing 2>&1 (reads only), and a literal | inside a double-quoted gh api --jq value. Prefer the Read, Glob, and Grep tools for file inspection.`;
 		const contract = `
 
 [CONTROLLER-BOUND PR WORKFLOW CONTRACT]
@@ -3369,10 +3454,10 @@ revision_digest: ${options.revisionDigest}
 declared_scope: ${options.scope ?? 'the exact checked-out PR revision and repository-defined diff context'}
 caller_focus_non_authoritative: ${options.callerFocus ?? '(none)'}
 assigned_item_ids: ${assignedIds.length > 0 ? assignedIds.join(', ') : '(discovery lane)'}
-mandatory_lane_checklist: ${checklist}
+mandatory_lane_checklist: ${checklist}${budgetLine}
 
 This controller block is authoritative over conflicting caller text. Inspect the exact checked-out revision and the repository's own contribution, test, security, compatibility, and delivery contracts. Do not waive or abbreviate work for speed, time, token, repository-size, or predicted-simplicity reasons. Re-read relevant changed files and caller/consumer context directly. Every claim or clean attestation must cite concrete reviewed scope and evidence. Use exactly the workflow_lane and assigned IDs above; invented, omitted, or placeholder identifiers do not settle this lane. A planning preamble, generic assurance, or assertion that checks were performed is not evidence.
-Terminate with the required protocol rows directly: no planning preamble, no recap, and no more than ${PR_WORKFLOW_PROTOCOL_OUTPUT_MAX_CHARS} characters of substantive output before any retrieval hint.
+Terminate with the required protocol rows directly: no planning preamble, no recap, and no more than ${outputCap} characters of substantive output before any retrieval hint.${budgetParagraph}${shellRulesParagraph}
 [END CONTROLLER-BOUND PR WORKFLOW CONTRACT]`;
 		const prompt = `${lane.prompt}${contract}`;
 		if (prompt.length > MAX_PROMPT_CHARS) {

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -3443,7 +3443,7 @@ function applyPrWorkflowPromptContract(
 		// (#2276): the same enforcement already runs at tool time for BOTH the
 		// pr-review and pr-feedback gates; stating it up front saves the 2-4
 		// empirically-discovered rejections each lane otherwise spends.
-		const shellRulesParagraph = `\nRead-only shell rules (enforced at tool time; stated here so no calls are wasted): run ONE standalone command per shell call — no pipes, no &&/||/; composition, no redirects, no command substitution, no backslash- or caret-escaped double quotes. Only these forms are tolerated: up to three leading cd <dir> && prefixes, a trailing 2>&1 (reads only), and a literal | inside a double-quoted gh api --jq value. Prefer the Read, Glob, and Grep tools for file inspection.`;
+		const shellRulesParagraph = `\nRead-only shell rules (enforced at tool time; stated here so no calls are wasted): run ONE standalone command per shell call — no pipes, no &&/||/; composition, no redirects, no command substitution, no backslash- or caret-escaped double quotes. Only these forms are tolerated: a single command optionally preceded by up to three leading cd <dir> && prefixes, a trailing 2>&1 (reads only), and a literal | inside a double-quoted gh api --jq value. Prefer the Read, Glob, and Grep tools for file inspection.`;
 		const contract = `
 
 [CONTROLLER-BOUND PR WORKFLOW CONTRACT]

--- a/tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from 'bun:test';
+import { _test_exports } from '../../../src/tools/dispatch-lanes.js';
+
+const PR_HEAD_SHA = 'abc123';
+const REVISION_DIGEST = 'revision-1';
+
+function contractOptions(mode: string) {
+	return {
+		mode,
+		prHeadSha: PR_HEAD_SHA,
+		revisionDigest: REVISION_DIGEST,
+	};
+}
+
+function baseLane(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'lane-1',
+		agent: 'explorer',
+		prompt: 'Caller-authored prompt',
+		...overrides,
+	};
+}
+
+function contractedPrompt(
+	mode: string,
+	laneOverrides: Record<string, unknown> = {},
+): string {
+	const contracted = _test_exports.applyPrWorkflowPromptContract(
+		[baseLane(laneOverrides)],
+		contractOptions(mode),
+	);
+	expect(contracted.ok).toBe(true);
+	if (!contracted.ok) throw new Error('expected prompt contract');
+	return contracted.lanes[0].prompt;
+}
+
+describe('pr-review lane response budget derivation (#2276)', () => {
+	test('scales the budget with the lane kind and owned workload', () => {
+		const { prReviewLaneResponseBudgetChars } = _test_exports;
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:base', baseLane()),
+		).toBe(18_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', baseLane()),
+		).toBe(12_000);
+		// Consolidated micro lanes (depth tiers S/M — the only lanes the dispatch
+		// gate allows to declare owned_workflow_lanes besides base) scale with
+		// the owned-lane count, floored at one owner and capped at the ceiling.
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {
+				owned_workflow_lanes: [
+					'correctness-state',
+					'security-trust',
+					'reliability-performance',
+				],
+			}),
+		).toBe(16_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {
+				owned_workflow_lanes: [
+					'intent-architecture',
+					'correctness-state',
+					'tests-falsifiability',
+					'security-trust',
+					'reliability-performance',
+					'compatibility-delivery',
+				],
+			}),
+		).toBe(18_000);
+		// Council lanes are flat: the dispatch gate forbids
+		// owned_workflow_lanes on council/reviewer/critic lanes outright.
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:council', baseLane()),
+		).toBe(12_000);
+		// Reviewer/critic budgets scale with the assigned item count…
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:reviewer', {
+				review_item_ids: ['C-1', 'C-2'],
+			}),
+		).toBe(9_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:critic', {
+				review_item_ids: ['C-1'],
+			}),
+		).toBe(7_500);
+		// …monotonically…
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:reviewer', {
+				review_item_ids: ['C-1', 'C-2', 'C-3', 'C-4'],
+			}),
+		).toBe(12_000);
+		// …and the ceiling kicks in before the budget can reach the preview cap.
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:reviewer', {
+				review_item_ids: Array.from(
+					{ length: 12 },
+					(_, index) => `C-${index + 1}`,
+				),
+			}),
+		).toBe(18_000);
+	});
+
+	test('modes outside swarm-pr-review:* have no derived budget', () => {
+		const { prReviewLaneResponseBudgetChars } = _test_exports;
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-feedback:verification', {
+				feedback_item_ids: ['F-1'],
+			}),
+		).toBeUndefined();
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-feedback:stage-b-reviewer', {}),
+		).toBeUndefined();
+	});
+});
+
+describe('controller-appended prompt budget block (#2276)', () => {
+	test('every swarm-pr-review:* mode carries its derived budget line', () => {
+		expect(
+			contractedPrompt('swarm-pr-review:base', {
+				workflow_lane: 'intent-architecture',
+			}),
+		).toContain('final_response_char_budget: 18000');
+		expect(
+			contractedPrompt('swarm-pr-review:micro', {
+				workflow_lane: 'api-schema-migrations',
+			}),
+		).toContain('final_response_char_budget: 12000');
+		const consolidatedMicroPrompt = contractedPrompt('swarm-pr-review:micro', {
+			workflow_lane: 'correctness-state',
+			owned_workflow_lanes: ['correctness-state', 'security-trust'],
+		});
+		expect(consolidatedMicroPrompt).toContain(
+			'final_response_char_budget: 14000',
+		);
+		const councilPrompt = contractedPrompt('swarm-pr-review:council', {
+			workflow_lane: 'correctness-state',
+		});
+		expect(councilPrompt).toContain('final_response_char_budget: 12000');
+		const reviewerPrompt = contractedPrompt('swarm-pr-review:reviewer', {
+			workflow_lane: 'review-chunk-1',
+			review_item_ids: ['C-1', 'C-2'],
+		});
+		expect(reviewerPrompt).toContain('final_response_char_budget: 9000');
+		expect(reviewerPrompt).toContain(
+			'no more than 9000 characters of substantive output',
+		);
+		const criticPrompt = contractedPrompt('swarm-pr-review:critic', {
+			workflow_lane: 'critic-chunk-1',
+			review_item_ids: ['C-1', 'C-2', 'C-3'],
+		});
+		expect(criticPrompt).toContain('final_response_char_budget: 10500');
+		// At least two distinct sizes are directly observable in the prompts.
+		expect(new Set(['18000', '12000', '14000', '9000', '10500']).size).toBe(5);
+	});
+
+	test('budget paragraph reserves terminal-row headroom and uncaps investigation', () => {
+		const prompt = contractedPrompt('swarm-pr-review:base', {
+			workflow_lane: 'intent-architecture',
+		});
+		expect(prompt).toContain(
+			'Only your final response is bounded: keep the complete final response at or below 18000 characters.',
+		);
+		expect(prompt).toContain(
+			'Investigation and tool-call volume are NOT capped by this budget.',
+		);
+		expect(prompt).toContain(
+			'must always fit inside the budget with room to spare',
+		);
+		expect(prompt).toContain('Verify each target exactly once.');
+		expect(prompt).toContain(
+			'The moment analysis is complete, emit the terminal rows immediately.',
+		);
+	});
+
+	test('swarm-pr-feedback:* blocks keep the flat cap and carry no budget line', () => {
+		for (const mode of [
+			'swarm-pr-feedback:verification',
+			'swarm-pr-feedback:stage-b-reviewer',
+			'swarm-pr-feedback:closeout-critic',
+		]) {
+			const prompt = contractedPrompt(mode, {
+				workflow_lane: 'stage-b-reviewer',
+			});
+			expect(prompt).toContain(
+				'no more than 12000 characters of substantive output',
+			);
+			expect(prompt).not.toContain('final_response_char_budget');
+		}
+	});
+});
+
+describe('controller-appended shell rules paragraph (#2276)', () => {
+	const SHELL_RULE_SENTENCES = [
+		'run ONE standalone command per shell call',
+		'no pipes, no &&/||/; composition, no redirects, no command substitution, no backslash- or caret-escaped double quotes',
+		'up to three leading cd <dir> && prefixes',
+		'a trailing 2>&1 (reads only)',
+		'a literal | inside a double-quoted gh api --jq value',
+		'Prefer the Read, Glob, and Grep tools for file inspection',
+	];
+
+	test('present in every swarm-pr-review:* mode block', () => {
+		const prompts = [
+			contractedPrompt('swarm-pr-review:base', {
+				workflow_lane: 'intent-architecture',
+			}),
+			contractedPrompt('swarm-pr-review:micro', {
+				workflow_lane: 'api-schema-migrations',
+			}),
+			contractedPrompt('swarm-pr-review:council', {
+				workflow_lane: 'correctness-state',
+			}),
+			contractedPrompt('swarm-pr-review:reviewer', {
+				workflow_lane: 'review-chunk-1',
+				review_item_ids: ['C-1'],
+			}),
+			contractedPrompt('swarm-pr-review:critic', {
+				workflow_lane: 'critic-chunk-1',
+				review_item_ids: ['C-1'],
+			}),
+		];
+		for (const prompt of prompts) {
+			expect(prompt).toContain('Read-only shell rules');
+			for (const sentence of SHELL_RULE_SENTENCES) {
+				expect(prompt).toContain(sentence);
+			}
+		}
+	});
+
+	test('present in swarm-pr-feedback:* blocks (same classifier governs both gates)', () => {
+		for (const mode of [
+			'swarm-pr-feedback:verification',
+			'swarm-pr-feedback:stage-b-reviewer',
+		]) {
+			const prompt = contractedPrompt(mode, {
+				workflow_lane: 'stage-b-reviewer',
+			});
+			expect(prompt).toContain('Read-only shell rules');
+			for (const sentence of SHELL_RULE_SENTENCES) {
+				expect(prompt).toContain(sentence);
+			}
+		}
+	});
+});
+
+// The ledger→collect-receipt projection of `salvaged_workflow_lane_recoveries`
+// (kind `truncated-preview-durable-artifact`) is already pinned end-to-end
+// through `executeDispatchLanesAsync` by #2272's
+// dispatch-lanes-pr-review-verdict-transport-recovery.test.ts (:172-185,
+// :274-287) — a second unit-level pin here would duplicate that coverage with
+// a type-bypassing record literal (implementation-review finding 2).

--- a/tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts
+++ b/tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts
@@ -98,6 +98,45 @@ describe('pr-review lane response budget derivation (#2276)', () => {
 				),
 			}),
 		).toBe(18_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:critic', {
+				review_item_ids: Array.from(
+					{ length: 12 },
+					(_, index) => `C-${index + 1}`,
+				),
+			}),
+		).toBe(18_000);
+		// Zero-item floors (defensive: the LaneSchema requires min(1), but the
+		// exported helper must not regress to NaN/0 if validation ever relaxes).
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:reviewer', {}),
+		).toBe(6_000);
+		expect(prReviewLaneResponseBudgetChars('swarm-pr-review:critic', {})).toBe(
+			6_000,
+		);
+		// An empty owned-lanes array floors to a single owner for micro.
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {
+				owned_workflow_lanes: [],
+			}),
+		).toBe(12_000);
+		// Cross-mode negatives: assigned item ids must never leak into modes
+		// whose budget is derived from lane kind or owned lanes alone.
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:base', {
+				review_item_ids: ['C-1', 'C-2'],
+			}),
+		).toBe(18_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:council', {
+				review_item_ids: ['C-1', 'C-2'],
+			}),
+		).toBe(12_000);
+		expect(
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {
+				review_item_ids: ['C-1', 'C-2'],
+			}),
+		).toBe(12_000);
 	});
 
 	test('modes outside swarm-pr-review:* have no derived budget', () => {
@@ -149,8 +188,26 @@ describe('controller-appended prompt budget block (#2276)', () => {
 			review_item_ids: ['C-1', 'C-2', 'C-3'],
 		});
 		expect(criticPrompt).toContain('final_response_char_budget: 10500');
-		// At least two distinct sizes are directly observable in the prompts.
-		expect(new Set(['18000', '12000', '14000', '9000', '10500']).size).toBe(5);
+		// At least two distinct sizes observable — asserted over values actually
+		// derived from the helper, so a budget collision regresses loudly.
+		const { prReviewLaneResponseBudgetChars } = _test_exports;
+		const derivedSizes = [
+			prReviewLaneResponseBudgetChars('swarm-pr-review:base', {}),
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {}),
+			prReviewLaneResponseBudgetChars('swarm-pr-review:micro', {
+				owned_workflow_lanes: ['correctness-state', 'security-trust'],
+			}),
+			prReviewLaneResponseBudgetChars('swarm-pr-review:reviewer', {
+				review_item_ids: ['C-1', 'C-2'],
+			}),
+			prReviewLaneResponseBudgetChars('swarm-pr-review:critic', {
+				review_item_ids: ['C-1', 'C-2', 'C-3'],
+			}),
+		];
+		expect(new Set(derivedSizes).size).toBe(5);
+		expect([...new Set(derivedSizes)].sort((a, b) => a - b)).toEqual([
+			9_000, 10_500, 12_000, 14_000, 18_000,
+		]);
 	});
 
 	test('budget paragraph reserves terminal-row headroom and uncaps investigation', () => {
@@ -185,6 +242,8 @@ describe('controller-appended prompt budget block (#2276)', () => {
 				'no more than 12000 characters of substantive output',
 			);
 			expect(prompt).not.toContain('final_response_char_budget');
+			// The budget PARAGRAPH (not just the labeled line) must stay absent.
+			expect(prompt).not.toContain('Delivery budget (#2276)');
 		}
 	});
 });
@@ -193,7 +252,7 @@ describe('controller-appended shell rules paragraph (#2276)', () => {
 	const SHELL_RULE_SENTENCES = [
 		'run ONE standalone command per shell call',
 		'no pipes, no &&/||/; composition, no redirects, no command substitution, no backslash- or caret-escaped double quotes',
-		'up to three leading cd <dir> && prefixes',
+		'a single command optionally preceded by up to three leading cd <dir> && prefixes',
 		'a trailing 2>&1 (reads only)',
 		'a literal | inside a double-quoted gh api --jq value',
 		'Prefer the Read, Glob, and Grep tools for file inspection',

--- a/tests/unit/tools/dispatch-lanes-read-only-tools.test.ts
+++ b/tests/unit/tools/dispatch-lanes-read-only-tools.test.ts
@@ -57,9 +57,12 @@ describe('dispatch_lanes read-only tool permissions', () => {
 			'mandatory_lane_checklist: re-read every assigned candidate',
 		);
 		expect(prompt).toContain('Do not waive or abbreviate work for speed');
+		// #2276: the flat 12k cap became a derived per-lane budget — a reviewer
+		// lane owning 2 items gets floor 6_000 + 2 × 1_500.
 		expect(prompt).toContain(
-			'no more than 12000 characters of substantive output',
+			'no more than 9000 characters of substantive output',
 		);
+		expect(prompt).toContain('final_response_char_budget: 9000');
 	});
 
 	test('passes the exact read-only tool map with shell and bash removed (#1691)', async () => {


### PR DESCRIPTION
## Summary

Closes #2276 — the lane delivery contract half. `/swarm pr-review` lanes now receive an explicit, workload-derived final-response budget and the read-only shell rules up front, in the controller-appended `[CONTROLLER-BOUND PR WORKFLOW CONTRACT]` block, instead of discovering both by trial and error (the observed tier-L run lost 7/13 lanes to overshoot loops and 2–4 wasted shell calls per lane).

**Stacked on #2272** (`codex/fix-2258-tier-l-recovery`) and intended to be retargeted to `main` immediately after #2272 merges, so `Closes #2276` fires against main with the full acceptance-criteria set satisfied. If #2272 moves, this branch rebases onto its new head before merge.

**Credit for #2276's Required Work #1 (already delivered by #2272, verified and re-run green here):** acceptance of preview-truncated-but-digest-verified lanes with a disclosed recovery (`truncated-preview-durable-artifact`) is pinned end-to-end at `tests/unit/tools/dispatch-lanes-pr-review-verdict-transport-recovery.test.ts:161-194,263-289`, and the `transcript_incomplete`/unverifiable-digest fail-closed behavior is pinned at `tests/unit/hooks/pr-workflow-gate-lane-validation-predicates.test.ts:291-303`. This PR does not touch `src/hooks/pr-workflow-gate.ts`.

What this PR adds:

- **Per-lane-kind budgets** (`src/tools/dispatch-lanes.ts`): base dimension lanes 18,000 chars; micro lanes 12,000, scaling +2,000 per additionally-owned workflow lane for tier-S/M consolidated dispatch (the only path where the dispatch gate admits `owned_workflow_lanes` on discovery lanes), capped at 18,000; council lanes flat 12,000 (the gate forbids multi-lane ownership on council); reviewer/critic lanes 6,000 + 1,500 × assigned review item, capped at 18,000. Every value keeps ≥2,000 chars of headroom under the 20,000-char inline preview window. Guidance only — no enforcement added, per the issue.
- **Budget discipline paragraph**: only the final response is bounded (investigation/tool-call volume explicitly uncapped); terminal machine-readable rows are spent first and must always fit with room to spare; verify each target once; never restate a verification; emit rows the moment analysis is complete. This is the instruction whose caller-side equivalent succeeded 5/5 in the observed run.
- **Pre-seeded read-only shell rules** in every appended block (both `swarm-pr-review:*` and `swarm-pr-feedback:*`): ONE standalone command per shell call — no pipes, no `&&`/`||`/`;`, no redirects or command substitution, no escaped double quotes; tolerated forms exactly as the classifier implements them (up to three leading `cd <dir> &&` prefixes per `PR_WORKFLOW_MAX_CD_PREFIX_STRIPS`, trailing `2>&1` for reads, literal `|` inside a double-quoted `gh api --jq` value); prefer Read/Glob/Grep. `swarm-pr-feedback:*` keeps its existing flat 12k guidance otherwise.
- Template reconciliation: the canonical `swarm-pr-review` prompt templates now defer to the controller-declared budget when present.

## Invariant audit

- 1 (plugin init):       not touched — no init-path change; `applyPrWorkflowPromptContract` runs at dispatch time.
- 2 (runtime portability): touched — `src/tools/dispatch-lanes.ts` is bundled. Evidence: `bun run build` completes; `node --input-type=module -e "await import('./dist/index.js')"` → `ESM-IMPORT-OK`; `bun test tests/unit/build/bundle-portability.test.ts tests/unit/build/bundle-plugin-shape.test.ts` → 12 pass / 0 fail. No new imports.
- 3 (subprocesses):       not touched — shell rules are quoted prompt text mirroring `classifyPrWorkflowShellSyntax`; no spawn changes.
- 4 (.swarm containment): not touched — no storage-path changes; trace artifacts under `.zcode/` are untracked working state.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched — validation used shell per-file loops, not broad `test_runner` scopes.
- 7 (test writing):       touched — new `tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts` (bun:test, `_test_exports` seam, no new `mock.module` targets, 251 lines < 500, no fs needed). Evidence: `scripts/mock-allowlist.txt` unchanged; biome clean.
- 8 (session state):      not touched — helper is pure.
- 9 (guardrails/retry):   touched (disclosure) — the acceptance-predicate loosening belongs to #2272 and is disclosed there via the durable `salvaged_workflow_lane_recoveries` record; this PR's budgets reduce retry pressure and state guidance only, never widening any gate.
- 10 (chat/system msg):   not touched — prompt strings are tool-side lane prompts; the `experimental.chat` transform chains are unmodified (`tests/unit/hooks/chat-transform-*.test.ts` untouched and green in the sweep).
- 11 (tool registration): not touched — no new tools/commands/agents; `bun run drift:check` → "No drift detected across skills, tools, commands, agents, docs claims, and dependency freshness."
- 12 (release/cache):     touched — ships `docs/releases/pending/2276-lane-delivery-budgets-shell-rules.md`; no version/CHANGELOG hand-edits.

## Test plan

- `bun test tests/unit/tools/dispatch-lanes-pr-review-prompt-budget.test.ts` → 7 pass / 0 fail: budget derivation (five distinct sizes; item-count and owned-lane scaling; ceiling kick-in at 12 items / 6 owned lanes; council flat; non-review modes undefined), prompt-level budget line + terminate cap per mode, uncapped/headroom/anti-repetition sentences, flat-cap + no-budget-line for pr-feedback modes, shell paragraph across all five review modes and two pr-feedback modes.
- `bun test` on `dispatch-lanes-read-only-tools` (updated reviewer pin: 2 items → 9000), both prompt-overflow fail-closed tests, `swarm-pr-review-dispatch-guidance` (template pin), `dispatch-lanes-pr-review-verdict-transport-recovery` (AC-1 end-to-end pin) → 25 pass / 0 fail / 445 expect() calls total.
- Post-review feedback closure (commit `0036ff29`, swarm-pr-review run `pr-2282-20260822`): PRR-005 tautology replaced with SUT-derived exact-value pins; PRR-003's seven missing pins added (zero-item floors, critic ceiling, micro empty-owned floor, cross-mode negatives, pr-feedback paragraph absence); PRR-011a shell-paragraph rewording; PRR-001 cleared by updating base PR #2272 onto main (`f524353f`) and rebasing this branch onto it (clock-lint now 0 new violations on both trees); PRR-007 filed as follow-up #2285.
- Per-file loop over every `tests/unit/tools/dispatch-lanes*.test.ts` → all green; predicate/batch/base-coverage/skills/`pending-delegations` suites → green.
- `bun run typecheck` → exit 0; `bunx biome check` → clean; `bun run drift:check` → clean.

Review gates (swarm contract): plan critic (Kimi K3) NEEDS_REVISION → all 9 items incorporated; independent implementation reviewer round 1 NEEDS_REVISION (4 findings: cd-prefix tolerance, redundant projection test, plan-doc mirror claim, escaped-quote omission) → all fixed and re-approved; final critic round 1 NEEDS_REVISION (3 findings: stale fragment clause, unreachable council-scaling branch → re-homed to the live micro-consolidation path, PR-body credit gate) → all fixed, round 2 **APPROVE**. Reviewer and critic approvals postdate the last code edit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


