### PR TITLE
fix(knowledge-gate): make gate denial ack format self-discoverable and surface directive content

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -461,13 +461,14 @@ The Architect prompt requires inspecting this block before:
 4. Calling `phase_complete`.
 5. Escalating or invoking `skill_improve`.
 
-For each applicable directive, the Architect emits:
+For each applicable directive, the Architect emits the exact colon-separated token pair
+carried by the block above (the `(trace_id, entry_id)` pair, not a bare entry id):
 
-- `KNOWLEDGE_APPLIED: <id>` — directive observed in the next compliant action.
-- `KNOWLEDGE_N_A: <id> reason=<short>` — does not apply this turn (neutral).
-- `KNOWLEDGE_IGNORED: <id> reason=<short>` — judged relevant but deliberately not followed (counts against the directive).
-- `KNOWLEDGE_CONTRADICTED: <id> reason=<short>` — current authority or repository evidence disproves it.
-- `KNOWLEDGE_VIOLATED: <id> reason=<short>` — runtime evidence shows it was breached.
+- `KNOWLEDGE_APPLIED:<trace_id>:<entry_id>` — directive observed in the next compliant action.
+- `KNOWLEDGE_N_A:<trace_id>:<entry_id> reason=<short>` — does not apply this turn (neutral).
+- `KNOWLEDGE_IGNORED:<trace_id>:<entry_id> reason=<short>` — judged relevant but deliberately not followed (counts against the directive).
+- `KNOWLEDGE_CONTRADICTED:<trace_id>:<entry_id> reason=<short>` — current authority or repository evidence disproves it.
+- `KNOWLEDGE_VIOLATED:<trace_id>:<entry_id> reason=<short>` — runtime evidence shows it was breached.
 
 Chat-text markers (KNOWLEDGE_APPLIED/N_A/IGNORED/CONTRADICTED/VIOLATED) are the sole mechanism that
 satisfies the knowledge-application enforcement gate. The `knowledge_receipt` tool

--- a/docs/releases/pending/2299-gate-denial-ack-discoverability.md
+++ b/docs/releases/pending/2299-gate-denial-ack-discoverability.md
@@ -1,0 +1,42 @@
+# knowledge-gate: make the `KNOWLEDGE_ENFORCE_GATE_DENY` ack format self-discoverable
+
+## What changed
+
+The `KNOWLEDGE_ENFORCE_GATE_DENY` denial thrown by `src/hooks/knowledge-application-gate.ts`
+when an architect attempts a high-risk action with an unacknowledged critical
+knowledge directive now:
+
+- Renders unacknowledged memberships in a single canonical **colon** pair form
+  (`<trace_id>:<entry_id>`), matching the ack grammar — previously they were
+  shown as slash pairs (`trace/entry`) while the ack demanded colons.
+- Lists all five valid ack verbs (`KNOWLEDGE_APPLIED`, `KNOWLEDGE_IGNORED`,
+  `KNOWLEDGE_CONTRADICTED`, `KNOWLEDGE_N_A`, `KNOWLEDGE_VIOLATED`) with their
+  exact token grammar.
+- Emits one fully-instantiated, copy-pasteable ack line per unacknowledged
+  membership (`KNOWLEDGE_N_A:<trace_id>:<entry_id> reason=<reason>`), so the
+  architect can acknowledge correctly on the first retry instead of guessing the
+  format.
+- Surfaces the directive lesson content being acknowledged (looked up from the
+  knowledge store, best-effort) and, when content is not found, points the agent
+  at the most recent `<swarm_knowledge_directives>` block or `knowledge_recall`.
+
+## Why
+
+On v7.144.6 an architect misparsed the slash pair as two entry IDs, acked a
+wrong trace (rejected), and the correct recovery was undiscoverable until a
+post-hoc source read — wasting two delegations and ~10 idle minutes for a gate
+whose satisfaction was three tokens sitting in the denial text all along.
+
+## Migration
+
+No migration required. Enforcement semantics, exact-pair integrity, and the two
+bounded escape hatches (staleness TTL, denial-count clear) are unchanged. The
+audit `events.jsonl` internal pair formatting and the `swarmState.gateDenialCounts`
+keys are unchanged.
+
+## Known caveats
+
+- `docs/knowledge.md` previously documented a legacy one-token ack form
+  (`KNOWLEDGE_APPLIED: <id>`) that the V2 gate never accepts; it was corrected
+  to the exact-pair colon form in this release to match the deny message and the
+  architect prompt guidance.

