### PR TITLE
fix(tools): boolean enum in knowledge_recall breaks all Gemini-API providers

### DIFF
--- a/docs/releases/pending/2354-knowledge-recall-gemini-schema-fix.md
+++ b/docs/releases/pending/2354-knowledge-recall-gemini-schema-fix.md
@@ -1,0 +1,47 @@
+# Fix `knowledge_recall` tool schema rejection on Gemini-family providers
+
+## What
+
+The `knowledge_recall` tool's `repair_re_evaluation.scope_complete` field used
+`z.literal(true)`, which serializes to a single-value enum constraint on a
+boolean. Gemini-family API providers (Gemini CLI, Google Antigravity, and
+direct `google/*` model endpoints) strictly validate enum values as
+`TYPE_STRING` and reject the entire request, making every `google/*` model
+unusable alongside this tool.
+
+## Fix
+
+Replace `scope_complete: z.literal(true)` with `scope_complete: z.boolean()`.
+The runtime handler at `src/tools/knowledge-recall.ts` already enforces
+`candidate.scope_complete !== true` and returns
+`RECEIPT_REEVALUATION_PROOF_INVALID` when the value is anything other than the
+literal `true`, so the visible behavior is unchanged for valid inputs. Invalid
+inputs are now rejected at execute-time instead of schema-parse-time.
+
+## Why
+
+Verified on opencode 1.18.23 + opencode-swarm 7.146.0 with a Google
+Antigravity OAuth account. The runtime error path was:
+
+```
+AI_APICallError: Invalid value at
+'request.tools[0].function_declarations[99].parameters.properties[4].value.properties[3].value.enum[0]'
+(TYPE_STRING), true
+```
+
+Anthropic and OpenAI tolerate the original schema; the rejection only surfaces
+on Gemini-validated endpoints.
+
+## Migration
+
+No migration required. Existing call sites that send `scope_complete: true`
+continue to work unchanged.
+
+## Caveats
+
+- The `repair_re_evaluation` subobject is architect-only; non-architect callers
+  still receive `RECEIPT_REEVALUATION_ARCHITECT_ONLY` before the
+  `scope_complete` check runs.
+- A new test file `tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts`
+  covers execute-time rejection of `scope_complete: false` and other malformed
+  inputs.

--- a/src/tools/knowledge-recall.ts
+++ b/src/tools/knowledge-recall.ts
@@ -59,8 +59,12 @@ export const knowledge_recall: ReturnType<typeof createSwarmTool> =
 					repair_id: z.string().uuid(),
 					phase: z.string().min(1).max(256),
 					task_id: z.string().min(1).max(256).optional(),
-					// z.literal(true) serializes as {"enum":[true]}, which Gemini-family
-					// APIs reject (enum must be strings). Runtime check below still requires true.
+					// Gemini-family APIs reject single-value enum constraints on
+					// boolean literals (z.literal(true) serializes to either
+					// {"const":true,"type":"boolean"} under Zod v4 default target or
+					// {"enum":[true],"type":"boolean"} under draft-04/openapi-3.0; both
+					// forms are rejected by Gemini/Google Antigravity validators).
+					// Runtime check below still requires === true.
 					scope_complete: z.boolean(),
 				})
 				.optional()

--- a/src/tools/knowledge-recall.ts
+++ b/src/tools/knowledge-recall.ts
@@ -59,7 +59,9 @@ export const knowledge_recall: ReturnType<typeof createSwarmTool> =
 					repair_id: z.string().uuid(),
 					phase: z.string().min(1).max(256),
 					task_id: z.string().min(1).max(256).optional(),
