### PR TITLE
fix(test): remove the rewrite-then-read race in knowledge-query category test

### DIFF
--- a/docs/releases/pending/2283-knowledge-query-category-flake.md
+++ b/docs/releases/pending/2283-knowledge-query-category-flake.md
@@ -1,0 +1,35 @@
+# Fix: a flaky knowledge-query test was evicting PRs from the merge queue
+
+## What
+
+`tests/unit/tools/knowledge-query.test.ts` → `Applies all valid categories
+correctly` rewrote the **same** `.swarm/knowledge.jsonl` on each of ten
+iterations and re-read it immediately. On `windows-latest` that raced: the read
+returned the previous iteration's content and the assertion failed on
+`integration`, the eighth of ten.
+
+The blast radius is what makes it worth a release note rather than a silent test
+tweak. The test runs in the `unit` job, which the merge queue executes on every
+`merge_group` event — so each occurrence dropped whichever pull request was
+queued at the time, regardless of whether that PR had anything to do with
+knowledge storage. It evicted PR #2261 and cost a full re-queue cycle.
+
+## Fix
+
+The race is removed rather than suppressed. All ten entries are written **once**,
+then the per-category queries run against that single write. No retry, no sleep,
+no widened timeout — those would have hidden the race while leaving the window
+open.
+
+This loses no coverage: the tool's own category filter already isolates each
+entry, so writing them together and querying one at a time exercises exactly what
+the per-iteration rewrite did. The test still asserts, per category, both the
+matching entry id and the echoed filter line, and the file still reports the same
+42 tests.
+
+## Note for future edits
+
+Do not reintroduce a write inside that loop. The file carries an inline comment
+saying so, because the failure is invisible on a developer machine — it did not
+reproduce locally across five consecutive runs on the same OS that CI failed on,
+and only shows up under the timing and filesystem behavior of a loaded CI runner.

--- a/tests/unit/tools/knowledge-query.test.ts
+++ b/tests/unit/tools/knowledge-query.test.ts
@@ -551,30 +551,30 @@ describe('knowledge-query tool verification tests', () => {
 				'todo',
 				'other',
 			] as const;
-
+			// Write every entry ONCE (#2283): a per-iteration rewrite-then-read
+			// raced on windows and evicted queued PRs. Never write in the loop.
+			const entries: SwarmKnowledgeEntry[] = categories.map((cat) => ({
+				id: `entry-${cat}`,
+				tier: 'swarm',
+				lesson: `${cat} lesson`,
+				category: cat,
+				tags: [],
+				scope: 'global',
+				confidence: 0.8,
+				status: 'established',
+				confirmed_by: [],
+				retrieval_outcomes: {
+					applied_count: 0,
+					succeeded_after_count: 0,
+					failed_after_count: 0,
+				},
+				schema_version: 1,
+				created_at: '2024-01-01T00:00:00Z',
+				updated_at: '2024-01-01T00:00:00Z',
+				project_name: 'test-project',
+			}));
+			writeSwarmKnowledge(entries);
 			for (const cat of categories) {
-				const swarmData: SwarmKnowledgeEntry = {
-					id: `entry-${cat}`,
-					tier: 'swarm',
-					lesson: `${cat} lesson`,
-					category: cat,
-					tags: [],
-					scope: 'global',
-					confidence: 0.8,
-					status: 'established',
-					confirmed_by: [],
-					retrieval_outcomes: {
-						applied_count: 0,
-						succeeded_after_count: 0,
-						failed_after_count: 0,
-					},
-					schema_version: 1,
-					created_at: '2024-01-01T00:00:00Z',
-					updated_at: '2024-01-01T00:00:00Z',
-					project_name: 'test-project',
-				};
-				writeSwarmKnowledge([swarmData]);
-
 				const result = await knowledge_query.execute({
 					tier: 'swarm',
 					category: cat,


### PR DESCRIPTION
Closes #2283

## Summary

- `Applies all valid categories correctly` rewrote the SAME `.swarm/knowledge.jsonl` on each of ten iterations and re-read it immediately. On windows-latest that raced — the read served the previous iteration's content and the assertion failed on `integration`, the 8th of ten.
- It matters more than an ordinary flake because it fails inside **`merge_group`**, so every occurrence drops whichever PR is queued. It evicted PR #2261 and would keep costing a re-queue cycle for any PR in the repo.
- Fixed by **removing the race**, not masking it with a retry or a sleep: all ten entries are written once, then the queries run. The category filter already isolates each entry, so one write loses no coverage.
- Held at **exactly 1316 lines** so the FR-006 ratchet stays clean — this file is pre-existing debt at 1316 against a 500-line cap, so any growth would block.

## Invariant audit

- 1 (plugin init): not touched — test-only change.
- 2 (runtime portability): not touched.
- 3 (subprocesses): not touched — no spawn added or altered.
- 4 (.swarm containment): not touched — the fixture still writes only under its own `tmpDir/.swarm/`.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): **touched** — one test in `tests/unit/tools/knowledge-query.test.ts` restructured; assertions preserved, count unchanged at 42.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): not touched.

## Test plan

- [x] `bun test tests/unit/tools/knowledge-query.test.ts` — **42 pass / 0 fail, 5 consecutive runs** (same count as before the change; nothing dropped).
- [x] `bun run check:test-file-cap` — 0 new-file violations, 0 ratchet violations. File held at exactly its 1316-line baseline.
- [x] `bun run typecheck` — clean.
- [x] `bunx biome ci` on the changed file — clean.
- [ ] Not reproducible locally on Windows before the fix (5/5 passed pre-change too), so this is a race narrowed by reasoning about the mechanism plus the CI evidence, not by a local red-to-green transition. The write-then-immediately-read of one path in a tight ten-iteration loop is the only shared mutable state in the test, and the observed failure was exactly "read returned the prior iteration's content".

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

