### PR TITLE
fix(ci): shard the merge-queue coverage gate and raise the queue timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,11 +477,12 @@ jobs:
       # `unit (ubuntu-latest, 1)`, which made that one cell execute the entire
       # unit suite twice (sharded run + full-suite coverage run) inside the 40m
       # budget — ~30-35 min in practice, intermittently timing out and blocking
-      # the merge queue (PR #1573). It now lives in the dedicated `coverage` job
-      # below so the full-suite run gets its own timeout and the unit cells stay
-      # fast. `coverage` is already enforced: it's a required status check in
-      # branch-protection ruleset 17809658 (confirmed active — issue #1737
-      # FR-014, correcting this comment, which previously and incorrectly
+      # the merge queue (PR #1573). It now lives in the dedicated
+      # `coverage-shard` matrix + `coverage` aggregator below (issue #2341) so
+      # the coverage measurement gets its own generous timeouts and the unit
+      # cells stay fast. `coverage` is already enforced: it's a required status
+      # check in branch-protection ruleset 17809658 (confirmed active — issue
+      # #1737 FR-014, correcting this comment, which previously and incorrectly
       # described enforcement as still-pending).
 
   # Issue #1737 FR-013: aggregate job so branch-protection ruleset 17809658 can
@@ -507,31 +508,48 @@ jobs:
           fi
           echo "All unit matrix cells that ran succeeded."
 
-  # Merge-queue-only coverage gate. Runs the full unit suite once with coverage
-  # and enforces the line-coverage threshold. Isolated from the `unit` job so the
-  # inherently ~26-31 min full-suite coverage measurement gets its own generous
-  # timeout instead of stacking onto a sharded unit cell's 40m budget (see the
-  # NOTE in the `unit` job above and PR #1573). On pull_request all steps are
-  # skipped and the job reports success to satisfy the required check without
+  # Merge-queue-only coverage gate, sharded (issue #2341). The gate used to be
+  # one serial job: a single runner executing the entire gated suite per-file
+  # under coverage took ~48 of the merge queue's check_response_timeout budget
+  # (measured on the PR #2313 eviction at 2026-08-25T00:35Z: coverage started
+  # 9 min after enqueue and succeeded at 47.8 min, leaving the group no margin
+  # at any queue position > 1). The shard matrix below partitions the gated set
+  # with the SAME round-robin as the `unit` job ("Collect and partition test
+  # files" step), so coverage shard N measures exactly the files of
+  # unit (ubuntu-latest, N) and a failing file maps back to one debuggable
+  # shard pair. Each shard uploads its merged lcov; the dependent `coverage`
+  # aggregator below merges all shard reports and enforces the threshold ONCE,
+  # failing closed if any shard report is missing (a dropped shard would
+  # otherwise silently shrink the measured set). On pull_request all steps are
+  # skipped and both jobs report success to satisfy the required check without
   # doing work (same pattern as integration/smoke). Skipped for release-please
   # branches (version bumps don't change coverage).
-  coverage:
+  #
+  # CI-004 invariant (PR #2290, preserved by issue #2341's sharding): the
+  # coverage measurement must stay PARALLEL to the unit matrix — these shards
+  # need only [detect-release, quality], never `unit` — because serializing the
+  # measurement behind the unit matrix produced 63-minute merge-group runs that
+  # the queue evicted 26-43 seconds before the coverage result arrived.
+  # tests/unit/scripts/ci/ci-coverage-sharding.test.ts pins this graph.
+  #
+  # The shard cells have NO job-level `if:` (only step-level guards) so they
+  # conclude `success` — not `skipped` — on pull_request and release-please
+  # runs; a skipped conclusion would cascade through the aggregator's `needs:`
+  # and wrongly fail the required `coverage` check (see the detect-paths job's
+  # comment for the same pattern).
+  coverage-shard:
     needs: [detect-release, quality]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     runs-on: ubuntu-latest
-    # Coverage is the merge-group long pole: clean runs for PR #2290 took about
-    # 45 minutes. It must start after `quality`, in parallel with the unit matrix,
-    # so the required result arrives within ruleset 17809658's 60-minute
-    # check_response_timeout_minutes. Serializing it behind `unit` produced
-    # 63-minute merge-group runs; GitHub evicted them 26-43 seconds before the
-    # successful coverage result arrived (CI-004).
-    #
-    # A failing unit shard no longer cancels this independent job early, which
-    # may spend extra runner time on an already-blocked merge group. Correctness
-    # is unchanged: both unit checks and coverage remain required, while the
-    # parallel graph keeps successful groups inside the queue deadline. On
-    # pull_request, coverage's steps remain gated on `merge_group` and report
-    # success without doing work.
-    timeout-minutes: 60
+    # 30m: a typical shard is ~12 min (cached install + build + ~278 per-file
+    # coverage runs at ~1.6 s each); the per-file retry budget (2 retries at up
+    # to 60 s each) can add minutes on a flaky window, and a false-positive
+    # shard cancellation costs the whole merge group a requeue — headroom is
+    # cheaper than that (issue #2341).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
@@ -556,46 +574,152 @@ jobs:
         run: bun run build
       - name: Coverage gate enforcement
         if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        env:
+          COVERAGE_SHARD_INDEX: ${{ matrix.shard }}
+          COVERAGE_SHARD_COUNT: 6
         shell: bash
         run: |
           set -e
           echo "Running coverage measurement for gate enforcement..."
           # Run each file in its own coverage process so file-scoped mocks and
           # runtime state cannot contaminate later files in the merge-queue
-          # coverage gate (issue #1712). The helper merges the per-file lcov
-          # records before enforcing the threshold, so the gate still measures
-          # the full non-quarantined suite rather than a single shard.
+          # coverage gate (issue #1712). In shard mode the helper merges this
+          # shard's per-file lcov records into one coverage/lcov.info and
+          # skips threshold enforcement; the aggregator below merges all
+          # shards and enforces the threshold once (issue #2341).
           bash scripts/ci/run-coverage-gate.sh