-					scope_complete: z.literal(true),
+					// z.literal(true) serializes as {"enum":[true]}, which Gemini-family
+					// APIs reject (enum must be strings). Runtime check below still requires true.
+					scope_complete: z.boolean(),
 				})
 				.optional()
 				.describe(

--- a/tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts
+++ b/tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { rmSync } from 'node:fs';
+import { knowledge_recall } from '../../../src/tools/knowledge-recall';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const ctx = (directory: string, agent = 'architect'): any => ({
+	directory,
+	sessionID: 'sess-scope-falsy',
+	agent,
+});
+
+describe('knowledge_recall — repair_re_evaluation scope_complete falsy rejection', () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = canonicalMkdtemp('swarm-recall-falsy-');
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('rejects scope_complete:false from the architect at execute time with RECEIPT_REEVALUATION_PROOF_INVALID', async () => {
+		const raw = await knowledge_recall.execute(
+			{
+				query: 'manual retrieval re-evaluation',
+				tier: 'swarm',
+				repair_re_evaluation: {
+					repair_id: '00000000-0000-4000-8000-000000000000',
+					phase: 'phase-x',
+					scope_complete: false,
+				},
+			},
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.results).toEqual([]);
+		expect(parsed.total).toBe(0);
+		expect(parsed.unverifiable).toBe(true);
+		expect(parsed.code).toBe('RECEIPT_REEVALUATION_PROOF_INVALID');
+		expect(parsed.error).toContain('scope_complete=true');
+	});
+
+	it('architect gate fires before scope_complete check — non-architect caller with scope_complete:false surfaces RECEIPT_REEVALUATION_ARCHITECT_ONLY', async () => {
+		const raw = await knowledge_recall.execute(
+			{
+				query: 'manual retrieval re-evaluation',
+				tier: 'swarm',
+				repair_re_evaluation: {
+					repair_id: '00000000-0000-4000-8000-000000000000',
+					phase: 'phase-x',
+					scope_complete: false,
+				},
+			},
+			ctx(dir, 'reviewer'),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.code).toBe('RECEIPT_REEVALUATION_ARCHITECT_ONLY');
+	});
+
+	it('accepts scope_complete:true from the architect when no repair ledger state matches (returns empty results, not unverifiable)', async () => {
+		const raw = await knowledge_recall.execute(
+			{
+				query: 'manual retrieval re-evaluation',
+				tier: 'swarm',
+				repair_re_evaluation: {
+					repair_id: '00000000-0000-4000-8000-000000000000',
+					phase: 'phase-x',
+					scope_complete: true,
+				},
+			},
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.code).toBeUndefined();
+		expect(parsed.total).toBe(0);
+		expect(parsed.unverifiable).toBeUndefined();
+	});
+
+	it('rejects when repair_re_evaluation is missing the required repair_id even with scope_complete:true', async () => {
+		const raw = await knowledge_recall.execute(
+			{
+				query: 'manual retrieval re-evaluation',
+				tier: 'swarm',
+				repair_re_evaluation: {
+					repair_id: '',
+					phase: 'phase-x',
+					scope_complete: true,
+				},
+			},
+			ctx(dir),
+		);
+		const parsed = JSON.parse(raw);
+		expect(parsed.code).toBe('RECEIPT_REEVALUATION_PROOF_INVALID');
+	});
+});


### PR DESCRIPTION
Closes #2354 (review-driven follow-up for PR #2354)

## Summary

Replaces `z.literal(true)` with `z.boolean()` for the `repair_re_evaluation.scope_complete`
field in `knowledge_recall`. Gemini-family providers (Gemini CLI, Google Antigravity, all
`google/*` models) strictly require enum values to be `TYPE_STRING` and reject the
serialized `{enum:[true], type:"boolean"}` (or `{const:true, type:"boolean"}` under Zod v4
default target) form that `z.literal(true)` emits, making every `google/*` model unusable
alongside this tool.

The runtime handler at `src/tools/knowledge-recall.ts:123` already enforces
`candidate.scope_complete !== true` and returns `RECEIPT_REEVALUATION_PROOF_INVALID` when
the value is anything other than the literal `true`, so the visible behavior is unchanged
for valid inputs.

This follow-up commit (maintainer-applied via `maintainerCanModify`) also:
- Corrects the inline JSON Schema shape comment to cite both Zod v4 default target
  (`{const:true}`) and `draft-04`/`openapi-3.0` (`{enum:[true]}`) serialization forms
  (PRR-2354-001).
- Adds `tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts` covering the
  execute-time rejection of `scope_complete: false`, the architect-only gate ordering, and
  the adjacent `repair_id` guard (PRR-2354-003 / PRR-2354-004).
- Adds the AGENTS.md release fragment at
  `docs/releases/pending/2354-knowledge-recall-gemini-schema-fix.md`.

