### PR TITLE
feat(symbol-graph): harden c/c++ and swift extraction

### DIFF
--- a/docs/releases/pending/1530-cpp-swift-symbol-graph.md
+++ b/docs/releases/pending/1530-cpp-swift-symbol-graph.md
@@ -1,0 +1,64 @@
+# Harden C/C++ and Swift Symbol Graph Support
+
+## What
+
+Hardens `src/lang/symbol-graph.ts` / `src/lang/symbol-visibility.ts` /
+`src/tools/repo-graph/builder.ts` extraction for C/C++ (`.c`, `.h`, `.cpp`,
+`.hpp`, `.cc`, `.cxx`) and Swift (`.swift`), which previously carried only a
+thin baseline query set (issue #1530, KG-09):
+
+- **Header-declared public symbols are represented.** C/C++ prototypes
+  (`int add(int, int);`, including pointer-return forms like `char *concat()`)
+  now produce exported function defs — a `.h` file previously yielded zero
+  defs.
+- **C/C++ include edges are represented.** Quoted includes (`#include
+  "util.h"`) normalize to `./`-relative default imports that resolve to real
+  file edges; angle includes (`#include <vector>`) stay external/unresolved
+  namespace imports.
+- **C++ class members, constructors, enums, and typedefs are extracted.**
+  Method declarations/definitions inside class/struct/union bodies
+  (`field_identifier` declarators), in-class constructors, out-of-class
+  qualified definitions (`void engine::run()`), `enum`, and `typedef` are all
+  captured; members are re-typed to `method` like the JVM/.NET languages.
+- **C++ internals are conservative.** `static` file-scope functions and
+  anything inside an anonymous `namespace { … }` block are marked
+  not-exported; class/struct members default by container kind (class →
+  private, struct/union → public) and are never file-level exports. Access
+  specifier sections (`public:`) are not tracked (documented limitation).
+- **Swift struct/enum/extension/typealias and protocol members are
+  represented.** Extension blocks produce a `type` def for the extended type
+  and their members are attributed as `method`; protocol requirements are
+  extracted.
+- **Swift visibility is correct in full.** `open`/`public` map to public,
+  `internal` to internal, `fileprivate`/`private` to private; members without
+  a modifier now default to Swift's implicit `internal` (previously forced to
+  `public`); multi-line attributes (`@available(iOS 14, *)` on the line above
+  a `public func`) no longer hide the modifier.
+- **Swift imports split module vs symbol.** `import class Foo.Bar` yields
+  specifier `Foo` with a named `Bar` binding (all kind keywords supported);
+  attribute-prefixed imports (`@_testable import MyApp`) are no longer
+  dropped.
+- **`context_pack` serves C/C++ and Swift member spans.** `exportRanges` is
+  widened to all defs for cpp/swift (mirroring the Java/Kotlin/C# widening),
+  so internal and private symbols get real spans instead of the
+  "span unavailable" placeholder.
+
+## Why
+
+A merged-but-discarded prior attempt never landed on current main, and the
+remaining baseline missed explicit acceptance criteria of the graph-memory
+roadmap: headers produced no symbols at all, Swift members were mis-typed and
+mis-defaulted, and native-language imports carried no resolvable semantics.
+
+## How to use
+
+Rebuild the repo graph (`repo_map` action `build`) and query
+`repo_map` action `context_pack` with a native-language `file`/`symbol`. See
+`docs/repo-graph-symbol-graph.md` → "Native language limitations" for the
+conservative-by-design caveats (quoted-only include resolution, overload
+collapse, macro blindness, template best-effort, Swift module resolution).
+
+## Migration
+
+No migration required. Graph payloads gain `exportRanges` entries for
+non-exported cpp/swift defs; schema is unchanged.

--- a/docs/releases/pending/1530-cpp-swift-symbol-graph.md
+++ b/docs/releases/pending/1530-cpp-swift-symbol-graph.md
@@ -12,9 +12,11 @@ thin baseline query set (issue #1530, KG-09):
   now produce exported function defs — a `.h` file previously yielded zero
   defs.
 - **C/C++ include edges are represented.** Quoted includes (`#include
-  "util.h"`) normalize to `./`-relative default imports that resolve to real
-  file edges; angle includes (`#include <vector>`) stay external/unresolved
-  namespace imports.
+  "util.h"`) normalize to `./`-relative namespace imports (whole-file import
+  semantics) that resolve to real file edges — so `callers`, `consumers`,
+  and `dead_exports` treat an included header as a whole-file dependency
+  rather than per-symbol usage; angle includes (`#include <vector>`) stay
+  external/unresolved.
 - **C++ class members, constructors, enums, and typedefs are extracted.**
   Method declarations/definitions inside class/struct/union bodies
   (`field_identifier` declarators), in-class constructors, out-of-class
@@ -26,9 +28,10 @@ thin baseline query set (issue #1530, KG-09):
   private, struct/union → public) and are never file-level exports. Access
   specifier sections (`public:`) are not tracked (documented limitation).
 - **Swift struct/enum/extension/typealias and protocol members are
-  represented.** Extension blocks produce a `type` def for the extended type
-  and their members are attributed as `method`; protocol requirements are
-  extracted.
+  represented.** Extension blocks produce a non-exported `type` def for the
+  extended type (the type's own declaration keeps its span and exports
+  entry) and their members are attributed as `method`; protocol requirements
+  are extracted.
 - **Swift visibility is correct in full.** `open`/`public` map to public,
   `internal` to internal, `fileprivate`/`private` to private; members without
   a modifier now default to Swift's implicit `internal` (previously forced to

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -591,8 +591,10 @@ from the tree-sitter parse alone.
   CMake/VCPkg/Xcode search paths), which are not known to the extractor.
 - **Overload collapse is conservative.** All C++ overloads of a name are
   extracted, but the graph is name-keyed: `exportRanges` holds one span per
-  name (last-exported document-order wins), so `context_pack` cannot
-  distinguish overload signatures.
+  name (resolved by the three-rule duplicate-name policy — an exported def
+  outranks a non-exported one; two exported defs take the last; two
+  non-exported defs take the first), so `context_pack` cannot distinguish
+  overload signatures.
 - **Macros can hide definitions and references.** A definition or reference
   manufactured by the preprocessor (`#define MAKE_FN(name) ...`) is invisible
   to the syntactic pass.
@@ -622,5 +624,15 @@ from the tree-sitter parse alone.
   module-level import; kind-qualified imports (`import class Foo.Bar`) split
   into module specifier + named binding. Module names never resolve to
   workspace files (a Swift module spans many files and needs build metadata
-  to map), so Swift file-level edges come from other signals, and Xcode
+  to map), so Swift imports produce no file-level edges — `context_pack` on a
+  Swift symbol is served by the target file's own spans. Xcode
   project-specific resolution is out of scope.
