### PR TITLE
fix(pr-review): report all findings-persistence violations with expected-vs-actual (#2277)

### DIFF
--- a/.opencode/skills/swarm-pr-review/SKILL.md
+++ b/.opencode/skills/swarm-pr-review/SKILL.md
@@ -683,8 +683,8 @@ Do not rely on conversation context to preserve review findings. On Profile A,
 use `write_pr_review_artifact` with `kind: "findings"`; the controller creates
 and appends `.swarm/pr-review/<run_id>/findings.jsonl` without granting generic
 write authority over `.swarm/`. On Profiles B/C, append the same records to a
-`findings.jsonl` ledger file in your harness's session/task workspace (never
-under `.swarm/`), with the review head SHA recorded at the top of the file.
+`findings.jsonl` ledger in your harness workspace (never under `.swarm/`), with
+the review head SHA recorded at the top.
 
 Each persisted finding record must include at least:
 
@@ -696,12 +696,11 @@ Minimum field contract:
 
 - `finding_id`: stable ID from the candidate/reviewer/critic ledger.
 - `status`: one of `PENDING`, `CONFIRMED`, `DISPROVED`, or `PRE_EXISTING`.
-- `file_line`: exact `file:line` reference, or `N/A` with reason when the
-  finding is cross-file or artifact-only.
-- `evidence`: compact source-backed proof, including lane/reviewer/critic IDs or
-  command output references when available.
-- `next_action`: the next required action, such as `route_to_reviewer`,
-  `route_to_critic`, `report`, `suppress_with_reason`, or `handoff_to_feedback`.
+- `file_line`: exact `file:line`, or `N/A` with reason when cross-file.
+- `evidence`: compact source-backed proof (lane/reviewer/critic IDs or command
+  output references when available).
+- `next_action`: `route_to_reviewer`, `route_to_critic`, `report`,
+  `suppress_with_reason`, or `handoff_to_feedback`.
 
 Persist after every major validation boundary (Profile A via the controller
 calls below; Profiles B/C by appending the same boundary-tagged records to the
@@ -718,17 +717,18 @@ ledger file):
    `boundary: "post_critic"` and update final status,
    severity/action notes in `evidence`, and final reporting or handoff action.
 
-Resume/reload procedure:
+**Enforced order, dispositions, and error reporting (Profile A).** Checkpoints
+are admitted only after the trigger evaluation completes, then strictly
+`post_explorer` → `post_reviewer` → `post_critic`, each requiring the prior
+checkpoint persisted; records must match the authoritative reviewer/critic
+verdict rows, and an invalid payload is rejected in ONE call listing every
+violation as `finding_id: field expected <value>, got <value>`. Full contract
+(write order, disposition matrix, severity-omission, handoff schema):
+references/findings-persistence-contract.md.
 
-1. Before continuing any compacted or resumed review, read the latest
-   `findings.jsonl` artifact and reconstruct the candidate/reviewer/critic
-   ledger from disk before dispatching more lanes.
-2. If the artifact is missing but a review context says prior lanes ran, stop and
-   surface the missing artifact as a coverage gap instead of reclassifying from
-   memory.
-3. Append new records rather than overwriting history unless the artifact format
-   explicitly tracks revisions; latest record for a `finding_id` wins during
-   reload.
+Resume/reload procedure: read the latest `findings.jsonl` and reconstruct the
+ledger from disk before dispatching more lanes; surface a missing artifact as a
+coverage gap, never reclassify from memory; append (latest record wins).
 
 ---
 
@@ -996,8 +996,8 @@ candidate parser rather than preview-text extraction:
 If a lane has `output_degraded: true`, no usable `output_ref`, or `transcript_incomplete: true` without typed positive-candidate recovery, apply the COVERAGE GATE (Phase 3). An incomplete base or micro discovery lane may proceed only when it is explicitly named by a `salvaged_workflow_lane_recoveries` entry whose `kind` is `transcript-incomplete-terminal-candidate`; that recovery validates the retained positive `[CANDIDATE]` row only. Council, reviewer, and critic lanes never qualify for this incomplete-transcript recovery and must retry. Recovery never validates `[CLEAN]`, candidate absence, an unowned sibling lane, or an incomplete lane with no matching entry. Do not use blocking or direct-Task fallbacks while the controller is active, mark affected candidates UNVERIFIED to proceed, or infer candidate absence from a preview. Under Profiles B/C, which have no typed recovery validation, a truncated, incomplete, empty, or attestation-free subagent report is the same lane-output failure and takes the same COVERAGE GATE.
 
 After candidate parsing and before reviewer dispatch, persist the post-explorer
-candidate ledger using the Review Finding Persistence contract. This is the
-durable recovery point for context compaction before Phase 6.
+candidate ledger; it is admitted only once trigger-eval completes — from then it
+is the durable recovery point for context compaction ahead of Phase 6.
 
 **Profiles B/C row convention:** without the parser, the `[CANDIDATE]` row
 format is the extraction contract itself. Explorers emit the rows directly in