+      - name: Upload shard coverage report
+        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: |
+            coverage/lcov.info
+            coverage-output.txt
+          if-no-files-found: ignore
+      # Upload this shard's flake-annotations file `if: always()` so the
+      # downstream flake-detection workflow_run can pick it up alongside the
+      # unit shards' annotations (issue #1782). run-coverage-gate.sh always
+      # creates the file unconditionally (`: >`), even on a clean run with no
+      # retries/failures, so this step normally always has a file to upload
+      # (a 0-byte one on a clean run); if-no-files-found: ignore covers the
+      # case where the script never executed (failed install/build). Both the
+      # artifact name AND the internal filename carry the shard index:
+      # flake-detection.yml downloads the flake-annotations-* pattern with
+      # merge-multiple: true, so same-named files from different shards would
+      # collide on extraction.
+      - name: Upload coverage flake annotations
+        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: flake-annotations-coverage-shard-${{ matrix.shard }}
+          path: flake-annotations-coverage-shard-${{ matrix.shard }}.txt
+          if-no-files-found: ignore
+
+  # The coverage gate's single required check (ruleset 17809658): merges every
+  # coverage-shard lcov report and enforces the threshold ONCE over the union
+  # (issue #2341). Fail-closed three ways: (1) the shard matrix result must be
+  # `success` — a failed/cancelled shard cannot be papered over by the others;
+  # (2) the pattern download fails when zero shard artifacts exist
+  # (if-no-files-found: error); and (3) an explicit per-shard presence check
+  # rejects a partially-uploaded set, because a missing shard would silently
+  # shrink the measured set and lower the measured percentage. The shard count
+  # (1..6) here is pinned equal to the unit and coverage-shard matrices by
+  # tests/unit/scripts/ci/ci-coverage-sharding.test.ts; changing it is a
+  # three-place, test-enforced edit.
+  #
+  # `if: always()` mirrors the unit-passed aggregate pattern so this job still
+  # runs (and FAILS, fast) when a shard failed, instead of being skipped and
+  # leaving the required check unreported — the failure mode that made the
+  # merge queue burn its whole timeout before evicting PR #2313's group (a
+  # skipped required check never reports, so the queue can only time out).
+  # All steps except the final upload carry the merge_group event guard: on
+  # pull_request and release-please runs the shards upload nothing, so the
+  # download must not run there — the job reports success with all steps
+  # skipped, exactly like the pre-sharding single coverage job did.
+  #
+  # `detect-release` MUST stay a declared direct dependency: the step guards
+  # below read needs.detect-release.outputs.is-release, and GitHub's needs
+  # context only exposes outputs of DIRECT dependencies — without this entry
+  # the reference silently resolves to null, the is-release clause goes inert,
+  # and on a release-please merge group (where the shards skip and upload
+  # nothing) the download's if-no-files-found: error would fail the required
+  # `coverage` check and evict the release. ci-coverage-sharding.test.ts
+  # enforces the no-dangling-needs rule file-wide.
+  coverage:
+    needs: [coverage-shard, detect-release]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        with:
+          bun-version: "1.3.13"
+      # merge-lcov.mjs imports only node: builtins — no bun install, no build.
+      - name: Check coverage shard results (fail closed)
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        env:
+          COVERAGE_SHARD_RESULT: ${{ needs.coverage-shard.result }}
+        run: |
+          if [ "$COVERAGE_SHARD_RESULT" != "success" ]; then
+            echo "::error::coverage-shard matrix result was '$COVERAGE_SHARD_RESULT', not 'success'"
+            exit 1
+          fi
+          echo "All coverage shard matrix cells that ran succeeded."
+      - name: Download shard reports
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-shard-*
+          path: shard-reports
+          if-no-files-found: error
+      - name: Merge shard reports and enforce threshold
+        if: github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for n in 1 2 3 4 5 6; do
+            f="shard-reports/coverage-shard-${n}/coverage/lcov.info"
+            if [ ! -s "$f" ]; then
+              echo "::error::Missing or empty coverage shard report: ${f}"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Fail closed: not all 6 coverage shard reports are present (issue #2341)"
+            exit 1
+          fi
+          mkdir -p merged-parts coverage
+          for n in 1 2 3 4 5 6; do
+            cp "shard-reports/coverage-shard-${n}/coverage/lcov.info" "merged-parts/part-${n}.info"
+          done
+          bun scripts/ci/merge-lcov.mjs merged-parts coverage/lcov.info coverage-value.txt
+          threshold="${COVERAGE_THRESHOLD:-65.00}"
+          if [ ! -s coverage-value.txt ]; then
+            echo "::warning::Could not parse coverage output"
+            echo "0" > coverage-value.txt
+          fi
+          read -r coverage_value < coverage-value.txt || coverage_value="0"
+          echo "Coverage: ${coverage_value}% (threshold: ${threshold}%)"
+          if awk "BEGIN {exit !($coverage_value < $threshold)}"; then
+            echo "::error::Coverage gate failed: ${coverage_value}% < ${threshold}%"
+            exit 1
+          fi
+          echo "Coverage gate passed: ${coverage_value}% >= ${threshold}%"
       - name: Upload coverage report
         if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: |
-            coverage-output.txt
             coverage/lcov.info
+            coverage-value.txt
           if-no-files-found: warn
-      # Upload the coverage job's flake-annotations file `if: always()` so the
-      # downstream flake-detection workflow_run can pick it up alongside the
-      # unit shards' annotations (issue #1782). run-coverage-gate.sh always
-      # creates flake-annotations-coverage.txt unconditionally (`: >`), even
-      # on a clean run with no retries/failures, so this step normally always
-      # has a file to upload (a 0-byte one on a clean run). if-no-files-found:
-      # ignore is not about the skipped case — a step whose `if:` is false
-      # never evaluates the setting at all. It covers the case where the file
-      # was never created. The two upload steps are the only ones in this job
-      # carrying `always()`, so they still run when an earlier step failed:
-      # if install / build / the gate step itself fails, the script never
-      # executes and never creates the file (the common case), and likewise
-      # if the script aborts under `set -euo pipefail` before creating it.
-      # Neither must fail the job over a missing artifact.
-      - name: Upload coverage flake annotations
-        if: always() && github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: flake-annotations-coverage
-          path: flake-annotations-coverage.txt
-          if-no-files-found: ignore
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success
   # to satisfy required checks without doing work. Also skipped for release-please.

--- a/TESTING.md
+++ b/TESTING.md
@@ -139,7 +139,7 @@ Phase 4 also consolidated knowledge-curator tests with shared fixtures (`tests/u
 
 ### Coverage Gate
 
-CI enforces a minimum code coverage threshold (41.48%) on the merge queue. Coverage is measured using `bun test --coverage` with output configured in `bunfig.toml`:
+CI enforces a minimum line-coverage threshold of 65.00% (recalibrated in issue #1778 H4 when the measured set grew to `src/**` + the orphan test trees; measured 73.41% at the time) on the merge queue. Coverage is measured using `bun test --coverage` with output configured in `bunfig.toml`:
 
 ```toml
 # bunfig.toml
@@ -148,7 +148,7 @@ coverageReporter = ["lcov", "text"]
 coverageDir = "./coverage"
 ```
 
-The coverage gate runs in a dedicated `coverage` job (a required status check) but only on `merge_group` events (not on every PR for speed). It runs the full unit suite once with coverage in its own job, separate from the sharded `unit` job, so the long full-suite measurement does not stack onto a unit shard's timeout budget. To measure coverage locally:
+The coverage gate is a required status check but only runs on `merge_group` events (not on every PR, for speed). Since issue #2341 it is sharded: a `coverage-shard` matrix (6 ubuntu shards, the same round-robin partition as the `unit` job) each measures its partition per-file under coverage and uploads its merged lcov, and the dependent `coverage` aggregator job merges all shard reports and enforces the threshold **once** over the union, failing closed if any shard report is missing — a dropped shard can never silently shrink the measured set. To measure coverage locally (unsharded, full set + inline threshold):
 
 ```bash
 bun test --coverage tests/unit/ --timeout 60000

--- a/contributing.md
+++ b/contributing.md
@@ -225,7 +225,8 @@ All of these must be green. They run automatically on every PR.
 |---|---|
 | `quality` | TypeScript compiles (`tsc --noEmit`), Biome lint + format clean |
 | `unit` (Ubuntu, macOS, Windows) | Unit tests pass on all platforms |
-| `coverage` (merge queue only) | Code coverage ≥ 41.48% (enforced via `bun test --coverage`) |
+| `unit-passed` | Aggregate of every `unit` matrix cell (fails fast in the merge queue when any cell fails, instead of leaving the queue to time out on skipped downstream checks) |
+| `coverage` (merge queue only) | Code coverage ≥ 65.00% over the merged union of the 6-way `coverage-shard` matrix (issue #2341; fail-closed if any shard report is missing) |
 | `dist-check` | Committed `dist/` matches a fresh build |
 | `package-check` | Package metadata and publishable artifact checks pass |
 | `integration` (Ubuntu) | Integration tests pass (circuit breakers, gate workflows, state machines) |

--- a/contributing.md
+++ b/contributing.md
@@ -227,7 +227,6 @@ All of these must be green. They run automatically on every PR.
 | `unit` (Ubuntu, macOS, Windows) | Unit tests pass on all platforms |
 | `unit-passed` | Aggregate of every `unit` matrix cell (fails fast in the merge queue when any cell fails, instead of leaving the queue to time out on skipped downstream checks) |
 | `coverage` (merge queue only) | Code coverage ≥ 65.00% over the merged union of the 6-way `coverage-shard` matrix (issue #2341; fail-closed if any shard report is missing) |
-| `dist-check` | Committed `dist/` matches a fresh build |
 | `package-check` | Package metadata and publishable artifact checks pass |
 | `integration` (Ubuntu) | Integration tests pass (circuit breakers, gate workflows, state machines) |
 | `security` (Ubuntu) | Security and adversarial tests pass |
@@ -390,5 +389,5 @@ gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
 - [ ] New tests are in the correct `tests/` subdirectory
 - [ ] Tests updated for any changed behavior (defaults, validation, error messages)
 - [ ] If adding/modifying a workflow, all `uses:` references are SHA-pinned
-- [ ] All CI checks pass locally or remotely as appropriate (`typecheck`, `biome ci`, `unit`, `integration`, `security`, `dist-check`, `package-check`, `php-validation`, `rust-sandbox-runner`, `smoke`)
+- [ ] All CI checks pass locally or remotely as appropriate (`typecheck`, `biome ci`, `unit`, `integration`, `security`, `package-check`, `php-validation`, `rust-sandbox-runner`, `smoke`)
 - [ ] PR description includes a summary and test plan

--- a/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
+++ b/docs/releases/pending/1737-quarantine-debt-and-ci-portability-lints.md
@@ -77,6 +77,9 @@ No migration required.
   intentional, deferred to a follow-up change once this branch lands on `main`
   (adding it now would break the merge queue for every other open PR, since the
   check doesn't exist on `main` yet).
+  (Superseded: `unit-passed` became a required check in the issue #2341
+  merge-queue fix, together with raising `check_response_timeout_minutes`
+  60 → 90.)
 - Several plan items from issue #1737 require live CI signal (a CI-only injection
   budget test failure, remaining quarantined integration tests, and macOS
   `provisionWorktree` root-cause diagnosis) and are intentionally left for

--- a/docs/releases/pending/2341-shard-coverage-gate.md
+++ b/docs/releases/pending/2341-shard-coverage-gate.md
@@ -1,0 +1,34 @@
+# CI: sharded coverage gate + 90-minute merge-queue timeout (issue #2341)
+
+## What changed
+
+Green pull requests were being evicted from the merge queue with
+`checks_timed_out` through no fault of their own. The merge-queue budget
+(`check_response_timeout_minutes: 60`, and the clock starts at **enqueue**,
+including queue wait) was smaller than the CI graph's critical path, whose
+long pole was the `coverage` gate: a single serial job running the entire
+gated test suite per-file under coverage (~48 minutes measured on the
+PR #2313 eviction — it started 9 minutes after enqueue and succeeded at
+47.8 minutes, leaving the group minutes of margin at position 1 and none
+behind anything else in the queue).
+
+- **Ruleset (main branch protection, 17809658):** `check_response_timeout_minutes` raised 60 → 90, and `unit-passed` added to the required status checks. The second change fixes the eviction mode actually observed on PR #2313: when a single unit matrix cell failed, the required `integration`/`smoke` checks were *skipped* (never reported), and because the failing cells themselves were not required checks, the queue could only sit and time out for the full window. `unit-passed` fails fast in exactly that situation, converting a silent 60-minute eviction into an immediate `checks_failed` eviction.
+- **Coverage gate sharded:** the single `coverage` job is now a `coverage-shard` matrix (6 ubuntu shards, the same round-robin partition as the `unit` job, so coverage shard N measures exactly the files of `unit (ubuntu-latest, N)`) plus a `coverage` aggregator job that keeps the required-check name, merges every shard's lcov report with `scripts/ci/merge-lcov.mjs`, and enforces the 65.00% line-coverage threshold **once** over the union. The aggregator fails closed three ways (shard-matrix result check, zero-artifact download error, explicit per-shard presence loop) — a dropped shard can never silently shrink the measured set. Per-shard wall clock is ~12 minutes
+(typical, cached; bounded by a 30-minute job timeout) instead of a ~48-minute
+serial run, so the coverage leg is no longer the merge-group long pole at any
+queue position.
+- **Structural guards extended:** `tests/unit/scripts/ci/ci-coverage-sharding.test.ts` pins the new graph (CI-004 "coverage never behind unit" inherited by the shards, shard-count parity across unit/coverage/aggregator, ubuntu-only partition pinning, fail-closed aggregator, single-sourced threshold literal, event guards on every aggregator step so pull_request and release-please runs stay green), and the existing `ci-yml-integration.test.ts` CI-004 assertions moved there.
+- **Docs corrections:** `TESTING.md` and `contributing.md` still documented a 41.48% coverage threshold — the actual floor has been 65.00% since the issue #1778 H4 recalibration. Both now state the real threshold and describe the sharded gate; `unit-passed` is listed in the required-checks table.
+
+## Why this is a strengthening, not a loosening
+
+The threshold, the measured set, and the per-file coverage isolation
+(`bun test --isolate`, issue #1712) are all unchanged; only the wall-clock
+distribution changed. Merging shard lcov reports with max-union line-hit
+semantics is equivalent to the previous flat merge, and the aggregator rejects
+an incomplete shard set rather than measuring a smaller denominator.
+
+## Migration
+
+None. Contributors see faster merge-group runs and the same required checks
+(`coverage` remains the single coverage gate).

--- a/docs/releases/pending/2341-shard-coverage-gate.md
+++ b/docs/releases/pending/2341-shard-coverage-gate.md
@@ -28,6 +28,20 @@ distribution changed. Merging shard lcov reports with max-union line-hit
 semantics is equivalent to the previous flat merge, and the aggregator rejects
 an incomplete shard set rather than measuring a smaller denominator.
 
+Post-fix queue math: the merge-group critical path is the unit chain —
+quality (~2 min) → unit matrix (Windows pole ~20-25 min) → integration
+(~5-10 min) → smoke (~10 min) ≈ 40-50 minutes — with the coverage leg
+(shards ~12 min + aggregator ~2, starting after quality) fully in parallel,
+versus a 90-minute from-enqueue budget at any queue position (~2x margin).
+Before: coverage alone ended ~48-57 min after enqueue with the smoke chain
+still to run.
+
+Known caveat (pre-existing, tracked in #2344): within an otherwise-green
+coverage shard, a test file for which bun produces no lcov report only logs a
+warning — that file's lines drop out of the measured denominator. The
+aggregator's fail-closed checks bound this to per-file granularity; a shard
+that produces no lcov at all still fails the gate.
+
 ## Migration
 
 None. Contributors see faster merge-group runs and the same required checks

--- a/docs/testing/test-stability.md
+++ b/docs/testing/test-stability.md
@@ -158,8 +158,9 @@ Do NOT un-quarantine without a merge-group validation run confirming the fix.
 
 When a merge-group CI run fails, `.github/workflows/flake-detection.yml`
 (`workflow_run` trigger) downloads every `flake-annotations-*` artifact
-ci.yml uploads — the per-shard unit annotations AND the coverage job's
-`flake-annotations-coverage` artifact (both jobs run a bounded retry, two
+ci.yml uploads — the per-shard unit annotations AND the coverage shards'
+`flake-annotations-coverage-shard-N` artifacts (the unit shards and the
+coverage shards both run a bounded retry, two
 retries / three attempts total, before treating a failure as real) —
 concatenates them, and runs `scripts/ci/detect-and-quarantine-flakes.sh`.
 The script:
@@ -184,7 +185,7 @@ merge-group run failed, the run goes green and detection never fires — the
 retry is logged in that job's own step output but is not auto-surfaced as a
 quarantine suggestion. This is a property of the trigger, not of any one job:
 it applies to the **unit shards' annotations exactly as much as the coverage
-job's**. Detection only ever sees annotations from runs that failed for some
+shards'**. Detection only ever sees annotations from runs that failed for some
 reason; a run that self-heals everywhere is invisible to it.
 
 ## Known limitations

--- a/scripts/ci/run-coverage-gate.sh
+++ b/scripts/ci/run-coverage-gate.sh
@@ -7,6 +7,43 @@ set -euo pipefail
 # 65.00 with ~8pt headroom for run-to-run variance. This is a STRONGER gate than
 # the old tests/unit-only 41.48%, not a weakening.
 threshold="${COVERAGE_THRESHOLD:-65.00}"
+# Issue #2341: the merge queue's check_response_timeout budget starts at
+# ENQUEUE, and this script's single serial per-file loop (~48 min for the full
+# gated set) consumed nearly all of it. CI therefore runs this script as the
+# coverage-shard matrix: set both COVERAGE_SHARD_INDEX and COVERAGE_SHARD_COUNT
+# to measure only this shard's partition (the SAME round-robin as the unit
+# job's "Collect and partition test files" step) and merge it into a single
+# coverage/lcov.info for upload. In shard mode the threshold is NOT enforced
+# here — a shard's local percentage is meaningless in isolation — the dependent
+# `coverage` aggregator job enforces it once over the merged union of all
+# shards' reports, failing closed if any shard report is missing. Unsharded
+# invocations behave exactly as before (full set + inline threshold).
+shard_index="${COVERAGE_SHARD_INDEX:-}"
+shard_count="${COVERAGE_SHARD_COUNT:-}"
+sharded=0
+if [ -n "$shard_index" ] || [ -n "$shard_count" ]; then
+	if [ -z "$shard_index" ] || [ -z "$shard_count" ]; then
+		echo "::error::COVERAGE_SHARD_INDEX and COVERAGE_SHARD_COUNT must be set together"
+		exit 2
+	fi
+	case "$shard_index" in
+		*[!0-9]*)
+			echo "::error::COVERAGE_SHARD_INDEX must be a positive integer (got '${shard_index}')"
+			exit 2
+			;;
+	esac
+	case "$shard_count" in
+		*[!0-9]*)
+			echo "::error::COVERAGE_SHARD_COUNT must be a positive integer (got '${shard_count}')"
+			exit 2
+			;;
+	esac
+	if [ "$shard_index" -lt 1 ] || [ "$shard_index" -gt "$shard_count" ]; then
+		echo "::error::COVERAGE_SHARD_INDEX must be between 1 and COVERAGE_SHARD_COUNT (got ${shard_index}/${shard_count})"
+		exit 2
+	fi
+	sharded=1
+fi
 tmpdir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
 parts_dir="$tmpdir/opencode-swarm-coverage-parts-$$"
 all_tests="${COVERAGE_TEST_LIST:-all-tests.txt}"
@@ -23,7 +60,14 @@ rm -f coverage-value.txt
 # its markers to the log only — it writes and uploads no annotation file.
 # Written to a workspace-relative path so it survives past this script and is
 # uploaded by the coverage job `if: always()`.
-: > flake-annotations-coverage.txt
+# In shard mode the filename carries the shard index: flake-detection.yml
+# downloads every flake-annotations-* artifact with merge-multiple: true, so
+# same-named files from different shards would collide on extraction.
+flake_ann="flake-annotations-coverage.txt"
+if [ "$sharded" -eq 1 ]; then
+	flake_ann="flake-annotations-coverage-shard-${shard_index}.txt"
+fi
+: > "$flake_ann"
 
 if [ -z "${COVERAGE_TEST_LIST:-}" ]; then
 	# Mirror the unit job's expanded glob (issue #1778 H4) so the coverage gate
@@ -41,6 +85,24 @@ if [ -z "${COVERAGE_TEST_LIST:-}" ]; then
 else
 	sort "$COVERAGE_TEST_LIST" > gated-tests.txt
 	all_tests="gated-tests.txt"
+fi
+
+if [ "$sharded" -eq 1 ]; then
+	# Same round-robin over the same sorted gated set as the unit job's
+	# "Collect and partition test files" step, so coverage shard N measures
+	# exactly the files of unit (ubuntu-latest, N) and a failing file maps
+	# back to one debuggable shard pair. This script intentionally applies
+	# ONLY the base quarantined-tests.txt — it must never branch on the
+	# runner OS or consult a per-OS quarantine file — because coverage
+	# shards run ubuntu-only; an OS branch here would silently diverge the
+	# partition from the ubuntu unit cells (pinned by
+	# tests/unit/scripts/ci/ci-coverage-sharding.test.ts).
+	awk -v s="$shard_index" -v n="$shard_count" '(NR - 1) % n == (s - 1)' gated-tests.txt > shard-tests.txt
+	if [ ! -s shard-tests.txt ]; then
+		echo "::error::No test files found for coverage shard ${shard_index}/${shard_count}"
+		exit 1
+	fi
+	mv shard-tests.txt gated-tests.txt
 fi
 
 { grep -vE '^\s*#|^\s*$' scripts/ci/quarantined-tests.txt || true; } | sort > quarantined.txt
@@ -62,12 +124,14 @@ while IFS= read -r test_file; do
 	# editing ci.yml shifts those numbers and stale citations here have
 	# already had to be corrected twice).
 	#
-	# This job is merge-queue-only, and nothing in the workflow depends on it
-	# (`needs: [detect-release, quality]`, and no job lists `coverage` in its own
-	# `needs`), so it runs in parallel with the unit matrix after quality rather
-	# than extending the merge-group critical path beyond the queue deadline.
-	# With `timeout-minutes: 60` and the whole suite run per-file under
-	# `--isolate --coverage`, it is typically the long pole. Either way
+	# This shard is merge-queue-only, and the only workflow dependency on it
+	# is the trivial `coverage` aggregator (which consumes the lcov artifact);
+	# nothing serializes it behind the unit matrix (CI-004, issue #2341), so
+	# it runs in parallel with the unit matrix after quality rather than
+	# extending the merge-group critical path beyond the queue deadline.
+	# With the shard matrix's `timeout-minutes: 30` and the whole partition
+	# run per-file under `--isolate --coverage`, each shard is typically
+	# ~12 min. Either way
 	# the stake is the same: unlike a PR-branch unit shard, a single transient
 	# flake here evicts the whole PR from the queue with no chance to
 	# self-heal — a requeue costs a full ~30-60 min re-run.
@@ -91,7 +155,7 @@ while IFS= read -r test_file; do
 		bun test --isolate --coverage --timeout 60000 "$test_file" > "$tmpout" 2>&1 || exit_code=$?
 		if [ "$exit_code" -eq 0 ]; then
 			echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}"
-			echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> flake-annotations-coverage.txt
+			echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> "$flake_ann"
 		fi
 	done
 	{
@@ -104,7 +168,7 @@ while IFS= read -r test_file; do
 		cat "$tmpout"
 		echo "::endgroup::"
 		echo "::error file=${test_file}::Coverage test failed: ${test_file}"
-		echo "::error file=${test_file}::FAILED: ${test_file}" >> flake-annotations-coverage.txt
+		echo "::error file=${test_file}::FAILED: ${test_file}" >> "$flake_ann"
 		failed=1
 	elif [ -f coverage/lcov.info ]; then
 		cp coverage/lcov.info "$parts_dir/part-$index.info"
@@ -134,12 +198,22 @@ if [ ! -s coverage-value.txt ]; then
 	echo "0" > coverage-value.txt
 fi
 read -r coverage_value < coverage-value.txt || coverage_value="0"
-echo "Coverage: ${coverage_value}% (threshold: ${threshold}%)"
-if awk "BEGIN {exit !($coverage_value < $threshold)}"; then
-	echo "::error::Coverage gate failed: ${coverage_value}% < ${threshold}%"
-	failed=1
+if [ "$sharded" -eq 1 ]; then
+	# Shard-local percentage is informational only. The threshold is enforced
+	# ONCE by the coverage aggregator job over the merged union of all shards'
+	# lcov reports (issue #2341) — enforcing it per shard would be wrong (a
+	# shard's file mix skews its ratio) and un-fixable from here (a missing
+	# sibling shard must fail closed in the aggregator, not silently shrink
+	# the measured set).
+	echo "Shard ${shard_index}/${shard_count} local coverage: ${coverage_value}% (informational; threshold ${threshold}% is enforced by the aggregator over the merged union — issue #2341)"
 else
-	echo "Coverage gate passed: ${coverage_value}% >= ${threshold}%"
+	echo "Coverage: ${coverage_value}% (threshold: ${threshold}%)"
+	if awk "BEGIN {exit !($coverage_value < $threshold)}"; then
+		echo "::error::Coverage gate failed: ${coverage_value}% < ${threshold}%"
+		failed=1
+	else
+		echo "Coverage gate passed: ${coverage_value}% >= ${threshold}%"
+	fi
 fi
 
 rm -rf "$parts_dir"

--- a/tests/unit/sandbox/bwrap-setenv-injection.test.ts
+++ b/tests/unit/sandbox/bwrap-setenv-injection.test.ts
@@ -42,8 +42,9 @@ import {
  *
  * NOTE ON CI: no CI job would have caught this. Both the `unit` job and the
  * merge-queue `coverage` gate run ONE FILE PER PROCESS
- * (`scripts/ci/run-coverage-gate.sh:53` loops and invokes
- * `bun test --isolate` per file, per issue #1712). What contamination breaks is
+ * (the per-file
+ * `bun test --isolate --coverage` loop in `scripts/ci/run-coverage-gate.sh`, per
+ * issue #1712). What contamination breaks is
  * a plain local `bun test a.test.ts b.test.ts` — which developers run
  * constantly — so the seam matters for the humans, not for the build.
  *

--- a/tests/unit/sandbox/bwrap-setenv-injection.test.ts
+++ b/tests/unit/sandbox/bwrap-setenv-injection.test.ts
@@ -41,12 +41,12 @@ import {
  * probe.
  *
  * NOTE ON CI: no CI job would have caught this. Both the `unit` job and the
- * merge-queue `coverage` gate run ONE FILE PER PROCESS
- * (the per-file
- * `bun test --isolate --coverage` loop in `scripts/ci/run-coverage-gate.sh`, per
- * issue #1712). What contamination breaks is
- * a plain local `bun test a.test.ts b.test.ts` — which developers run
- * constantly — so the seam matters for the humans, not for the build.
+ * merge-queue `coverage` gate run ONE FILE PER PROCESS (the coverage gate via
+ * the per-file `bun test --isolate --coverage` loop in
+ * `scripts/ci/run-coverage-gate.sh`; the unit job via its own per-file wrapper
+ * `scripts/ci/run-test-with-timeout.ts`; per issue #1712). What contamination
+ * breaks is a plain local `bun test a.test.ts b.test.ts` — which developers
+ * run constantly — so the seam matters for the humans, not for the build.
  *
  * The seam is per-module and genuinely restorable, so the original is captured
  * once here and put back after every test.

--- a/tests/unit/scripts/ci/ci-coverage-sharding.test.ts
+++ b/tests/unit/scripts/ci/ci-coverage-sharding.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CI_YML_PATH = join(
+	import.meta.dir,
+	'../../../../.github/workflows/ci.yml',
+);
+const COVERAGE_GATE_SCRIPT_PATH = join(
+	import.meta.dir,
+	'../../../../scripts/ci/run-coverage-gate.sh',
+);
+const FLAKE_DETECTION_YML_PATH = join(
+	import.meta.dir,
+	'../../../../.github/workflows/flake-detection.yml',
+);
+
+/*
+ * Structural guard for the sharded merge-queue coverage gate (issue #2341,
+ * extending the CI-004 guard class from ci-yml-integration.test.ts).
+ *
+ * The gate is a `coverage-shard` matrix (one cell per unit-shard partition)
+ * plus a `coverage` aggregator job that keeps the required-check name and
+ * enforces the threshold ONCE over the merged union, failing closed when any
+ * shard report is missing. These tests pin that graph so a future edit cannot
+ * re-serialize the long pole behind the unit matrix (CI-004) or silently
+ * weaken the gate (dropped shard → smaller measured set → lower percentage).
+ */
+
+// CRLF-normalize: Windows checkouts can hold CRLF working copies while the
+// committed file is LF (.gitattributes eol=lf); assertions must hold on both.
+function readText(path: string): string {
+	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/*
+ * Job slicer: lazy match from the job's two-space key to the next two-space
+ * job key or EOF. Do NOT "simplify" the EOF alternative to `$` — under /m, `$`
+ * matches at every line end and the lookahead succeeds immediately,
+ * collapsing each slice (see ci-yml-integration.test.ts's header comment).
+ */
+function extractJob(yml: string, job: string): string {
+	const match = yml.match(
+		new RegExp(
+			`^ {2}${escapeRegExp(job)}:[\\s\\S]*?(?=^ {2}[A-Za-z][\\w-]*:|(?![\\s\\S]))`,
+			'm',
+		),
+	);
+	return match ? match[0] : '';
+}
+
+// Step slicer: a named step's content ends before the next step (named or
+// uses-only), a step-level comment, the next job, or EOF.
+function extractStep(yml: string, name: string): string {
+	const match = yml.match(
+		new RegExp(
+			`- name: ${escapeRegExp(name)}[\\s\\S]*?(?=\\n {6}- name:|\\n {6}- uses:|\\n {6}#|\\n {2}[A-Za-z][\\w-]*:|(?![\\s\\S]))`,
+			'm',
+		),
+	);
+	return match ? match[0] : '';
+}
+
+describe('ci.yml coverage sharding — CI-004 + issue #2341', () => {
+	const yml = readText(CI_YML_PATH);
+	const coverageShardJob = extractJob(yml, 'coverage-shard');
+	const coverageAggJob = extractJob(yml, 'coverage');
+	const unitJob = extractJob(yml, 'unit');
+	const gateStep = extractStep(yml, 'Coverage gate enforcement');
+	const coverageGateScript = readText(COVERAGE_GATE_SCRIPT_PATH);
+	const flakeDetectionYml = readText(FLAKE_DETECTION_YML_PATH);
+
+	const EVENT_GUARD =
+		"github.event_name == 'merge_group' && needs.detect-release.outputs.is-release != 'true'";
+
+	test('coverage-shard matrix mirrors the unit job shard list (partition parity)', () => {
+		// The coverage shard matrix must partition the gated test set with the
+		// same shard count as the unit job so coverage shard N measures exactly
+		// the files of unit (ubuntu-latest, N) and failures map to one
+		// debuggable shard pair (issue #2341's partition-parity requirement).
+		expect(coverageShardJob).toContain('shard: [1, 2, 3, 4, 5, 6]');
+		expect(unitJob).toContain('shard: [1, 2, 3, 4, 5, 6]');
+	});
+
+	test('coverage shards start after quality instead of waiting for the unit matrix (CI-004)', () => {
+		// Previous workflow serialized the 45-minute coverage gate behind the
+		// unit matrix, so GitHub's merge-queue timeout evicted green runs
+		// seconds before coverage completed (PR #2290). The shard matrix
+		// inherits the same invariant.
+		expect(coverageShardJob).toContain('needs: [detect-release, quality]');
+		expect(coverageShardJob).not.toMatch(/needs: \[[^\]]*\bunit\b/);
+	});
+
+	test('coverage shards run ubuntu-only with no OS matrix dimension', () => {
+		// Partition parity with unit (ubuntu-latest, N) only holds because the
+		// coverage script applies the base quarantine list alone; running
+		// coverage shards on macOS/Windows would apply different quarantine
+		// lists and silently diverge the partitions.
+		expect(coverageShardJob).toContain('runs-on: ubuntu-latest');
+		expect(coverageShardJob).not.toMatch(/matrix:\s*\n\s*os:/);
+		expect(coverageShardJob).not.toContain('matrix.os');
+	});
+
+	test('coverage-shard matrix does not cancel sibling shards on one failure', () => {
+		// fail-fast: false keeps a failed shard's siblings uploading their
+		// flake annotations and lcov reports (cancelled cells run no steps,
+		// so if:always() upload steps would not fire under fail-fast).
+		expect(coverageShardJob).toContain('fail-fast: false');
+	});
+
+	test('coverage shards get a bounded timeout with requeue-priced headroom', () => {
+		// 30m: typical shard ~12 min; a false-positive cancellation costs the
+		// whole merge group a requeue (issue #2341 sizing decision).
+		expect(coverageShardJob).toContain('timeout-minutes: 30');
+	});
+
+	test('"Coverage gate enforcement" step runs the helper in shard mode', () => {
+		expect(gateStep).toContain('bash scripts/ci/run-coverage-gate.sh');
+		expect(gateStep).toContain('COVERAGE_SHARD_INDEX: ${{ matrix.shard }}');
+		expect(gateStep).toContain('COVERAGE_SHARD_COUNT: 6');
+	});
+
+	test('coverage aggregator is the dependent single gate over the shard matrix', () => {
+		// detect-release MUST be a declared direct dependency: the aggregator's
+		// step guards read needs.detect-release.outputs.is-release, and GitHub
+		// only exposes outputs of DIRECT dependencies — a dangling reference
+		// silently resolves to null, the is-release clause goes inert, and a
+		// release-please merge group (shards skipped, zero artifacts) would
+		// fail the download step and evict the release (final-critic F1).
+		expect(coverageAggJob).toContain('needs: [coverage-shard, detect-release]');
+		expect(coverageAggJob).toContain('if: always()');
+		expect(coverageAggJob).toContain('timeout-minutes: 10');
+	});
+
+	test('coverage aggregator fail-closes on a non-success shard matrix result', () => {
+		// Mirrors unit-passed: with if:always() the aggregator still runs when
+		// a shard failed, and this check makes it FAIL fast so the required
+		// `coverage` check reports failure (immediate queue eviction) instead
+		// of being skipped and never reporting (the 60-minute silent-timeout
+		// eviction mode observed on PR #2313).
+		expect(coverageAggJob).toContain(
+			'COVERAGE_SHARD_RESULT: ${{ needs.coverage-shard.result }}',
+		);
+		expect(coverageAggJob).toContain(
+			'if [ "$COVERAGE_SHARD_RESULT" != "success" ]; then',
+		);
+	});
+
+	test('coverage aggregator fail-closes when any shard report is missing', () => {
+		// A dropped shard would silently shrink the measured set and lower the
+		// measured percentage's denominator — the issue's explicit
+		// non-negotiable. The expected-shard loop must appear twice (presence
+		// check + collection) and stay pinned to the same 6 shards as both
+		// matrices.
+		const loops = coverageAggJob.match(/for n in 1 2 3 4 5 6; do/g);
+		expect(loops).not.toBeNull();
+		expect(loops?.length).toBe(2);
+		expect(coverageAggJob).toContain(
+			'shard-reports/coverage-shard-${n}/coverage/lcov.info',
+		);
+		expect(coverageAggJob).toContain(
+			'::error::Missing or empty coverage shard report',
+		);
+		expect(coverageAggJob).toContain(
+			'::error::Fail closed: not all 6 coverage shard reports are present (issue #2341)',
+		);
+	});
+
+	test('coverage aggregator merges shard reports and enforces the threshold once', () => {
+		expect(coverageAggJob).toContain(
+			'bun scripts/ci/merge-lcov.mjs merged-parts coverage/lcov.info coverage-value.txt',
+		);
+		expect(coverageAggJob).toContain('Coverage gate passed');
+		expect(coverageAggJob).toContain('Coverage gate failed');
+	});
+
+	test('threshold literal is single-sourced between aggregator and helper script', () => {
+		expect(coverageAggJob).toContain(
+			'threshold="${COVERAGE_THRESHOLD:-65.00}"',
+		);
+		expect(coverageGateScript).toContain(
+			'threshold="${COVERAGE_THRESHOLD:-65.00}"',
+		);
+	});
+
+	test('every aggregator work step carries the merge_group event guard (PR/release stays green)', () => {
+		// On pull_request and release-please runs the shards upload nothing, so
+		// an unguarded download (if-no-files-found: error) would fail the
+		// required `coverage` check on every PR. All work steps must carry the
+		// guard; only the final upload keeps always() alongside it.
+		for (const stepName of [
+			'Check coverage shard results (fail closed)',
+			'Download shard reports',
+			'Merge shard reports and enforce threshold',
+		]) {
+			const step = extractStep(yml, stepName);
+			expect(step).toContain(`if: ${EVENT_GUARD}`);
+		}
+		const uploadStep = extractStep(yml, 'Upload coverage report');
+		expect(uploadStep).toContain(`if: always() && ${EVENT_GUARD}`);
+	});
+
+	test('shard-report download is pinned to the same download-artifact SHA as flake-detection.yml', () => {
+		const downloadStep = extractStep(yml, 'Download shard reports');
+		const pinnedSha = flakeDetectionYml.match(
+			/actions\/download-artifact@([a-f0-9]{40})/,
+		)?.[1];
+		expect(pinnedSha).toBeDefined();
+		expect(downloadStep).toContain(`actions/download-artifact@${pinnedSha}`);
+		expect(downloadStep).toContain('pattern: coverage-shard-*');
+		expect(downloadStep).toContain('if-no-files-found: error');
+	});
+
+	test('all coverage upload steps pin the same upload-artifact SHA as the unit job', () => {
+		const unitUploadStep = extractStep(yml, 'Upload flake annotations');
+		const pinnedShaMatch = unitUploadStep.match(
+			/uses: actions\/upload-artifact@([a-f0-9]+) # v[\d.]+/,
+		);
+		expect(pinnedShaMatch).not.toBeNull();
+		const sha = pinnedShaMatch?.[1];
+		for (const stepName of [
+			'Upload shard coverage report',
+			'Upload coverage flake annotations',
+			'Upload coverage report',
+		]) {
+			const step = extractStep(yml, stepName);
+			expect(step).toContain(`uses: actions/upload-artifact@${sha}`);
+		}
+	});
+});
+
+describe('run-coverage-gate.sh shard mode — issue #2341', () => {
+	const coverageGateScript = readText(COVERAGE_GATE_SCRIPT_PATH);
+
+	test('shard env contract: both-or-neither with numeric validation', () => {
+		expect(coverageGateScript).toContain('COVERAGE_SHARD_INDEX');
+		expect(coverageGateScript).toContain('COVERAGE_SHARD_COUNT');
+		expect(coverageGateScript).toContain(
+			'COVERAGE_SHARD_INDEX and COVERAGE_SHARD_COUNT must be set together',
+		);
+		expect(coverageGateScript).toContain(
+			'COVERAGE_SHARD_INDEX must be between 1 and COVERAGE_SHARD_COUNT',
+		);
+	});
+
+	test('shard partition uses the unit job round-robin over the gated set', () => {
+		expect(coverageGateScript).toContain("'(NR - 1) % n == (s - 1)'");
+	});
+
+	test('empty shard partition fails closed with an explicit error', () => {
+		// Without this guard an empty partition would fall through to the
+		// threshold check and emit a misleading "0% < threshold" failure
+		// instead of naming the actual problem (mirrors the unit job's
+		// "No test files found for shard" guard).
+		expect(coverageGateScript).toContain(
+			'No test files found for coverage shard',
+		);
+	});
+
+	test('shard mode skips threshold enforcement (aggregator owns the union)', () => {
+		expect(coverageGateScript).toContain(
+			'Shard ${shard_index}/${shard_count} local coverage',
+		);
+		expect(coverageGateScript).toContain(
+			'flake-annotations-coverage-shard-${shard_index}.txt',
+		);
+	});
+
+	test('helper script never diverges from the ubuntu partition (no OS branches)', () => {
+		// The unit job adds macOS/Windows quarantine lists per RUNNER_OS; the
+		// coverage helper must NOT, or coverage shard N would stop matching
+		// unit (ubuntu-latest, N)'s file set while every parity assertion
+		// above still passed.
+		expect(coverageGateScript).not.toContain('RUNNER_OS');
+		expect(coverageGateScript).not.toContain('quarantined-tests-macos');
+		expect(coverageGateScript).not.toContain('quarantined-tests-windows');
+	});
+});
+
+describe('ci.yml — no dangling needs references (final-critic F1, issue #2341)', () => {
+	const yml = readText(CI_YML_PATH);
+
+	test('every needs.<job>. reference is a declared direct dependency of its job', () => {
+		// GitHub's needs context only exposes outputs/results of DIRECT
+		// dependencies; a needs.<x>. reference to an undeclared job silently
+		// resolves to null instead of erroring, so a guard like
+		// `needs.detect-release.outputs.is-release != 'true'` quietly goes
+		// inert (null != 'true' is always true). Caught concretely on the
+		// coverage aggregator, whose event guard would have degenerated and
+		// failed the required `coverage` check on release-please merge groups.
+		const violations: string[] = [];
+		const jobIds = [...yml.matchAll(/^ {2}([A-Za-z][\w-]*):/gm)].map(
+			(m) => m[1],
+		);
+		expect(jobIds.length).toBeGreaterThan(0);
+		for (const jobId of jobIds) {
+			const slice = extractJob(yml, jobId);
+			// Strip comment lines: prose may legitimately cite a needs.<x>.
+			// reference it does not use.
+			const code = slice
+				.split('\n')
+				.filter((line) => !/^\s*#/.test(line))
+				.join('\n');
+			const declared = new Set<string>();
+			const inlineList = code.match(/^ {4}needs: \[([^\]]+)\]/m)?.[1] ?? '';
+			for (const dep of inlineList
+				.split(',')
+				.map((d) => d.trim())
+				.filter(Boolean)) {
+				declared.add(dep);
+			}
+			const blockList = /^ {4}needs:\n((?: {6}- [^\n]+\n)+)/m.exec(code);
+			if (blockList) {
+				for (const dep of blockList[1].matchAll(/- ([\w-]+)/g)) {
+					declared.add(dep[1]);
+				}
+			}
+			for (const ref of code.matchAll(/needs\.([A-Za-z][\w-]*)\./g)) {
+				if (!declared.has(ref[1])) {
+					violations.push(
+						`${jobId} references needs.${ref[1]}.* but does not declare '${ref[1]}' in its needs: list`,
+					);
+				}
+			}
+		}
+		expect(violations).toEqual([]);
+	});
+});

--- a/tests/unit/scripts/ci/ci-coverage-sharding.test.ts
+++ b/tests/unit/scripts/ci/ci-coverage-sharding.test.ts
@@ -204,6 +204,32 @@ describe('ci.yml coverage sharding — CI-004 + issue #2341', () => {
 		expect(uploadStep).toContain(`if: always() && ${EVENT_GUARD}`);
 	});
 
+	test('EVERY step in both coverage jobs carries the merge_group event guard (PRR-006)', () => {
+		// The named-step test above only pins the four load-bearing steps. A
+		// dropped guard on any SETUP step (checkout / setup-bun / cache /
+		// install / build) would not fail the gate — it would just run those
+		// steps on every pull_request: ~6 shards x (install + build) of pure
+		// waste per PR. Split each job slice on its step boundaries
+		// (6-space "- name:" / "- uses:") and require the guard in every one.
+		for (const [jobLabel, jobSlice] of [
+			['coverage-shard', coverageShardJob],
+			['coverage', coverageAggJob],
+		] as const) {
+			const stepBlocks = jobSlice
+				.split(/\n(?= {6}- (?:name|uses):)/)
+				.filter((block) => /^\s*- (?:name|uses):/.test(block));
+			// 8 steps in coverage-shard, 6 in the aggregator.
+			expect(stepBlocks.length).toBeGreaterThanOrEqual(6);
+			// Fail with the offending step heads rather than an opaque slice.
+			const unguarded = stepBlocks
+				.filter(
+					(block) => !block.includes(`github.event_name == 'merge_group'`),
+				)
+				.map((block) => `${jobLabel}: ${block.split('\n')[0]?.trim()}`);
+			expect(unguarded.join('\n')).toBe('');
+		}
+	});
+
 	test('shard-report download is pinned to the same download-artifact SHA as flake-detection.yml', () => {
 		const downloadStep = extractStep(yml, 'Download shard reports');
 		const pinnedSha = flakeDetectionYml.match(
@@ -265,9 +291,36 @@ describe('run-coverage-gate.sh shard mode — issue #2341', () => {
 		expect(coverageGateScript).toContain(
 			'Shard ${shard_index}/${shard_count} local coverage',
 		);
+		// PRR-007: pin the REASSIGNMENT of $flake_ann in shard mode, not just
+		// the filename string anywhere in the script — a dead variable holding
+		// the shard name while $flake_ann keeps the unsharded default would
+		// silently collide annotations under merge-multiple extraction and
+		// pass a bare substring assertion.
 		expect(coverageGateScript).toContain(
-			'flake-annotations-coverage-shard-${shard_index}.txt',
+			'flake_ann="flake-annotations-coverage-shard-${shard_index}.txt"',
 		);
+		// PRR-012: anchored slice of the sharded threshold branch — the
+		// informational message must be there and the enforcement strings must
+		// NOT be, so a future edit cannot keep the message while quietly
+		// re-adding per-shard enforcement (which would fail slow shards whose
+		// file mix skews the local ratio).
+		const readIdx = coverageGateScript.indexOf(
+			'read -r coverage_value < coverage-value.txt',
+		);
+		expect(readIdx).toBeGreaterThan(-1);
+		const shardedIfIdx = coverageGateScript.indexOf(
+			'if [ "$sharded" -eq 1 ]; then',
+			readIdx,
+		);
+		expect(shardedIfIdx).toBeGreaterThan(readIdx);
+		const elseIdx = coverageGateScript.indexOf('\nelse\n', shardedIfIdx);
+		expect(elseIdx).toBeGreaterThan(shardedIfIdx);
+		const shardedBranch = coverageGateScript.slice(shardedIfIdx, elseIdx);
+		expect(shardedBranch).toContain(
+			'Shard ${shard_index}/${shard_count} local coverage',
+		);
+		expect(shardedBranch).not.toContain('Coverage gate failed');
+		expect(shardedBranch).not.toContain('failed=1');
 	});
 
 	test('helper script never diverges from the ubuntu partition (no OS branches)', () => {

--- a/tests/unit/scripts/ci/ci-yml-integration.test.ts
+++ b/tests/unit/scripts/ci/ci-yml-integration.test.ts
@@ -58,14 +58,6 @@ function extractCoverageMeasurementStep(yml: string): string {
 	return match ? match[0] : '';
 }
 
-function extractCoverageJob(yml: string): string {
-	const normalized = yml.replace(/\r\n/g, '\n');
-	const match = normalized.match(
-		/^ {2}coverage:[\s\S]*?(?=^ {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
-	);
-	return match ? match[0] : '';
-}
-
 function extractIntegrationTestsStep(yml: string): string {
 	const normalized = yml.replace(/\r\n/g, '\n');
 	const match = normalized.match(
@@ -143,16 +135,14 @@ describe('ci.yml integration — integration quarantine extraction', () => {
 describe('ci.yml integration — merge-queue coverage isolation', () => {
 	const yml = readFileSync(CI_YML_PATH, 'utf8');
 	const step = extractCoverageMeasurementStep(yml);
-	const coverageJob = extractCoverageJob(yml);
 	const coverageGateScript = readFileSync(COVERAGE_GATE_SCRIPT_PATH, 'utf8');
 
-	test('coverage starts after quality instead of waiting for the unit matrix (CI-004)', () => {
-		// Previous workflow serialized the 45-minute coverage gate behind the unit
-		// matrix, so GitHub's 60-minute merge-queue timeout evicted green runs
-		// seconds before coverage completed.
-		expect(coverageJob).toContain('needs: [detect-release, quality]');
-		expect(coverageJob).not.toMatch(/needs: \[[^\]]*\bunit\b/);
-	});
+	// The job-graph invariants (CI-004 "coverage never behind unit", the shard
+	// matrix's parity with the unit job, and the fail-closed `coverage`
+	// aggregator) moved to tests/unit/scripts/ci/ci-coverage-sharding.test.ts
+	// when the single coverage job became a coverage-shard matrix + aggregator
+	// (issue #2341). This describe keeps the script-content contracts that are
+	// independent of the job graph.
 
 	test('"Coverage gate enforcement" step delegates to the coverage helper', () => {
 		expect(step).toContain('bash scripts/ci/run-coverage-gate.sh');
@@ -236,24 +226,35 @@ describe('ci.yml integration — coverage gate bounded retry (issue #1782 parity
 		expect(bunTestIdx).toBeGreaterThan(mkdirIdx);
 	});
 
-	test('coverage helper appends the "passed on retry" notice to flake-annotations-coverage.txt', () => {
+	test('coverage helper appends the "passed on retry" notice to the flake-annotation file', () => {
+		// The annotation filename is a variable since issue #2341 sharded the
+		// gate: unsharded runs keep `flake-annotations-coverage.txt`, shard runs
+		// write `flake-annotations-coverage-shard-<i>.txt` (distinct internal
+		// names are mandatory — flake-detection.yml downloads the
+		// flake-annotations-* pattern with merge-multiple: true and same-named
+		// files would collide on extraction).
 		expect(coverageGateScript).toContain(
-			'echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> flake-annotations-coverage.txt',
+			'flake_ann="flake-annotations-coverage.txt"',
+		);
+		expect(coverageGateScript).toContain(
+			'echo "::notice file=${test_file}::Passed on retry ${retry_num} (flaky): ${test_file}" >> "$flake_ann"',
 		);
 	});
 
-	test('coverage helper appends the hard-failure error to flake-annotations-coverage.txt', () => {
+	test('coverage helper appends the hard-failure error to the flake-annotation file', () => {
 		expect(coverageGateScript).toContain(
-			'echo "::error file=${test_file}::FAILED: ${test_file}" >> flake-annotations-coverage.txt',
+			'echo "::error file=${test_file}::FAILED: ${test_file}" >> "$flake_ann"',
 		);
 	});
 
-	test('ci.yml uploads flake-annotations-coverage.txt from the coverage job', () => {
+	test('ci.yml uploads the per-shard flake-annotation files from the coverage-shard job (issue #2341)', () => {
 		const coverageUploadStep = extractCoverageFlakeAnnotationsUploadStep(yml);
 		const unitUploadStep = extractUnitFlakeAnnotationsUploadStep(yml);
-		expect(coverageUploadStep).toContain('name: flake-annotations-coverage');
 		expect(coverageUploadStep).toContain(
-			'path: flake-annotations-coverage.txt',
+			'name: flake-annotations-coverage-shard-${{ matrix.shard }}',
+		);
+		expect(coverageUploadStep).toContain(
+			'path: flake-annotations-coverage-shard-${{ matrix.shard }}.txt',
 		);
 		expect(coverageUploadStep).toContain('if-no-files-found: ignore');
 

--- a/tests/unit/worktree/cleanup-orphaned-branches-prune-order-2261.test.ts
+++ b/tests/unit/worktree/cleanup-orphaned-branches-prune-order-2261.test.ts
@@ -42,12 +42,12 @@ import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
  * tests/unit/git/branch.test.ts.
  *
  * NOTE ON CI: no CI job would have caught it. Both the `unit` job and the
- * merge-queue `coverage` gate run ONE FILE PER PROCESS
- * (the per-file
- * `bun test --isolate --coverage` loop in `scripts/ci/run-coverage-gate.sh`, per
- * issue #1712). What breaks is a plain local
- * `bun test a.test.ts b.test.ts`. `Bun.spawnSync` is unaffected by a
- * node-module mock, so the fixture is honest under every runner.
+ * merge-queue `coverage` gate run ONE FILE PER PROCESS (the coverage gate via
+ * the per-file `bun test --isolate --coverage` loop in
+ * `scripts/ci/run-coverage-gate.sh`; the unit job via its own per-file wrapper
+ * `scripts/ci/run-test-with-timeout.ts`; per issue #1712). What breaks is a
+ * plain local `bun test a.test.ts b.test.ts`. `Bun.spawnSync` is unaffected by
+ * a node-module mock, so the fixture is honest under every runner.
  *
  * The code under test is unaffected either way — it reaches git via `bunSpawn`.
  */

--- a/tests/unit/worktree/cleanup-orphaned-branches-prune-order-2261.test.ts
+++ b/tests/unit/worktree/cleanup-orphaned-branches-prune-order-2261.test.ts
@@ -43,8 +43,9 @@ import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
  *
  * NOTE ON CI: no CI job would have caught it. Both the `unit` job and the
  * merge-queue `coverage` gate run ONE FILE PER PROCESS
- * (`scripts/ci/run-coverage-gate.sh:53` loops and invokes `bun test --isolate`
- * per file, per issue #1712). What breaks is a plain local
+ * (the per-file
+ * `bun test --isolate --coverage` loop in `scripts/ci/run-coverage-gate.sh`, per
+ * issue #1712). What breaks is a plain local
  * `bun test a.test.ts b.test.ts`. `Bun.spawnSync` is unaffected by a
  * node-module mock, so the fixture is honest under every runner.
  *


### PR DESCRIPTION
Closes #2341

## Summary

Green PRs were evicted from the merge queue with `checks_timed_out` through no fault of their own. Two causes, both fixed:

1. **Budget < critical path.** The ruleset gave merge groups 60 minutes *from enqueue* (queue wait included), while the single serial `coverage` job alone took ~48 minutes (measured on PR #2313's eviction: started 9 min after enqueue, succeeded at 47.8 min). Any queue position > 1 evicted a green group.
2. **The observed eviction's literal trigger.** `unit (macos-latest, 1)` failed; `integration`/`smoke` (required) were *skipped* and never reported, and the failing checks themselves were not required — so the queue could only sit and time out. The eviction at 01:27:03 happened ~4 minutes *after* coverage had already succeeded.

### Changes

**Ruleset 17809658 (applied live via API, admin; verified by GET diff — exactly two deltas, all else byte-identical):** `check_response_timeout_minutes` 60 → 90, and `unit-passed` added to required status checks — a failing unit cell now evicts the group immediately with `checks_failed` instead of a silent full-window timeout.

**ci.yml** — the `coverage` job becomes:

- a `coverage-shard` matrix: 6 ubuntu shards, the *same round-robin partition as the `unit` job* (coverage shard N measures exactly the files of `unit (ubuntu-latest, N)`), `needs: [detect-release, quality]` (CI-004 invariant preserved: parallel to unit, never behind it), `timeout-minutes: 30`, `fail-fast: false`; each shard uploads its merged lcov (`coverage-shard-N`) and a per-shard flake-annotation artifact with a distinct internal filename (required — flake-detection.yml downloads the `flake-annotations-*` pattern with `merge-multiple: true`);
- a `coverage` aggregator (keeps the required-check name): downloads all shard reports and enforces the 65.00% threshold **once** over the merged union. Fail-closed three ways: matrix-result check (fails fast when any shard failed/cancelled), `if-no-files-found: error` on the pattern download (zero artifacts), and an explicit per-shard presence loop (partial set). All work steps carry the `merge_group` event guard so PR and release-please runs stay green with all steps skipped; `detect-release` is a declared direct dependency so the is-release guard actually resolves (a dangling `needs` reference silently resolves to null under GitHub Actions semantics — caught by the final critic, would have failed release-please merge groups).

**run-coverage-gate.sh** — optional shard mode (`COVERAGE_SHARD_INDEX`/`COVERAGE_SHARD_COUNT`, both-or-neither, validated), unit-job awk partition, per-shard annotation filenames, threshold enforcement *skipped* in shard mode (aggregator owns the union). Unsharded local behavior unchanged.

**Structural guards** — new `tests/unit/scripts/ci/ci-coverage-sharding.test.ts` (332 lines) pins: CI-004 inherited by shards, three-way shard-count parity (unit matrix == coverage matrix == aggregator loop), ubuntu-only partition pinning (no OS branches in the helper), fail-closed aggregator, single-sourced threshold literal, event guards on every aggregator step, action SHA pins, and a file-wide **no-dangling-needs** rule. Existing `ci-yml-integration.test.ts` updated to the shard shape. Both new guards mutation-verified (revert fix → intended assertions fail; restore → green).

**Docs** — `TESTING.md`/`contributing.md` corrected the stale 41.48% → the real 65.00% threshold (stale since issue #1778 H4 recalibrated it) and describe the sharded gate; `test-stability.md` annotation names updated; the 1737 pending-fragment caveat about `unit-passed` marked superseded.

### Queue math after the fix

The merge-group critical path is the unit chain — quality (~2 min) → unit matrix (Windows pole ~20-25 min) → integration (~5-10 min) → smoke (~10 min) ≈ **40-50 minutes** — with the coverage leg (shards ~12 min + aggregator ~2, starting after quality) fully in parallel, versus a 90-minute from-enqueue budget at any queue position (~2x margin). The coverage leg drops from the 48-min pole to ~17 min. A 90-min-only fix was rejected: it leaves a 48-min pole + ~10-min smoke tail against a from-enqueue budget — deep queue wait or runner-start spikes re-open the CI-004 eviction class.

Known caveat (pre-existing, tracked in #2344): within an otherwise-green coverage shard, a test file for which bun produces no lcov report only logs a warning — that file's lines drop out of the measured denominator. The aggregator's fail-closed checks bound this to per-file granularity; a shard producing no lcov at all still fails the gate.

## Invariant audit

- 1 (plugin init):       not touched — no changes to src/index.ts or plugin startup; `node scripts/repro-704.mjs` still green (server() resolved in ~322-330 ms, deadline 10000 ms).
- 2 (runtime portability): not touched — no src/, package exports, or build config changes; `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` → "dist import OK".
- 3 (subprocesses):       touched (CI-level only) — ci.yml shard jobs run the existing bounded helper (`bash scripts/ci/run-coverage-gate.sh`); every new job has `timeout-minutes` (30/10); spawn-call-site audit over the diff: "no spawn call sites added"; `bash -n` clean.
- 4 (.swarm containment): not touched — no runtime state paths; CI artifacts live in Actions storage.
- 5 (plan durability):    not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing):       touched — new test file (332 lines < 500 cap), bun:test only, zero mocks (pure file-content structural tests), CRLF-normalized reads, writing-tests skill loaded; `bun run check:test-file-cap` → "New-file violations: 0, Ratchet violations: 0"; mutation-verified the dangling-needs guard (revert-fix → 2 intended assertion failures; restore → green).
- 8 (session state):      not touched.
- 9 (guardrails/retry):   touched (CI-level only) — shard cells keep the helper's bounded retry (2 retries/3 attempts); the aggregator fails closed, never open. Evidence: aggregator replay of the exact ci.yml run block — pass / threshold-fail / missing-shard / zero-shard cases all correct.
- 10 (chat/system msg):   not touched.
- 11 (tool registration): not touched — no tools/agents/commands; `bun run scripts/check-tool-registration.ts` → "126 tools, coherent"; parity test green (quality-job commands unchanged).
- 12 (release/cache):     touched — `docs/releases/pending/2341-shard-coverage-gate.md` shipped (AGENTS mandate); no hand-edits to version/CHANGELOG/manifest; `bun run check:pending-fragment` green post-commit.

## Test plan

- [x] `bun --smol test tests/unit/scripts/ci/ci-coverage-sharding.test.ts tests/unit/scripts/ci/ci-yml-integration.test.ts tests/security/ci-workflow-security.test.ts` → 49 pass / 0 fail (includes the security scan over the new ci.yml).
- [x] `bun run test:unit:ci <the 5 touched/adjacent test files>` (CI-equivalent wrapper, quarantine ledgers + retry budget) → all exit 0.
- [x] `bun test tests/security tests/adversarial --timeout 120000` → 1018 tests, 0 fail, 4 skip.
- [x] Full quality contract locally: typecheck, `lint:ci` (3727 files), tool-registration, mock-cleanup, invariants, cross-contamination, test-clock, runtime-src-refs, events, retention, test-file-cap, pending-fragment, gate-portability, bare-spawn, test-tmpdir, bash-portability, swarm-model node:test — all pass.
- [x] `bun run build` + dist Node import + `node scripts/repro-704.mjs` + `bun run package:smoke` (v7.147.0 tarball, 1121 files) — all pass.
- [x] Functional: real 2-shard micro-run of run-coverage-gate.sh (correct partitions, per-shard lcov, distinct annotation files, threshold correctly skipped in shard mode); aggregator replay of the exact ci.yml run block (6/6+low → pass; 6/6+99.99 → fail; 5/6 → fail closed; 0/6 → fail closed); merge-equivalence proof (flat vs hierarchical merge-lcov byte-identical, 85.71% matches hand-computed 6/7).
- [x] Mutation verification of both new guards (shard graph pin + no-dangling-needs).
- [ ] Live: this PR's own merge-group run exercises the new sharded graph end-to-end; coverage union expected ≈ the pre-fix ~73-74%.