+- **C++ operator overloads, conversion operators, and destructors are not
+  extracted.** Their names parse as dedicated grammar nodes
+  (`operator+`, `operator int`, `~Foo`), not plain identifiers, and the
+  query set does not model them. Regular member/static/free functions are
+  unaffected.
+- **Swift extension blocks augment, never re-export.** An `extension Foo`
+  emits a non-exported def for `Foo` so the type's own declaration keeps its
+  `exportRanges` span and `exports[]` entry; extension members are still
+  extracted and attributed as methods.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -576,3 +576,51 @@ repo_map { "action": "context_pack", "file": "src/foo.ts", "symbol": "doThing", 
   such an edge as "depends on this package", not as "references this exact
   file". Consumers needing precise per-symbol attribution should use symbol
   edges, which are only emitted for imports that bind a specific name.
+
+### Native language limitations (C/C++ and Swift)
+
+Extraction for C/C++ (`.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.cxx`) and Swift
+(`.swift`) is syntax-only and deliberately conservative. No compiler or
+SourceKit is invoked (an explicit non-goal), so everything below is derived
+from the tree-sitter parse alone.
+
+- **Include resolution is quoted-only.** A quoted include (`#include
+  "util.h"`) resolves relative to the including file and produces a file edge.
+  An angle include (`#include <vector>`) is treated as external/unresolved and
+  produces no edge: real include paths come from the build system (`-I` flags,
+  CMake/VCPkg/Xcode search paths), which are not known to the extractor.
+- **Overload collapse is conservative.** All C++ overloads of a name are
+  extracted, but the graph is name-keyed: `exportRanges` holds one span per
+  name (last-exported document-order wins), so `context_pack` cannot
+  distinguish overload signatures.
+- **Macros can hide definitions and references.** A definition or reference
+  manufactured by the preprocessor (`#define MAKE_FN(name) ...`) is invisible
+  to the syntactic pass.
+- **Templates are best-effort.** A `template <typename T>` function or class
+  is extracted as a plain symbol; template instantiations and specializations
+  are not resolved, and ranges cover only the declaration as written.
+- **C++ access specifiers are not tracked.** `public:`/`protected:`/`private:`
+  sections carry no per-member visibility: class members default by container
+  kind (class → private, struct/union → public) and are never file-level
+  exports. Before this hardening they were not extracted at all; the
+  conservative non-exported representation avoids advertising
+  access-restricted members as public API.
+- **`static` and anonymous namespaces are internal.** A `static`
+  file-scope function and anything inside `namespace { … }` is marked
+  not-exported (internal linkage), mirroring the linker's view.
+- **Swift struct/enum are modeled as class kind.** The tree-sitter Swift
+  grammar parses `struct`, `enum`, and `extension` blocks all as
+  `class_declaration`; kind discrimination is not modeled, so a struct or enum
+  def carries kind `class` and an extension contributes a `type` def for the
+  extended type. Members inside any of them (including extensions) are
+  attributed as `method`.
+- **Swift `init`/`deinit` and stored properties are not extracted.**
+  Constructors have no name node in the grammar, and properties are outside
+  the issue's symbol scope; only functions, classes/structs/enums, protocols,
+  extensions, and typealiases are represented.
+- **Swift module resolution is conservative.** `import Foundation` records a
+  module-level import; kind-qualified imports (`import class Foo.Bar`) split
+  into module specifier + named binding. Module names never resolve to
+  workspace files (a Swift module spans many files and needs build metadata
+  to map), so Swift file-level edges come from other signals, and Xcode
+  project-specific resolution is out of scope.

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -61,8 +61,11 @@ export interface FileSymbolFacts {
 const AST_TIMEOUT_MS = 500;
 
 /**
- * Per-grammar query sets. Task 1.1 defines only 'typescript' as the exemplar;
- * additional grammars are added in task 1.2.
+ * Per-grammar query sets — one defs/imports/refs triple per registered
+ * grammar id. Patterns must be verified against the shipped grammar WASMs
+ * (s-expression dumps) before being added: node types and field names differ
+ * from what source syntax suggests (e.g. C++ method names live in
+ * field_identifier declarators; Swift structs parse as class_declaration).
  */
 const QUERIES: Record<
 	string,
@@ -768,7 +771,7 @@ function buildFacts(
 			const nameNode = asTs(nc.node);
 			const localName = nameNode.text;
 			const commonJsExport = commonJsExports.get(localName);
-			const visibilityInfo = getSymbolVisibilityInfo({
+			let visibilityInfo = getSymbolVisibilityInfo({
 				grammarId,
 				localName,
 				kind,
@@ -781,6 +784,18 @@ function buildFacts(
 				pythonParentClassExported,
 				parentContainerType,
 			});
+			// A Swift extension block augments an already-declared type — it is
+			// not itself a new file-level export. Keeping the extension def
+			// non-exported lets the builder's exported-outranks-non-exported
+			// policy keep the type's OWN declaration span in exportRanges, and
+			// keeps `exports[]` free of the duplicated name (PR #2351 review,
+			// F-001/PRR-002: an exported extension def carries the same name as
+			// the type it extends and displaced that type's span under the
+			// duplicate-name policy — order-independently, since an exported
+			// def outranks a non-exported one in both document orders).
+			if (grammarId === 'swift' && kindKey === 'extension') {
+				visibilityInfo = { ...visibilityInfo, exported: false };
+			}
 			const exportedName = isDefaultExport
 				? 'default'
 				: (commonJsExport?.exportedName ?? localName);
@@ -1590,12 +1605,17 @@ function parseCppInclude(text: string): FileSymbolFacts['imports'][0] | null {
 	// Quoted include: #include "foo.h" / #include "sub/foo.h" / #include "../x.h".
 	// Local includes resolve relative to the including file, so the specifier is
 	// normalized to a './'-prefixed form that resolveModuleSpecifier can turn
-	// into a file edge.
+	// into a file edge. The import TYPE is 'namespace': an include binds the
+	// whole header with no per-symbol binding, and the graph consumers
+	// (getCallers/getSymbolConsumers/getDeadExports) treat namespace imports
+	// as whole-file — a 'default' edge with empty usedSymbols made callers
+	// vanish and flagged every header export as a dead candidate (PR #2351
+	// review, PRR-001).
 	const quoted = t.match(/^#\s*include\s+"([^"]+)"/);
 	if (quoted) {
 		const raw = quoted[1];
 		const specifier = raw.startsWith('.') ? raw : `./${raw}`;
-		return { specifier, importType: 'default', bindings: [] };
+		return { specifier, importType: 'namespace', bindings: [] };
 	}
 	// Angle include: #include <foo.h>. Without build-system include paths these
 	// stay external/unresolved (bare specifier; resolveModuleSpecifier returns

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -283,8 +283,44 @@ const QUERIES: Record<
 					declarator: (identifier) @func.name
 				)
 			) @func.def
+			(function_definition
+				declarator: (pointer_declarator
+					declarator: (function_declarator
+						declarator: (identifier) @func.name
+					)
+				)
+			) @func.def
+			(function_definition
+				(function_declarator
+					declarator: (qualified_identifier (identifier) @func.name)
+				)
+			) @func.def
+			(declaration
+				declarator: (function_declarator
+					declarator: (identifier) @func.name
+				)
+			) @func.def
+			(declaration
+				declarator: (pointer_declarator
+					declarator: (function_declarator
+						declarator: (identifier) @func.name
+					)
+				)
+			) @func.def
+			(function_definition
+				(function_declarator
+					declarator: (field_identifier) @method.name
+				)
+			) @method.def
+			(field_declaration
+				(function_declarator
+					declarator: (field_identifier) @method.name
+				)
+			) @method.def
 			(class_specifier name: (type_identifier) @class.name) @class.def
 			(struct_specifier name: (type_identifier) @struct.name) @struct.def
+			(enum_specifier name: (type_identifier) @enum.name) @enum.def
+			(type_definition declarator: (type_identifier) @type.name) @type.def
 		`,
 		imports: `
 			(preproc_include) @import
@@ -293,14 +329,20 @@ const QUERIES: Record<
 		refs: `
 			(identifier) @ref.identifier
 			(namespace_identifier) @ref.identifier
+			(type_identifier) @ref.identifier
 		`,
 		exports: ``,
 	},
 	swift: {
 		defs: `
 			(function_declaration name: (simple_identifier) @func.name) @func.def
+			(protocol_function_declaration name: (simple_identifier) @func.name) @func.def
 			(class_declaration name: (type_identifier) @class.name) @class.def
+			(class_declaration
+				name: (user_type (type_identifier) @extension.name)
+			) @extension.def
 			(protocol_declaration name: (type_identifier) @protocol.name) @protocol.def
+			(typealias_declaration name: (type_identifier) @type.name) @type.def
 		`,
 		imports: `
 			(import_declaration) @import
@@ -308,6 +350,7 @@ const QUERIES: Record<
 		refs: `
 			(identifier) @ref.identifier
 			(simple_identifier) @ref.identifier
+			(type_identifier) @ref.identifier
 		`,
 		exports: ``,
 	},
@@ -383,6 +426,10 @@ const CAPTURE_KIND: Record<string, FileSymbolFacts['defs'][0]['kind']> = {
 	// The `Object.hasOwn` guard at the lookup site closes the class for any
 	// future prefix; this name keeps the query readable regardless.
 	ctor: 'method',
+	// Swift extension blocks parse as `class_declaration` with a `user_type`
+	// name; the extended type is already declared elsewhere, so the extension
+	// contributes a type-level augmentation rather than a new type.
+	extension: 'type',
 };
 
 const DEF_TYPES = new Set([
@@ -438,6 +485,24 @@ const JVM_CONTAINER_TYPES = new Set([
 	'record_declaration',
 ]);
 
+/**
+ * Type-container node types for the cpp/swift member re-typing and container
+ * defaults. Only the SPECIFIER/DECLARATION nodes are listed, never the body
+ * (`field_declaration_list`): the ancestor walk passes through the body to the
+ * specifier, and the specifier kind is what the cpp container default needs
+ * (class members default private, struct/union members public).
+ */
+const NATIVE_CONTAINER_TYPES = new Set([
+	// cpp: class/struct/union (an in-class constructor prototype parses as a
+	// plain `declaration` inside the specifier's field_declaration_list).
+	'class_specifier',
+	'struct_specifier',
+	'union_specifier',
+	// swift: class/struct/enum/extension all parse as class_declaration.
+	'class_declaration',
+	'protocol_declaration',
+]);
+
 const PARAM_TYPES = new Set([
 	'formal_parameters',
 	'required_parameter',
@@ -446,6 +511,18 @@ const PARAM_TYPES = new Set([
 	'array_pattern',
 	'object_pattern',
 ]);
+
+/**
+ * Swift-only addition to {@link PARAM_TYPES}. The swift grammar's `parameter`
+ * node wraps each parameter's names and type, and without this skip the
+ * parameter NAMES (`func f(_ input: Int)`) leak into refs. The skip is
+ * deliberately grammar-scoped rather than added to PARAM_TYPES: the same node
+ * type name exists in the csharp, kotlin, and rust grammars, where a
+ * parameter-position TYPE is a genuine reference signal — most notably for
+ * Kotlin named imports, whose bindings are marked used by body/parameter
+ * refs (final-critic finding on issue #1530).
+ */
+const SWIFT_REF_PARAM_TYPES = new Set([...PARAM_TYPES, 'parameter']);
 
 /**
  * Extract symbol, import, and reference facts from a source string using
@@ -605,6 +682,19 @@ function buildFacts(
 				parentContainerType !== undefined &&
 				(kindKey === 'func' || kindKey === 'ctor')
 			) {
+				kind = 'method';
+			}
+		}
+		// cpp/swift: members are re-typed the same way, and the container type
+		// feeds the container-scoped implicit-visibility default (Swift members
+		// default `internal`; C++ class members default private, struct/union
+		// members public — see containerScopedDefaultVisibility).
+		if (grammarId === 'cpp' || grammarId === 'swift') {
+			parentContainerType = nearestAncestorType(
+				originalDefNode,
+				NATIVE_CONTAINER_TYPES,
+			);
+			if (parentContainerType !== undefined && kindKey === 'func') {
 				kind = 'method';
 			}
 		}
@@ -830,6 +920,8 @@ function buildFacts(
 		.map((d) => ({ name: d.name, node: d.node }));
 
 	const refs: FileSymbolFacts['refs'] = [];
+	const refParamTypes =
+		grammarId === 'swift' ? SWIFT_REF_PARAM_TYPES : PARAM_TYPES;
 	for (const m of refMatches) {
 		const cap = m.captures.find((c) => c.name === 'ref.identifier');
 		if (!cap) continue;
@@ -838,7 +930,7 @@ function buildFacts(
 		if (defNameKeys.has(nodeKey(refNode))) continue;
 		if (hasAncestorOfType(refNode, 'import_statement')) continue;
 		if (isInsideImportStatement(refNode)) continue;
-		if (hasAncestorOfType(refNode, PARAM_TYPES)) continue;
+		if (hasAncestorOfType(refNode, refParamTypes)) continue;
 		if (refNode.text === 'require' && isInsideRequireCall(refNode)) continue;
 
 		refs.push({
@@ -1495,13 +1587,25 @@ function parseCSharpUsing(text: string): FileSymbolFacts['imports'][0] | null {
 
 function parseCppInclude(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
-	// #include <foo>
-	// #include "foo"
-	// using foo::bar;
-	const include = t.match(/^#\s*include\s+[<"]([^>"]+)[>"]/);
-	if (include) {
-		return { specifier: include[1], importType: 'namespace', bindings: [] };
+	// Quoted include: #include "foo.h" / #include "sub/foo.h" / #include "../x.h".
+	// Local includes resolve relative to the including file, so the specifier is
+	// normalized to a './'-prefixed form that resolveModuleSpecifier can turn
+	// into a file edge.
+	const quoted = t.match(/^#\s*include\s+"([^"]+)"/);
+	if (quoted) {
+		const raw = quoted[1];
+		const specifier = raw.startsWith('.') ? raw : `./${raw}`;
+		return { specifier, importType: 'default', bindings: [] };
 	}
+	// Angle include: #include <foo.h>. Without build-system include paths these
+	// stay external/unresolved (bare specifier; resolveModuleSpecifier returns
+	// null and they are not reported as unresolved relative imports).
+	const angle = t.match(/^#\s*include\s+<([^>]+)>/);
+	if (angle) {
+		return { specifier: angle[1], importType: 'namespace', bindings: [] };
+	}
+	// using foo::bar;
+	// using namespace foo;
 	const using = t.match(/^using\s+(?:namespace\s+)?(.+?)\s*;?\s*$/);
 	if (using) {
 		return {
@@ -1515,13 +1619,34 @@ function parseCppInclude(text: string): FileSymbolFacts['imports'][0] | null {
 
 function parseSwiftImport(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
-	// import foo
-	// import class foo.Bar
-	const m = t.match(/^import\s+(?:class\s+)?([^;\s]+)/);
-	if (m) {
-		return { specifier: m[1], importType: 'namespace', bindings: [] };
+	// Optional leading attributes: @_testable import Foo / @_exported import Foo
+	const attrs = /^(?:@\w+(?:\([^)\n]*\))?\s+)*/.source;
+	// import Foo                        → namespace import of module Foo
+	// import Foo.Bar                    → namespace import of submodule Foo.Bar
+	// import class Foo.Bar              → named import: module Foo, symbol Bar
+	// import class Foo.Bar.Baz          → named import: module Foo, symbol Baz
+	//   (middle components are a nested module path; the LAST component is the
+	//   imported symbol — conservative, matches how the symbol is referenced)
+	// The kind group requires its own trailing whitespace, so a module that
+	// merely starts with a keyword (`import classFoo`) is not split.
+	const m = t.match(
+		new RegExp(
+			`${attrs}import\\s+((?:class|struct|enum|protocol|typealias|func|var|let)\\s+)?([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)*)\\s*$`,
+		),
+	);
+	if (!m) return null;
+	const path = m[2]!.split('.');
+	if (m[1] !== undefined && path.length >= 2) {
+		const imported = path[path.length - 1]!;
+		return {
+			specifier: path[0]!,
+			importType: 'named',
+			bindings: [{ imported, local: imported }],
+		};
 	}
-	return null;
+	// No kind keyword, or a kind with no dotted path (not valid Swift — keep
+	// the whole specifier rather than dropping the import).
+	return { specifier: m[2]!, importType: 'namespace', bindings: [] };
 }
 
 function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -105,7 +105,13 @@ const PRIVATE_INFO: SymbolVisibilityInfo = {
  * Grammars whose members' implicit visibility depends on the *kind* of the
  * enclosing type container rather than on a naming convention.
  */
-const CONTAINER_SCOPED_GRAMMARS = new Set(['java', 'kotlin', 'csharp']);
+const CONTAINER_SCOPED_GRAMMARS = new Set([
+	'java',
+	'kotlin',
+	'csharp',
+	'swift',
+	'cpp',
+]);
 
 /** Node types that declare a type (as opposed to a member of a type). */
 const TYPE_DECLARATION_NODE_TYPES = new Set([
@@ -142,6 +148,17 @@ function containerScopedDefaultVisibility(
 			return 'public';
 		case 'java':
 			return 'package';
+		case 'swift':
+			// Swift's implicit visibility is `internal` everywhere — for members
+			// of any type container and for nested types alike.
+			return 'internal';
+		case 'cpp':
+			// C++ language defaults; access-specifier sections (`public:`) are
+			// not tracked, so these apply conservatively.
+			return containerType === 'struct_specifier' ||
+				containerType === 'union_specifier'
+				? 'public'
+				: 'private';
 		default:
 			// csharp: top-level types default to `internal`, members of a type
 			// default to `private`.
@@ -430,6 +447,11 @@ function modifierLanguageVisibility(
 }
 
 function cppVisibility(ctx: SymbolVisibilityContext): SymbolVisibilityInfo {
+	// Anonymous namespaces give their contents internal linkage — walk the
+	// ancestors for a `namespace_definition` with no `name` child.
+	if (isInsideAnonymousNamespace(ctx.defNode)) {
+		return { ...PRIVATE_INFO };
+	}
 	const text = ctx.defNode.text.trimStart();
 	if (/^static\b/.test(text) || ctx.localName.startsWith('_')) {
 		return { ...PRIVATE_INFO };
@@ -440,6 +462,26 @@ function cppVisibility(ctx: SymbolVisibilityContext): SymbolVisibilityInfo {
 		exportedReason: 'namespace_public',
 		apiSurfaceKind: 'public',
 	};
+}
+
+/**
+ * True when `node` sits inside an anonymous C++ `namespace { … }` block: a
+ * `namespace_definition` ancestor whose children contain no
+ * `namespace_identifier` (the grammar omits the name field for the anonymous
+ * form, and the name child with it).
+ */
+function isInsideAnonymousNamespace(node: SymbolVisibilityNode): boolean {
+	let current = node.parent;
+	while (current) {
+		if (current.type === 'namespace_definition') {
+			const named = current.children.some(
+				(child) => child !== null && child.type === 'namespace_identifier',
+			);
+			if (!named) return true;
+		}
+		current = current.parent;
+	}
+	return false;
 }
 
 function visibilityFromText(grammarId: string, text: string): SymbolVisibility {
@@ -463,10 +505,17 @@ function visibilityFromText(grammarId: string, text: string): SymbolVisibility {
 /**
  * Grammars for which a declaration may begin with annotations/attributes that
  * must be skipped before the visibility modifier is reached. Restricted to the
- * JVM/.NET grammars so decorator-carrying TypeScript/Python/PHP declarations
- * keep their existing behavior.
+ * JVM/.NET and Swift grammars so decorator-carrying TypeScript/Python/PHP
+ * declarations keep their existing behavior. Swift attributes (`@available`,
+ * `@MainActor`, …) sit on their own line before the declaration and would
+ * otherwise consume the first-line header window and hide the modifier.
  */
-const ANNOTATED_DECLARATION_GRAMMARS = new Set(['java', 'kotlin', 'csharp']);
+const ANNOTATED_DECLARATION_GRAMMARS = new Set([
+	'java',
+	'kotlin',
+	'csharp',
+	'swift',
+]);
 
 /**
  * Index just past a balanced bracket group starting at `open`, or -1 if the

--- a/src/lang/symbol-visibility.ts
+++ b/src/lang/symbol-visibility.ts
@@ -75,14 +75,17 @@ export interface SymbolVisibilityContext {
 	/**
 	 * Tree-sitter node type of the nearest enclosing type container
 	 * (`class_declaration`, `interface_declaration`, `enum_declaration`,
-	 * `record_declaration`, `struct_declaration`, `object_declaration`), or
-	 * `undefined` when the declaration has no enclosing type container.
+	 * `record_declaration`, `struct_declaration`, `object_declaration`,
+	 * and for cpp the class/struct/union specifiers), or `undefined` when the
+	 * declaration has no enclosing type container.
 	 *
-	 * Only populated for the JVM/.NET grammars (java/kotlin/csharp), where the
-	 * *kind* of container decides the implicit visibility of a member that
-	 * carries no explicit modifier (an interface member is implicitly public in
-	 * both Java and C#, a C# class member is implicitly private, a Java class
-	 * member is implicitly package-private).
+	 * Populated for the JVM/.NET grammars (java/kotlin/csharp) and for
+	 * cpp/swift, where the *kind* of container decides the implicit visibility
+	 * of a member that carries no explicit modifier (an interface member is
+	 * implicitly public in both Java and C#, a C# class member is implicitly
+	 * private, a Java class member is implicitly package-private, a Swift
+	 * member is implicitly internal, and a C++ member defaults by container
+	 * kind — class private, struct/union public).
 	 */
 	parentContainerType?: string;
 }
@@ -127,16 +130,20 @@ const TYPE_DECLARATION_NODE_TYPES = new Set([
  * Implicit visibility of a declaration that carries no explicit modifier,
  * given its language and the kind of type container it lives in.
  *
- * | container            | java    | kotlin | csharp   |
- * |----------------------|---------|--------|----------|
- * | interface            | public  | public | public   |
- * | class / record       | package | public | private  |
- * | enum                 | package | public | private  |
- * | struct               | —       | —      | private  |
- * | (none)               | package | public | internal |
+ * | container            | java    | kotlin | csharp   | swift    | cpp     |
+ * |----------------------|---------|--------|----------|----------|---------|
+ * | interface/protocol   | public  | public | public   | internal | —       |
+ * | class / record       | package | public | private  | internal | private |
+ * | enum                 | package | public | private  | internal | —       |
+ * | struct               | —       | —      | private  | internal | public  |
+ * | union                | —       | —      | —        | —        | public  |
+ * | (none)               | package | public | internal | internal | public  |
  *
  * Java and C# interface members are *implicitly public* — that row is the
- * reason this takes the container node type and not a boolean.
+ * reason this takes the container node type and not a boolean. Swift's
+ * implicit visibility is `internal` regardless of container kind; C++ class
+ * members default private and struct/union members public (access-specifier
+ * sections are not tracked, so these defaults apply conservatively).
  */
 function containerScopedDefaultVisibility(
 	grammarId: string,
@@ -697,9 +704,10 @@ function maskStringLiterals(text: string): string {
 
 /**
  * The header of a declaration — everything before the body or the first line
- * break. For JVM/.NET grammars, leading annotations are skipped first, so
- * `@Override\npublic void run()` still exposes the `public` modifier instead of
- * truncating to `@Override`.
+ * break. For grammars in ANNOTATED_DECLARATION_GRAMMARS (JVM/.NET and
+ * Swift), leading annotations are skipped first, so `@Override\npublic void
+ * run()` and `@available(iOS 14, *)\npublic func f()` still expose the
+ * `public` modifier instead of truncating at the annotation.
  */
 /**
  * Upper bound on how much of a declaration's text is scanned to find its

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -2121,11 +2121,20 @@ function getLanguage(filePath: string): string {
 
 /**
  * Grammars whose `exportRanges` map is populated from *all* defs rather than
- * only exported ones. JVM/.NET members are intentionally never `exported`
- * (they are not file-level module exports), so without this `context_pack`
- * could never return a span for a Java method (issue #1529, RC-7).
+ * only exported ones. JVM/.NET and native-language members are intentionally
+ * never `exported` (they are not file-level module exports — a Java method, a
+ * C++ class member, a Swift member inside a type), so without this
+ * `context_pack` could never return a span for them (issue #1529 RC-7 for
+ * JVM/.NET; issue #1530 for C/C++ and Swift, whose static and anonymous-
+ * namespace internals are likewise non-exported).
  */
-const JVM_DOTNET_RANGE_GRAMMARS = new Set(['java', 'kotlin', 'csharp']);
+const RANGE_WIDENED_GRAMMARS = new Set([
+	'java',
+	'kotlin',
+	'csharp',
+	'cpp',
+	'swift',
+]);
 
 /**
  * Check if file content appears to be binary.
@@ -2421,25 +2430,25 @@ export async function scanFileAsync(
 	for (const d of exportedDefs) {
 		exportLines[d.name] = d.startLine;
 	}
-	// `exports` and `exportLines` stay exported-only — the "a JVM/.NET member is
+	// `exports` and `exportLines` stay exported-only — the "a member of a type is
 	// not a file-level module export" contract must not change. `exportRanges`
-	// is widened to ALL defs for java/kotlin/csharp so `context_pack` can return
-	// a real member span instead of the "internal symbol — span unavailable"
-	// placeholder (issue #1529, RC-7).
+	// is widened to ALL defs for java/kotlin/csharp/cpp/swift so `context_pack`
+	// can return a real member span instead of the "internal symbol — span
+	// unavailable" placeholder (issue #1529 RC-7; cpp/swift per issue #1530).
 	//
-	// The widening is language-scoped because only JVM/.NET members are wanted
-	// in `exportRanges`: admitting every non-exported def for other grammars
-	// would put private TypeScript/Python/Rust/Go helpers into a persisted,
-	// schema-validated graph field for no benefit. Non-widened grammars keep the
-	// original exported-only, unconditionally-assigned behavior, so their
-	// payloads are unchanged.
+	// The widening is language-scoped because only member-bearing grammars with
+	// non-exported members are wanted in `exportRanges`: admitting every
+	// non-exported def for other grammars would put private
+	// TypeScript/Python/Rust/Go helpers into a persisted, schema-validated graph
+	// field for no benefit. Non-widened grammars keep the original exported-only,
+	// unconditionally-assigned behavior, so their payloads are unchanged.
 	//
 	// The duplicate-name policy below is likewise scoped, and mirrors
 	// `exportLines` rather than diverging from it: among EXPORTED defs both maps
 	// take the last, so they cannot disagree; among non-exported defs (which
 	// never reach `exportLines`) the first wins, so a constructor or a later
 	// overload cannot displace its enclosing type.
-	const isWidenedGrammar = JVM_DOTNET_RANGE_GRAMMARS.has(grammarId);
+	const isWidenedGrammar = RANGE_WIDENED_GRAMMARS.has(grammarId);
 	// Tracks whether the def currently holding each `exportRanges` slot was
 	// exported. Widening admits non-exported members, so without this an
 	// unexported member could outrank the exported symbol of the same name.

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -24,7 +24,7 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  *
  * 1.2.0 adds per-node `exportRanges` (1-based inclusive line spans keyed by
  * symbol name — exported symbols for every grammar, plus non-exported member
- * defs for java/kotlin/csharp; see the field docs) and the top-level
+ * defs for java/kotlin/csharp/cpp/swift; see the field docs) and the top-level
  * `symbolEdges` array (direct symbol-to-
  * symbol reference edges). Both fields are optional, so 1.0.0 and 1.1.0 graphs
  * still load without corruption. New queries may use these fields to provide
@@ -225,10 +225,12 @@ export interface GraphNode {
 	 * Each span value uses `startLine` / `endLine` to match the codebase
 	 * convention (see `ContextPackSpan` and `FileSymbolFacts`).
 	 *
-	 * SCOPE (issue #1529): exported symbols for every grammar, PLUS
-	 * non-exported member defs for java/kotlin/csharp. A JVM/.NET member is
+	 * SCOPE (issues #1529 and #1530): exported symbols for every grammar,
+	 * PLUS non-exported member defs for java/kotlin/csharp/cpp/swift. A
+	 * JVM/.NET or native-language member (or a Swift extension block) is
 	 * deliberately never a file-level export, so without that widening
-	 * `context_pack` could return no span at all for a Java method.
+	 * `context_pack` could return no span at all for a Java method or a
+	 * private C++ helper.
 	 * `exports` and `exportLines` stay exported-only in every language.
 	 *
 	 * Duplicate names resolve so this map cannot disagree with `exportLines`:

--- a/tests/unit/lang/language-extraction-coverage.test.ts
+++ b/tests/unit/lang/language-extraction-coverage.test.ts
@@ -97,17 +97,21 @@ const EXPECTATIONS: Record<string, Expectation> = {
 	},
 	cpp: {
 		source: '#include <m>\nclass C { public: void m() {} };\n',
-		expectMethods: false,
+		expectMethods: true,
+		// C/C++ includes bind no named symbol: a quoted include imports the
+		// whole file and an angle include is external (issue #1530).
 		expectBindings: false,
 		reason:
-			'C/C++ hardening is issue #1530. parseCppInclude returns bindings: [] for both #include forms, and the cpp defs query does not type members as methods.',
+			'C/C++ includes never carry named bindings: quoted includes import the whole file, angle includes are external/unresolved.',
 	},
 	swift: {
 		source: 'import M\npublic class C { public func m() {} }\n',
-		expectMethods: false,
+		expectMethods: true,
+		// A bare `import M` binds a whole module; only kind-qualified imports
+		// (`import class M.C`) carry a named binding (issue #1530).
 		expectBindings: false,
 		reason:
-			'Swift hardening is issue #1530. A Swift `import M` binds a whole module, and members are not re-typed to method.',
+			'A bare Swift `import M` binds a whole module; named bindings require a kind-qualified import (`import class M.C`).',
 	},
 	dart: {
 		source: "import 'm.dart';\nclass C { void m() {} }\n",

--- a/tests/unit/lang/symbol-graph-cpp-swift-imports.test.ts
+++ b/tests/unit/lang/symbol-graph-cpp-swift-imports.test.ts
@@ -4,9 +4,10 @@
  * mocks, asserting the normalized import records the graph builder consumes.
  *
  * The include/import distinction is an acceptance criterion: quoted local
- * includes become './'-relative default imports (resolvable to file edges by
- * resolveModuleSpecifier); angle-bracket includes stay external/unresolved
- * namespace imports; Swift kind-qualified imports split module vs symbol.
+ * includes become './'-relative namespace imports (whole-file semantics,
+ * resolvable to file edges by resolveModuleSpecifier); angle-bracket includes
+ * stay external/unresolved namespace imports; Swift kind-qualified imports
+ * split module vs symbol.
  */
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { clearParserCache } from '../../../src/lang/runtime';
@@ -17,7 +18,7 @@ describe('extractFileSymbols C/C++ include forms (issue #1530)', () => {
 		clearParserCache();
 	});
 
-	test('quoted include is a ./-relative default import', async () => {
+	test('quoted include is a ./-relative whole-file (namespace) import', async () => {
 		const facts = await extractFileSymbols(
 			'cpp',
 			'#include "util.h"\nint main() { return 0; }\n',
@@ -25,7 +26,7 @@ describe('extractFileSymbols C/C++ include forms (issue #1530)', () => {
 		expect(facts).not.toBeNull();
 		expect(facts!.imports).toContainEqual({
 			specifier: './util.h',
-			importType: 'default',
+			importType: 'namespace',
 			bindings: [],
 		});
 	});
@@ -38,13 +39,13 @@ describe('extractFileSymbols C/C++ include forms (issue #1530)', () => {
 		expect(facts).not.toBeNull();
 		expect(facts!.imports).toContainEqual({
 			specifier: './sub/nested.h',
-			importType: 'default',
+			importType: 'namespace',
 			bindings: [],
 		});
 		// Already-relative specifiers are not re-prefixed.
 		expect(facts!.imports).toContainEqual({
 			specifier: '../other/up.h',
-			importType: 'default',
+			importType: 'namespace',
 			bindings: [],
 		});
 	});
@@ -190,6 +191,21 @@ describe('extractFileSymbols Swift import forms (issue #1530)', () => {
 		});
 	});
 
+	test('attribute with nested parens on an import is a documented drop', async () => {
+		// Known limitation (PR #2351 review PRR-003): the attribute-argument
+		// scanner stops at the first ')' and cannot span nested parens, so
+		// `@objc(foo(bar)) import X` fails to parse and yields no import.
+		// Real Swift import attributes (@_testable, @_exported,
+		// @_implementationOnly) never carry nested parens; pinned so a change
+		// here is conscious.
+		const facts = await extractFileSymbols(
+			'swift',
+			'@objc(foo(bar)) import Foundation\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports.length).toBe(0);
+	});
+
 	test('attribute-prefixed imports are parsed, not dropped', async () => {
 		const facts = await extractFileSymbols(
 			'swift',
@@ -228,6 +244,28 @@ describe('extractFileSymbols Swift import forms (issue #1530)', () => {
 		expect(facts!.refs.some((r) => r.identifier === '_')).toBe(false);
 		const bodyUses = facts!.refs.filter((r) => r.identifier === 'input');
 		expect(bodyUses.length).toBe(1);
+	});
+
+	test('swift type references appear in refs (type_identifier capture)', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'class Holder {}',
+				'',
+				'func make(_ h: Holder) -> Holder {',
+				'    return Holder()',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		// Return-type AND constructor-call type references surface (pins the
+		// (type_identifier) @ref.identifier pattern in the swift refs query).
+		// The parameter-position `h: Holder` does NOT — the swift-only
+		// parameter-node ref filter (see SWIFT_REF_PARAM_TYPES) skips the
+		// whole parameter node, so exactly 2 remain.
+		const holderRefs = facts!.refs.filter((r) => r.identifier === 'Holder');
+		expect(holderRefs.length).toBe(2);
 	});
 
 	test('parameter-position type refs stay captured for csharp/kotlin (final-critic pin)', async () => {

--- a/tests/unit/lang/symbol-graph-cpp-swift-imports.test.ts
+++ b/tests/unit/lang/symbol-graph-cpp-swift-imports.test.ts
@@ -1,0 +1,258 @@
+/**
+ * C/C++ and Swift import-form coverage for issue #1530. Mirrors the KG-08
+ * `symbol-graph-jvm-dotnet-imports.test.ts` structure: real grammars, no
+ * mocks, asserting the normalized import records the graph builder consumes.
+ *
+ * The include/import distinction is an acceptance criterion: quoted local
+ * includes become './'-relative default imports (resolvable to file edges by
+ * resolveModuleSpecifier); angle-bracket includes stay external/unresolved
+ * namespace imports; Swift kind-qualified imports split module vs symbol.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+describe('extractFileSymbols C/C++ include forms (issue #1530)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('quoted include is a ./-relative default import', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'#include "util.h"\nint main() { return 0; }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: './util.h',
+			importType: 'default',
+			bindings: [],
+		});
+	});
+
+	test('quoted include with subpath keeps its relative shape', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'#include "sub/nested.h"\n#include "../other/up.h"\nint main() { return 0; }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: './sub/nested.h',
+			importType: 'default',
+			bindings: [],
+		});
+		// Already-relative specifiers are not re-prefixed.
+		expect(facts!.imports).toContainEqual({
+			specifier: '../other/up.h',
+			importType: 'default',
+			bindings: [],
+		});
+	});
+
+	test('angle include stays an external namespace import', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'#include <stdio.h>\n#include <vector>\nint main() { return 0; }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'stdio.h',
+			importType: 'namespace',
+			bindings: [],
+		});
+		expect(facts!.imports).toContainEqual({
+			specifier: 'vector',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('using declaration and using directive are namespace imports', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'using engine::Engine;',
+				'using namespace std;',
+				'int main() { return 0; }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'engine::Engine',
+			importType: 'namespace',
+			bindings: [],
+		});
+		expect(facts!.imports).toContainEqual({
+			specifier: 'std',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('non-include preprocessor lines are not imports', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'#define MAX 10\n#ifdef WIN32\n#endif\nint main() { return MAX; }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports.length).toBe(0);
+	});
+});
+
+describe('extractFileSymbols Swift import forms (issue #1530)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('bare module import is a namespace import', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'import Foundation\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foundation',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('kind-qualified import splits module specifier and named binding', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'import class Foo.Bar',
+				'import struct Foundation.Date',
+				'import func Darwin.exit',
+				'func f() { return 1 }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foo',
+			importType: 'named',
+			bindings: [{ imported: 'Bar', local: 'Bar' }],
+		});
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foundation',
+			importType: 'named',
+			bindings: [{ imported: 'Date', local: 'Date' }],
+		});
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Darwin',
+			importType: 'named',
+			bindings: [{ imported: 'exit', local: 'exit' }],
+		});
+	});
+
+	test('submodule dotted import without a kind stays a namespace import', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'import Foo.Sub\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foo.Sub',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('multi-dot kind-qualified import resolves module and trailing symbol', async () => {
+		// Pre-fix regression (review finding): `import class Foo.Bar.Baz` was
+		// silently dropped (null) — the qualified regex allowed exactly one dot.
+		const facts = await extractFileSymbols(
+			'swift',
+			'import class Foo.Bar.Baz\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foo',
+			importType: 'named',
+			bindings: [{ imported: 'Baz', local: 'Baz' }],
+		});
+	});
+
+	test('kind keyword without a dotted path is kept, not dropped', async () => {
+		// Not valid Swift, but the conservative behavior is a namespace import
+		// of the written specifier — never a silently missing import.
+		const facts = await extractFileSymbols(
+			'swift',
+			'import classFoo\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'classFoo',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('attribute-prefixed imports are parsed, not dropped', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'@_testable import MyApp\n@_exported import Foundation\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual({
+			specifier: 'MyApp',
+			importType: 'namespace',
+			bindings: [],
+		});
+		expect(facts!.imports).toContainEqual({
+			specifier: 'Foundation',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('import identifiers do not leak into refs', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'import Foundation\nfunc f() { return 1 }\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(facts!.refs.some((r) => r.identifier === 'Foundation')).toBe(false);
+	});
+
+	test('swift parameter names are filtered from refs', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'func f(_ input: Int) -> Int { return input }\n',
+		);
+		expect(facts).not.toBeNull();
+		// The parameter NAMES ('_', 'input') are declarations, not references;
+		// the body usage of `input` IS a reference.
+		expect(facts!.refs.some((r) => r.identifier === '_')).toBe(false);
+		const bodyUses = facts!.refs.filter((r) => r.identifier === 'input');
+		expect(bodyUses.length).toBe(1);
+	});
+
+	test('parameter-position type refs stay captured for csharp/kotlin (final-critic pin)', async () => {
+		// The swift-only `parameter` ref skip must NOT leak into grammars that
+		// share the node-type name: a Kotlin named-import binding referenced
+		// ONLY in parameter position must still count as used (it feeds
+		// usedSymbols and symbol edges in the graph builder).
+		const kotlinFacts = await extractFileSymbols(
+			'kotlin',
+			'import m.Widget\n\nfun build(w: Widget) { }\n',
+		);
+		expect(kotlinFacts).not.toBeNull();
+		expect(
+			kotlinFacts!.refs.some((r) => r.identifier === 'Widget'),
+			'kotlin parameter-position type ref must stay a ref',
+		).toBe(true);
+
+		const csharpFacts = await extractFileSymbols(
+			'csharp',
+			'using M.Thing;\n\nclass C {\n    void Handle(Thing t) { }\n}\n',
+		);
+		expect(csharpFacts).not.toBeNull();
+		expect(
+			csharpFacts!.refs.some((r) => r.identifier === 'Thing'),
+			'csharp parameter-position type ref must stay a ref',
+		).toBe(true);
+	});
+});

--- a/tests/unit/lang/symbol-graph-cpp-swift.test.ts
+++ b/tests/unit/lang/symbol-graph-cpp-swift.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Grammar-level acceptance evidence for issue #1530 (C/C++ and Swift symbol
+ * graph hardening). Mirrors the KG-08 (#1529) file structure for java/kotlin/
+ * csharp: real tree-sitter grammars, no mocks. Each test maps to an explicit
+ * acceptance criterion of the issue:
+ *   - C/C++ header-declared public symbols are represented
+ *   - C/C++ internal/static caveats handled conservatively (static +
+ *     anonymous namespace)
+ *   - C++ namespace/class/function/method/enum/typedef extraction, overload
+ *     representation + name-collapse caveat, template best-effort
+ *   - Swift visibility modifiers (open/public/internal/fileprivate/private),
+ *     implicit internal, extension blocks, protocol members, typealias,
+ *     attribute-prefixed declarations
+ *   - malformed input fails open for both grammars
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function byName(
+	facts: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>,
+	name: string,
+) {
+	return facts.defs.find((d) => d.name === name);
+}
+
+describe('extractFileSymbols — cpp grammar hardening (issue #1530)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('C header: prototypes and pointer-return prototypes are public defs', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'#ifndef UTIL_H',
+				'#define UTIL_H',
+				'int add(int a, int b);',
+				'char *concat(const char *a, const char *b);',
+				'#endif',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const add = byName(facts!, 'add');
+		expect(add).toBeDefined();
+		expect(add!.kind).toBe('function');
+		expect(add!.exported).toBe(true);
+		expect(add!.visibilityInfo?.visibility).toBe('public');
+		const concat = byName(facts!, 'concat');
+		expect(concat).toBeDefined();
+		expect(concat!.exported).toBe(true);
+	});
+
+	test('C source: static is private, plain function is public', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'#include <stdio.h>',
+				'#include "util.h"',
+				'',
+				'static int helper(int v) { return v * 2; }',
+				'int add(int a, int b) { return helper(a) + b; }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'helper')?.exported).toBe(false);
+		expect(byName(facts!, 'helper')?.visibilityInfo?.visibility).toBe(
+			'private',
+		);
+		expect(byName(facts!, 'add')?.exported).toBe(true);
+	});
+
+	test('C++ namespace/class: members, ctor, enum, struct, typedef represented', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'namespace engine {',
+				'  class Engine {',
+				'  public:',
+				'    Engine(int capacity);',
+				'    void start();',
+				'    int capacity() const { return capacity_; }',
+				'  private:',
+				'    int capacity_;',
+				'  };',
+				'  enum Status { Idle, Running };',
+				'  struct Config { int retries; };',
+				'  typedef unsigned long token_t;',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const engine = byName(facts!, 'Engine');
+		expect(engine?.kind).toBe('class');
+		expect(engine?.exported).toBe(true);
+		// The constructor reuses the free-prototype pattern; the container walk
+		// must re-type it to method and resolve a non-unknown visibility.
+		const ctor = facts!.defs.filter((d) => d.name === 'Engine');
+		expect(ctor.some((d) => d.kind === 'method')).toBe(true);
+		const start = byName(facts!, 'start');
+		expect(start?.kind).toBe('method');
+		expect(start?.exported).toBe(false);
+		const capacity = byName(facts!, 'capacity');
+		expect(capacity?.kind).toBe('method');
+		expect(capacity?.exported).toBe(false);
+		// Class members default private (class_specifier container); access
+		// specifiers are not tracked — conservative by design (documented).
+		expect(capacity?.visibilityInfo?.visibility).toBe('private');
+		expect(byName(facts!, 'Status')?.kind).toBe('enum');
+		expect(byName(facts!, 'Config')?.kind).toBe('type');
+		expect(byName(facts!, 'token_t')?.kind).toBe('type');
+	});
+
+	test('C++ struct members default public visibility (non-exported)', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'struct Config {\n  int retries;\n  void reset() {}\n};\n',
+		);
+		expect(facts).not.toBeNull();
+		const reset = byName(facts!, 'reset');
+		expect(reset?.kind).toBe('method');
+		expect(reset?.exported).toBe(false);
+		expect(reset?.visibilityInfo?.visibility).toBe('public');
+	});
+
+	test('C++ overload pair is fully represented; names collapse conservatively', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'void run(int times);',
+				'int run(int times, int retries);',
+				'void run(int times) { }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const overloads = facts!.defs.filter((d) => d.name === 'run');
+		// All three declarations (two prototypes + one definition) are defs.
+		// Overload resolution is conservative: same-name defs are NOT merged —
+		// downstream (exportRanges) collapses them by name with a documented
+		// last-exported-wins policy.
+		expect(overloads.length).toBe(3);
+		expect(overloads.every((d) => d.exported)).toBe(true);
+	});
+
+	test('C++ out-of-class qualified definition is named by the function, not the namespace', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'namespace engine {\nvoid run();\n}\nvoid engine::run() { }\n',
+		);
+		expect(facts).not.toBeNull();
+		// qualified_identifier's namespace segment parses as
+		// namespace_identifier (a different node type), so only the trailing
+		// `identifier` can be captured: the def must be `run`, never `engine`.
+		expect(byName(facts!, 'run')).toBeDefined();
+		expect(byName(facts!, 'engine')).toBeUndefined();
+	});
+
+	test('C++ anonymous namespace members are internal (not exported)', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'namespace {\n',
+				'int internal_fn() { return 1; }\n',
+				'}\n',
+				'int public_fn() { return 2; }\n',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const internal = byName(facts!, 'internal_fn');
+		expect(internal?.exported).toBe(false);
+		expect(internal?.visibilityInfo?.visibility).toBe('private');
+		expect(byName(facts!, 'public_fn')?.exported).toBe(true);
+	});
+
+	test('C++ named namespace members stay exported', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'namespace engine {\nint visible() { return 1; }\n}\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'visible')?.exported).toBe(true);
+	});
+
+	test('C++ anonymous namespace nested in a named namespace is still internal', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'namespace engine {',
+				'namespace {',
+				'void nested_hidden() { }',
+				'}',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		// The ancestor walk must see THROUGH the named namespace to the
+		// anonymous one — anything inside an anonymous namespace has internal
+		// linkage regardless of nesting depth.
+		expect(byName(facts!, 'nested_hidden')?.exported).toBe(false);
+	});
+
+	test('C++ template function and class get best-effort extraction', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'template <typename T>',
+				'T identity(T x) { return x; }',
+				'',
+				'template <typename T>',
+				'class Box {',
+				'public:',
+				'  T value;',
+				'};',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'identity')).toBeDefined();
+		expect(byName(facts!, 'Box')).toBeDefined();
+	});
+
+	test('cpp malformed input fails open', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			'class {{{ int x(;;; \n#include <<<\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(Array.isArray(facts!.defs)).toBe(true);
+	});
+});
+
+describe('extractFileSymbols — swift grammar hardening (issue #1530)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('all five explicit visibility modifiers are represented', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'open class OpenC { }',
+				'public class PublicC { }',
+				'internal class InternalC { }',
+				'fileprivate class FileC { }',
+				'private class PrivateC { }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'OpenC')?.visibilityInfo?.visibility).toBe('public');
+		expect(byName(facts!, 'OpenC')?.exported).toBe(true);
+		expect(byName(facts!, 'PublicC')?.visibilityInfo?.visibility).toBe(
+			'public',
+		);
+		expect(byName(facts!, 'InternalC')?.visibilityInfo?.visibility).toBe(
+			'internal',
+		);
+		expect(byName(facts!, 'InternalC')?.exported).toBe(true);
+		expect(byName(facts!, 'FileC')?.visibilityInfo?.visibility).toBe('private');
+		expect(byName(facts!, 'FileC')?.exported).toBe(false);
+		expect(byName(facts!, 'PrivateC')?.visibilityInfo?.visibility).toBe(
+			'private',
+		);
+		expect(byName(facts!, 'PrivateC')?.exported).toBe(false);
+	});
+
+	test('members without modifiers default to internal (module-public)', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'public class PublicC {\n    func implicitInternal() {}\n}\n',
+		);
+		expect(facts).not.toBeNull();
+		const member = byName(facts!, 'implicitInternal');
+		expect(member?.kind).toBe('method');
+		expect(member?.exported).toBe(false);
+		expect(member?.visibilityInfo?.visibility).toBe('internal');
+		expect(member?.visibilityInfo?.exportedReason).toBe('module_public');
+	});
+
+	test('member visibility modifiers override the container default', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'public class Mixed {',
+				'    public func open_() {}',
+				'    private func hidden() {}',
+				'    fileprivate func fileOnly() {}',
+				'    internal func moduleOnly() {}',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'open_')?.visibilityInfo?.visibility).toBe('public');
+		expect(byName(facts!, 'hidden')?.visibilityInfo?.visibility).toBe(
+			'private',
+		);
+		expect(byName(facts!, 'fileOnly')?.visibilityInfo?.visibility).toBe(
+			'private',
+		);
+		expect(byName(facts!, 'moduleOnly')?.visibilityInfo?.visibility).toBe(
+			'internal',
+		);
+		// No member is a file-level module export.
+		for (const name of ['open_', 'hidden', 'fileOnly', 'moduleOnly']) {
+			expect(byName(facts!, name)?.exported).toBe(false);
+		}
+	});
+
+	test('struct, enum, extension, protocol member, and typealias are represented', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'internal struct DataPayload {',
+				'    func compute() -> Int { return 1 }',
+				'}',
+				'private enum Hidden { case one }',
+				'protocol Serializable {',
+				'    func serialize() -> Int',
+				'}',
+				'extension DataPayload {',
+				'    func extended() -> Int { return 2 }',
+				'}',
+				'typealias Handler = (Int) -> Void',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		// struct/enum both parse as class_declaration; kind stays 'class'
+		// (documented limitation — keyword-child discrimination is not modeled).
+		const payload = byName(facts!, 'DataPayload');
+		expect(payload?.kind).toBe('class');
+		expect(payload?.visibilityInfo?.visibility).toBe('internal');
+		expect(byName(facts!, 'compute')?.kind).toBe('method');
+		expect(byName(facts!, 'Hidden')?.exported).toBe(false);
+		// Protocol requirements are extracted as methods.
+		const serialize = byName(facts!, 'serialize');
+		expect(serialize?.kind).toBe('method');
+		expect(serialize?.exported).toBe(false);
+		// The extension contributes a second DataPayload def (type kind) whose
+		// members are attributed as methods.
+		const payloadDefs = facts!.defs.filter((d) => d.name === 'DataPayload');
+		expect(payloadDefs.some((d) => d.kind === 'type')).toBe(true);
+		expect(byName(facts!, 'extended')?.kind).toBe('method');
+		expect(byName(facts!, 'Handler')?.kind).toBe('type');
+	});
+
+	test('protocol/class/function ranges span their declarations', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'protocol Serializable {',
+				'    func serialize() -> Int',
+				'}',
+				'class Holder {',
+				'    func compute() -> Int { return 1 }',
+				'}',
+				'func topLevel() -> Int { return 3 }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		expect(byName(facts!, 'Serializable')).toMatchObject({
+			startLine: 1,
+			endLine: 3,
+		});
+		expect(byName(facts!, 'Holder')).toMatchObject({
+			startLine: 4,
+			endLine: 6,
+		});
+		expect(byName(facts!, 'topLevel')).toMatchObject({
+			startLine: 7,
+			endLine: 7,
+		});
+	});
+
+	test('attribute-prefixed declarations keep their real modifier', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'@available(iOS 14, *)',
+				'public func attributed() -> Int { return 1 }',
+				'',
+				'@MainActor',
+				'internal func actorScoped() -> Int { return 2 }',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		// Pre-fix: declarationPrefix truncated at the newline inside the
+		// attribute and `attributed` resolved internal instead of public.
+		expect(byName(facts!, 'attributed')?.visibilityInfo?.visibility).toBe(
+			'public',
+		);
+		expect(byName(facts!, 'actorScoped')?.visibilityInfo?.visibility).toBe(
+			'internal',
+		);
+	});
+
+	test('swift malformed input fails open', async () => {
+		const facts = await extractFileSymbols(
+			'swift',
+			'class {{{ func (( \nimport <<<<\n',
+		);
+		expect(facts).not.toBeNull();
+		expect(Array.isArray(facts!.defs)).toBe(true);
+	});
+
+	test('swift init and stored properties are deliberately not extracted', async () => {
+		// Documented non-goal (grammar gives init no name node; properties are
+		// outside the symbol scope). Pinned so a future regression toward
+		// half-extracted inits (e.g. named by parameter text) is caught.
+		const facts = await extractFileSymbols(
+			'swift',
+			[
+				'public class Service {',
+				'    public init() {}',
+				'    public var stored = 1',
+				'    public func work() -> Int { return stored }',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const names = facts!.defs.map((d) => d.name);
+		expect(names).not.toContain('init');
+		expect(names).not.toContain('stored');
+		expect(byName(facts!, 'work')?.kind).toBe('method');
+	});
+});

--- a/tests/unit/lang/symbol-graph-cpp-swift.test.ts
+++ b/tests/unit/lang/symbol-graph-cpp-swift.test.ts
@@ -221,8 +221,54 @@ describe('extractFileSymbols — cpp grammar hardening (issue #1530)', () => {
 			].join('\n'),
 		);
 		expect(facts).not.toBeNull();
-		expect(byName(facts!, 'identity')).toBeDefined();
-		expect(byName(facts!, 'Box')).toBeDefined();
+		const identity = byName(facts!, 'identity');
+		expect(identity?.kind).toBe('function');
+		expect(identity?.exported).toBe(true);
+		const box = byName(facts!, 'Box');
+		expect(box?.kind).toBe('class');
+		expect(box?.exported).toBe(true);
+	});
+
+	test('C++ type references appear in refs (type_identifier capture)', async () => {
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'struct Config { int retries; };',
+				'',
+				'Config makeConfig() {',
+				'    Config c = { 1 };',
+				'    return c;',
+				'}',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		// Signature AND body type references must surface as refs.
+		const configRefs = facts!.refs.filter((r) => r.identifier === 'Config');
+		expect(configRefs.length).toBeGreaterThanOrEqual(2);
+	});
+
+	test('C++ operators and destructors are deliberately not extracted (documented)', async () => {
+		// Documented limitation (PR #2351 review PRR-009): their names parse
+		// as dedicated grammar nodes (operator_name / destructor_name), not
+		// plain identifiers. Pinned so a future change is a conscious one.
+		const facts = await extractFileSymbols(
+			'cpp',
+			[
+				'class Vec {',
+				'public:',
+				'    Vec operator+(const Vec &other) const { return other; }',
+				'    operator int() const { return 0; }',
+				'    ~Vec() {}',
+				'};',
+				'',
+			].join('\n'),
+		);
+		expect(facts).not.toBeNull();
+		const names = facts!.defs.map((d) => d.name);
+		expect(names).not.toContain('operator+');
+		expect(names).not.toContain('operator int');
+		expect(names).not.toContain('~Vec');
 	});
 
 	test('cpp malformed input fails open', async () => {

--- a/tests/unit/lang/symbol-graph-visibility.test.ts
+++ b/tests/unit/lang/symbol-graph-visibility.test.ts
@@ -84,6 +84,15 @@ describe('extractFileSymbols visibility metadata and exported semantics', () => 
 				privateName: 'private_fn',
 			},
 			{
+				// Anonymous namespaces give their contents internal linkage
+				// (issue #1530): the contained fn must not be exported.
+				grammarId: 'cpp',
+				source:
+					'int public_fn() { return 1; }\nnamespace {\nint anon_fn() { return 3; }\n}\n',
+				publicName: 'public_fn',
+				privateName: 'anon_fn',
+			},
+			{
 				grammarId: 'swift',
 				source: 'public class PublicS {}\nfileprivate class PrivateS {}',
 				publicName: 'PublicS',

--- a/tests/unit/tools/repo-graph-cpp-swift.test.ts
+++ b/tests/unit/tools/repo-graph-cpp-swift.test.ts
@@ -12,7 +12,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { buildWorkspaceGraphAsync } from '../../../src/tools/repo-graph/builder';
-import { getContextPack } from '../../../src/tools/repo-graph/query';
+import {
+	getCallers,
+	getContextPack,
+	getDeadExports,
+} from '../../../src/tools/repo-graph/query';
 import type { RepoGraph } from '../../../src/tools/repo-graph/types';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
@@ -73,7 +77,12 @@ describe('repo-graph: C header/source include edges + public symbols (issue #153
 		const edge = graph.edges.find((e) => e.target === utilNode.filePath);
 		expect(edge).toBeDefined();
 		expect(edge!.importSpecifier).toBe('./util.h');
-		expect(edge!.importType).toBe('default');
+		// Whole-file (namespace) semantics: an include binds the entire header,
+		// and callers/consumers/dead_exports must treat it as a whole-file
+		// dependency — a 'default' edge with empty usedSymbols made callers
+		// vanish and flagged every header export dead (PR #2351 review PRR-001).
+		expect(edge!.importType).toBe('namespace');
+		expect(edge!.usedSymbols).toBeUndefined();
 	});
 
 	test('criterion 1: angle include is external — no fabricated edge', async () => {
@@ -265,5 +274,126 @@ describe('repo-graph: Swift visibility, members, and context pack (issue #1530)'
 		expect(node.exportRanges?.globalFn).toEqual({ startLine: 5, endLine: 5 });
 		const pack = getContextPack(graph, node.moduleName, 'Serializable');
 		expect(pack.spans[0]?.mode).toBe('full');
+	});
+});
+
+describe('repo-graph: PR #2351 review fixes (F-001 / PRR-001 / PRR-005 / PRR-006 / PRR-014)', () => {
+	beforeEach(() => {
+		writeFile(
+			'util.h',
+			[
+				'#ifndef UTIL_H',
+				'#define UTIL_H',
+				'int add(int a, int b);',
+				'#endif',
+				'',
+			].join('\n'),
+		);
+		writeFile(
+			'main.c',
+			[
+				'#include <stdio.h>',
+				'#include "util.h"',
+				'',
+				'int add(int a, int b) { return a + b; }',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test('F-001: same-file extension keeps the class declaration span (executed repro)', async () => {
+		writeFile(
+			'Model.swift',
+			[
+				'public class PublicService {',
+				'    public func visible() -> Int { return 1 }',
+				'}',
+				'',
+				'extension PublicService {',
+				'    func extended() -> Int { return 5 }',
+				'}',
+				'',
+			].join('\n'),
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Model.swift');
+		// The extension def is non-exported: the class declaration keeps the
+		// exports slot AND the span (pre-fix the extension deterministically
+		// displaced it — extensions are always textually after their type).
+		expect(
+			node.exports.filter((n: string) => n === 'PublicService').length,
+		).toBe(1);
+		expect(node.exportRanges?.PublicService).toEqual({
+			startLine: 1,
+			endLine: 3,
+		});
+		const pack = getContextPack(graph, node.moduleName, 'PublicService');
+		expect(pack.spans[0]?.startLine).toBe(1);
+		expect(pack.spans[0]?.endLine).toBe(3);
+		// Extension members are still attributed.
+		expect(node.exportRanges?.extended).toEqual({ startLine: 6, endLine: 6 });
+	});
+
+	test('F-001 cross-file: extension file does not re-export the extended type', async () => {
+		writeFile(
+			'Type.swift',
+			'public class Payload {\n    public func base() -> Int { return 1 }\n}\n',
+		);
+		writeFile(
+			'Ext.swift',
+			'import Foundation\n\nextension Payload {\n    func extra() -> Int { return 2 }\n}\n',
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const typeNode = nodeFor(graph, 'Type.swift');
+		const extNode = nodeFor(graph, 'Ext.swift');
+		expect(typeNode.exports).toContain('Payload');
+		expect(extNode.exports).not.toContain('Payload');
+		expect(typeNode.exportRanges?.Payload).toEqual({
+			startLine: 1,
+			endLine: 3,
+		});
+	});
+
+	test('PRR-001: quoted include consumers — callers report imported, dead exports skip header', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const utilNode = nodeFor(graph, 'util.h');
+		// Whole-file include: main.c is a caller with resolution 'imported'.
+		const callers = getCallers(graph, utilNode.moduleName, 'add');
+		expect(callers).toContainEqual({ file: 'main.c', resolution: 'imported' });
+		// The header's usage is per-symbol-unresolvable → skipped, not flagged.
+		const dead = getDeadExports(graph);
+		expect(dead.candidates.filter((c) => c.file.endsWith('util.h'))).toEqual(
+			[],
+		);
+	});
+
+	test('PRR-005: unresolvable quoted include lands in unresolvedImports diagnostics', async () => {
+		writeFile(
+			'broken.c',
+			'#include "missing.h"\n\nint broken() { return 0; }\n',
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const entries = (graph.diagnostics?.unresolvedImports ?? []).filter(
+			(e) => e.specifier === './missing.h',
+		);
+		expect(entries.length).toBe(1);
+		expect(entries[0]!.file).toContain('broken.c');
+	});
+
+	test('PRR-006: bare Swift module imports produce no file edges', async () => {
+		writeFile(
+			'Only.swift',
+			'import Foundation\n\nfunc f() -> Int { return 1 }\n',
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Only.swift');
+		expect(node.imports).toContain('Foundation');
+		expect(graph.edges.filter((e) => e.source === node.filePath)).toEqual([]);
+	});
+
+	test('PRR-014: header file nodes carry the cpp language id', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const utilNode = nodeFor(graph, 'util.h');
+		expect(utilNode.language).toBe('cpp');
 	});
 });

--- a/tests/unit/tools/repo-graph-cpp-swift.test.ts
+++ b/tests/unit/tools/repo-graph-cpp-swift.test.ts
@@ -1,0 +1,269 @@
+/**
+ * End-to-end acceptance evidence for issue #1530 (C/C++ and Swift symbol
+ * graph hardening): include edges, header-declared public symbols,
+ * static/anonymous-namespace conservatism, and context-pack member spans.
+ *
+ * These tests build a REAL workspace on disk and run the REAL graph builder
+ * (no mocking of the extraction path) so they pin the actual fixed behavior,
+ * not a mocked stand-in — the same contract as the KG-08 file for Java/
+ * Kotlin/C# (tests/unit/tools/repo-graph-jvm-dotnet.test.ts).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { buildWorkspaceGraphAsync } from '../../../src/tools/repo-graph/builder';
+import { getContextPack } from '../../../src/tools/repo-graph/query';
+import type { RepoGraph } from '../../../src/tools/repo-graph/types';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = canonicalMkdtemp('cpp-swift-graph-');
+});
+
+afterEach(() => {
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeFile(relPath: string, contents: string) {
+	const full = path.join(tempDir, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, contents);
+}
+
+function nodeFor(graph: RepoGraph, relPath: string) {
+	const target = path.normalize(relPath).replace(/\\/g, '/');
+	const match = Object.values(graph.nodes).find((n: any) =>
+		n.moduleName.replace(/\\/g, '/').endsWith(target),
+	);
+	return match as any;
+}
+
+describe('repo-graph: C header/source include edges + public symbols (issue #1530)', () => {
+	beforeEach(() => {
+		writeFile(
+			'util.h',
+			[
+				'#ifndef UTIL_H',
+				'#define UTIL_H',
+				'int add(int a, int b);',
+				'char *concat(const char *a, const char *b);',
+				'#endif',
+				'',
+			].join('\n'),
+		);
+		writeFile(
+			'main.c',
+			[
+				'#include <stdio.h>',
+				'#include "util.h"',
+				'',
+				'static int helper(int v) { return v * 2; }',
+				'int add(int a, int b) { return helper(a) + b; }',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test('criterion 1: quoted include resolves to a file edge onto util.h', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const utilNode = nodeFor(graph, 'util.h');
+		expect(utilNode).toBeDefined();
+		const edge = graph.edges.find((e) => e.target === utilNode.filePath);
+		expect(edge).toBeDefined();
+		expect(edge!.importSpecifier).toBe('./util.h');
+		expect(edge!.importType).toBe('default');
+	});
+
+	test('criterion 1: angle include is external — no fabricated edge', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const mainNode = nodeFor(graph, 'main.c');
+		expect(mainNode).toBeDefined();
+		const stdioEdge = graph.edges.find(
+			(e) =>
+				e.source === mainNode.filePath && e.importSpecifier.includes('stdio'),
+		);
+		expect(stdioEdge).toBeUndefined();
+	});
+
+	test('criterion 2: header-declared public symbols are exported', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const utilNode = nodeFor(graph, 'util.h');
+		expect(utilNode.exports).toContain('add');
+		expect(utilNode.exports).toContain('concat');
+		// The prototype span backs context_pack.
+		expect(utilNode.exportRanges?.add).toEqual({ startLine: 3, endLine: 3 });
+	});
+
+	test('criterion 3: static helper is not exported', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const mainNode = nodeFor(graph, 'main.c');
+		expect(mainNode.exports).not.toContain('helper');
+		expect(mainNode.exports).toContain('add');
+	});
+
+	test('criterion 6: context_pack returns a real span for the header symbol', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const utilNode = nodeFor(graph, 'util.h');
+		const pack = getContextPack(graph, utilNode.moduleName, 'add');
+		expect(pack.spans.length).toBeGreaterThan(0);
+		expect(pack.spans[0].mode).toBe('full');
+		expect(pack.spans[0].startLine).toBe(3);
+	});
+});
+
+describe('repo-graph: C++ internals conservatism + member spans (issue #1530)', () => {
+	beforeEach(() => {
+		writeFile(
+			'engine.cpp',
+			[
+				'namespace engine {',
+				'  class Engine {',
+				'  public:',
+				'    Engine(int capacity);',
+				'    void start();',
+				'  private:',
+				'    int capacity_;',
+				'  };',
+				'  void run(const Engine &e);',
+				'}',
+				'',
+				'namespace {',
+				'int internal_counter = 0;',
+				'void internal_fn() { internal_counter++; }',
+				'}',
+				'',
+				'static int file_local(int x) { return x; }',
+				'',
+				'void engine::run(const Engine &e) { file_local(1); }',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test('criterion 3: anonymous-namespace and static symbols are not exported', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'engine.cpp');
+		expect(node.exports).not.toContain('internal_fn');
+		expect(node.exports).not.toContain('file_local');
+		// Namespace-level public symbols still are.
+		expect(node.exports).toContain('Engine');
+		expect(node.exports).toContain('run');
+	});
+
+	// Mutation-proven pin (mirrors the kotlin/csharp comments in the KG-08
+	// file): removing `cpp` from RANGE_WIDENED_GRAMMARS must fail here — this
+	// is the only cpp assertion that needs a non-exported member span.
+	test('criterion 6: private member spans reach exportRanges and context_pack', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'engine.cpp');
+		expect(node.exportRanges?.start).toEqual({ startLine: 5, endLine: 5 });
+		const pack = getContextPack(graph, node.moduleName, 'start');
+		expect(pack.spans[0]?.mode).toBe('full');
+		expect(pack.spans[0]?.startLine).toBe(5);
+	});
+
+	test('overload collapse caveat: same-name namespace prototypes collapse by name', async () => {
+		writeFile(
+			'overload.cpp',
+			[
+				'int process(int x);',
+				'int process(int x, int y);',
+				'int process(int x) { return x; }',
+				'',
+			].join('\n'),
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'overload.cpp');
+		// Each overload contributes its own entry to exports[] (pre-existing
+		// per-def semantics, same as Java overload rows in the KG-08 fixture);
+		// the CONSERVATIVE COLLAPSE is at the range level — one name, one span.
+		const entries = node.exports.filter((n: string) => n === 'process');
+		expect(entries.length).toBe(3);
+		expect(node.exportRanges?.process).toBeDefined();
+		// The collapsed span points at ONE of the overloads (last exported wins
+		// document-order policy); it must be a real line, never undefined.
+		expect(Number.isInteger(node.exportRanges?.process?.startLine)).toBe(true);
+	});
+
+	test('qualified out-of-class definition is exported under the function name', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'engine.cpp');
+		expect(node.exports).not.toContain('engine');
+	});
+});
+
+describe('repo-graph: Swift visibility, members, and context pack (issue #1530)', () => {
+	beforeEach(() => {
+		writeFile(
+			'Model.swift',
+			[
+				'import Foundation',
+				'',
+				'public class PublicService {',
+				'    public func visible() -> Int { return 1 }',
+				'    private func hidden() -> Int { return 2 }',
+				'    func implicitInternal() -> Int { return 3 }',
+				'}',
+				'',
+				'private func filePrivateFn() -> Int { return 4 }',
+				'',
+				'extension PublicService {',
+				'    func extended() -> Int { return 5 }',
+				'}',
+				'',
+			].join('\n'),
+		);
+	});
+
+	test('criterion 4/5: public symbols exported, private ones not', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Model.swift');
+		expect(node.exports).toContain('PublicService');
+		expect(node.exports).not.toContain('filePrivateFn');
+	});
+
+	test('criterion 5: Swift module imports are recorded', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Model.swift');
+		expect(node.imports).toContain('Foundation');
+	});
+
+	// Mutation-proven pin (mirrors the kotlin/csharp comments in the KG-08
+	// file): removing `swift` from RANGE_WIDENED_GRAMMARS must fail here.
+	test('criterion 6: member spans reach exportRanges and context_pack in full mode', async () => {
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Model.swift');
+		expect(node.exportRanges?.visible).toEqual({ startLine: 4, endLine: 4 });
+		const pack = getContextPack(graph, node.moduleName, 'visible');
+		expect(pack.spans[0]?.mode).toBe('full');
+		// A private member also gets a real span (widened), not a placeholder.
+		const hiddenPack = getContextPack(graph, node.moduleName, 'hidden');
+		expect(hiddenPack.spans[0]?.mode).toBe('full');
+		expect(hiddenPack.spans[0]?.startLine).toBe(5);
+	});
+
+	test('criterion 6: protocol/class/function ranges back context_pack', async () => {
+		writeFile(
+			'Proto.swift',
+			[
+				'protocol Serializable {',
+				'    func serialize() -> Int',
+				'}',
+				'',
+				'func globalFn() -> Int { return 9 }',
+				'',
+			].join('\n'),
+		);
+		const graph = await buildWorkspaceGraphAsync(tempDir);
+		const node = nodeFor(graph, 'Proto.swift');
+		expect(node.exportRanges?.Serializable).toEqual({
+			startLine: 1,
+			endLine: 3,
+		});
+		expect(node.exportRanges?.globalFn).toEqual({ startLine: 5, endLine: 5 });
+		const pack = getContextPack(graph, node.moduleName, 'Serializable');
+		expect(pack.spans[0]?.mode).toBe('full');
+	});
+});

--- a/tests/unit/tools/repo-graph-jvm-dotnet-regressions.test.ts
+++ b/tests/unit/tools/repo-graph-jvm-dotnet-regressions.test.ts
@@ -251,7 +251,7 @@ describe('repo-graph JVM/.NET — implementation-review regressions', () => {
 
 	test('the exportRanges widening does not reach non-JVM grammars', async () => {
 		// Pins the LANGUAGE SCOPING itself, not just the widening. Adding
-		// 'typescript' to JVM_DOTNET_RANGE_GRAMMARS previously survived the whole
+		// 'typescript' to RANGE_WIDENED_GRAMMARS (formerly JVM_DOTNET_RANGE_GRAMMARS) previously survived the whole
 		// suite: nothing asserted that a non-exported TypeScript helper stays OUT
 		// of exportRanges, which is the entire reason the set is scoped.
 		writeFile(

--- a/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
+++ b/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
@@ -213,7 +213,7 @@ describe('repo-graph: Kotlin import/symbol resolution + ontology (issue #1529)',
 		expect(edge).toBeDefined();
 	});
 
-	// Mutation-proven gap: removing `kotlin` from JVM_DOTNET_RANGE_GRAMMARS left
+	// Mutation-proven gap: removing `kotlin` from RANGE_WIDENED_GRAMMARS (formerly JVM_DOTNET_RANGE_GRAMMARS) left
 	// the whole suite green, because only Java asserted a member span or a
 	// symbolEdge. The widening is the entire point of the change for Kotlin too.
 	test('kotlin: member span reaches exportRanges and context_pack in full mode', async () => {
@@ -290,7 +290,7 @@ describe('repo-graph: C# file-scoped and block namespace resolution (issue #1529
 		expect(apiNode.ontology?.packageBoundary).toBe('Example.App.Services');
 	});
 
-	// Mutation-proven gap: removing `csharp` from JVM_DOTNET_RANGE_GRAMMARS left
+	// Mutation-proven gap: removing `csharp` from RANGE_WIDENED_GRAMMARS (formerly JVM_DOTNET_RANGE_GRAMMARS) left
 	// the whole suite green — only Java pinned a member span or a symbolEdge.
 	test('csharp: member span reaches exportRanges and context_pack in full mode', async () => {
 		const graph = await buildWorkspaceGraphAsync(tempDir);


### PR DESCRIPTION
Closes #1530

## Summary

Harden C/C++ (`.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.cxx`) and Swift (`.swift`) symbol-graph extraction (KG-09), mirroring the merged KG-08 (#1529) architecture: grammar-level tree-sitter queries + a per-grammar member re-typing walk + the `symbol-visibility.ts` framework + widened `exportRanges` for `context_pack`. Every query pattern was verified against the shipped grammar WASMs via s-expression dumps — no regex augmentation, no compiler invocation (non-goals respected).

- **Header-declared public symbols**: C/C++ prototypes (incl. pointer-return forms) now produce exported defs — a `.h` file previously yielded **zero** defs.
- **Include edges**: quoted includes (`#include "util.h"`) → `./`-relative **namespace imports** (whole-file import semantics) that resolve to real file edges, so `callers`/`consumers`/`dead_exports` treat an included header as a whole-file dependency; angle includes (`#include <vector>`) → external/unresolved (build-system `-I` paths are a documented non-goal).
- **C++ classes**: method declarations/definitions (`field_identifier` declarators), in-class constructors, out-of-class qualified definitions (`void engine::run()` — named `run`, not `engine`), enums, typedefs; members re-typed to `method`.
- **C++ internals conservative**: `static` and anonymous-namespace symbols not-exported (incl. anonymous nested inside named namespaces); class members default by container kind (class → private, struct/union → public), never file-level exports; access-specifier sections deliberately untracked (documented).
- **Swift**: all five visibility modifiers; implicit member default corrected to `internal` (was forced `public`); multi-line attributes (`@available(iOS 14, *)` above `public func`) no longer hide the modifier; extension blocks (non-exported defs that augment the extended type without displacing its span or duplicating `exports[]`), protocol members, typealiases extracted; `import class Foo.Bar` (and multi-dot `Foo.Bar.Baz`, `@_testable import MyApp`) parsed with module/binding split.
- **context_pack**: `exportRanges` widening extended to cpp/swift (`RANGE_WIDENED_GRAMMARS`, renamed from `JVM_DOTNET_RANGE_GRAMMARS`) so internal/private members get real spans instead of "span unavailable".
- **Docs**: new "Native language limitations (C/C++ and Swift)" section covering every caveat the issue lists; release fragment added.

**Review round** (swarm-pr-review + swarm-pr-feedback): two independent swarm reviews (one posted as a PR comment) surfaced one HIGH ship blocker and one MEDIUM correctness bug, both fixed with executed regression tests in the second commit — (a) Swift `extension` defs are non-exported so the type's own declaration keeps its `exportRanges` span and `exports[]` stays deduped; (b) quoted includes use `namespace` (whole-file) import semantics so `getCallers` reports importers and `dead_exports` does not flag used headers. Twelve smaller doc/test findings also closed; two pre-existing issues (extensionless-include resolution, `using`-regex backtracking — both present on main) were deferred to main-scoped follow-ups per critic downgrade.

Prior art note: PR #1681 claimed to fix this but its merge was discarded by a main history rewrite (merge commit 59596840 is not an ancestor of main); none of its code/tests/docs survive, so this is implemented fresh on current main.

## Invariant audit

- 1 (plugin init): not touched — no changes to `src/index.ts` or any init path; extraction remains behind the existing lazy grammar loading with the 500 ms `AST_TIMEOUT_MS` race.
- 2 (runtime portability): touched — `src/lang/symbol-graph.ts` and `src/lang/symbol-visibility.ts` are in the bundle. Evidence: `bun run build` OK; `node --input-type=module -e "await import('./dist/index.js')"` → OK; `tests/unit/build/bundle-portability.test.ts` 10 pass; `bundle-plugin-shape.test.ts` 2 pass. No `bun:` imports or `Bun.*` calls added.
- 3 (subprocesses): not touched — zero spawn/exec calls in the diff (verified by the final critic via grep; non-goal "do not shell out to compilers" respected).
- 4 (.swarm containment): not touched — no runtime state; tests use `canonicalMkdtemp` only.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation used shell loops per the skill.
- 7 (test writing): touched — 3 new bun:test files (436/258/269 lines, all under the FR-006 500-line cap; `bun run check:test-file-cap` → 0 violations), zero `mock.module` (real grammars + real builder, `check-mock-cleanup.sh` pass), `check-test-tmpdir.sh` pass. **Disclosure (final-critic requirement)**: the swift parameter-name ref filter uses a **swift-only** param-type set (`SWIFT_REF_PARAM_TYPES`, `src/lang/symbol-graph.ts`); a flat addition to the shared `PARAM_TYPES` would also have suppressed refs inside `parameter` nodes for csharp/kotlin/rust (the node-type name exists in those grammars), causing a Kotlin-only loss of parameter-position type refs feeding `usedSymbols`/symbol-edges. `PARAM_TYPES` on this branch is byte-identical to `origin/main`; the scoping is pinned by tests that the critic mutation-verified (flat re-add fails exactly `kotlin parameter-position type ref must stay a ref`).
- 8 (session state): not touched — no module-level mutable state added.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tool/agent-map/command changes; `check-tool-registration.ts` pass; `drift:check` clean.
- 12 (release/cache): touched — release fragment added at `docs/releases/pending/1530-cpp-swift-symbol-graph.md`; `package.json#version`, `CHANGELOG.md`, `.release-please-manifest.json` untouched (verified empty diff); `check:pending-fragment` pass.

## Test plan

New tests (58 pass across the three files after the review round; 24 of the original 46 fail against pre-fix source — verified by `git checkout origin/main -- src/` then restore):

```
bun test tests/unit/lang/symbol-graph-cpp-swift.test.ts          # 21 pass
bun test tests/unit/lang/symbol-graph-cpp-swift-imports.test.ts  # 16 pass
bun test tests/unit/tools/repo-graph-cpp-swift.test.ts           # 19 pass  (mutation-proven widening pins + review-fix regressions)
```

Regression + gates (all executed locally, all green, on the final tree):

```
bun test tests/unit/lang/                    # 839 pass / 0 fail (38 files)
per-file loop: tests/unit/tools/repo-graph*.test.ts + repo-map*.test.ts   # ALL pass
bun run typecheck                            # clean
bunx biome ci .                              # clean
bun run build && node --input-type=module -e "await import('./dist/index.js')"   # OK
ALL 15 CI quality-job gates (check-invariants, mock-cleanup, tool-registration,
runtime-src-refs, events, retention, cross-contamination, test-clock,
test-file-cap, pending-fragment, gate-portability, bare-spawn, test-tmpdir,
bash-portability, drift:check)               # all pass
```

Acceptance-criteria mapping (issue #1530): include edges → `repo-graph-cpp-swift.test.ts` "quoted include resolves to a file edge" + "angle include is external"; header public symbols → "header-declared public symbols are exported" + `symbol-graph-cpp-swift.test.ts` "C header"; static/anon-namespace → "static helper is not exported" + "anonymous namespace…" (incl. nested-in-named); Swift visibility → "all five explicit visibility modifiers" + "members without modifiers default to internal"; Swift imports/public symbols → imports file + "public symbols exported"; context_pack → span tests incl. per-grammar mutation-proven pins; limitations → `docs/repo-graph-symbol-graph.md` "Native language limitations (C/C++ and Swift)"; fragment → `docs/releases/pending/1530-cpp-swift-symbol-graph.md`.

Quality trail: plan critic (NEEDS_REVISION → reconciled: 2 spec-detail fixes accepted, 2 claims disproven by AST dumps), implementation reviewer round 1 (APPROVE + 1 finding: multi-dot Swift imports dropped — fixed + regression-tested), reviewer round 2 (APPROVE), final critic round 1 (APPROVE + cross-grammar PARAM_TYPES finding — grammar-scoped + pinned), reviewer round 3 + final critic round 2 (APPROVE); swarm-pr-review (6 lanes + 11 risk families → 2 reviewer shards → 2-pass critic on the MEDIUM finding, execution-settled), swarm-pr-feedback (fix commit reviewed by fresh reviewer APPROVE; final critic NEEDS_REVISION → both items closed and re-critic APPROVE).
