### PR TITLE
fix(guardrails): PR #2335 follow-ups — test-clock lint violations + cadence total_timeout_ms threading

### DIFF
--- a/src/full-auto/cadence.ts
+++ b/src/full-auto/cadence.ts
@@ -226,6 +226,11 @@ export function tickAndMaybeDispatchCadence(
 				config.full_auto?.oversight?.max_dispatch_retries ?? 2,
 			max_consecutive_dispatch_failures:
 				config.full_auto?.oversight?.max_consecutive_dispatch_failures ?? 3,
+			// Issue #2103 workstream G: thread the configured total deadline so
+			// cadence-triggered oversight (on_plan_change / phase boundaries)
+			// honors it too — without this the dispatcher silently defaults.
+			total_timeout_ms:
+				config.full_auto?.oversight?.total_timeout_ms ?? 120_000,
 		},
 	})
 		.catch((err) => {

--- a/tests/unit/commands/full-auto.test.ts
+++ b/tests/unit/commands/full-auto.test.ts
@@ -25,6 +25,7 @@ import {
 	_internals as stateInternals,
 	swarmState,
 } from '../../../src/state';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 let tmpDir: string;
 let originalXdgConfigHome: string | undefined;
@@ -137,28 +138,32 @@ describe('handleFullAutoCommand — durable-first / fail-closed', () => {
 		).toBe('healthy');
 	});
 
-	test('resume refuses when recovery blockers remain', async () => {
-		await handleFullAutoCommand(tmpDir, ['on'], SESSION_ID);
-		const { pauseFullAutoRun, recordFullAutoRecoveryProbe } = await import(
-			'../../../src/full-auto/state'
-		);
-		pauseFullAutoRun(
-			tmpDir,
-			SESSION_ID,
-			'oversight infrastructure failure after 1 attempt(s): server error',
-		);
-		recordFullAutoRecoveryProbe(tmpDir, SESSION_ID, {
-			pauseGeneration:
-				loadFullAutoRunState(tmpDir, SESSION_ID)?.pauseGeneration ?? 0,
-			checkedAt: new Date().toISOString(),
-			expiresAt: new Date(Date.now() + 60_000).toISOString(),
-			attempts: 1,
-			outcome: 'healthy',
-			reason: 'ok',
-		});
-		registerFullAutoRecoveryBlockerEvaluator(() => ['policy_circuit']);
-		const out = await handleFullAutoCommand(tmpDir, ['resume'], SESSION_ID);
-		expect(out).toContain('policy_circuit');
-		expect(loadFullAutoRunState(tmpDir, SESSION_ID)?.status).toBe('paused');
-	});
+	test('resume refuses when recovery blockers remain', async () =>
+		withFrozenClock(
+			async () => {
+				await handleFullAutoCommand(tmpDir, ['on'], SESSION_ID);
+				const { pauseFullAutoRun, recordFullAutoRecoveryProbe } = await import(
+					'../../../src/full-auto/state'
+				);
+				pauseFullAutoRun(
+					tmpDir,
+					SESSION_ID,
+					'oversight infrastructure failure after 1 attempt(s): server error',
+				);
+				recordFullAutoRecoveryProbe(tmpDir, SESSION_ID, {
+					pauseGeneration:
+						loadFullAutoRunState(tmpDir, SESSION_ID)?.pauseGeneration ?? 0,
+					checkedAt: new Date().toISOString(),
+					expiresAt: new Date(Date.now() + 60_000).toISOString(),
+					attempts: 1,
+					outcome: 'healthy',
+					reason: 'ok',
+				});
+				registerFullAutoRecoveryBlockerEvaluator(() => ['policy_circuit']);
+				const out = await handleFullAutoCommand(tmpDir, ['resume'], SESSION_ID);
+				expect(out).toContain('policy_circuit');
+				expect(loadFullAutoRunState(tmpDir, SESSION_ID)?.status).toBe('paused');
+			},
+			{ fixedNow: Date.parse('2026-01-01T00:00:00Z'), tickMs: 1 },
+		));
 });

--- a/tests/unit/utils/model-dispatch-fallback.test.ts
+++ b/tests/unit/utils/model-dispatch-fallback.test.ts
@@ -17,6 +17,7 @@ import {
 	ModelDispatchTimeoutError,
 	parseModelString,
 } from '../../../src/utils/model-dispatch-fallback';
+import { withFrozenClock } from '../../helpers/test-clock.js';
 
 const noWait = async () => {};
 