--- a/src/hooks/knowledge-application-gate.ts
+++ b/src/hooks/knowledge-application-gate.ts
@@ -34,6 +34,7 @@
  * Non-architect agents are never gated.
  */
 
+import { existsSync } from 'node:fs';
 import { appendFile, mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
@@ -59,7 +60,15 @@ import {
 	queryLiveMemberships,
 	type ReceiptMembership,
 } from './knowledge-receipt-ledger.js';
-import type { MessageWithParts } from './knowledge-types.js';
+import {
+	readKnowledge,
+	resolveHiveKnowledgePath,
+	resolveSwarmKnowledgePath,
+} from './knowledge-store.js';
+import type {
+	MessageWithParts,
+	SwarmKnowledgeEntry,
+} from './knowledge-types.js';
 
 /** Tools that require knowledge-directive acknowledgment before execution. */
 export const HIGH_RISK_TOOLS = new Set([
@@ -141,6 +150,93 @@ function groupMembershipsByTrace(
 		byTrace.set(membership.trace_id, group);
 	}
 	return byTrace;
+}
+
+/**
+ * Best-effort lookup of directive lesson text by knowledge entry id, for
+ * surfacing the acknowledged content inside a gate denial (issue #2299).
+ *
+ * Reads the project-local swarm store always (cached by `readKnowledge` and
+ * bounded in size by the store's own knowledge cap) and the cross-project hive
+ * store only when the hive file exists. A hive entry can only be an
+ * unacknowledged architect-directive membership if it was displayed, which
+ * requires hive to have been enabled at display time, so reading it back here
+ * is not a fresh disclosure. Fail-open: any read error simply omits the
+ * content echo and never alters the denial outcome.
+ */
+export async function loadDirectiveContents(
+	directory: string,
+	entryIds: string[],
+): Promise<Map<string, string>> {
+	const contents = new Map<string, string>();
+	if (entryIds.length === 0) return contents;
+	const want = new Set(entryIds);
+	const sources: string[] = [resolveSwarmKnowledgePath(directory)];
+	try {
+		const hivePath = resolveHiveKnowledgePath();
+		if (existsSync(hivePath)) sources.push(hivePath);
+	} catch {
+		/* hive resolution unavailable — content echo is best-effort */
+	}
+	for (const filePath of sources) {
+		try {
+			const entries = await readKnowledge<SwarmKnowledgeEntry>(filePath);
+			for (const entry of entries) {
+				if (
+					want.has(entry.id) &&
+					!contents.has(entry.id) &&
+					typeof entry.lesson === 'string'
+				) {
+					contents.set(entry.id, entry.lesson);
+				}
+			}
+		} catch {
+			/* fail-open: never let content echo break the denial */
+		}
+	}
+	return contents;
+}
+
+/**
+ * Build the KNOWLEDGE_ENFORCE_GATE_DENY message (issue #2299). Renders
+ * unacknowledged memberships in the single canonical colon pair form
+ * `<trace_id>:<entry_id>`, lists every valid verb with its token grammar,
+ * and emits one fully-instantiated, copy-pasteable `KNOWLEDGE_N_A` example per
+ * membership plus the directive content being acknowledged.
+ */
+export function buildGateDenialMessage(
+	toolName: string,
+	memberships: ReceiptMembership[],
+	contents: Map<string, string>,
+): string {
+	const pairs = memberships.map((m) => `${m.trace_id}:${m.entry_id}`);
+	const examples = memberships.map(
+		(m) => `  KNOWLEDGE_N_A:${m.trace_id}:${m.entry_id} reason=<reason>`,
+	);
+	const contentLines = memberships.map((m) => {
+		const lesson = contents.get(m.entry_id);
+		return `  [${m.trace_id}:${m.entry_id}] ${
+			lesson ??
+			'content not found in knowledge store — see the most recent <swarm_knowledge_directives> block or run knowledge_recall'
+		}`;
+	});
+	return [
+		`KNOWLEDGE_ENFORCE_GATE_DENY: ${toolName} blocked — unacknowledged critical knowledge directive(s): ${pairs.join(', ')}.`,
+		'',
+		'Acknowledge each directive using its exact, colon-separated tokens (<trace_id>:<entry_id>) with one of these verb markers:',
+		'  KNOWLEDGE_APPLIED:<trace_id>:<entry_id>',
+		'  KNOWLEDGE_IGNORED:<trace_id>:<entry_id> reason=<short reason>',
+		'  KNOWLEDGE_CONTRADICTED:<trace_id>:<entry_id> reason=<observable conflict>',
+		'  KNOWLEDGE_N_A:<trace_id>:<entry_id> reason=<short reason>',
+		'  KNOWLEDGE_VIOLATED:<trace_id>:<entry_id> reason=<short reason>',
+		'KNOWLEDGE_N_A (does not apply; neutral) is a valid, penalty-free acknowledgment when the directive does not pertain to the current step.',
+		'',
+		'Copy-paste to acknowledge each directive now (replace <reason> with a short reason):',
+		...examples,
+		'',
+		'Directive content being acknowledged:',
+		...contentLines,
+	].join('\n');
 }
 
 /**
@@ -371,9 +467,9 @@ export async function knowledgeApplicationGateBefore(
 			return;
 		}
 
-		const ids = unackedPairs.join(', ');
+		const contents = await loadDirectiveContents(directory, unacked);
 		throw new Error(
-			`KNOWLEDGE_ENFORCE_GATE_DENY: ${toolName} blocked — critical knowledge membership(s) ${ids} require exact-pair KNOWLEDGE_APPLIED:<trace_id>:<entry_id>, KNOWLEDGE_N_A:<trace_id>:<entry_id> reason=... (does not apply; neutral), KNOWLEDGE_IGNORED:<trace_id>:<entry_id> reason=... (relevant but deliberately not followed), KNOWLEDGE_CONTRADICTED:<trace_id>:<entry_id> reason=..., or KNOWLEDGE_VIOLATED:<trace_id>:<entry_id> reason=... before this action.`,
+			buildGateDenialMessage(toolName, unackedMemberships, contents),
 		);
 	}
 	const unacked = [
@@ -521,4 +617,6 @@ export const _internals = {
 	writeWarnEvent,
 	selectCurrentArchitectDirectiveMemberships,
 	selectStaleUnmarkedMemberships,
+	loadDirectiveContents,
+	buildGateDenialMessage,
 };

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -1,7 +1,13 @@
 /** V2-authoritative knowledge application gate integration tests. */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import * as path from 'node:path';
 import {
 	buildAckDedupKey,
@@ -9,7 +15,6 @@ import {
 	parseAcknowledgments,
 	resolveApplicationLogPath,
 } from '../../../src/hooks/knowledge-application.js';
-import { resolveSwarmKnowledgePath } from '../../../src/hooks/knowledge-store.js';
 import {
 	knowledgeApplicationGateBefore,
 	knowledgeApplicationTransformScan,
@@ -20,6 +25,7 @@ import {
 	queryLiveMemberships,
 	validateAndCommitTerminalBatch,
 } from '../../../src/hooks/knowledge-receipt-ledger.js';
+import { resolveSwarmKnowledgePath } from '../../../src/hooks/knowledge-store.js';
 import type { MessageWithParts } from '../../../src/hooks/knowledge-types.js';
 import { swarmState } from '../../../src/state.js';
 import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
@@ -134,7 +140,10 @@ describe('knowledgeApplicationGateBefore V2 authority', () => {
 		const lesson = 'Always confirm exact-pair ack tokens before delegating.';
 		const swarmPath = resolveSwarmKnowledgePath(directory);
 		mkdirSync(path.dirname(swarmPath), { recursive: true });
-		writeFileSync(swarmPath, `${JSON.stringify({ id: ENTRY, tier: 'swarm', lesson })}\n`);
+		writeFileSync(
+			swarmPath,
+			`${JSON.stringify({ id: ENTRY, tier: 'swarm', lesson })}\n`,
+		);
 		await display('trace-discover');
 		const denial = await knowledgeApplicationGateBefore(
 			directory,

--- a/tests/unit/hooks/knowledge-application-gate.test.ts
+++ b/tests/unit/hooks/knowledge-application-gate.test.ts
@@ -1,13 +1,15 @@
 /** V2-authoritative knowledge application gate integration tests. */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import {
 	buildAckDedupKey,
 	DEFAULT_KNOWLEDGE_APPLICATION_CONFIG,
+	parseAcknowledgments,
 	resolveApplicationLogPath,
 } from '../../../src/hooks/knowledge-application.js';
+import { resolveSwarmKnowledgePath } from '../../../src/hooks/knowledge-store.js';
 import {
 	knowledgeApplicationGateBefore,
 	knowledgeApplicationTransformScan,
@@ -106,7 +108,7 @@ describe('knowledgeApplicationGateBefore V2 authority', () => {
 				{ tool: 'save_plan', agent: 'architect', sessionID: 'session-a' },
 				enforce,
 			),
-		).rejects.toThrow(new RegExp(`trace-pending/${ENTRY}`));
+		).rejects.toThrow(new RegExp(`trace-pending:${ENTRY}`));
 	});
 
 	it('denial message lists every accepted marker form including KNOWLEDGE_N_A (#2032 PRR-015)', async () => {
@@ -128,6 +130,103 @@ describe('knowledgeApplicationGateBefore V2 authority', () => {
 		expect(denial).toContain('KNOWLEDGE_VIOLATED:<trace_id>:<entry_id>');
 	});
 
+	it('renders canonical colon pairs, an instantiated example, and directive content echo (#2299)', async () => {
+		const lesson = 'Always confirm exact-pair ack tokens before delegating.';
+		const swarmPath = resolveSwarmKnowledgePath(directory);
+		mkdirSync(path.dirname(swarmPath), { recursive: true });
+		writeFileSync(swarmPath, `${JSON.stringify({ id: ENTRY, tier: 'swarm', lesson })}\n`);
+		await display('trace-discover');
+		const denial = await knowledgeApplicationGateBefore(
+			directory,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 'session-a' },
+			enforce,
+		).catch((err: unknown): string =>
+			err instanceof Error ? err.message : String(err),
+		);
+		expect(denial).toContain(`trace-discover:${ENTRY}`);
+		expect(denial).toContain(
+			`KNOWLEDGE_N_A:trace-discover:${ENTRY} reason=<reason>`,
+		);
+		expect(denial).toContain(lesson);
+	});
+
+	it('keeps the copy-paste example reason free of the neutral hint (#2299)', async () => {
+		await display('trace-hint');
+		const denial = await knowledgeApplicationGateBefore(
+			directory,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 'session-a' },
+			enforce,
+		).catch((err: unknown): string =>
+			err instanceof Error ? err.message : String(err),
+		);
+		const example = denial
+			.split('\n')
+			.map((line) => line.trim())
+			.find(
+				(line) =>
+					line.includes(`KNOWLEDGE_N_A:trace-hint:${ENTRY}`) &&
+					line.includes('reason='),
+			);
+		expect(example).toBeDefined();
+		const [ack] = parseAcknowledgments(example!);
+		expect(ack.trace_id).toBe('trace-hint');
+		expect(ack.id).toBe(ENTRY);
+		expect(ack.result).toBe('n_a');
+		expect(ack.reason).not.toContain('neutral');
+		expect(ack.reason).not.toContain('(does not apply');
+	});
+
+	it('lets a consumer who copies the example line verbatim (plus a reason) satisfy the gate on first retry (#2299)', async () => {
+		await display('trace-retry');
+		const denial = await knowledgeApplicationGateBefore(
+			directory,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 'session-a' },
+			enforce,
+		).catch((err: unknown): string =>
+			err instanceof Error ? err.message : String(err),
+		);
+		// No knowledge.jsonl is present: the content-echo falls back to a
+		// retrievable guidance note rather than a bare token.
+		expect(denial).toContain('content not found in knowledge store');
+		const example = denial
+			.split('\n')
+			.map((line) => line.trim())
+			.find(
+				(line) =>
+					line.includes(`KNOWLEDGE_N_A:trace-retry:${ENTRY}`) &&
+					line.includes('reason='),
+			);
+		expect(example).toBeDefined();
+		const ackLine = example!.replace(
+			'<reason>',
+			'not applicable to the current step',
+		);
+
+		await knowledgeApplicationTransformScan(
+			directory,
+			{ messages: [architectMessage(ackLine)] },
+			'session-a',
+		);
+
+		const state = await queryLiveMemberships(directory, {
+			session_id: 'session-a',
+			include_terminal: true,
+		});
+		if (!state.ok) throw new Error(state.detail);
+		const membership = state.memberships.find(
+			(item) => item.trace_id === 'trace-retry',
+		);
+		expect(membership?.application_marker?.outcome).toBe('n_a');
+
+		// The exact-pair ack satisfies the gate: a subsequent deny-path call
+		// no longer throws.
+		await knowledgeApplicationGateBefore(
+			directory,
+			{ tool: 'save_plan', agent: 'architect', sessionID: 'session-a' },
+			enforce,
+		);
+	});
+
 	it('does not let one trace terminal hide the same entry on another trace', async () => {
 		await display('trace-closed');
 		await display('trace-open');
@@ -139,7 +238,7 @@ describe('knowledgeApplicationGateBefore V2 authority', () => {
 				{ tool: 'Task', agent: 'paid_architect', sessionID: 'session-a' },
 				enforce,
 			),
-		).rejects.toThrow(new RegExp(`trace-open/${ENTRY}`));
+		).rejects.toThrow(new RegExp(`trace-open:${ENTRY}`));
 	});
 
 	it('does not let a knowledge_receipt terminal satisfy the architect marker gate', async () => {


### PR DESCRIPTION
Closes #2299

## Summary
- The `KNOWLEDGE_ENFORCE_GATE_DENY` thrown by the v2 knowledge-application gate
  (`src/hooks/knowledge-application-gate.ts`) rendered unacknowledged critical
  memberships as **slash** pairs (`trace/entry`) while demanding **colon**
  ack tokens (`KNOWLEDGE_N_A:<trace>:<entry>`), never rendered a worked
  copy-pasteable example, and never surfaced the directive content — so an
  architect whose `<swarm_knowledge_directives>` block was lost to compaction
  could not ack correctly on the first retry (observed: misparsed slash pair as
  two entry IDs, two wasted delegations, ~10 idle minutes).
- Added `buildGateDenialMessage(...)` — the denial now uses a single canonical
  colon pair form, lists all five verbs with exact token grammar, emits one
  fully-instantiated `KNOWLEDGE_N_A:<trace>:<entry> reason=<reason>` copy-paste
  line per membership, and echoes the directive lesson content (with a
  retrievable fallback note when content is absent).
- Added `loadDirectiveContents(...)` — best-effort `entry_id -> lesson` lookup
  across swarm (always) + hive (existsSync-gated), first-wins swarm priority,
  fail-open per source; invoked only on the deny path, so it adds no I/O to
  pass/escape-hatch paths and can never change the gate outcome.
- Enforcement semantics, exact-pair integrity, both bounded escape hatches
  (staleness TTL, denial-count clear), the audit `events.jsonl` pair text, and
  the internal `swarmState.gateDenialCounts` keys are unchanged.
- Corrected a related discoverability defect: `docs/knowledge.md` taught the
  legacy one-token ack form (`KNOWLEDGE_APPLIED: <id>`) the V2 gate never
  accepts; it now documents the exact-pair colon form, matching
  `src/agents/architect.ts` and the new deny message.
- New tests cover the canonical colon form, the instantiated example, an
  absence-of-neutral-hint reason check, a first-retry regression (consumer that
  copies the example verbatim + a reason satisfies the gate on first retry),
  and the missing-knowledge fallback.
- This follow-up commit (03395dfe) applies Biome format/import-order fixes to
  the test file (resolves PRR-001 from the swarm-pr-review and the external
  Multi-Stage PR Review bot). No logic, test content, or semantics change;
  only the auto-format and import-sort.

## Invariant audit
- 1 (plugin init): not touched — the gate is a `tool.execute.before` runtime
  hook; `loadDirectiveContents` runs only on the deny path, not at plugin init;
  no change to `src/index.ts` init time.
- 2 (runtime portability): not touched — no `src/index.ts`/package exports/
  `package.json#main`/`bun build`/entry-shape change; added only `node:fs`
  (`existsSync`) + existing `./knowledge-store.js` ESM imports (no `bun:`
  scheme); `bundle-portability` + `bundle-plugin-shape` tests pass (12 tests).
- 3 (subprocesses): not touched — `git diff` shows no spawn/subprocess added.
- 4 (.swarm containment): touched — content echo reads the knowledge store via
  existing `resolveSwarmKnowledgePath`/`resolveHiveKnowledgePath` (read-only,
  fail-open); no new `.swarm` writes, no `process.cwd()` caller added; directory
  flows through the `directory` param.
- 5 (plan durability): not touched — no plan/ledger/projection change.
- 6 (test_runner safety): not touched — validation used `bun test` /
  `bun run test:unit:ci <scoped files>`, not broad `test_runner` scopes.
- 7 (test writing): touched — new tests in `knowledge-application-gate.test.ts`
  (442 lines < 500 cap); uses `_internals` seam (both new helpers exposed), no
  new `mock.module`; per-file isolation.
- 8 (session state): not touched — helpers are stateless (pure function + cached
  `readKnowledge`); no new module-level mutable global state.
- 9 (guardrails/retry): not touched — enforcement mode, exact-pair binding, and
  both escape hatches are bit-for-bit unchanged.
- 10 (chat/system msg): not touched — denial is a thrown Error surfaced by
  tool-before, not a `chat.messages/system` transform chain.
- 11 (tool registration): not touched — no tool/agent/command added or removed.
- 12 (release/cache): touched — release fragment
  `docs/releases/pending/2299-gate-denial-ack-discoverability.md` added; no
  version/`CHANGELOG`/`.release-please-manifest`/cache changes.

## Test plan
- `bun test tests/unit/hooks/knowledge-application-gate.test.ts` → 17 pass / 0 fail
- `bun test` (isolation) on gate escape-hatch, escape-hatch-regression, scope,
  ack-parsing, knowledge-application, filter-confidence, architect/role/delegate
  ack contract tests → all pass (per-file isolation)
- `bun run test:unit:ci <5 scoped files>` → all exit 0 (CI-equivalent gate)
- `bun run typecheck` → clean
- `biome ci .` → exit 0 (PRR-001 resolved)
- `bun run drift:check`, `check:events`, `check:gate-portability`,
  `check:runtime-src-refs`, `check:bare-spawn`, `check:test-file-cap`,
  `scripts/check-tool-registration.ts`, `scripts/check-invariants.sh` → all pass
- `bun test tests/unit/build/bundle-portability.test.ts bundle-plugin-shape.test.ts`
  → 12 pass / 0 fail
- Note: a bulk `bun test tests/unit/hooks/` (whole directory in one process)
  shows many failures — the KNOWN Bun `mock.module` cross-file pollution artifact
  (AGENTS.md invariant 7, repo forbids bulk dir-runs). All touched files pass in
  isolation; CI and this trace run files individually.

## PR feedback closure ledger
- F1 (PRR-001, HIGH blocking) — Biome format + import-order on
  `tests/unit/hooks/knowledge-application-gate.test.ts`. FIXED in 03395dfe
  via `bunx biome format --write` + organize-imports; `bun run lint:ci` exit 0.
- F2 (advisory MEDIUM) — hive-store precedence / first-wins has no dedicated
  test. **Known follow-up**: would require either a new `_internals` seam or a
  `mock.module` for `knowledge-store`, which the repo's invariant 7 cautions
  against for cross-file leak risk. Not merge-blocking per the bot review;
  documented here rather than silently deferred.
- F3 (advisory LOW) — `readKnowledge` fail-open catch is realistically
  untestable as written. BENIGN — informational.
- F4 (advisory LOW) — repeated deny-path knowledge-store re-reads (cached,
  bounded by `enforceKnowledgeCap`). BENIGN — informational.
- F5 (advisory INFO) — defensive try/catch around `resolveHiveKnowledgePath`
  /`existsSync` guards nothing real. BENIGN — kept as fail-safe.
- F6 (out of scope) — `phase-complete-directive-gate.ts` slash-pair
  `record_directive_override` is a separate mechanism; not touched by this PR.

## Pre-existing failures
None introduced.