## Root cause

`scope_complete: z.literal(true)` in the tool's Zod schema serializes to a single-value
enum constraint on a boolean. Gemini-family validators interpret the inner enum value
as a string and reject the entire tool declaration, so any request that includes
`knowledge_recall` in its tool set fails before any prompt content reaches the model.

Anthropic and OpenAI accept either form, so the bug only surfaces on
Gemini-validated endpoints.

## Fix

- `src/tools/knowledge-recall.ts:62-68`: replace `z.literal(true)` with `z.boolean()`,
  keeping the runtime guard at line 123 (`candidate.scope_complete !== true`) as the
  sole enforcement of the `=== true` invariant.
- Inline comment updated to accurately describe both serialization shapes; the
  "runtime check still requires === true" invariant is preserved verbatim.

## Verification

- Reproduced on opencode 1.18.23 + opencode-swarm 7.146.0 with a Google Antigravity
  OAuth account; request succeeds after removing the enum locally.
- New test file `tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts` —
  4 tests, all pass locally.
- Existing `tests/unit/tools/knowledge-recall-events.test.ts` (3 tests),
  `tests/unit/tools/knowledge-recall-receipt-authority.test.ts` (3 tests), and
  `tests/unit/hooks/knowledge-receipt-ledger-repair.test.ts` (8 tests) continue to pass.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed.
- 2 (runtime portability): not touched — schema-only change, no `bun:*` import changes.
- 3 (subprocesses): not touched — no spawn / shell / fs ops modified.
- 4 (.swarm containment): not touched — no `.swarm/` writes; tool args are read-only.
- 5 (plan durability): not touched — no ledger or projection changes.
- 6 (test_runner safety): not touched — no test_runner config changes.
- 7 (test writing): touched — added one new test file. Uses `bun:test`,
  `canonicalMkdtemp` from `tests/helpers/tmpdir.js` (passes `check-test-tmpdir.sh`),
  no raw `Date.now()` (passes `check-test-clock.sh`), no `mock.module`
  (no allowlist growth), under the FR-006 500-line cap (94 lines).
- 8 (session state): not touched — no session-scoped state added.
- 9 (guardrails/retry): touched — the execute-time guard at
  `src/tools/knowledge-recall.ts:123` now becomes the sole `=== true` enforcement.
  The downstream sink at `src/hooks/knowledge-receipt-ledger.ts:2258`
  (`!proof?.scope_complete`) provides a second defense layer. Net safety preserved.
- 10 (chat/system msg): not touched — no chat-message hook changes.
- 11 (tool registration): not touched — `knowledge_recall` registration,
  `TOOL_NAMES`, and `AGENT_TOOL_MAP` entries all unchanged.
- 12 (release/cache): touched — added pending release fragment under
  `docs/releases/pending/2354-knowledge-recall-gemini-schema-fix.md`
  (AGENTS.md mandate; satisfies `check:pending-fragment` gate).

## Test plan

Local commands run and their results (verified on this branch at commit `4f9ffe6c`):

```text
$ bun test tests/unit/tools/knowledge-recall-scope-complete-falsy.test.ts \
          tests/unit/tools/knowledge-recall-events.test.ts \
          tests/unit/tools/knowledge-recall-receipt-authority.test.ts \
          tests/unit/hooks/knowledge-receipt-ledger-repair.test.ts
 18 pass, 0 fail, 71 expect() calls (1.83s)

$ bash scripts/check-test-clock.sh
All test-clock checks passed (0 new violations; 432 pre-existing warnings).

$ bash scripts/check-test-tmpdir.sh
All new/changed test temp roots are external and canonicalized (0 new violations).

$ bun run scripts/check-test-file-cap.ts
All test-file-cap checks passed.

$ bun run scripts/check-pending-fragment.ts
[check-pending-fragment] OK — pending fragment present.

$ bash scripts/check-mock-cleanup.sh
All test files with mock.module have proper cleanup and spread real exports.
```

CI will run on push; expected green checks: `pr-standards`, `quality`,
`unit-passed`, `coverage-shard`, `php-validation`, `security`, `package-check`,
`unit`, `smoke`.