@@ -191,99 +192,111 @@ describe('dispatchWithModelFallback', () => {
 		expect(second.fallbackIndex).toBe(0);
 	});
 
-	it('throws a recognizable timeout error when dispatch ignores the deadline', async () => {
-		const originalSetTimeout = _internals.setTimeout;
-		const originalClearTimeout = _internals.clearTimeout;
-		try {
-			_internals.setTimeout = ((callback: () => void, _ms: number) => {
-				const token = { unref() {} };
-				queueMicrotask(callback);
-				return token;
-			}) as typeof setTimeout;
-			_internals.clearTimeout = (() => undefined) as typeof clearTimeout;
-			await expect(
-				dispatchWithModelFallback<string>({
-					dispatch: async () => await new Promise<never>(() => {}),
-					classify: alwaysTransient,
-					deadlineAtMs: Date.now() + 20,
-					maxTransientRetriesPerModel: 0,
-				}),
-			).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
-			await expect(
-				dispatchWithModelFallback<string>({
-					dispatch: async () => await new Promise<never>(() => {}),
-					classify: alwaysTransient,
-					deadlineAtMs: Date.now() + 20,
-					maxTransientRetriesPerModel: 0,
-				}),
-			).rejects.toHaveProperty('name', 'TimeoutError');
-		} finally {
-			_internals.setTimeout = originalSetTimeout;
-			_internals.clearTimeout = originalClearTimeout;
-		}
-	});
-
-	it('clamps retry backoff to the remaining total deadline', async () => {
-		let nowMs = 0;
-		const slept: number[] = [];
-		await expect(
-			dispatchWithModelFallback<string>({
-				dispatch: async () => {
-					nowMs += 3;
-					throw new Error('503 unavailable');
-				},
-				classify: alwaysTransient,
-				maxTransientRetriesPerModel: 2,
-				backoffMs: () => 50,
-				deadlineAtMs: 10,
-				now: () => nowMs,
-				sleep: async (ms) => {
-					slept.push(ms);
-					nowMs += ms;
-				},
-			}),
-		).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
-		expect(slept).toEqual([7]);
-	});
-
-	it('clears outer timeout timers on success and timeout', async () => {
-		const originalSetTimeout = _internals.setTimeout;
-		const originalClearTimeout = _internals.clearTimeout;
-		const cleared: unknown[] = [];
-		let nextTimer = 0;
-		try {
-			_internals.setTimeout = ((callback: () => void, ms: number) => {
-				const token = { id: ++nextTimer, unref() {} };
-				if (ms <= 1) {
-					queueMicrotask(callback);
+	it('throws a recognizable timeout error when dispatch ignores the deadline', async () =>
+		withFrozenClock(
+			async () => {
+				const originalSetTimeout = _internals.setTimeout;
+				const originalClearTimeout = _internals.clearTimeout;
+				try {
+					_internals.setTimeout = ((callback: () => void, _ms: number) => {
+						const token = { unref() {} };
+						queueMicrotask(callback);
+						return token;
+					}) as typeof setTimeout;
+					_internals.clearTimeout = (() => undefined) as typeof clearTimeout;
+					await expect(
+						dispatchWithModelFallback<string>({
+							dispatch: async () => await new Promise<never>(() => {}),
+							classify: alwaysTransient,
+							deadlineAtMs: Date.now() + 20,
+							maxTransientRetriesPerModel: 0,
+						}),
+					).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
+					await expect(
+						dispatchWithModelFallback<string>({
+							dispatch: async () => await new Promise<never>(() => {}),
+							classify: alwaysTransient,
+							deadlineAtMs: Date.now() + 20,
+							maxTransientRetriesPerModel: 0,
+						}),
+					).rejects.toHaveProperty('name', 'TimeoutError');
+				} finally {
+					_internals.setTimeout = originalSetTimeout;
+					_internals.clearTimeout = originalClearTimeout;
 				}
-				return token;
-			}) as typeof setTimeout;
-			_internals.clearTimeout = ((timer: unknown) => {
-				cleared.push(timer);
-			}) as typeof clearTimeout;
+			},
+			{ tickMs: 5 },
+		));
 
-			await expect(
-				dispatchWithModelFallback<string>({
-					dispatch: async () => 'ok',
-					classify: alwaysTransient,
-					deadlineAtMs: Date.now() + 50,
-				}),
-			).resolves.toMatchObject({ result: 'ok' });
+	it('clamps retry backoff to the remaining total deadline', async () =>
+		withFrozenClock(
+			async () => {
+				let nowMs = 0;
+				const slept: number[] = [];
+				await expect(
+					dispatchWithModelFallback<string>({
+						dispatch: async () => {
+							nowMs += 3;
+							throw new Error('503 unavailable');
+						},
+						classify: alwaysTransient,
+						maxTransientRetriesPerModel: 2,
+						backoffMs: () => 50,
+						deadlineAtMs: 10,
+						now: () => nowMs,
+						sleep: async (ms) => {
+							slept.push(ms);
+							nowMs += ms;
+						},
+					}),
+				).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
+				expect(slept).toEqual([7]);
+			},
+			{ tickMs: 1 },
+		));
 
-			await expect(
-				dispatchWithModelFallback<string>({
-					dispatch: async () => await new Promise<never>(() => {}),
-					classify: alwaysTransient,
-					deadlineAtMs: Date.now() + 1,
-					maxTransientRetriesPerModel: 0,
-				}),
-			).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
+	it('clears outer timeout timers on success and timeout', async () =>
+		withFrozenClock(
+			async () => {
+				const originalSetTimeout = _internals.setTimeout;
+				const originalClearTimeout = _internals.clearTimeout;
+				const cleared: unknown[] = [];
+				let nextTimer = 0;
+				try {
+					_internals.setTimeout = ((callback: () => void, ms: number) => {
+						const token = { id: ++nextTimer, unref() {} };
+						if (ms <= 1) {
+							queueMicrotask(callback);
+						}
+						return token;
+					}) as typeof setTimeout;
+					_internals.clearTimeout = ((timer: unknown) => {
+						cleared.push(timer);
+					}) as typeof clearTimeout;
 
-			expect(cleared.length).toBeGreaterThanOrEqual(2);
-		} finally {
-			_internals.setTimeout = originalSetTimeout;
-			_internals.clearTimeout = originalClearTimeout;
-		}
-	});
+					await expect(
+						dispatchWithModelFallback<string>({
+							dispatch: async () => 'ok',
+							classify: alwaysTransient,
+							deadlineAtMs: Date.now() + 50,
+						}),
+					).resolves.toMatchObject({ result: 'ok' });
+
+					await expect(
+						dispatchWithModelFallback<string>({
+							dispatch: async () => await new Promise<never>(() => {}),
+							classify: alwaysTransient,
+							deadlineAtMs: Date.now() + 1,
+							maxTransientRetriesPerModel: 0,
+						}),
+					).rejects.toBeInstanceOf(ModelDispatchTimeoutError);
+
+					expect(cleared.length).toBeGreaterThanOrEqual(2);
+				} finally {
+					_internals.setTimeout = originalSetTimeout;
+					_internals.clearTimeout = originalClearTimeout;
+				}
+			},
+			{ tickMs: 1 },
+		));
 });