--- a/.opencode/skills/swarm-pr-review/references/findings-persistence-contract.md
+++ b/.opencode/skills/swarm-pr-review/references/findings-persistence-contract.md
@@ -1,0 +1,102 @@
+# Findings Persistence Contract (Profile A)
+
+The enforced write order, per-boundary disposition matrix, severity semantics,
+error-reporting shape, and handoff schema for `write_pr_review_artifact`
+(issue #2277). The entry SKILL.md carries the summary; this reference is the
+full contract.
+
+## Enforced write order and prerequisites
+
+The controller admits findings checkpoints only in this exact sequence, each
+step a hard prerequisite for the next:
+
+1. Base lanes settle and micro lanes settle.
+2. `write_pr_review_trigger_eval` completes — every findings boundary is
+   refused until this artifact exists (the refusal names the producing call).
+3. `boundary: "post_explorer"` checkpoint: records must exactly cover the
+   discovered candidate inventory, every record `PENDING` with
+   `next_action: "route_to_reviewer"`. The coverage refusal lists the
+   `missing:`, `extra:`, and `duplicates:` ids.
+4. `boundary: "post_reviewer"` checkpoint: requires the persisted
+   `post_explorer` checkpoint and a settled reviewer phase.
+5. `boundary: "post_critic"` checkpoint: requires the persisted
+   `post_reviewer` checkpoint and a settled critic phase whenever any
+   CONFIRMED CRITICAL/HIGH/MEDIUM verdict exists.
+
+Writing a boundary after a later checkpoint already exists is also refused.
+Every ordering refusal names the missing prerequisite boundary. There is no
+durable findings checkpoint between explorer settlement and trigger-eval
+completion; from trigger-eval completion onward, the persisted ledger is the
+durable recovery point for context compaction.
+
+## Disposition matrix
+
+Records are validated against the authenticated reviewer/critic verdict rows,
+never against caller claims.
+
+| Reviewer verdict | expected `status` | expected `next_action` |
+| --- | --- | --- |
+| CONFIRMED CRITICAL/HIGH/MEDIUM | `CONFIRMED` | `route_to_critic` |
+| CONFIRMED LOW/INFO | `CONFIRMED` | `report` |
+| PRE_EXISTING | `PRE_EXISTING` | `report` |
+| DISPROVED | `DISPROVED` | `suppress_with_reason` |
+| UNVERIFIED | `PENDING` | `route_to_reviewer` |
+
+At `post_critic`, records the reviewer did NOT route to the critic keep the
+reviewer disposition above; critic-routed records follow the critic verdict:
+
+| Critic verdict | expected `status` | expected `next_action` |
+| --- | --- | --- |
+| DISPROVED | `DISPROVED` | `suppress_with_reason` |
+| UPHELD / DOWNGRADED (any non-DISPROVED) | `CONFIRMED` | `report` or `handoff_to_feedback` |
+
+At `post_explorer` every record must be `PENDING` with
+`next_action: "route_to_reviewer"`.
+
+## Severity semantics
+
+`severity` is optional at every boundary and is not validated on
+`post_explorer` records. When present it must equal the authoritative severity
+verbatim: the reviewer `final_severity` at `post_reviewer` (and for
+non-critic-routed records at `post_critic`); for critic-routed records at
+`post_critic` it must satisfy BOTH the reviewer and critic severities — so
+when the critic downgrades (reviewer `MEDIUM`, critic `LOW`), the only
+accepted record omits `severity` entirely until the severity-dialect
+unification lands (#2279). Omitting the field is accepted at every boundary.
+
+## Error reporting
+
+An invalid records payload is rejected in ONE call: every violation across
+every record is listed with the field, the expected value, and the actual
+value, sorted by finding_id — for example:
+
+```
+BLOCKED: PR_REVIEW post_reviewer artifact invalid — 4 violation(s):
+  C-0: status expected "DISPROVED", got "CONFIRMED"
+  C-0: next_action expected "suppress_with_reason", got "report"
+  C-1: next_action expected "route_to_critic", got "report"
+  C-1: severity expected "HIGH", got "LOW"
+```
+
+A critic-downgraded record that carries a severity is told the only passing
+value explicitly: `severity expected NONE (omit field; reviewer "MEDIUM" and
+critic "LOW" disagree), got "LOW"`. Repair every listed violation and resubmit
+in a single round trip; do not guess-and-retry one record at a time.
+
+## Handoff artifact schema
+
+The `kind: "handoff"` write is a different schema from findings records — no
+`boundary` and no `records` keys; it takes
+`handoff: {pr_url, finding_ids, summary, provenance}`, and `finding_ids` must
+exactly equal the set of latest records whose status is `CONFIRMED` and whose
+`next_action` is `handoff_to_feedback`.
+
+## Resume/reload detail
+
+Before continuing any compacted or resumed review, read the latest
+`findings.jsonl` artifact and reconstruct the candidate/reviewer/critic ledger
+from disk before dispatching more lanes. If the artifact is missing but a
+review context says prior lanes ran, stop and surface the missing artifact as
+a coverage gap instead of reclassifying from memory. Append new records rather
+than overwriting history unless the artifact format explicitly tracks
+revisions; the latest record for a `finding_id` wins during reload.

--- a/.opencode/skills/swarm-pr-review/references/findings-persistence-contract.md
+++ b/.opencode/skills/swarm-pr-review/references/findings-persistence-contract.md
@@ -49,6 +49,14 @@ reviewer disposition above; critic-routed records follow the critic verdict:
 | --- | --- | --- |
 | DISPROVED | `DISPROVED` | `suppress_with_reason` |
 | UPHELD / DOWNGRADED (any non-DISPROVED) | `CONFIRMED` | `report` or `handoff_to_feedback` |
+| no critic verdict for a critic-routed record | (defensive) | (defensive) |
+
+The "no critic verdict" row is defensive: through the controller the critic
+phase must already be settled over every critic-routed item before the
+`post_critic` boundary is admitted, so a critic-routed record without a critic
+verdict indicates an invariant break, not a caller mistake — the rejection
+reports `no authoritative critic verdict (absent from the settled critic map)`
+(and any reviewer-severity mismatch alongside it).
 
 At `post_explorer` every record must be `PENDING` with
 `next_action: "route_to_reviewer"`.

--- a/docs/releases/pending/2277-persistence-validator-errors.md
+++ b/docs/releases/pending/2277-persistence-validator-errors.md
@@ -1,0 +1,24 @@
+# All-at-once PR-review findings validation errors and a truthful persistence contract
+
+## What changed
+
+Persisting `/swarm pr-review` findings checkpoints now fails informatively instead of one record at a time (issue #2277).
+
+- **Every violation, one rejection.** `write_pr_review_artifact` with `kind: "findings"` previously rejected on the first failing check of the first failing record, with no expected-vs-actual values — a real review run needed 9 sequential rejected writes to discover the full contract. The validator now collects every violation across every record and throws once, each line naming the finding id, the field, the expected value, and the actual value, sorted by finding id:
+  ```
+  BLOCKED: PR_REVIEW post_reviewer artifact invalid — 4 violation(s):
+    C-0: status expected "DISPROVED", got "CONFIRMED"
+    C-0: next_action expected "suppress_with_reason", got "report"
+    C-1: next_action expected "route_to_critic", got "report"
+    C-1: severity expected "HIGH", got "LOW"
+  ```
+- **Severity-omission semantics made error-driven.** At `post_critic`, a critic-routed record whose reviewer and critic severities disagree can only satisfy both presence-guarded checks by omitting `severity`; that rejection now says so explicitly (`severity expected NONE (omit field; reviewer "MEDIUM" and critic "LOW" disagree), got "LOW"`) instead of surfacing as two unrelated single-check failures.
+- **Prerequisite and coverage refusals carry the remedy.** The trigger-evaluation prerequisite names the producing call (`write_pr_review_trigger_eval must complete first`); the candidate-inventory coverage check now lists `missing:`, `extra:`, and `duplicates:` ids in the same shape the dispatch-time ownership validator already uses; boundary-ordering refusals continue to name the missing prior checkpoint.
+- **The bundled `swarm-pr-review` skill now documents the enforced contract** instead of leaving it discoverable only by rejection: the exact write order (base lanes settle → micro lanes settle → trigger-eval → `post_explorer` → `post_reviewer` → `post_critic`, each findings boundary requiring the prior checkpoint and the completed trigger evaluation), the full disposition matrix for `status`/`next_action` at every boundary, the optional-`severity` semantics including the downgrade-omission rule (until the #2279 severity-dialect unification), the separate handoff schema, and the one-round-trip error-reporting behavior. The entry SKILL.md carries a compact summary and the full contract lives in `references/findings-persistence-contract.md` (progressive disclosure — the entry file stays at its 1988-line issue #2131 ratchet baseline). The "durable recovery point … before Phase 6" claim was corrected: there is no durable findings checkpoint between explorer settlement and trigger-eval completion.
+- No acceptance criteria changed: every predicate the validator enforced before it still enforces; only the error reporting and the documentation changed.
+
+## Why
+
+The discovered-by-failure contract made findings persistence a guess-and-retry loop that lower-tier orchestrators could not survive, and the skill's persistence-timing claim promised a checkpoint the controller structurally refuses until trigger evaluation completes. Validation predicates stay byte-identical — operators and orchestrators now learn the whole contract from one rejection and the skill states it up front.
+
+Closes #2277.

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -5019,7 +5019,7 @@ export async function assertPrReviewArtifactBoundary(
 	let state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
 	if (!state.prReviewTriggerEvalPath) {
 		throw new Error(
-			'BLOCKED: PR_REVIEW findings persistence requires the trigger evaluation artifact',
+			'BLOCKED: PR_REVIEW findings persistence requires the trigger evaluation artifact (write_pr_review_trigger_eval must complete first)',
 		);
 	}
 	const persistedBoundaries = state.prReviewArtifactBoundaries ?? [];
@@ -5110,8 +5110,17 @@ export async function assertPrReviewArtifactBoundary(
 		JSON.stringify(normalizedFindingIds) !==
 			JSON.stringify([...expectedFindingIds].sort())
 	) {
+		const actualSet = new Set(normalizedFindingIds);
+		const expectedSet = new Set(expectedFindingIds);
+		const missing = [...expectedSet].filter((id) => !actualSet.has(id));
+		const extra = [...actualSet].filter((id) => !expectedSet.has(id));
+		const duplicates = [
+			...new Set(
+				findingIds.filter((id, index) => findingIds.indexOf(id) !== index),
+			),
+		].sort();
 		throw new Error(
-			`BLOCKED: PR_REVIEW ${boundary} findings must exactly cover the discovered candidate inventory`,
+			`BLOCKED: PR_REVIEW ${boundary} findings must exactly cover the discovered candidate inventory; missing: ${missing.join(', ') || '(none)'}; extra: ${extra.join(', ') || '(none)'}; duplicates: ${duplicates.join(', ') || '(none)'}`,
 		);
 	}
 	return state;
@@ -5120,7 +5129,10 @@ export async function assertPrReviewArtifactBoundary(
 /**
  * Artifact records are a projection of lane receipts, never a caller-controlled
  * replacement for them. Keep their workflow status/action aligned with the
- * reviewer and critic rows that the gate already authenticated.
+ * reviewer and critic rows that the gate already authenticated. Every violation
+ * across every record is reported in a single rejection, one line per violation
+ * with the expected and actual value, so a caller repairs a payload in one
+ * round trip instead of one rejected write per defect (issue #2277).
  */
 export async function assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
 	directory: string,
@@ -5129,131 +5141,232 @@ export async function assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(
 	records: readonly PrReviewArtifactRecord[],
 ): Promise<void> {
 	const state = await requireBoundState(directory, sessionID, 'PR_REVIEW');
+	const violations: Array<{ findingId: string; detail: string }> = [];
+	const report = (
+		findingId: string,
+		field: string,
+		expected: string,
+		actual: string,
+	): void => {
+		violations.push({
+			findingId,
+			detail: `${field} expected ${expected}, got ${actual}`,
+		});
+	};
 	if (boundary === 'post_explorer') {
 		for (const record of records) {
-			if (
-				record.status !== 'PENDING' ||
-				record.next_action !== 'route_to_reviewer'
-			) {
-				throw new Error(
-					`BLOCKED: PR_REVIEW post_explorer record ${record.finding_id} must remain PENDING and route_to_reviewer`,
+			if (record.status !== 'PENDING') {
+				report(record.finding_id, 'status', '"PENDING"', `"${record.status}"`);
+			}
+			if (record.next_action !== 'route_to_reviewer') {
+				report(
+					record.finding_id,
+					'next_action',
+					'"route_to_reviewer"',
+					`"${record.next_action}"`,
 				);
 			}
 		}
-		return;
+	} else {
+		const ctx = await createPrReviewGateContext(directory, state);
+		// B1: this is the gate that used to emit the misleading "no authoritative
+		// reviewer verdict" per record. When the real cause is a settled-but-empty
+		// verdict map, the guarded accessors name that cause instead.
+		const reviewerVerdicts = authoritativeReviewerVerdictsForGate(
+			directory,
+			state,
+			ctx,
+			`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
+		);
+		const criticVerdicts =
+			boundary === 'post_critic'
+				? authoritativeCriticVerdictsForGate(
+						directory,
+						state,
+						ctx,
+						`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
+					)
+				: undefined;
+		for (const record of records) {
+			const reviewer = reviewerVerdicts.get(record.finding_id);
+			if (!reviewer) {
+				violations.push({
+					findingId: record.finding_id,
+					detail:
+						'no authoritative reviewer verdict (absent from the settled reviewer map)',
+				});
+				continue;
+			}
+			const requiresCritic =
+				reviewer.classification === 'CONFIRMED' &&
+				['CRITICAL', 'HIGH', 'MEDIUM'].includes(reviewer.severity);
+			const expectedStatus =
+				reviewer.classification === 'UNVERIFIED'
+					? 'PENDING'
+					: reviewer.classification;
+			if (boundary === 'post_reviewer') {
+				if (record.status !== expectedStatus) {
+					report(
+						record.finding_id,
+						'status',
+						`"${expectedStatus}"`,
+						`"${record.status}"`,
+					);
+				}
+				const expectedAction = requiresCritic
+					? 'route_to_critic'
+					: reviewer.classification === 'CONFIRMED' ||
+							reviewer.classification === 'PRE_EXISTING'
+						? 'report'
+						: reviewer.classification === 'DISPROVED'
+							? 'suppress_with_reason'
+							: 'route_to_reviewer';
+				if (record.next_action !== expectedAction) {
+					report(
+						record.finding_id,
+						'next_action',
+						`"${expectedAction}"`,
+						`"${record.next_action}"`,
+					);
+				}
+				if (record.severity && record.severity !== reviewer.severity) {
+					report(
+						record.finding_id,
+						'severity',
+						`"${reviewer.severity}"`,
+						`"${record.severity}"`,
+					);
+				}
+				continue;
+			}
+
+			// post_critic, non-critic-routed: the reviewer disposition is final.
+			if (!requiresCritic) {
+				const expectedAction =
+					reviewer.classification === 'CONFIRMED' ||
+					reviewer.classification === 'PRE_EXISTING'
+						? 'report'
+						: reviewer.classification === 'DISPROVED'
+							? 'suppress_with_reason'
+							: 'route_to_reviewer';
+				if (record.status !== expectedStatus) {
+					report(
+						record.finding_id,
+						'status',
+						`"${expectedStatus}"`,
+						`"${record.status}"`,
+					);
+				}
+				if (record.next_action !== expectedAction) {
+					report(
+						record.finding_id,
+						'next_action',
+						`"${expectedAction}"`,
+						`"${record.next_action}"`,
+					);
+				}
+				if (record.severity && record.severity !== reviewer.severity) {
+					report(
+						record.finding_id,
+						'severity',
+						`"${reviewer.severity}"`,
+						`"${record.severity}"`,
+					);
+				}
+				continue;
+			}
+
+			// post_critic, critic-routed: the critic verdict is authoritative.
+			const critic = criticVerdicts?.get(record.finding_id);
+			if (!critic) {
+				if (record.severity && record.severity !== reviewer.severity) {
+					report(
+						record.finding_id,
+						'severity',
+						`"${reviewer.severity}"`,
+						`"${record.severity}"`,
+					);
+				}
+				violations.push({
+					findingId: record.finding_id,
+					detail:
+						'no authoritative critic verdict (absent from the settled critic map)',
+				});
+				continue;
+			}
+			if (critic.status === 'DISPROVED') {
+				if (record.status !== 'DISPROVED') {
+					report(
+						record.finding_id,
+						'status',
+						'"DISPROVED"',
+						`"${record.status}"`,
+					);
+				}
+				if (record.next_action !== 'suppress_with_reason') {
+					report(
+						record.finding_id,
+						'next_action',
+						'"suppress_with_reason"',
+						`"${record.next_action}"`,
+					);
+				}
+			} else {
+				if (record.status !== 'CONFIRMED') {
+					report(
+						record.finding_id,
+						'status',
+						'"CONFIRMED"',
+						`"${record.status}"`,
+					);
+				}
+				if (!['report', 'handoff_to_feedback'].includes(record.next_action)) {
+					report(
+						record.finding_id,
+						'next_action',
+						'"report" or "handoff_to_feedback"',
+						`"${record.next_action}"`,
+					);
+				}
+			}
+			if (record.severity) {
+				if (reviewer.severity === critic.severity) {
+					if (record.severity !== reviewer.severity) {
+						report(
+							record.finding_id,
+							'severity',
+							`"${reviewer.severity}"`,
+							`"${record.severity}"`,
+						);
+					}
+				} else {
+					// The reviewer and critic severities disagree, so no present
+					// value satisfies both presence-guarded checks; omitting the
+					// optional field is the only passing option.
+					report(
+						record.finding_id,
+						'severity',
+						`NONE (omit field; reviewer "${reviewer.severity}" and critic "${critic.severity}" disagree)`,
+						`"${record.severity}"`,
+					);
+				}
+			}
+		}
 	}
-
-	const ctx = await createPrReviewGateContext(directory, state);
-	// B1: this is the gate that emits the misleading "no authoritative reviewer
-	// verdict" per record. When the real cause is a settled-but-empty verdict
-	// map, the guarded accessors name that cause instead.
-	const reviewerVerdicts = authoritativeReviewerVerdictsForGate(
-		directory,
-		state,
-		ctx,
-		`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
-	);
-	const criticVerdicts =
-		boundary === 'post_critic'
-			? authoritativeCriticVerdictsForGate(
-					directory,
-					state,
-					ctx,
-					`assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts(${boundary})`,
-				)
-			: undefined;
-	for (const record of records) {
-		const reviewer = reviewerVerdicts.get(record.finding_id);
-		if (!reviewer) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW ${boundary} record ${record.finding_id} has no authoritative reviewer verdict`,
-			);
-		}
-		if (record.severity && record.severity !== reviewer.severity) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW ${boundary} record ${record.finding_id} severity differs from its reviewer verdict`,
-			);
-		}
-		const requiresCritic =
-			reviewer.classification === 'CONFIRMED' &&
-			['CRITICAL', 'HIGH', 'MEDIUM'].includes(reviewer.severity);
-		if (boundary === 'post_reviewer') {
-			const expectedStatus =
-				reviewer.classification === 'UNVERIFIED'
-					? 'PENDING'
-					: reviewer.classification;
-			if (record.status !== expectedStatus) {
-				throw new Error(
-					`BLOCKED: PR_REVIEW post_reviewer record ${record.finding_id} status differs from its reviewer verdict`,
-				);
-			}
-			const expectedAction = requiresCritic
-				? 'route_to_critic'
-				: reviewer.classification === 'CONFIRMED' ||
-						reviewer.classification === 'PRE_EXISTING'
-					? 'report'
-					: reviewer.classification === 'DISPROVED'
-						? 'suppress_with_reason'
-						: 'route_to_reviewer';
-			if (record.next_action !== expectedAction) {
-				throw new Error(
-					`BLOCKED: PR_REVIEW post_reviewer record ${record.finding_id} action does not match reviewer disposition`,
-				);
-			}
-			continue;
-		}
-
-		if (!requiresCritic) {
-			const expectedStatus =
-				reviewer.classification === 'UNVERIFIED'
-					? 'PENDING'
-					: reviewer.classification;
-			const expectedAction =
-				reviewer.classification === 'CONFIRMED' ||
-				reviewer.classification === 'PRE_EXISTING'
-					? 'report'
-					: reviewer.classification === 'DISPROVED'
-						? 'suppress_with_reason'
-						: 'route_to_reviewer';
-			if (
-				record.status !== expectedStatus ||
-				record.next_action !== expectedAction
-			) {
-				throw new Error(
-					`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} cannot override its non-critic reviewer disposition`,
-				);
-			}
-			continue;
-		}
-
-		const critic = criticVerdicts?.get(record.finding_id);
-		if (!critic) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} has no authoritative critic verdict`,
-			);
-		}
-		if (record.severity && record.severity !== critic.severity) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} severity differs from its critic verdict`,
-			);
-		}
-		if (critic.status === 'DISPROVED') {
-			if (
-				record.status !== 'DISPROVED' ||
-				record.next_action !== 'suppress_with_reason'
-			) {
-				throw new Error(
-					`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} must preserve the critic DISPROVED disposition`,
-				);
-			}
-		} else if (
-			record.status !== 'CONFIRMED' ||
-			!['report', 'handoff_to_feedback'].includes(record.next_action)
-		) {
-			throw new Error(
-				`BLOCKED: PR_REVIEW post_critic record ${record.finding_id} action does not match its critic verdict`,
-			);
-		}
+	if (violations.length > 0) {
+		violations.sort((left, right) =>
+			left.findingId < right.findingId
+				? -1
+				: left.findingId > right.findingId
+					? 1
+					: 0,
+		);
+		const lines = violations.map(
+			(violation) => `  ${violation.findingId}: ${violation.detail}`,
+		);
+		throw new Error(
+			`BLOCKED: PR_REVIEW ${boundary} artifact invalid — ${violations.length} violation(s):\n${lines.join('\n')}`,
+		);
 	}
 }
 

--- a/tests/helpers/pr-review-artifact-fixtures.ts
+++ b/tests/helpers/pr-review-artifact-fixtures.ts
@@ -1,0 +1,309 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { storeLaneOutput } from '../../src/background/lane-output-store.js';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../src/background/pending-delegations.js';
+import {
+	activatePrWorkflow,
+	enforcePrReviewBaseDimensions,
+	markPrReviewTriggerEvaluationComplete,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
+	recordPrReviewValidationBatch,
+} from '../../src/hooks/pr-workflow-gate.js';
+import { executeWritePrReviewArtifact } from '../../src/tools/write-pr-review-artifact.js';
+
+export const PR_ARTIFACT_SESSION_ID = 'write-pr-review-artifact';
+export const PR_ARTIFACT_HEAD_SHA = 'abc123';
+export const PR_ARTIFACT_REVISION_DIGEST = 'revision-1';
+
+const MICRO_CANDIDATE_HEADER =
+	'[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence';
+
+/**
+ * Shared lane-persistence fixture for `write_pr_review_artifact` tests. These
+ * helpers own no lifecycle: they never touch `_test_exports`, install no
+ * beforeEach/afterEach, and create no directory — every importing test file
+ * keeps its own `_test_exports` snapshot/restore and its own temp root.
+ */
+export async function persistPrReviewBatch(
+	directory: string,
+	batchId: string,
+	mode: string,
+	lanes: ReadonlyArray<{ laneId: string; workflowLane: string }>,
+	options: {
+		status?: 'completed' | 'error';
+		head?: string;
+		empty?: boolean;
+		textOverride?: string;
+		transcriptIncomplete?: boolean;
+		artifactRole?: string;
+		subagentSessionId?: string;
+	} = {},
+): Promise<void> {
+	for (const [index, lane] of lanes.entries()) {
+		const correlationId = `${batchId}-${index}`;
+		const subagentSessionId = options.subagentSessionId ?? correlationId;
+		await recordPendingDelegation(directory, {
+			correlationId,
+			jobId: null,
+			subagentSessionId,
+			parentSessionId: PR_ARTIFACT_SESSION_ID,
+			callID: `call-${correlationId}`,
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId,
+			laneId: lane.laneId,
+			mode,
+			workflowLane: lane.workflowLane,
+			workspace: {
+				directory,
+				gitHead: PR_ARTIFACT_HEAD_SHA,
+				dirtyHash: null,
+				prHeadSha: options.head ?? PR_ARTIFACT_HEAD_SHA,
+				scope: null,
+			},
+		});
+		const text =
+			options.textOverride ??
+			(options.empty
+				? ''
+				: mode === 'swarm-pr-review:reviewer'
+					? '[REVIEWED] | C-001 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer'
+					: mode === 'swarm-pr-review:critic'
+						? '[CRITIC] | C-001 | UPHELD | HIGH | reason | no change'
+						: mode === 'swarm-pr-feedback:verification'
+							? `[FEEDBACK-VERIFIED] | ${lane.workflowLane} | CONFIRMED | evidence`
+							: `${mode === 'swarm-pr-review:micro' ? MICRO_CANDIDATE_HEADER : '[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence'}\nC-${index} | ${lane.workflowLane} | HIGH | correctness | file.ts:1 | claim | evidence | impact | HIGH`);
+		const stored = storeLaneOutput(directory, {
+			batchId,
+			laneId: lane.laneId,
+			agent: 'reviewer',
+			role: options.artifactRole ?? 'reviewer',
+			sessionId: subagentSessionId,
+			parentSessionId: PR_ARTIFACT_SESSION_ID,
+			mode,
+			workflowLane: lane.workflowLane,
+			prHeadSha: options.head ?? PR_ARTIFACT_HEAD_SHA,
+			gitHead: PR_ARTIFACT_HEAD_SHA,
+			revisionDigest: PR_ARTIFACT_REVISION_DIGEST,
+			source: 'collect_lane_results',
+			text,
+			transcriptIncomplete: options.transcriptIncomplete,
+		});
+		await appendDelegationTransition(directory, correlationId, {
+			status: options.status ?? 'completed',
+			result: {
+				text,
+				chars: stored.chars,
+				truncated: false,
+				digest: stored.digest,
+				...(stored.ref ? { outputRef: stored.ref } : {}),
+				...(options.transcriptIncomplete ? { transcriptIncomplete: true } : {}),
+			},
+		});
+	}
+}
+
+/**
+ * Drives the gate through base settlement, all eleven micro lanes, and trigger
+ * evaluation so a findings boundary write is admissible. Candidate inventory is
+ * the six base candidates C-0..C-5 (base lanes each contribute one candidate).
+ */
+export async function establishPrReviewPrerequisites(
+	directory: string,
+	runId: string = 'test-run',
+	sessionID: string = PR_ARTIFACT_SESSION_ID,
+	headSha: string = PR_ARTIFACT_HEAD_SHA,
+	options: { skipTriggerEvaluation?: boolean } = {},
+): Promise<void> {
+	await activatePrWorkflow(directory, sessionID, 'PR_REVIEW', {
+		prHeadSha: headSha,
+	});
+	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
+		laneId: workflowLane,
+		workflowLane,
+	}));
+	await enforcePrReviewBaseDimensions(directory, sessionID, baseLanes, {
+		batchId: 'base-all',
+		prHeadSha: headSha,
+	});
+	await persistPrReviewBatch(
+		directory,
+		'base-all',
+		'swarm-pr-review:base',
+		baseLanes,
+	);
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		const batchId = `micro-${index}`;
+		const laneId = `micro-lane-${index}`;
+		await persistPrReviewBatch(
+			directory,
+			batchId,
+			'swarm-pr-review:micro',
+			[{ laneId, workflowLane }],
+			{
+				textOverride: `${MICRO_CANDIDATE_HEADER}\n[CLEAN] | ${workflowLane} | exact reviewed diff | no finding after focused invariant review`,
+			},
+		);
+	}
+	const triggerRows: Array<Record<string, string>> = [];
+	for (const [
+		index,
+		workflowLane,
+	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
+		triggerRows.push({
+			trigger_id: workflowLane,
+			result: 'MATCHED',
+			evidence: `Test fixture evidence for ${workflowLane}`,
+			source_batch_id: `micro-${index}`,
+			source_lane_id: `micro-lane-${index}`,
+		});
+	}
+	const triggerRelative = path.join('pr-review', runId, 'trigger-eval.json');
+	const triggerAbsolute = path.join(directory, '.swarm', triggerRelative);
+	await fs.mkdir(path.dirname(triggerAbsolute), { recursive: true });
+	await fs.writeFile(
+		triggerAbsolute,
+		JSON.stringify({ rows: triggerRows }),
+		'utf-8',
+	);
+	if (options.skipTriggerEvaluation) return;
+	await markPrReviewTriggerEvaluationComplete(
+		directory,
+		sessionID,
+		runId,
+		triggerRelative,
+	);
+}
+
+export function reviewedRow(
+	id: string,
+	classification: string,
+	severity: string,
+): string {
+	return `[REVIEWED] | ${id} | ${classification} | STRUCTURALLY_PROVEN | ${severity} | YES | file.ts:1 | rationale text | probe output | reviewer`;
+}
+
+export async function settleReviewerPhase(
+	directory: string,
+	runId: string,
+	rows: readonly string[],
+	itemIds: readonly string[],
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		directory,
+		PR_ARTIFACT_SESSION_ID,
+		'reviewer',
+		[
+			{
+				laneId: `${runId}-rv`,
+				workflowLane: `${runId}-rv`,
+				reviewItemIds: [...itemIds],
+			},
+		],
+		{ batchId: `${runId}-rv`, prHeadSha: PR_ARTIFACT_HEAD_SHA },
+	);
+	await persistPrReviewBatch(
+		directory,
+		`${runId}-rv`,
+		'swarm-pr-review:reviewer',
+		[{ laneId: `${runId}-rv`, workflowLane: `${runId}-rv` }],
+		{ textOverride: rows.join('\n') },
+	);
+}
+
+export async function settleCriticPhase(
+	directory: string,
+	runId: string,
+	rows: readonly string[],
+	itemIds: readonly string[],
+): Promise<void> {
+	await recordPrReviewValidationBatch(
+		directory,
+		PR_ARTIFACT_SESSION_ID,
+		'critic',
+		[
+			{
+				laneId: `${runId}-cr`,
+				workflowLane: `${runId}-cr`,
+				reviewItemIds: [...itemIds],
+			},
+		],
+		{ batchId: `${runId}-cr`, prHeadSha: PR_ARTIFACT_HEAD_SHA },
+	);
+	await persistPrReviewBatch(
+		directory,
+		`${runId}-cr`,
+		'swarm-pr-review:critic',
+		[{ laneId: `${runId}-cr`, workflowLane: `${runId}-cr` }],
+		{ textOverride: rows.join('\n') },
+	);
+}
+
+export type ArtifactRecord = {
+	finding_id: string;
+	status: 'PENDING' | 'CONFIRMED' | 'DISPROVED' | 'PRE_EXISTING';
+	file_line: string;
+	evidence: string;
+	next_action:
+		| 'route_to_reviewer'
+		| 'route_to_critic'
+		| 'report'
+		| 'suppress_with_reason'
+		| 'handoff_to_feedback';
+	severity?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO' | 'NONE';
+};
+
+export function artifactRecord(
+	id: string,
+	status: ArtifactRecord['status'],
+	nextAction: ArtifactRecord['next_action'],
+	severity?: ArtifactRecord['severity'],
+): ArtifactRecord {
+	return {
+		finding_id: id,
+		status,
+		file_line: 'src/index.ts:1',
+		evidence: 'validator-errors fixture evidence',
+		next_action: nextAction,
+		...(severity ? { severity } : {}),
+	};
+}
+
+export function writePrReviewFindings(
+	directory: string,
+	runId: string,
+	boundary: 'post_explorer' | 'post_reviewer' | 'post_critic',
+	records: readonly ArtifactRecord[],
+): Promise<string> {
+	return executeWritePrReviewArtifact(
+		{
+			kind: 'findings',
+			run_id: runId,
+			pr_head_sha: PR_ARTIFACT_HEAD_SHA,
+			boundary,
+			records,
+		},
+		directory,
+		{ sessionID: PR_ARTIFACT_SESSION_ID },
+	);
+}
+
+export async function rejectionMessage(
+	promise: Promise<string>,
+): Promise<string> {
+	try {
+		await promise;
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+	throw new Error('expected the artifact write to be rejected');
+}

--- a/tests/unit/hooks/pr-workflow-gate-b1-invariant.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-b1-invariant.test.ts
@@ -349,7 +349,7 @@ describe('pr-workflow-gate B1 invariant: no false positives on the settled path'
 		// Not confusable with the B1 empty-map message.
 		expect(coverage?.message).not.toContain('after successful settlement');
 		expect(projection?.message).toContain(
-			`record ${BASE_IDS[0]} has no authoritative reviewer verdict`,
+			`${BASE_IDS[0]}: no authoritative reviewer verdict (absent from the settled reviewer map)`,
 		);
 		expect(projection?.message).not.toContain('internal invariant violated');
 	});

--- a/tests/unit/hooks/pr-workflow-gate-review-item-coherence.test.ts
+++ b/tests/unit/hooks/pr-workflow-gate-review-item-coherence.test.ts
@@ -395,7 +395,7 @@ describe('pr-workflow-gate item-keyed reviewer/critic coherence', () => {
 				],
 			),
 		).rejects.toThrow(
-			`record ${BASE_IDS[0]} has no authoritative reviewer verdict`,
+			`${BASE_IDS[0]}: no authoritative reviewer verdict (absent from the settled reviewer map)`,
 		);
 	});
 

--- a/tests/unit/tools/write-pr-review-artifact-boundary-errors.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact-boundary-errors.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import {
+	_test_exports,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { executeWritePrReviewArtifact } from '../../../src/tools/write-pr-review-artifact.js';
+import {
+	artifactRecord,
+	establishPrReviewPrerequisites,
+	PR_ARTIFACT_HEAD_SHA,
+	PR_ARTIFACT_REVISION_DIGEST,
+	PR_ARTIFACT_SESSION_ID,
+	rejectionMessage,
+	reviewedRow,
+	settleCriticPhase,
+	settleReviewerPhase,
+	writePrReviewFindings,
+} from '../../helpers/pr-review-artifact-fixtures.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const HEAD_SHA = PR_ARTIFACT_HEAD_SHA;
+const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+
+let directory = '';
+const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	_test_exports.resolveCurrentGitHeadAsync;
+const originalResolveRevisionDigest =
+	_test_exports.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	_test_exports.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	_test_exports.resolveIsWorkingTreeCleanAsync;
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('pr-artifact-boundary-errors-');
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
+	_test_exports.resolvePrWorkflowRevisionDigest = () =>
+		PR_ARTIFACT_REVISION_DIGEST;
+	_test_exports.resolveIsWorkingTreeClean = () => true;
+	_test_exports.resolveCurrentGitHeadAsync = async (dir) =>
+		_test_exports.resolveCurrentGitHead(dir);
+	_test_exports.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		_test_exports.resolveIsWorkingTreeClean(dir);
+});
+
+afterEach(async () => {
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	_test_exports.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	_test_exports.resolvePrWorkflowRevisionDigest = originalResolveRevisionDigest;
+	_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	_test_exports.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+describe('write_pr_review_artifact boundary and coverage errors (issue #2277)', () => {
+	test('boundary-ordering refusal names the missing prerequisite boundary', async () => {
+		await establishPrReviewPrerequisites(directory, 'order-run');
+		await settleReviewerPhase(
+			directory,
+			'order-run',
+			[
+				reviewedRow('C-0', 'DISPROVED', 'LOW'),
+				...candidateIds
+					.slice(1)
+					.map((id) => reviewedRow(id, 'CONFIRMED', 'LOW')),
+			],
+			candidateIds,
+		);
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'order-run', 'post_reviewer', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				...candidateIds
+					.slice(1)
+					.map((id) => artifactRecord(id, 'CONFIRMED', 'report')),
+			]),
+		);
+		expect(message).toBe(
+			'BLOCKED: PR_REVIEW post_reviewer findings require the prior post_explorer checkpoint',
+		);
+	});
+
+	test('trigger-eval prerequisite refusal names the producing call', async () => {
+		await establishPrReviewPrerequisites(
+			directory,
+			'no-trigger',
+			PR_ARTIFACT_SESSION_ID,
+			HEAD_SHA,
+			{ skipTriggerEvaluation: true },
+		);
+		const message = await rejectionMessage(
+			writePrReviewFindings(
+				directory,
+				'no-trigger',
+				'post_explorer',
+				candidateIds.map((id) =>
+					artifactRecord(id, 'PENDING', 'route_to_reviewer'),
+				),
+			),
+		);
+		expect(message).toBe(
+			'BLOCKED: PR_REVIEW findings persistence requires the trigger evaluation artifact (write_pr_review_trigger_eval must complete first)',
+		);
+	});
+
+	test('inventory-coverage refusal lists missing, extra, and duplicate ids', async () => {
+		await establishPrReviewPrerequisites(directory, 'coverage-run');
+		const missingMessage = await rejectionMessage(
+			writePrReviewFindings(
+				directory,
+				'coverage-run',
+				'post_explorer',
+				candidateIds
+					.slice(0, -1)
+					.map((id) => artifactRecord(id, 'PENDING', 'route_to_reviewer')),
+			),
+		);
+		expect(missingMessage).toBe(
+			'BLOCKED: PR_REVIEW post_explorer findings must exactly cover the discovered candidate inventory; missing: C-5; extra: (none); duplicates: (none)',
+		);
+		const duplicateMessage = await rejectionMessage(
+			writePrReviewFindings(directory, 'coverage-run', 'post_explorer', [
+				artifactRecord('C-0', 'PENDING', 'route_to_reviewer'),
+				artifactRecord('C-0', 'PENDING', 'route_to_reviewer'),
+				...candidateIds
+					.slice(1, -1)
+					.map((id) => artifactRecord(id, 'PENDING', 'route_to_reviewer')),
+			]),
+		);
+		expect(duplicateMessage).toBe(
+			'BLOCKED: PR_REVIEW post_explorer findings must exactly cover the discovered candidate inventory; missing: C-5; extra: (none); duplicates: C-0',
+		);
+	});
+
+	test('empty records stay a tool-level schema rejection, not a validator rejection', async () => {
+		await establishPrReviewPrerequisites(directory, 'empty-run');
+		const result = await executeWritePrReviewArtifact(
+			{
+				kind: 'findings',
+				run_id: 'empty-run',
+				pr_head_sha: HEAD_SHA,
+				boundary: 'post_explorer',
+				records: [],
+			},
+			directory,
+			{ sessionID: PR_ARTIFACT_SESSION_ID },
+		);
+		expect(result).toContain('"success": false');
+		expect(result).toContain('records');
+		expect(result).not.toContain('artifact invalid');
+	});
+
+	test('clean multi-record payloads still pass at every boundary (no acceptance loosening)', async () => {
+		await establishPrReviewPrerequisites(directory, 'clean-run');
+		await settleReviewerPhase(
+			directory,
+			'clean-run',
+			[
+				reviewedRow('C-0', 'DISPROVED', 'LOW'),
+				reviewedRow('C-1', 'CONFIRMED', 'MEDIUM'),
+				reviewedRow('C-2', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-3', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-4', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-5', 'CONFIRMED', 'LOW'),
+			],
+			candidateIds,
+		);
+		await settleCriticPhase(
+			directory,
+			'clean-run',
+			['[CRITIC] | C-1 | DOWNGRADED | LOW | rationale | suggested change'],
+			['C-1'],
+		);
+		await expect(
+			writePrReviewFindings(
+				directory,
+				'clean-run',
+				'post_explorer',
+				candidateIds.map((id) =>
+					artifactRecord(id, 'PENDING', 'route_to_reviewer'),
+				),
+			),
+		).resolves.toContain('"success": true');
+		await expect(
+			writePrReviewFindings(directory, 'clean-run', 'post_reviewer', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		).resolves.toContain('"success": true');
+		await expect(
+			writePrReviewFindings(directory, 'clean-run', 'post_critic', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'report'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		).resolves.toContain('"success": true');
+	});
+});

--- a/tests/unit/tools/write-pr-review-artifact-boundary-errors.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact-boundary-errors.test.ts
@@ -136,6 +136,32 @@ describe('write_pr_review_artifact boundary and coverage errors (issue #2277)', 
 		expect(duplicateMessage).toBe(
 			'BLOCKED: PR_REVIEW post_explorer findings must exactly cover the discovered candidate inventory; missing: C-5; extra: (none); duplicates: C-0',
 		);
+		const nonConsecutiveDuplicateMessage = await rejectionMessage(
+			writePrReviewFindings(directory, 'coverage-run', 'post_explorer', [
+				artifactRecord('C-0', 'PENDING', 'route_to_reviewer'),
+				artifactRecord('C-1', 'PENDING', 'route_to_reviewer'),
+				artifactRecord('C-0', 'PENDING', 'route_to_reviewer'),
+				...candidateIds
+					.slice(2, -1)
+					.map((id) => artifactRecord(id, 'PENDING', 'route_to_reviewer')),
+			]),
+		);
+		expect(nonConsecutiveDuplicateMessage).toBe(
+			'BLOCKED: PR_REVIEW post_explorer findings must exactly cover the discovered candidate inventory; missing: C-5; extra: (none); duplicates: C-0',
+		);
+		const extraIdMessage = await rejectionMessage(
+			writePrReviewFindings(
+				directory,
+				'coverage-run',
+				'post_explorer',
+				candidateIds
+					.map((id) => artifactRecord(id, 'PENDING', 'route_to_reviewer'))
+					.concat(artifactRecord('C-9', 'PENDING', 'route_to_reviewer')),
+			),
+		);
+		expect(extraIdMessage).toBe(
+			'BLOCKED: PR_REVIEW post_explorer findings must exactly cover the discovered candidate inventory; missing: (none); extra: C-9; duplicates: (none)',
+		);
 	});
 
 	test('empty records stay a tool-level schema rejection, not a validator rejection', async () => {

--- a/tests/unit/tools/write-pr-review-artifact-validator-errors.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact-validator-errors.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import {
+	_test_exports,
+	PR_REVIEW_BASE_DIMENSION_IDS,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	artifactRecord,
+	establishPrReviewPrerequisites,
+	PR_ARTIFACT_HEAD_SHA,
+	PR_ARTIFACT_REVISION_DIGEST,
+	PR_ARTIFACT_SESSION_ID,
+	rejectionMessage,
+	reviewedRow,
+	settleCriticPhase,
+	settleReviewerPhase,
+	writePrReviewFindings,
+} from '../../helpers/pr-review-artifact-fixtures.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const HEAD_SHA = PR_ARTIFACT_HEAD_SHA;
+const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
+	(_dimension, index) => `C-${index}`,
+);
+
+let directory = '';
+const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
+const originalResolveCurrentGitHeadAsync =
+	_test_exports.resolveCurrentGitHeadAsync;
+const originalResolveRevisionDigest =
+	_test_exports.resolvePrWorkflowRevisionDigest;
+const originalResolveIsWorkingTreeClean =
+	_test_exports.resolveIsWorkingTreeClean;
+const originalResolveIsWorkingTreeCleanAsync =
+	_test_exports.resolveIsWorkingTreeCleanAsync;
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('pr-artifact-validator-errors-');
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = () => HEAD_SHA;
+	_test_exports.resolvePrWorkflowRevisionDigest = () =>
+		PR_ARTIFACT_REVISION_DIGEST;
+	_test_exports.resolveIsWorkingTreeClean = () => true;
+	_test_exports.resolveCurrentGitHeadAsync = async (dir) =>
+		_test_exports.resolveCurrentGitHead(dir);
+	_test_exports.resolveIsWorkingTreeCleanAsync = async (dir) =>
+		_test_exports.resolveIsWorkingTreeClean(dir);
+});
+
+afterEach(async () => {
+	_test_exports.resetTrackedStateCache();
+	_test_exports.resolveCurrentGitHead = originalResolveCurrentGitHead;
+	_test_exports.resolveCurrentGitHeadAsync = originalResolveCurrentGitHeadAsync;
+	_test_exports.resolvePrWorkflowRevisionDigest = originalResolveRevisionDigest;
+	_test_exports.resolveIsWorkingTreeClean = originalResolveIsWorkingTreeClean;
+	_test_exports.resolveIsWorkingTreeCleanAsync =
+		originalResolveIsWorkingTreeCleanAsync;
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+function persistExplorerCheckpoint(runId: string): Promise<string> {
+	return writePrReviewFindings(
+		directory,
+		runId,
+		'post_explorer',
+		candidateIds.map((id) =>
+			artifactRecord(id, 'PENDING', 'route_to_reviewer'),
+		),
+	);
+}
+
+describe('write_pr_review_artifact validator errors (issue #2277)', () => {
+	test('GOLDEN: every violation across every record is reported in one rejection with expected-vs-actual', async () => {
+		await establishPrReviewPrerequisites(directory, 'golden-run');
+		await expect(persistExplorerCheckpoint('golden-run')).resolves.toContain(
+			'"success": true',
+		);
+		await settleReviewerPhase(
+			directory,
+			'golden-run',
+			[
+				reviewedRow('C-0', 'DISPROVED', 'LOW'),
+				...candidateIds
+					.slice(1)
+					.map((id) => reviewedRow(id, 'CONFIRMED', 'HIGH')),
+			],
+			candidateIds,
+		);
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'golden-run', 'post_reviewer', [
+				artifactRecord('C-0', 'CONFIRMED', 'report'),
+				artifactRecord('C-1', 'CONFIRMED', 'report', 'LOW'),
+				artifactRecord('C-2', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-3', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-4', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-5', 'CONFIRMED', 'route_to_critic'),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_reviewer artifact invalid — 4 violation(s):',
+				'  C-0: status expected "DISPROVED", got "CONFIRMED"',
+				'  C-0: next_action expected "suppress_with_reason", got "report"',
+				'  C-1: next_action expected "route_to_critic", got "report"',
+				'  C-1: severity expected "HIGH", got "LOW"',
+			].join('\n'),
+		);
+	});
+
+	test('post_explorer violations accumulate per field', async () => {
+		await establishPrReviewPrerequisites(directory, 'explorer-errs');
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'explorer-errs', 'post_explorer', [
+				artifactRecord('C-0', 'CONFIRMED', 'route_to_reviewer'),
+				artifactRecord('C-1', 'PENDING', 'report'),
+				artifactRecord('C-2', 'CONFIRMED', 'report', 'HIGH'),
+				artifactRecord('C-3', 'PENDING', 'route_to_reviewer'),
+				artifactRecord('C-4', 'PENDING', 'route_to_reviewer'),
+				artifactRecord('C-5', 'PENDING', 'route_to_reviewer'),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_explorer artifact invalid — 4 violation(s):',
+				'  C-0: status expected "PENDING", got "CONFIRMED"',
+				'  C-1: next_action expected "route_to_reviewer", got "report"',
+				'  C-2: status expected "PENDING", got "CONFIRMED"',
+				'  C-2: next_action expected "route_to_reviewer", got "report"',
+			].join('\n'),
+		);
+	});
+
+	test('DISPOSITION MATRIX: post_reviewer next_action expectations per reviewer classification', async () => {
+		await establishPrReviewPrerequisites(directory, 'matrix-run');
+		await expect(persistExplorerCheckpoint('matrix-run')).resolves.toContain(
+			'"success": true',
+		);
+		await settleReviewerPhase(
+			directory,
+			'matrix-run',
+			[
+				reviewedRow('C-0', 'CONFIRMED', 'CRITICAL'),
+				reviewedRow('C-1', 'CONFIRMED', 'HIGH'),
+				reviewedRow('C-2', 'CONFIRMED', 'MEDIUM'),
+				reviewedRow('C-3', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-4', 'PRE_EXISTING', 'MEDIUM'),
+				reviewedRow('C-5', 'DISPROVED', 'HIGH'),
+			],
+			candidateIds,
+		);
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'matrix-run', 'post_reviewer', [
+				artifactRecord('C-0', 'CONFIRMED', 'report'),
+				artifactRecord('C-1', 'CONFIRMED', 'report'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'PRE_EXISTING', 'report'),
+				artifactRecord('C-5', 'DISPROVED', 'report'),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_reviewer artifact invalid — 4 violation(s):',
+				'  C-0: next_action expected "route_to_critic", got "report"',
+				'  C-1: next_action expected "route_to_critic", got "report"',
+				'  C-2: next_action expected "route_to_critic", got "report"',
+				'  C-5: next_action expected "suppress_with_reason", got "report"',
+			].join('\n'),
+		);
+	});
+
+	test('DISPOSITION MATRIX: UNVERIFIED reviewer verdicts expect PENDING and route_to_reviewer', async () => {
+		await establishPrReviewPrerequisites(directory, 'unverified-run');
+		await expect(
+			persistExplorerCheckpoint('unverified-run'),
+		).resolves.toContain('"success": true');
+		await settleReviewerPhase(
+			directory,
+			'unverified-run',
+			[
+				reviewedRow('C-0', 'UNVERIFIED', 'HIGH'),
+				...candidateIds
+					.slice(1)
+					.map((id) => reviewedRow(id, 'CONFIRMED', 'LOW')),
+			],
+			candidateIds,
+		);
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'unverified-run', 'post_reviewer', [
+				artifactRecord('C-0', 'CONFIRMED', 'report'),
+				...candidateIds
+					.slice(1)
+					.map((id) => artifactRecord(id, 'CONFIRMED', 'report')),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_reviewer artifact invalid — 2 violation(s):',
+				'  C-0: status expected "PENDING", got "CONFIRMED"',
+				'  C-0: next_action expected "route_to_reviewer", got "report"',
+			].join('\n'),
+		);
+	});
+
+	test('post_critic severity disagreement names omission as the only passing value', async () => {
+		await establishPrReviewPrerequisites(directory, 'downgrade-run');
+		await settleReviewerPhase(
+			directory,
+			'downgrade-run',
+			[
+				reviewedRow('C-0', 'DISPROVED', 'LOW'),
+				reviewedRow('C-1', 'CONFIRMED', 'MEDIUM'),
+				reviewedRow('C-2', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-3', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-4', 'CONFIRMED', 'LOW'),
+				reviewedRow('C-5', 'CONFIRMED', 'LOW'),
+			],
+			candidateIds,
+		);
+		await settleCriticPhase(
+			directory,
+			'downgrade-run',
+			['[CRITIC] | C-1 | DOWNGRADED | LOW | rationale | suggested change'],
+			['C-1'],
+		);
+		await expect(persistExplorerCheckpoint('downgrade-run')).resolves.toContain(
+			'"success": true',
+		);
+		await expect(
+			writePrReviewFindings(directory, 'downgrade-run', 'post_reviewer', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		).resolves.toContain('"success": true');
+
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'downgrade-run', 'post_critic', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'report', 'LOW'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_critic artifact invalid — 1 violation(s):',
+				'  C-1: severity expected NONE (omit field; reviewer "MEDIUM" and critic "LOW" disagree), got "LOW"',
+			].join('\n'),
+		);
+
+		// The omission cell of the severity truth table: omitting the optional
+		// field is accepted even when the authorities disagree.
+		await expect(
+			writePrReviewFindings(directory, 'downgrade-run', 'post_critic', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'report'),
+				artifactRecord('C-2', 'CONFIRMED', 'report'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		).resolves.toContain('"success": true');
+	});
+
+	test('post_critic disposition matrix: critic DISPROVED preservation and non-critic override refusal', async () => {
+		await establishPrReviewPrerequisites(directory, 'critic-matrix');
+		await settleReviewerPhase(
+			directory,
+			'critic-matrix',
+			[
+				reviewedRow('C-0', 'DISPROVED', 'LOW'),
+				reviewedRow('C-1', 'CONFIRMED', 'HIGH'),
+				reviewedRow('C-2', 'CONFIRMED', 'HIGH'),
+				...candidateIds
+					.slice(3)
+					.map((id) => reviewedRow(id, 'CONFIRMED', 'LOW')),
+			],
+			candidateIds,
+		);
+		await settleCriticPhase(
+			directory,
+			'critic-matrix',
+			[
+				'[CRITIC] | C-1 | DISPROVED | NONE | rationale | no change',
+				'[CRITIC] | C-2 | UPHELD | HIGH | rationale | required change',
+			],
+			['C-1', 'C-2'],
+		);
+		await expect(persistExplorerCheckpoint('critic-matrix')).resolves.toContain(
+			'"success": true',
+		);
+		await expect(
+			writePrReviewFindings(directory, 'critic-matrix', 'post_reviewer', [
+				artifactRecord('C-0', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-1', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-2', 'CONFIRMED', 'route_to_critic'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		).resolves.toContain('"success": true');
+
+		const message = await rejectionMessage(
+			writePrReviewFindings(directory, 'critic-matrix', 'post_critic', [
+				artifactRecord('C-0', 'CONFIRMED', 'report'),
+				artifactRecord('C-1', 'CONFIRMED', 'report'),
+				artifactRecord('C-2', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-3', 'CONFIRMED', 'report'),
+				artifactRecord('C-4', 'CONFIRMED', 'report'),
+				artifactRecord('C-5', 'CONFIRMED', 'report'),
+			]),
+		);
+		expect(message).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_critic artifact invalid — 6 violation(s):',
+				'  C-0: status expected "DISPROVED", got "CONFIRMED"',
+				'  C-0: next_action expected "suppress_with_reason", got "report"',
+				'  C-1: status expected "DISPROVED", got "CONFIRMED"',
+				'  C-1: next_action expected "suppress_with_reason", got "report"',
+				'  C-2: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-2: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+			].join('\n'),
+		);
+	});
+});

--- a/tests/unit/tools/write-pr-review-artifact-validator-errors.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact-validator-errors.test.ts
@@ -306,11 +306,13 @@ describe('write_pr_review_artifact validator errors (issue #2277)', () => {
 			]),
 		).resolves.toContain('"success": true');
 
+		// C-2's reviewer and critic severities AGREE (both HIGH), so its present
+		// but differing severity pins the agreement cell of the truth table.
 		const message = await rejectionMessage(
 			writePrReviewFindings(directory, 'critic-matrix', 'post_critic', [
 				artifactRecord('C-0', 'CONFIRMED', 'report'),
 				artifactRecord('C-1', 'CONFIRMED', 'report'),
-				artifactRecord('C-2', 'DISPROVED', 'suppress_with_reason'),
+				artifactRecord('C-2', 'DISPROVED', 'suppress_with_reason', 'LOW'),
 				artifactRecord('C-3', 'CONFIRMED', 'report'),
 				artifactRecord('C-4', 'CONFIRMED', 'report'),
 				artifactRecord('C-5', 'CONFIRMED', 'report'),
@@ -318,13 +320,14 @@ describe('write_pr_review_artifact validator errors (issue #2277)', () => {
 		);
 		expect(message).toBe(
 			[
-				'BLOCKED: PR_REVIEW post_critic artifact invalid — 6 violation(s):',
+				'BLOCKED: PR_REVIEW post_critic artifact invalid — 7 violation(s):',
 				'  C-0: status expected "DISPROVED", got "CONFIRMED"',
 				'  C-0: next_action expected "suppress_with_reason", got "report"',
 				'  C-1: status expected "DISPROVED", got "CONFIRMED"',
 				'  C-1: next_action expected "suppress_with_reason", got "report"',
 				'  C-2: status expected "CONFIRMED", got "DISPROVED"',
 				'  C-2: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+				'  C-2: severity expected "HIGH", got "LOW"',
 			].join('\n'),
 		);
 	});

--- a/tests/unit/tools/write-pr-review-artifact.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact.test.ts
@@ -3,27 +3,25 @@ import { mkdtempSync, realpathSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { storeLaneOutput } from '../../../src/background/lane-output-store.js';
-import {
-	appendDelegationTransition,
-	recordPendingDelegation,
-} from '../../../src/background/pending-delegations.js';
 import {
 	_test_exports,
-	activatePrWorkflow,
 	completePrWorkflow,
-	enforcePrReviewBaseDimensions,
-	markPrReviewTriggerEvaluationComplete,
 	PR_REVIEW_BASE_DIMENSION_IDS,
-	PR_REVIEW_REQUIRED_MICRO_LANE_IDS,
 	readPrWorkflowGateState,
 	recordPrReviewValidationBatch,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import { executeWritePrReviewArtifact } from '../../../src/tools/write-pr-review-artifact.js';
+import {
+	establishPrReviewPrerequisites,
+	PR_ARTIFACT_HEAD_SHA,
+	PR_ARTIFACT_REVISION_DIGEST,
+	PR_ARTIFACT_SESSION_ID,
+	persistPrReviewBatch,
+} from '../../helpers/pr-review-artifact-fixtures.js';
 
-const SESSION_ID = 'write-pr-review-artifact';
-const HEAD_SHA = 'abc123';
-const REVISION_DIGEST = 'revision-1';
+const SESSION_ID = PR_ARTIFACT_SESSION_ID;
+const HEAD_SHA = PR_ARTIFACT_HEAD_SHA;
+const REVISION_DIGEST = PR_ARTIFACT_REVISION_DIGEST;
 
 let directory = '';
 const originalResolveCurrentGitHead = _test_exports.resolveCurrentGitHead;
@@ -61,148 +59,9 @@ afterEach(async () => {
 	await fs.rm(directory, { recursive: true, force: true });
 });
 
-async function persistPrReviewBatch(
-	batchId: string,
-	mode: string,
-	lanes: ReadonlyArray<{ laneId: string; workflowLane: string }>,
-	options: {
-		status?: 'completed' | 'error';
-		head?: string;
-		empty?: boolean;
-		textOverride?: string;
-		transcriptIncomplete?: boolean;
-		artifactRole?: string;
-		subagentSessionId?: string;
-	} = {},
-): Promise<void> {
-	for (const [index, lane] of lanes.entries()) {
-		const correlationId = `${batchId}-${index}`;
-		const subagentSessionId = options.subagentSessionId ?? correlationId;
-		await recordPendingDelegation(directory, {
-			correlationId,
-			jobId: null,
-			subagentSessionId,
-			parentSessionId: SESSION_ID,
-			callID: `call-${correlationId}`,
-			normalizedAgent: 'reviewer',
-			swarmPrefixedAgent: 'reviewer',
-			planTaskId: null,
-			evidenceTaskId: null,
-			batchId,
-			laneId: lane.laneId,
-			mode,
-			workflowLane: lane.workflowLane,
-			workspace: {
-				directory,
-				gitHead: HEAD_SHA,
-				dirtyHash: null,
-				prHeadSha: options.head ?? HEAD_SHA,
-				scope: null,
-			},
-		});
-		const text =
-			options.textOverride ??
-			(options.empty
-				? ''
-				: mode === 'swarm-pr-review:reviewer'
-					? '[REVIEWED] | C-001 | CONFIRMED | STRUCTURALLY_PROVEN | HIGH | YES | file.ts:1 | rationale | probe | reviewer'
-					: mode === 'swarm-pr-review:critic'
-						? '[CRITIC] | C-001 | UPHELD | HIGH | reason | no change'
-						: mode === 'swarm-pr-feedback:verification'
-							? `[FEEDBACK-VERIFIED] | ${lane.workflowLane} | CONFIRMED | evidence`
-							: `${mode === 'swarm-pr-review:micro' ? '[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence' : '[CANDIDATE] | candidate_id | lane | severity | category | file:line | claim | evidence_summary | impact_context | confidence'}\nC-${index} | ${lane.workflowLane} | HIGH | correctness | file.ts:1 | claim | evidence | impact | HIGH`);
-		const stored = storeLaneOutput(directory, {
-			batchId,
-			laneId: lane.laneId,
-			agent: 'reviewer',
-			role: options.artifactRole ?? 'reviewer',
-			sessionId: subagentSessionId,
-			parentSessionId: SESSION_ID,
-			mode,
-			workflowLane: lane.workflowLane,
-			prHeadSha: options.head ?? HEAD_SHA,
-			gitHead: HEAD_SHA,
-			revisionDigest: REVISION_DIGEST,
-			source: 'collect_lane_results',
-			text,
-			transcriptIncomplete: options.transcriptIncomplete,
-		});
-		await appendDelegationTransition(directory, correlationId, {
-			status: options.status ?? 'completed',
-			result: {
-				text,
-				chars: stored.chars,
-				truncated: false,
-				digest: stored.digest,
-				...(stored.ref ? { outputRef: stored.ref } : {}),
-				...(options.transcriptIncomplete ? { transcriptIncomplete: true } : {}),
-			},
-		});
-	}
-}
-
-async function establishPrReviewPrerequisites(
-	runId: string = 'test-run',
-): Promise<void> {
-	await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
-		prHeadSha: HEAD_SHA,
-	});
-	const baseLanes = PR_REVIEW_BASE_DIMENSION_IDS.map((workflowLane) => ({
-		laneId: workflowLane,
-		workflowLane,
-	}));
-	await enforcePrReviewBaseDimensions(directory, SESSION_ID, baseLanes, {
-		batchId: 'base-all',
-		prHeadSha: HEAD_SHA,
-	});
-	await persistPrReviewBatch('base-all', 'swarm-pr-review:base', baseLanes);
-	for (const [
-		index,
-		workflowLane,
-	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
-		const batchId = `micro-${index}`;
-		const laneId = `micro-lane-${index}`;
-		await persistPrReviewBatch(
-			batchId,
-			'swarm-pr-review:micro',
-			[{ laneId, workflowLane }],
-			{
-				textOverride: `[CANDIDATE] | candidate_id | micro_lane | severity | category | file:line | claim | invariant_violated | evidence_summary | confidence\n[CLEAN] | ${workflowLane} | exact reviewed diff | no finding after focused invariant review`,
-			},
-		);
-	}
-	const triggerRows: Array<Record<string, string>> = [];
-	for (const [
-		index,
-		workflowLane,
-	] of PR_REVIEW_REQUIRED_MICRO_LANE_IDS.entries()) {
-		triggerRows.push({
-			trigger_id: workflowLane,
-			result: 'MATCHED',
-			evidence: `Test fixture evidence for ${workflowLane}`,
-			source_batch_id: `micro-${index}`,
-			source_lane_id: `micro-lane-${index}`,
-		});
-	}
-	const triggerRelative = path.join('pr-review', runId, 'trigger-eval.json');
-	const triggerAbsolute = path.join(directory, '.swarm', triggerRelative);
-	await fs.mkdir(path.dirname(triggerAbsolute), { recursive: true });
-	await fs.writeFile(
-		triggerAbsolute,
-		JSON.stringify({ rows: triggerRows }),
-		'utf-8',
-	);
-	await markPrReviewTriggerEvaluationComplete(
-		directory,
-		SESSION_ID,
-		runId,
-		triggerRelative,
-	);
-}
-
 describe('write_pr_review_artifact', () => {
 	test('ARTIFACT-ORDER regression: requires explorer, reviewer, then critic checkpoints', async () => {
-		await establishPrReviewPrerequisites('coverage-order');
+		await establishPrReviewPrerequisites(directory, 'coverage-order');
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
 		);
@@ -281,7 +140,7 @@ describe('write_pr_review_artifact', () => {
 	});
 
 	test('ARTIFACT-VERDICT regression: persists only reviewer and critic-authoritative dispositions', async () => {
-		await establishPrReviewPrerequisites('review-boundaries');
+		await establishPrReviewPrerequisites(directory, 'review-boundaries');
 		const candidateIds = PR_REVIEW_BASE_DIMENSION_IDS.map(
 			(_dimension, index) => `C-${index}`,
 		);
@@ -335,6 +194,7 @@ describe('write_pr_review_artifact', () => {
 			{ batchId: 'review-boundaries', prHeadSha: HEAD_SHA },
 		);
 		await persistPrReviewBatch(
+			directory,
 			'review-boundaries',
 			'swarm-pr-review:reviewer',
 			[{ laneId: 'review-boundaries', workflowLane: 'review-boundaries' }],
@@ -357,6 +217,7 @@ describe('write_pr_review_artifact', () => {
 			{ batchId: 'critic-boundaries', prHeadSha: HEAD_SHA },
 		);
 		await persistPrReviewBatch(
+			directory,
 			'critic-boundaries',
 			'swarm-pr-review:critic',
 			[{ laneId: 'critic-boundaries', workflowLane: 'critic-boundaries' }],
@@ -392,7 +253,10 @@ describe('write_pr_review_artifact', () => {
 				directory,
 				{ sessionID: SESSION_ID },
 			),
-		).rejects.toThrow(/status differs from its reviewer verdict/i);
+			// All violations are reported at once with expected-vs-actual (issue #2277).
+		).rejects.toThrow(
+			/C-1: status expected "CONFIRMED", got "DISPROVED"[\s\S]*C-1: next_action expected "route_to_critic", got "suppress_with_reason"/,
+		);
 		await expect(
 			executeWritePrReviewArtifact(
 				{
@@ -409,7 +273,9 @@ describe('write_pr_review_artifact', () => {
 				directory,
 				{ sessionID: SESSION_ID },
 			),
-		).rejects.toThrow(/action does not match reviewer disposition/i);
+		).rejects.toThrow(
+			/C-0: next_action expected "suppress_with_reason", got "report"/,
+		);
 
 		await expect(
 			executeWritePrReviewArtifact(
@@ -440,7 +306,9 @@ describe('write_pr_review_artifact', () => {
 				directory,
 				{ sessionID: SESSION_ID },
 			),
-		).rejects.toThrow(/action does not match its critic verdict/i);
+		).rejects.toThrow(
+			/C-1: status expected "CONFIRMED", got "DISPROVED"[\s\S]*C-1: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"/,
+		);
 
 		await expect(
 			executeWritePrReviewArtifact(

--- a/tests/unit/tools/write-pr-review-artifact.test.ts
+++ b/tests/unit/tools/write-pr-review-artifact.test.ts
@@ -17,6 +17,7 @@ import {
 	PR_ARTIFACT_REVISION_DIGEST,
 	PR_ARTIFACT_SESSION_ID,
 	persistPrReviewBatch,
+	rejectionMessage,
 } from '../../helpers/pr-review-artifact-fixtures.js';
 
 const SESSION_ID = PR_ARTIFACT_SESSION_ID;
@@ -237,7 +238,7 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 		).resolves.toContain('"success": true');
-		await expect(
+		const reviewerOverrideMessage = await rejectionMessage(
 			executeWritePrReviewArtifact(
 				{
 					kind: 'findings',
@@ -254,8 +255,21 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 			// All violations are reported at once with expected-vs-actual (issue #2277).
-		).rejects.toThrow(
-			/C-1: status expected "CONFIRMED", got "DISPROVED"[\s\S]*C-1: next_action expected "route_to_critic", got "suppress_with_reason"/,
+		);
+		expect(reviewerOverrideMessage).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_reviewer artifact invalid — 10 violation(s):',
+				'  C-1: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-1: next_action expected "route_to_critic", got "suppress_with_reason"',
+				'  C-2: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-2: next_action expected "route_to_critic", got "suppress_with_reason"',
+				'  C-3: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-3: next_action expected "route_to_critic", got "suppress_with_reason"',
+				'  C-4: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-4: next_action expected "route_to_critic", got "suppress_with_reason"',
+				'  C-5: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-5: next_action expected "route_to_critic", got "suppress_with_reason"',
+			].join('\n'),
 		);
 		await expect(
 			executeWritePrReviewArtifact(
@@ -290,7 +304,7 @@ describe('write_pr_review_artifact', () => {
 				{ sessionID: SESSION_ID },
 			),
 		).resolves.toContain('"success": true');
-		await expect(
+		const criticOverrideMessage = await rejectionMessage(
 			executeWritePrReviewArtifact(
 				{
 					kind: 'findings',
@@ -306,8 +320,21 @@ describe('write_pr_review_artifact', () => {
 				directory,
 				{ sessionID: SESSION_ID },
 			),
-		).rejects.toThrow(
-			/C-1: status expected "CONFIRMED", got "DISPROVED"[\s\S]*C-1: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"/,
+		);
+		expect(criticOverrideMessage).toBe(
+			[
+				'BLOCKED: PR_REVIEW post_critic artifact invalid — 10 violation(s):',
+				'  C-1: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-1: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+				'  C-2: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-2: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+				'  C-3: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-3: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+				'  C-4: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-4: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+				'  C-5: status expected "CONFIRMED", got "DISPROVED"',
+				'  C-5: next_action expected "report" or "handoff_to_feedback", got "suppress_with_reason"',
+			].join('\n'),
 		);
 
 		await expect(


### PR DESCRIPTION
Closes #2277

## Summary

`write_pr_review_artifact` findings validation now reports **every violation in one rejection** instead of one record at a time, and the `swarm-pr-review` skill now documents the persistence contract it enforces instead of leaving it discoverable only by rejection.

- **All-at-once validation with expected-vs-actual** (`src/hooks/pr-workflow-gate.ts`, `assertPrReviewArtifactRecordsMatchAuthoritativeVerdicts`): every violation across every record is collected and thrown once, one line per violation — `<finding_id>: <field> expected <value>, got <value>` — sorted by finding id, modeled on the dispatch-time ownership validator's message shape. A payload the issue's run repaired through 9 sequential rejections now repairs in one round trip:
  ```
  BLOCKED: PR_REVIEW post_reviewer artifact invalid — 4 violation(s):
    C-0: status expected "DISPROVED", got "CONFIRMED"
    C-0: next_action expected "suppress_with_reason", got "report"
    C-1: next_action expected "route_to_critic", got "report"
    C-1: severity expected "HIGH", got "LOW"
  ```
- **Severity-omission made error-driven**: at `post_critic`, a critic-routed record whose reviewer and critic severities disagree can only pass by omitting `severity`; that rejection now says so (`severity expected NONE (omit field; reviewer "MEDIUM" and critic "LOW" disagree), got "LOW"`).
- **Precheck refusals carry the remedy**: the trigger-eval prerequisite names the producing call (`write_pr_review_trigger_eval must complete first`); the candidate-inventory coverage check lists `missing:`/`extra:`/`duplicates:` ids; boundary-ordering refusals continue to name the missing prior checkpoint (now exact-pinned).
- **SKILL.md truth-up** (`.opencode/skills/swarm-pr-review/SKILL.md` + new `references/findings-persistence-contract.md`): documents the enforced write order (base settle → micro settle → trigger-eval → `post_explorer` → `post_reviewer` → `post_critic`, each findings boundary requiring the prior checkpoint and the completed trigger evaluation), the full disposition matrix for `status`/`next_action`, the optional-`severity` semantics including the downgrade-omission rule (until #2279), the separate handoff schema, and the one-round-trip error reporting. Per the progressive-disclosure ratchet (issue #2131 G — the entry file may never grow past its 1988-line baseline), the entry SKILL.md carries a compact summary and the full contract lives in the new reference file; the entry file lands at exactly 1988 lines. The "durable recovery point … before Phase 6" claim is corrected: there is no durable findings checkpoint between explorer settlement and trigger-eval completion.
- **No acceptance loosening**: every predicate the validator enforced before it still enforces — verified branch-by-branch by the independent reviewer and re-derived independently by the final critic; all 62 pre-existing interacting test files stay green (message pins updated to the new fragments with identical rejection semantics).
- Test fixtures shared by the artifact tests were extracted to `tests/helpers/pr-review-artifact-fixtures.ts` (the previous test file was at the 500-line cap); helpers own no lifecycle and never touch `_test_exports` (invariant 7).

## Invariant audit

- 1 (plugin init): not touched — no init-path code; validator runs only inside the `write_pr_review_artifact` tool call.
- 2 (runtime portability): not touched — no `bun:`/`Bun.*` usage, no bundle/entry-shape change; `bun run build` completed and `tsc --noEmit` exit 0.
- 3 (subprocesses): not touched — no spawn changes.
- 4 (.swarm containment): not touched — no new paths; artifacts stay under `.swarm/pr-review/<run_id>/`.
- 5 (plan durability): not touched — no plan/ledger code.
- 6 (test_runner safety): not touched — validation ran via shell per-file loops.
- 7 (test writing): touched — bun:test only; `_test_exports` snapshot/restore per file (helpers mutate nothing, no `mock.module`, allowlist untouched); `os.tmpdir()`+`realpathSync(mkdtempSync())` everywhere; new test files 335/215 lines (<500); `check-test-file-cap` → "Ratchet violations: 0"; `check-test-clock` → passed; `check-mock-cleanup` → passed.
- 8 (session state): not touched — no new module-level state (violations array is call-local).
- 9 (guardrails/retry): not touched — error surface only; same fail-closed conditions.
- 10 (chat/system msg): touched (adjacent) — operator-facing `BLOCKED` error text made more informative; no chat-stream noise added; no message-shape changes.
- 11 (tool registration): not touched — no tool/agent-map/command changes; `bun run drift:check` → "✅ No drift detected across skills, tools, commands, agents, docs claims, and dependency freshness."
- 12 (release/cache): touched — fragment `docs/releases/pending/2277-persistence-validator-errors.md` added; no version/CHANGELOG/manifest hand-edits.

## Test plan

- `bun test tests/unit/tools/write-pr-review-artifact-validator-errors.test.ts tests/unit/tools/write-pr-review-artifact-boundary-errors.test.ts tests/unit/tools/write-pr-review-artifact.test.ts` → **13 pass / 0 fail / 42 expect()** (post-review closeout commit `31f35ca6` additionally pins the agree-cell severity line, extra-id/non-consecutive-duplicate coverage cells, and exact full-message 10-violation pins for the two previously regex-only assertions) (golden all-at-once message, per-field accumulation, disposition matrix incl. UNVERIFIED, severity-omission + omission-pass control, critic matrix, boundary-order/trigger-eval/coverage refusals, empty-records tool-level pin, clean-payload control).
- Skill-surface pins after the progressive-disclosure restructure: `bun test` on progressive-disclosure-ratchet (1988 ≤ 1988), process-improvements-guidance, swarm-pr-review-dispatch-guidance, swarm-pr-review-runtime-friction-guidance, pr-workflow-checkout-bootstrap, drift-check-docs-claims, pr-review-recovery.integration → **65 pass / 0 fail**.
- Per-file isolation loop over `tests/unit/hooks/pr-workflow-gate*.test.ts` + `tests/unit/tools/write-pr-review*.test.ts` + `tests/unit/commands/pr-feedback-transition.test.ts` → **PASS=62 FAIL=0**.
- Reproduction: with HEAD's validator restored temporarily, the new golden suite fails 0/6 with the old single-violation message (`record C-0 status differs from its reviewer verdict`); with this branch it passes 6/6.
- `bun run typecheck` → exit 0. `bun run build` → success. `bunx biome check --write` on touched files → clean. `bun run drift:check` → clean. `sh scripts/check-test-file-cap.sh` / `check-test-clock.sh` / `check-mock-cleanup.sh` → all passed.

Reviewed through the full swarm gates: plan critic (Kimi K3, NEEDS_REVISION items folded) → independent implementation reviewer (Kimi K2.7, APPROVE — predicate equivalence verified per branch) → final critic (Kimi K3, APPROVE — closure claim independently re-verified).