### PR DESCRIPTION
Follow-ups to #2335 (issue #2103), found by the independent reviewer/critic gates run on the parallel effort in #2336 (now superseded by #2335):

## Fixes
1. **CI `quality` failure (blocking)**: `tests/unit/utils/model-dispatch-fallback.test.ts` and `tests/unit/commands/full-auto.test.ts` used the real clock (`Date.now`/`new Date`) without the `freezeClock` helper — the two blocking `check-test-clock.sh` violations that failed the quality job and skipped `unit` entirely. Both now wrap the time-sensitive tests in `withFrozenClock` with a `tickMs` advance so deadline semantics still function under a deterministic clock.
2. **`total_timeout_ms` dead on the cadence path**: `src/hooks/full-auto-permission.ts` threads `full_auto.oversight.total_timeout_ms` into the oversight dispatch slice, but `src/full-auto/cadence.ts` omitted it — so a user-configured deadline was silently ignored (dispatcher default 120s) on every cadence-triggered oversight dispatch (on_plan_change / phase boundaries, the primary trigger route). Threading added, matching the permission-hook slice.

## Verification (on this branch)
- `bash scripts/check-test-clock.sh` → New violations (blocking): 0 (was 2)
- `bun run typecheck` → clean; `bun run lint:ci` → clean
- `bun test`: model-dispatch-fallback 13/0, commands/full-auto 6/0, full-auto dir 190/0 (incl. oversight-total-deadline 2/0), models 9/0, failures 25/0

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

