### PR TITLE
feat(symbol-graph): harden Dart, Ruby, and PHP symbol graph support (#1531)

### DIFF
--- a/docs/php-laravel.md
+++ b/docs/php-laravel.md
@@ -126,3 +126,23 @@ When the `test_engineer` agent works on Laravel projects, it receives these cons
 ## Issue #308
 
 This release closes [GitHub Issue #308](https://github.com/zaxbysauce/opencode-swarm/issues/308) — PHP/Laravel Support? — with verified, CI-tested first-class PHP support and a meaningful Laravel baseline.
+
+## Symbol-graph and `symbols` coverage for PHP (issue #1531)
+
+`.php`, `.phtml`, and `.blade.php` files are now part of the repo-graph symbol
+layer and the `symbols` tool. Extraction is regex-based in the `symbols` tool
+and tree-sitter + conservative regex augmentation in the repo-graph symbol
+layer — no PHP runtime or Composer execution is involved.
+
+Blade caveats:
+
+- Blade directives (`@foreach`, `@include`, `@component`, `{{ }}` echo blocks)
+  are opaque to the extractor and produce no symbol facts.
+- `@php ... @endphp` blocks are scanned as ordinary PHP on a best-effort basis;
+  declarations inside them are extracted like any other PHP.
+- Component/tag syntax (`<x-alert />`) is not resolved; Laravel view
+  composition happens at runtime and stays out of the static graph.
+
+See `docs/repo-graph-symbol-graph.md` → "Dynamic language limitations" for the
+full PHP/Dart/Ruby extraction contract (visibility modifiers, `use` binding
+semantics, dynamic-construct limitations).

--- a/docs/releases/pending/1531-dart-ruby-php-symbol-graph.md
+++ b/docs/releases/pending/1531-dart-ruby-php-symbol-graph.md
@@ -67,3 +67,38 @@ awareness is out of scope); Blade directives are opaque to the extractor;
 Dart class members (including Flutter `build` methods) are not method defs —
 the enclosing type carries the span. See
 `docs/repo-graph-symbol-graph.md` → "Dynamic language limitations".
+
+## Review round 2 (PR #2361 feedback)
+
+Hardening from the swarm PR review and maintainer review:
+
+- **CRLF-correct line arithmetic** for the Ruby/PHP/Dart line scanners —
+  CRLF and LF sources now produce identical facts (previously CRLF Ruby
+  files accumulated one byte of offset drift per line, producing duplicate
+  defs with wrong spans; the #1526 bug class).
+- **Bounded modifier quantifiers** in the PHP function regex — an unbounded
+  star measured ~8s (quadratic backtracking) on 1MB adversarial modifier
+  runs; now ~15ms.
+- **String-literal-aware masking** — braces/semicolons/import-shaped text
+  inside string literals no longer corrupt spans or create false edges;
+  multiline Dart `'''` strings and PHP string constants are opaque to the
+  augmenters and fallback importer.
+- **Ruby visibility**: nested class/module bodies save and restore the outer
+  `private`/`protected` section; targeted `private :a, :b` marks the named
+  methods.
+- **PHP**: 8.1 `enum` declarations are extracted (`enum` kind) with their
+  methods; trait `use X;` inside a class body no longer becomes a false
+  namespace import edge.
+- **Dart**: class members in the `symbols` tool are qualified
+  `TypeName.member` (kind `method`) instead of top-level functions, so
+  same-named members of different classes no longer collapse; conditional
+  imports record both URIs; multiline `show` clauses parse whole and yield a
+  single import.
+- **Import resolution is importer-language aware**: a Ruby
+  `require_relative 'foo'` resolves `foo.rb` even when a sibling `foo.ts`
+  exists.
+- **AST fail-open preserves export metadata** for dart/ruby/php (the sync
+  fallback export collector now covers the new languages).
+- Direct parser unit tests via new `_internals` seams, CRLF/enum/nested/
+  trait/conditional/qualified-member regression rows, and regex time-budget
+  tests.

--- a/docs/releases/pending/1531-dart-ruby-php-symbol-graph.md
+++ b/docs/releases/pending/1531-dart-ruby-php-symbol-graph.md
@@ -1,0 +1,69 @@
+# Harden Dart, Ruby, and PHP Symbol Graph Support
+
+## What
+
+- **Dart (`.dart`)**: `_`-prefix privacy convention; `class`/`mixin`/`enum`/
+  `extension`/`typedef` type defs including Dart 3 forms (`extension type`
+  captures the type's name; `base`/`final`/`interface`/`sealed`/`abstract`
+  modifiers don't change the captured name; unnamed `extension on X` produces
+  no def); `import` directives with `show` named bindings and `as` prefix
+  semantics (namespace, no fake named binding — including `as` combined with
+  `show`/`hide`); `export` directives produce re-export edges with exported
+  bindings; `package:` URIs recorded as specifiers (external, no file edge).
+- **Ruby (`.rb`, `.rake`, `.gemspec`)**: `module`/`class`/constant defs;
+  `def` methods typed `method` with bare `private`/`protected` section
+  tracking (reset on class/module; the `private :sym` form targets one method
+  and does not switch the section; heredoc bodies are skipped so string data
+  never flips visibility or creates defs); singleton methods (`def self.x`)
+  keyed by their literal `self.`-prefixed name; `require_relative 'x'`
+  normalizes to `./x` and resolves to the target workspace file; `require`
+  stays a namespace import.
+- **PHP (`.php`, `.phtml`, `.blade.php`)**: namespace defs (`;` and brace
+  forms), `trait`/`class`/`interface` defs, methods with
+  `public`/`protected`/`private` visibility modifiers (default public) and
+  `_`-prefix privacy; aliased `use A\B\C as D` now binds the SHORT name
+  (`C`), matching what body expressions actually spell.
+- **`symbols` tool**: new Dart/Ruby/PHP regex extractors (with a `_internals`
+  DI seam); supported extensions extended accordingly.
+- **`repo_map context_pack`**: dart/ruby/php joined the widened-range
+  grammars, so member spans (Ruby/PHP methods) are served instead of
+  "internal symbol — span unavailable" placeholders.
+- Import fallback + semantic dedup plumbing so tree-sitter captures and
+  line-based fallbacks for the same statement yield one import fact;
+  commented-out declarations are masked before augmentation.
+
+## Why
+
+The 12-language support contract (KG roadmap, issue #1531) required
+hardened graph extraction for Dart, Ruby, and PHP beyond the basic
+tree-sitter scaffolding: public/private conventions, import/export edges,
+method-level facts, and `context_pack` usability. A prior implementation
+(PR #1681) was reviewed but landed on a side branch that never reached main;
+this ports its Dart/Ruby/PHP subset onto the current architecture.
+
+## How to use
+
+- Rebuild the repo graph with `repo_map` action `build`.
+- Query focused context with `repo_map` action `context_pack`, passing the
+  target `file` and `symbol` — Ruby singleton methods are keyed as
+  `self.build` (with the `self.` prefix).
+- Use the `symbols` tool for direct exported-symbol inspection on `.dart`,
+  `.rb`, `.rake`, `.gemspec`, `.php`, and `.phtml` files.
+
+## Migration
+
+No migration required. Graph payloads for these languages gain defs/edges;
+other languages' payloads are unchanged (the import dedup only collapses
+semantically identical statements).
+
+## Dynamic limitations
+
+Extraction is syntax-only; no language runtimes, Flutter, Bundler, or
+Composer tooling are invoked. Ruby metaprogramming (`send`, `const_get`,
+`define_method`) and `include`/`extend` composition produce no facts; PHP
+variable functions/classes and grouped `use A\B, C\D;` statements are not
+modeled; non-aliased PHP `use` FQNs do not resolve to files (composer PSR-4
+awareness is out of scope); Blade directives are opaque to the extractor;
+Dart class members (including Flutter `build` methods) are not method defs —
+the enclosing type carries the span. See
+`docs/repo-graph-symbol-graph.md` → "Dynamic language limitations".

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -14,12 +14,12 @@ module: per-edge `usedSymbols` (which exported names an importer actually
 references) and per-node `exportLines` (exported symbol → definition line), plus
 the `repo_map` actions `callers` and `dead_exports`. That work deliberately used
 the module's existing **conservative regex scanner** and covered only TS/JS/Python
-(`SUPPORTED_EXTENSIONS` at `src/tools/repo-graph/builder.ts:113`).
+(`SUPPORTED_EXTENSIONS` at `src/tools/repo-graph/builder.ts:140`).
 
 Two ceilings remain, and they are exactly what an external "codebase memory" MCP
 server claims to break through:
 
-1. **Answers are file-level.** Edges are file→file (`GraphEdge`, `types.ts:216`).
+1. **Answers are file-level.** Edges are file→file (`GraphEdge`, `types.ts:269`).
    The graph can say "file A references symbol `foo` from file B" but not
    "function `bar()` calls `foo()`". Agents still open whole files to act, which
    is where context burden actually accrues.
@@ -65,7 +65,7 @@ first-class, **on-demand** dependency used at tool time:
 - `src/tools/syntax-check.ts` and `src/tools/placeholder-scan.ts` follow the same
   pattern with bounded concurrency.
 
-`loadGrammar(languageId)` (`src/lang/runtime.ts:185`) is lazy, memoized, request-
+`loadGrammar(languageId)` (`src/lang/runtime.ts:196`) is lazy, memoized, request-
 coalesced, and 10 s-bounded. Crucially, **`src/index.ts` never imports the
 tree-sitter runtime** — init is triggered only by query-time tools, so this work
 adds **zero** init-path cost. Regex cannot give reliable declaration boundaries or
@@ -181,7 +181,7 @@ export interface ContextPackResult {
 }
 ```
 
-`GRAPH_SCHEMA_VERSION` (`types.ts:25`) bumps to `'1.2.0'`. Every new query
+`GRAPH_SCHEMA_VERSION` (now `'1.4.0'` at `types.ts:52`; this design originally bumped it to `'1.2.0'`). Every new query
 self-gates with `isSchemaVersionAtLeast(graph.schema_version, '1.2.0')` and returns
 `{ schemaSupported: false, note: 'rebuild with repo_map action="build"' }` on older
 graphs (the `getDeadExports` pattern, `query.ts:257`).
@@ -214,9 +214,9 @@ graphs (the `getDeadExports` pattern, `query.ts:257`).
 Per the `callers`/`dead_exports` precedent, a new action is incomplete until it
 touches **every** one of these (no unwired code):
 
-1. `VALID_ACTIONS` array (`repo-map.ts:49`).
-2. The duplicated zod `action` enum + its `.describe()` (`repo-map.ts:163`).
-3. The tool `description` action catalog (`repo-map.ts:150`).
+1. `VALID_ACTIONS` array (`repo-map.ts:60`).
+2. The duplicated zod `action` enum + its `.describe()` (`repo-map.ts:245`).
+3. The tool `description` action catalog (`repo-map.ts:60`).
 4. The args schema — add `max_depth`/budget handling to `RepoMapArgs` if needed
    (`repo-map.ts:68`,`162`).
 5. The dispatch branch in `execute` (file+symbol required → after the `!a.file`
@@ -226,10 +226,10 @@ touches **every** one of these (no unwired code):
 
 ## The sync/async + #1144 parity decision
 
-`loadGrammar` is async; the sync `buildWorkspaceGraph` (`builder.ts:1216`) cannot
+`loadGrammar` is async; the sync `buildWorkspaceGraph` (`builder.ts:3032`) cannot
 await it. Investigation shows the production build hook already defaults to
-`buildWorkspaceGraphAsync` (`src/hooks/repo-graph-builder.ts:110`), and
-`loadGraphSync` only **reads** persisted JSON (`src/hooks/repo-graph-injection.ts:59`).
+`buildWorkspaceGraphAsync` (`src/hooks/repo-graph-builder.ts:177`), and
+`loadGraphSync` only **reads** persisted JSON (`src/hooks/repo-graph-injection.ts:105`).
 
 **Decision:** symbol-level data (`exportRanges`, `symbolEdges`) is populated **only
 by the async builder**. The sync builder remains for the homedir-guard tests and
@@ -644,9 +644,14 @@ Extraction for Dart (`.dart`), Ruby (`.rb`, `.rake`, `.gemspec`), and PHP
 Tree-sitter queries remain the primary source; a regex augmentation layer
 (`augmentNativeDynamicDefs` in `src/lang/symbol-graph.ts`) adds facts the
 queries cannot express (Ruby visibility sections/constants/singleton methods,
-PHP method visibility/namespaces, Dart mixin/enum/extension). Commented-out
-declarations are masked before augmentation. No language runtime, Flutter,
-Bundler, or Composer tooling is invoked (explicit non-goals).
+PHP method visibility/namespaces/enums, Dart mixin/enum/extension). Commented
+and string-literal text is masked before augmentation (length-preserving, so
+line/offset arithmetic is exact and CRLF-safe — the #1526 bug class). The
+line scanners advance offsets by the actual separator width, so CRLF and LF
+sources produce identical facts. Modifier-keyword quantifiers are bounded
+(an unbounded `(?:(kw)\s+)*` star measured ~8s at 1MB — quadratic
+backtracking). No language runtime, Flutter, Bundler, or Composer tooling is
+invoked (explicit non-goals).
 
 - **Dart visibility is the `_`-prefix convention.** Public-by-default names are
   exported; `_`-prefixed names are private and never file-level exports.
@@ -655,7 +660,10 @@ Bundler, or Composer tooling is invoked (explicit non-goals).
   import of everything minus the hidden names — correct for graph purposes);
   `as` prefix imports are namespace imports with no named binding, including
   when a `show`/`hide` clause follows the prefix (`import 'x' as p show A;`).
-  `export 'x' show A` produces a re-export edge with exported bindings.
+  `export 'x' show A` produces a re-export edge with exported bindings. A show
+list split across lines is parsed whole. Conditional imports
+(`import 'a' if (dart.library.io) 'b';`) record BOTH URIs — resolution
+happens at runtime, so either target can carry an edge.
 - **Dart type declarations include Dart 3 forms.** `class`/`mixin`/`enum`/
   `extension`/`typedef` and `extension type` (extension types capture the
   type's name) are extracted as defs; Dart 3 class modifiers
@@ -669,12 +677,13 @@ Bundler, or Composer tooling is invoked (explicit non-goals).
 - **Ruby singleton methods keep their `self.` prefix in the name.** A
   `def self.build` is keyed as `self.build` in `exportRanges` and
   `context_pack` lookups — query it as `self.build`, not `build`.
-- **Ruby visibility sections are line-tracked.** Bare `private`/`protected`
-  statements switch the section for the remainder of the class body; a `class`
-  or `module` line resets it to public. The symbol-argument form
-  (`private :method_name`) targets one method and deliberately does NOT switch
-  the section. `private_class_method` and per-definition `private def x` forms
-  are not modeled.
+- **Ruby visibility sections are line-tracked with nesting restore.** Bare
+  `private`/`protected` statements switch the section for the remainder of the
+  class body; entering a nested `class`/`module` pushes a fresh public section
+  and closing it (approximate `end`-keyword balance) restores the outer one.
+  The symbol-argument form (`private :a, :b`) marks the named methods in place
+  without switching the section. `private_class_method` and per-definition
+  `private def x` forms are not modeled.
 - **Ruby heredoc bodies are skipped.** A literal `private` or a `def`/`class`
   line inside a heredoc body is string data, not code — it neither flips the
   visibility section nor creates defs; the opener line's own declarations
@@ -693,14 +702,17 @@ Bundler, or Composer tooling is invoked (explicit non-goals).
   bindings, so no Ruby symbol edges arise from imports.
 - **PHP method visibility comes from modifiers** (`public`/`protected`/
   `private`, defaulting public), and `_`-prefixed names are treated private.
-  Trait declarations are extracted typed `interface`. Namespaces
-  (`namespace X;` and brace form) are extracted as `type` defs.
+  Trait declarations are extracted typed `interface` (matching the Rust
+  trait→interface precedent). Namespaces (`namespace X;` and brace form) are
+  extracted as `type` defs. PHP 8.1 `enum` declarations are extracted as
+  `enum` defs with their methods.
 - **PHP `use` semantics.** An aliased `use A\B\C as D` binds the SHORT name
   (`C`) to `D` — what body expressions spell. A non-aliased `use A\B\C;` is a
   namespace import with no bindings, and its FQN specifier does not resolve to
   a workspace file: mapping namespaces to paths requires composer PSR-4
   awareness, which is out of scope. Grouped `use A\B, C\D;` statements are
-  skipped entirely (known limitation).
+  skipped entirely (known limitation). A `use TraitName;` INSIDE a class or
+  trait body is a trait inclusion, not an import — it produces no edge.
 - **PHP dynamic constructs are invisible by design.** Variable functions
   (`$f()`), variable classes (`new $cls`), `call_user_func`, and string-built
   symbol references produce no facts.
@@ -714,5 +726,12 @@ Bundler, or Composer tooling is invoked (explicit non-goals).
 - **`dart`, `ruby`, `php` are `RANGE_WIDENED_GRAMMARS`.** Non-exported member
   defs (Ruby/PHP methods) enter `exportRanges` so `context_pack` can serve
   member spans; `exports[]`/`exportLines` stay exported-only. The sync
-  `buildWorkspaceGraph` path wires imports only (no exports) for these
-  languages — same as java/kotlin/csharp/cpp/swift.
+  `buildWorkspaceGraph` fallback also collects exports for these languages
+  via the regex extractors, so an AST timeout does not lose export metadata.
+- **Import resolution is importer-language aware.** An extensionless relative
+  specifier probes the importing file's own language family first: a Ruby
+  `require_relative 'foo'` resolves `foo.rb` even when a sibling `foo.ts`
+  exists.
+- **The `symbols` tool qualifies Dart class members** as `TypeName.member`
+  with kind `method` (mirroring the Swift extractor), so same-named members of
+  different classes do not collapse.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -290,7 +290,7 @@ change.
 
 | grammars | contents |
 |---|---|
-| java, kotlin, csharp | extracted defs including non-exported members, subject to the collision rules and the malformed-range guard below |
+| java, kotlin, csharp, cpp, swift (#1530), dart, ruby, php (#1531) | extracted defs including non-exported members, subject to the collision rules and the malformed-range guard below |
 | all others | exported defs only (scope unchanged) |
 
 "Including non-exported members" is not "every def": a name collision keeps one
@@ -636,3 +636,83 @@ from the tree-sitter parse alone.
   emits a non-exported def for `Foo` so the type's own declaration keeps its
   `exportRanges` span and `exports[]` entry; extension members are still
   extracted and attributed as methods.
+
+### Dynamic language limitations (Dart, Ruby, PHP — issue #1531)
+
+Extraction for Dart (`.dart`), Ruby (`.rb`, `.rake`, `.gemspec`), and PHP
+(`.php`, `.phtml`, `.blade.php`) is syntax-only and deliberately conservative.
+Tree-sitter queries remain the primary source; a regex augmentation layer
+(`augmentNativeDynamicDefs` in `src/lang/symbol-graph.ts`) adds facts the
+queries cannot express (Ruby visibility sections/constants/singleton methods,
+PHP method visibility/namespaces, Dart mixin/enum/extension). Commented-out
+declarations are masked before augmentation. No language runtime, Flutter,
+Bundler, or Composer tooling is invoked (explicit non-goals).
+
+- **Dart visibility is the `_`-prefix convention.** Public-by-default names are
+  exported; `_`-prefixed names are private and never file-level exports.
+- **Dart `show`/`hide`/`as` clauses.** `show` imports produce named bindings;
+  `hide` is intentionally unhandled (the import is recorded as a namespace
+  import of everything minus the hidden names — correct for graph purposes);
+  `as` prefix imports are namespace imports with no named binding, including
+  when a `show`/`hide` clause follows the prefix (`import 'x' as p show A;`).
+  `export 'x' show A` produces a re-export edge with exported bindings.
+- **Dart type declarations include Dart 3 forms.** `class`/`mixin`/`enum`/
+  `extension`/`typedef` and `extension type` (extension types capture the
+  type's name) are extracted as defs; Dart 3 class modifiers
+  (`base`/`final`/`interface`/`sealed`/`abstract`) do not change the captured
+  name. Unnamed `extension on X` carries no def (there is no name to record).
+- **Dart class members are not def-captured as methods.** Only top-level
+  `function_signature` defs and type defs exist. Flutter widget `build`
+  methods are therefore invisible as method defs; the enclosing widget class
+  def carries the span. `package:` URIs are recorded as import specifiers but
+  do not resolve to workspace files (pub package layout is external).
+- **Ruby singleton methods keep their `self.` prefix in the name.** A
+  `def self.build` is keyed as `self.build` in `exportRanges` and
+  `context_pack` lookups — query it as `self.build`, not `build`.
+- **Ruby visibility sections are line-tracked.** Bare `private`/`protected`
+  statements switch the section for the remainder of the class body; a `class`
+  or `module` line resets it to public. The symbol-argument form
+  (`private :method_name`) targets one method and deliberately does NOT switch
+  the section. `private_class_method` and per-definition `private def x` forms
+  are not modeled.
+- **Ruby heredoc bodies are skipped.** A literal `private` or a `def`/`class`
+  line inside a heredoc body is string data, not code — it neither flips the
+  visibility section nor creates defs; the opener line's own declarations
+  (e.g. `QUERY = <<~SQL`) still count. Openers are context-anchored (line
+  start, after `=`/`(`/`,`/`[`, or a value-position keyword like `puts`), so
+  the binary shift operator (`arr <<item`, `x << y`) never opens a heredoc.
+  An unterminated heredoc (invalid Ruby) silently degrades augmentation after
+  the opener; tree-sitter query defs still survive.
+- **Ruby dynamic constructs are invisible by design.** `send`, `const_get`,
+  `define_method`, `method_missing`, and metaprogramming-generated methods
+  produce no facts. `include`/`extend`/`prepend` mixin composition is not an
+  import or symbol edge. Constants are extracted from simple `NAME = value`
+  lines only.
+- **Ruby requires bind no names.** `require`/`require_relative` produce file
+  edges only (`require_relative 'x'` normalizes to `./x`); there are no named
+  bindings, so no Ruby symbol edges arise from imports.
+- **PHP method visibility comes from modifiers** (`public`/`protected`/
+  `private`, defaulting public), and `_`-prefixed names are treated private.
+  Trait declarations are extracted typed `interface`. Namespaces
+  (`namespace X;` and brace form) are extracted as `type` defs.
+- **PHP `use` semantics.** An aliased `use A\B\C as D` binds the SHORT name
+  (`C`) to `D` — what body expressions spell. A non-aliased `use A\B\C;` is a
+  namespace import with no bindings, and its FQN specifier does not resolve to
+  a workspace file: mapping namespaces to paths requires composer PSR-4
+  awareness, which is out of scope. Grouped `use A\B, C\D;` statements are
+  skipped entirely (known limitation).
+- **PHP dynamic constructs are invisible by design.** Variable functions
+  (`$f()`), variable classes (`new $cls`), `call_user_func`, and string-built
+  symbol references produce no facts.
+- **Blade templates are best-effort.** `.blade.php` files parse through the
+  PHP path; Blade directives (`@foreach`, `{{ }}`) are opaque to the extractor
+  and `@php` blocks are scanned as ordinary PHP. See `docs/php-laravel.md`.
+- **Augmented defs carry a binary `apiSurfaceKind`.** Regex-augmented defs
+  populate `apiSurfaceKind` as `public`/`private` only (there is no AST node
+  to run the full visibility classifier against); the `visibility` field
+  remains precise (e.g. `protected` from a modifier).
+- **`dart`, `ruby`, `php` are `RANGE_WIDENED_GRAMMARS`.** Non-exported member
+  defs (Ruby/PHP methods) enter `exportRanges` so `context_pack` can serve
+  member spans; `exports[]`/`exportLines` stay exported-only. The sync
+  `buildWorkspaceGraph` path wires imports only (no exports) for these
+  languages — same as java/kotlin/csharp/cpp/swift.

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -816,6 +816,8 @@ function buildFacts(
 		}
 	}
 
+	augmentNativeDynamicDefs(grammarId, root.text, defs);
+
 	const importsWithIndex: Array<{
 		index: number;
 		entry: FileSymbolFacts['imports'][0];
@@ -921,14 +923,33 @@ function buildFacts(
 			}
 		}
 	}
-	if (isEsMGrammar(grammarId)) {
+	if (isEsMGrammar(grammarId) || grammarId === 'dart') {
 		for (const exportNode of exportNodes) {
 			addImport(parseImport(grammarId, exportNode.text.trim()), exportNode);
 		}
 	}
+	for (const fallback of fallbackImportsForSource(grammarId, root.text)) {
+		importsWithIndex.push(fallback);
+	}
+	// The tree-sitter import captures and the line-based fallback above both
+	// parse the same statement for dart/ruby/php; keep one entry per semantic
+	// import (same specifier/type/bindings/re-export shape).
+	const seenImports = new Set<string>();
 	const imports = importsWithIndex
 		.sort((a, b) => a.index - b.index)
-		.map((item) => item.entry);
+		.map((item) => item.entry)
+		.filter((entry) => {
+			const key = JSON.stringify([
+				entry.specifier,
+				entry.importType,
+				entry.bindings,
+				entry.reExport ?? false,
+				entry.exportedBindings ?? [],
+			]);
+			if (seenImports.has(key)) return false;
+			seenImports.add(key);
+			return true;
+		});
 
 	const topLevelDefs = defNodes
 		.filter((d) => isTopLevelDef(d.node, root))
@@ -985,7 +1006,458 @@ function buildFacts(
 		}
 	}
 
-	return { defs, imports, refs };
+	// Regex-augmented defs can yield an endLine that trails the startLine when
+	// a declaration has no braces/semicolon to scan to (unterminated input);
+	// widened-grammar range validation rejects inverted ranges, so clamp.
+	const normalizedDefs = defs.map((def) => ({
+		...def,
+		endLine: Math.max(def.endLine, def.startLine),
+	}));
+	return { defs: normalizedDefs, imports, refs };
+}
+
+/**
+ * Regex-based augmentation for the dynamic-language grammars (dart, ruby,
+ * php). Tree-sitter queries stay the primary source; these layers add facts
+ * the queries cannot express (Ruby visibility sections and constants, PHP
+ * method visibility and namespaces, Dart mixin/enum/extension) and re-type
+ * query defs that need it (Ruby `def` → method). Augmented defs upsert into
+ * query defs by (name, startLine) so spans from the AST win.
+ */
+function augmentNativeDynamicDefs(
+	grammarId: string,
+	source: string,
+	defs: FileSymbolFacts['defs'],
+): void {
+	switch (grammarId) {
+		case 'dart':
+			augmentDartDefs(source, defs);
+			return;
+		case 'ruby':
+			augmentRubyDefs(source, defs);
+			return;
+		case 'php':
+			augmentPhpDefs(source, defs);
+			return;
+	}
+}
+
+function upsertAugmentedDef(
+	defs: FileSymbolFacts['defs'],
+	def: FileSymbolFacts['defs'][0],
+): void {
+	const existing = defs.find(
+		(item) => item.name === def.name && item.startLine === def.startLine,
+	);
+	if (existing) {
+		existing.kind = def.kind;
+		existing.exported = def.exported;
+		existing.visibilityInfo = def.visibilityInfo;
+		existing.endLine = Math.max(existing.endLine, def.endLine);
+		return;
+	}
+	defs.push(def);
+}
+
+function symbolVisibilityInfo(
+	visibility: SymbolVisibilityInfo['visibility'],
+	exported: boolean,
+	exportedReason: SymbolVisibilityInfo['exportedReason'],
+): SymbolVisibilityInfo {
+	// Augmented defs carry a binary apiSurfaceKind approximation: there is no
+	// AST node to re-run getSymbolVisibilityInfo against, and nothing in
+	// production consumes apiSurfaceKind today. `visibility` below remains
+	// precise (protected/private/public from modifiers or sections).
+	return {
+		exported,
+		visibility,
+		exportedReason,
+		apiSurfaceKind: exported ? 'public' : 'private',
+	};
+}
+
+function addRegexDef(
+	defs: FileSymbolFacts['defs'],
+	source: string,
+	name: string,
+	kind: FileSymbolFacts['defs'][0]['kind'],
+	start: number,
+	end: number,
+	visibility: SymbolVisibilityInfo['visibility'],
+	exported: boolean,
+	exportedReason: SymbolVisibilityInfo['exportedReason'],
+): void {
+	upsertAugmentedDef(defs, {
+		name,
+		kind,
+		exported,
+		visibilityInfo: symbolVisibilityInfo(visibility, exported, exportedReason),
+		startLine: lineNumberAt(source, start),
+		endLine: lineNumberAt(source, end),
+	});
+}
+
+function findMatchingBrace(source: string, openIndex: number): number | null {
+	if (source[openIndex] !== '{') return null;
+	let depth = 0;
+	for (let i = openIndex; i < source.length; i++) {
+		const ch = source[i];
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+	return null;
+}
+
+/** 1-based line number of the character at `index` (matches tree-sitter row+1). */
+function lineNumberAt(text: string, index: number): number {
+	let line = 1;
+	for (let i = 0; i < index && i < text.length; i++) {
+		if (text[i] === '\n') line++;
+	}
+	return line;
+}
+
+function declarationEnd(source: string, start: number): number {
+	const open = source.indexOf('{', start);
+	const semi = source.indexOf(';', start);
+	if (open !== -1 && (semi === -1 || open < semi)) {
+		return findMatchingBrace(source, open) ?? open;
+	}
+	return semi === -1 ? start : semi;
+}
+
+/**
+ * Dart type declarations. `extension type` (Dart 3 extension types) must be
+ * matched BEFORE bare `extension` so the type's real name is captured instead
+ * of the literal word `type`. The `(?!on\b)` lookahead skips unnamed
+ * extensions (`extension on String { ... }`) — they carry no name to record.
+ * `typedef` aliases are included as `type` defs.
+ */
+const dartTypeRe =
+	/\b(extension\s+type|class|mixin|enum|extension|typedef)\s+(?!on\b)([A-Za-z_][A-Za-z0-9_]*)/g;
+
+/**
+ * Length-preserving comment mask for the regex augmenters: commented-out
+ * declarations must not become graph facts. `//`, `#` (php), and block
+ * comments become spaces; newlines survive so offsets and line numbers are
+ * unchanged. Best-effort: comment markers inside string literals are also
+ * masked (conservative in the safe direction — it can only suppress, never
+ * invent, a declaration).
+ */
+function maskCommentsForAugment(source: string): string {
+	let out = '';
+	let inBlock = false;
+	for (let i = 0; i < source.length; i++) {
+		const two = source.substring(i, i + 2);
+		if (!inBlock && two === '/*') {
+			inBlock = true;
+			out += '  ';
+			i++;
+			continue;
+		}
+		if (inBlock) {
+			if (two === '*/') {
+				inBlock = false;
+				out += '  ';
+				i++;
+			} else {
+				out += source[i] === '\n' ? '\n' : ' ';
+			}
+			continue;
+		}
+		if (two === '//' || source[i] === '#') {
+			// Line comment: mask the marker and everything to end of line.
+			out += two === '//' ? '  ' : ' ';
+			if (two === '//') i++;
+			while (i + 1 < source.length && source[i + 1] !== '\n') {
+				out += ' ';
+				i++;
+			}
+			continue;
+		}
+		out += source[i];
+	}
+	return out;
+}
+
+function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const masked = maskCommentsForAugment(source);
+	dartTypeRe.lastIndex = 0;
+	for (
+		let m = dartTypeRe.exec(masked);
+		m !== null;
+		m = dartTypeRe.exec(masked)
+	) {
+		const exported = !m[2].startsWith('_');
+		const kindWord = m[1].trim().split(/\s+/).pop() ?? m[1];
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			kindWord === 'enum' ? 'enum' : kindWord === 'class' ? 'class' : 'type',
+			m.index,
+			declarationEnd(masked, m.index),
+			exported ? 'public' : 'private',
+			exported,
+			exported ? 'naming_convention' : 'unknown',
+		);
+	}
+	// Dart function declarations are already captured by tree-sitter's
+	// (function_signature name: (identifier) @func.name) query — no regex
+	// fallback here (a `Type name(` pattern also matches calls and control
+	// flow; see the #1681 review round-3 finding).
+}
+
+const rubyMethodDefNameRe = /^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_?!]*)/;
+/** Heredoc opener: `<<~ID`, `<<-ID`, `<<ID`, `<<"ID"`, `<<'ID'` (no space). */
+/**
+ * Heredoc opener: `<<~ID`, `<<-ID`, `<<ID`, `<<"ID"`, `<<'ID'`. Context-
+ * anchored so the binary shift operator can never open a heredoc: a real
+ * opener sits at line start or after `=`, `(`, `,`, `[`, or a value-position
+ * keyword (`puts`/`print`/`raise`/`return`/`p`) — `arr <<item` and `x << y`
+ * have an identifier (operand) before the `<<` and do not match.
+ */
+const rubyHeredocOpenRe =
+	/(?:^|[=(,[]\s*|(?:puts|print|raise|return|p)\s+)<<[~-]?['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/;
+
+/**
+ * Skips heredoc BODY lines for the line-scoped Ruby augmenter: a line that is
+ * literally `private` inside a heredoc must not flip the visibility section,
+ * and `def`/`class` text inside heredoc bodies is string data, not code.
+ * Only well-formed (terminated) heredocs track correctly; for an unterminated
+ * one (invalid Ruby) augmentation silently degrades — tree-sitter's query
+ * defs still survive, since they do not pass through this line scanner.
+ */
+function augmentRubyDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const lines = source.split(/\r?\n/);
+	let offset = 0;
+	let currentVisibility: SymbolVisibilityInfo['visibility'] = 'public';
+	let heredocId: string | null = null;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (heredocId !== null) {
+			if (trimmed === heredocId) heredocId = null;
+		} else {
+			// The opener line itself still carries code (e.g. `QUERY = <<~SQL`
+			// declares a constant) — only the body lines are skipped.
+			const open = trimmed.match(rubyHeredocOpenRe);
+			if (open) heredocId = open[1];
+			augmentRubyLine(
+				trimmed,
+				line,
+				offset,
+				source,
+				defs,
+				(v) => {
+					currentVisibility = v;
+				},
+				() => currentVisibility,
+			);
+		}
+		offset += line.length + 1;
+	}
+}
+
+function augmentRubyLine(
+	trimmed: string,
+	line: string,
+	offset: number,
+	source: string,
+	defs: FileSymbolFacts['defs'],
+	setVisibility: (v: SymbolVisibilityInfo['visibility']) => void,
+	getVisibility: () => SymbolVisibilityInfo['visibility'],
+): void {
+	// Bare `private` / `protected` statements switch the section for the
+	// rest of the class body (an AST `call`, not a modifier — hence this
+	// line-scoped tracking rather than a query). The `private :sym` form
+	// targets ONE method and deliberately does NOT switch the section.
+	if (trimmed === 'private' || trimmed === 'protected') {
+		setVisibility(trimmed);
+	}
+	const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
+	if (moduleMatch) {
+		setVisibility('public');
+		addRegexDef(
+			defs,
+			source,
+			moduleMatch[1],
+			'type',
+			offset + line.indexOf(moduleMatch[0]),
+			offset + line.length,
+			'public',
+			true,
+			'module_public',
+		);
+	}
+	const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
+	if (classMatch) {
+		setVisibility('public');
+		addRegexDef(
+			defs,
+			source,
+			classMatch[1],
+			'class',
+			offset + line.indexOf(classMatch[0]),
+			offset + line.length,
+			'public',
+			true,
+			'module_public',
+		);
+	}
+	const constMatch = trimmed.match(/^([A-Z][A-Za-z0-9_]*)\s*=/);
+	if (constMatch) {
+		addRegexDef(
+			defs,
+			source,
+			constMatch[1],
+			'const',
+			offset + line.indexOf(constMatch[1]),
+			offset + line.length,
+			'public',
+			true,
+			'module_public',
+		);
+	}
+	const methodMatch = trimmed.match(rubyMethodDefNameRe);
+	if (methodMatch) {
+		const isSingleton = Boolean(methodMatch[1]);
+		const shortName = methodMatch[2];
+		const name = isSingleton ? `self.${shortName}` : shortName;
+		const visibility = isSingleton ? 'public' : getVisibility();
+		const exported = visibility !== 'private' && !shortName.startsWith('_');
+		addRegexDef(
+			defs,
+			source,
+			name,
+			'method',
+			offset + line.indexOf('def'),
+			offset + line.length,
+			visibility,
+			exported,
+			exported ? 'module_public' : 'unknown',
+		);
+	}
+}
+
+const phpNamespaceRe = /\bnamespace\s+([^;{]+)\s*[;{]/g;
+const phpTypeRe = /\b(trait|class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const phpFunctionRe =
+	/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+
+function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
+	const masked = maskCommentsForAugment(source);
+	phpNamespaceRe.lastIndex = 0;
+	for (
+		let m = phpNamespaceRe.exec(masked);
+		m !== null;
+		m = phpNamespaceRe.exec(masked)
+	) {
+		addRegexDef(
+			defs,
+			source,
+			m[1].trim(),
+			'type',
+			m.index,
+			m.index + m[0].length,
+			'public',
+			true,
+			'namespace_public',
+		);
+	}
+	const typeRanges: Array<{ start: number; end: number }> = [];
+	phpTypeRe.lastIndex = 0;
+	for (let m = phpTypeRe.exec(masked); m !== null; m = phpTypeRe.exec(masked)) {
+		const bodyStart = masked.indexOf('{', m.index);
+		const bodyEnd =
+			bodyStart === -1 ? null : findMatchingBrace(masked, bodyStart);
+		if (bodyStart !== -1 && bodyEnd !== null) {
+			typeRanges.push({ start: bodyStart, end: bodyEnd });
+		}
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			m[1] === 'class' ? 'class' : 'interface',
+			m.index,
+			declarationEnd(masked, m.index),
+			'public',
+			true,
+			'module_public',
+		);
+	}
+	phpFunctionRe.lastIndex = 0;
+	for (
+		let m = phpFunctionRe.exec(masked);
+		m !== null;
+		m = phpFunctionRe.exec(masked)
+	) {
+		const modifiers = m[0].slice(0, m[0].indexOf('function'));
+		const visibility =
+			(modifiers.match(/\b(public|protected|private)\b/)?.[1] as
+				| SymbolVisibilityInfo['visibility']
+				| undefined) ??
+			// PHP class members default to public; top-level functions are public.
+			'public';
+		const exported = visibility !== 'private' && !m[2].startsWith('_');
+		const effectiveVisibility = m[2].startsWith('_') ? 'private' : visibility;
+		const kind = typeRanges.some(
+			(range) => m.index >= range.start && m.index <= range.end,
+		)
+			? 'method'
+			: 'function';
+		addRegexDef(
+			defs,
+			source,
+			m[2],
+			kind,
+			m.index,
+			declarationEnd(masked, m.index),
+			effectiveVisibility,
+			exported,
+			exported ? 'module_public' : 'unknown',
+		);
+	}
+}
+
+/**
+ * Line-based import fallback for grammars whose import statements the
+ * tree-sitter capture can miss (multi-directive lines, unusual node shapes).
+ * Entries carry startLine/endLine and are deduplicated against query-captured
+ * imports by the semantic key in buildFacts.
+ */
+function fallbackImportsForSource(
+	grammarId: string,
+	source: string,
+): Array<{ index: number; entry: FileSymbolFacts['imports'][0] }> {
+	const entries: Array<{
+		index: number;
+		entry: FileSymbolFacts['imports'][0];
+	}> = [];
+	const lines = source.split(/\r?\n/);
+	let offset = 0;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		const startLine = lineNumberAt(source, offset);
+		let parsed: FileSymbolFacts['imports'][0] | null = null;
+		if (grammarId === 'dart') {
+			parsed = parseDartImport(trimmed);
+		} else if (grammarId === 'ruby') {
+			parsed = parseRubyRequire(trimmed);
+		} else if (grammarId === 'php') {
+			parsed = parsePhpUse(trimmed);
+		}
+		if (parsed) {
+			entries.push({
+				index: offset,
+				entry: { ...parsed, startLine, endLine: startLine },
+			});
+		}
+		offset += line.length + 1;
+	}
+	return entries;
 }
 
 function safeMatches(
@@ -1672,20 +2144,55 @@ function parseSwiftImport(text: string): FileSymbolFacts['imports'][0] | null {
 function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
 	const t = text.trim();
 	// import 'foo';
-	// import 'foo' as bar;
+	// import 'foo' as bar;   — namespace-prefix access, not a named binding
 	// import 'foo' show A, B;
-	// import 'foo' hide A;
-	const m = t.match(/^import\s+['"]([^'"]+)['"]\s+as\s+(\w+)/);
-	if (m) {
+	// import 'foo' hide A;   — hide clause intentionally unhandled: recorded as
+	//                          a namespace import (all symbols minus hidden),
+	//                          which is correct for graph purposes
+	// export 'foo' show A, B;
+	const exportMatch = t.match(
+		/^export\s+['"]([^'"]+)['"](?:\s+show\s+([^;]+))?/,
+	);
+	if (exportMatch) {
+		const shown = exportMatch[2]
+			?.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const bindings =
+			shown && shown.length > 0
+				? shown.map((name) => ({ imported: name, local: name }))
+				: [{ imported: '*', local: '*' }];
 		return {
-			specifier: m[1],
-			importType: 'named',
-			bindings: [{ imported: m[1], local: m[2] }],
+			specifier: exportMatch[1],
+			importType: shown && shown.length > 0 ? 'named' : 'namespace',
+			bindings,
+			reExport: true,
+			exportedBindings: bindings.map((binding) => ({
+				imported: binding.imported,
+				exported: binding.local,
+			})),
 		};
 	}
-	const simple = t.match(/^import\s+['"]([^'"]+)['"]/);
-	if (simple) {
-		return { specifier: simple[1], importType: 'namespace', bindings: [] };
+	const importMatch = t.match(/^import\s+['"]([^'"]+)['"]([^;]*)/);
+	if (importMatch) {
+		// A prefix (`as p`) makes all access prefix-qualified — even when a
+		// show/hide clause follows (`import 'x' as p show A;`), the import is
+		// classified as namespace with no named binding.
+		const clause = importMatch[2];
+		const alias = clause?.match(/\bas\s+\w+/);
+		const shown = clause
+			?.match(/\bshow\s+([^;]+)/)?.[1]
+			.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		return {
+			specifier: importMatch[1],
+			importType: !alias && shown && shown.length > 0 ? 'named' : 'namespace',
+			bindings:
+				!alias && shown && shown.length > 0
+					? shown.map((name) => ({ imported: name, local: name }))
+					: [],
+		};
 	}
 	return null;
 }
@@ -1696,13 +2203,19 @@ function parseRubyRequire(text: string): FileSymbolFacts['imports'][0] | null {
 	// e.g. "json" for require 'json'
 	// e.g. "./foo" for require_relative './foo'
 	// When the require keyword is included (full call text), strip it.
+	// require_relative resolves against the requiring file's directory — the
+	// specifier is normalized to './name' so downstream relative resolution
+	// can find the target file.
+	const isRequireRelative = /^require_relative\b/.test(t);
 	const stripped = t
 		.replace(/^(?:require(?:_relative)?)\s+['"]?/, '')
 		.replace(/['"]$/, '');
 	if (!stripped || stripped === t) return null;
-	const isRelative = stripped.startsWith('./') || stripped.startsWith('../');
+	const specifier =
+		isRequireRelative && !stripped.startsWith('.') ? `./${stripped}` : stripped;
+	const isRelative = specifier.startsWith('./') || specifier.startsWith('../');
 	return {
-		specifier: stripped,
+		specifier,
 		importType: isRelative ? 'default' : 'namespace',
 		bindings: [],
 	};
@@ -1721,7 +2234,9 @@ function parsePhpUse(text: string): FileSymbolFacts['imports'][0] | null {
 		return {
 			specifier: m[1],
 			importType: 'named',
-			bindings: [{ imported: m[1], local: m[2] }],
+			// Bindings match on the short name (what a referencing expression
+			// in the body actually spells), mirroring builder.ts semantics.
+			bindings: [{ imported: m[1].split('\\').pop() ?? m[1], local: m[2] }],
 		};
 	}
 	const simple = t.match(
@@ -1823,7 +2338,10 @@ const IMPORT_ANCESTOR_TYPES = new Set([
 	'use_declaration',
 	'using_directive',
 	'namespace_use_declaration',
+	'namespace_use_clause', // php use clause under a grouped declaration
 	'library_import', // dart
+	'library_export', // dart
+	'export_directive', // dart
 ]);
 
 function isInsideImportStatement(node: TsNode): boolean {

--- a/src/lang/symbol-graph.ts
+++ b/src/lang/symbol-graph.ts
@@ -397,6 +397,8 @@ const QUERIES: Record<
 			) @func.def
 			(class_declaration name: (name) @class.name) @class.def
 			(interface_declaration name: (name) @interface.name) @interface.def
+			(trait_declaration name: (name) @trait.name) @trait.def
+			(enum_declaration name: (name) @enum.name) @enum.def
 		`,
 		imports: `
 			(namespace_use_declaration) @import
@@ -1120,6 +1122,25 @@ function lineNumberAt(text: string, index: number): number {
 	return line;
 }
 
+/**
+ * Byte offset just past the line that starts at `offset` and is
+ * `lineLength` long, accounting for the ACTUAL separator width. CRLF sources
+ * consume two bytes per separator; advancing by `lineLength + 1` after
+ * `split(/\r?\n/)` drifts one byte per line, corrupting startLines and
+ * breaking (name, startLine) upsert matching (issue #1526 bug class,
+ * recurred as PR #2361 PRR-001).
+ */
+function advanceLineOffset(
+	source: string,
+	offset: number,
+	lineLength: number,
+): number {
+	const after = offset + lineLength;
+	if (source[after] === '\r' && source[after + 1] === '\n') return after + 2;
+	if (source[after] === '\n' || source[after] === '\r') return after + 1;
+	return after; // final line with no trailing separator
+}
+
 function declarationEnd(source: string, start: number): number {
 	const open = source.indexOf('{', start);
 	const semi = source.indexOf(';', start);
@@ -1140,18 +1161,37 @@ const dartTypeRe =
 	/\b(extension\s+type|class|mixin|enum|extension|typedef)\s+(?!on\b)([A-Za-z_][A-Za-z0-9_]*)/g;
 
 /**
- * Length-preserving comment mask for the regex augmenters: commented-out
- * declarations must not become graph facts. `//`, `#` (php), and block
- * comments become spaces; newlines survive so offsets and line numbers are
- * unchanged. Best-effort: comment markers inside string literals are also
- * masked (conservative in the safe direction — it can only suppress, never
- * invent, a declaration).
+ * Length-preserving lexical mask for the regex augmenters: commented-out or
+ * string-embedded text must not become graph facts, and structural brace/
+ * semicolon scans must not see braces inside literals. `//`, `#` (php), and
+ * block comments become spaces; single/double-quoted string CONTENTS become
+ * spaces (delimiters are kept). Newlines survive so offsets and line numbers
+ * are unchanged. Best-effort, conservative in the safe direction — it can
+ * only suppress, never invent, a declaration or a brace. Heredocs/nowdocs
+ * are not masked here (the ruby augmenter tracks them separately).
  */
 function maskCommentsForAugment(source: string): string {
 	let out = '';
 	let inBlock = false;
+	let quote: '"' | "'" | null = null;
 	for (let i = 0; i < source.length; i++) {
+		const ch = source[i];
 		const two = source.substring(i, i + 2);
+		if (quote !== null) {
+			if (ch === '\\') {
+				// escaped char: blank both
+				out += '  ';
+				i++;
+				continue;
+			}
+			if (ch === quote) {
+				quote = null;
+				out += ch;
+			} else {
+				out += ch === '\n' ? '\n' : ' ';
+			}
+			continue;
+		}
 		if (!inBlock && two === '/*') {
 			inBlock = true;
 			out += '  ';
@@ -1178,7 +1218,35 @@ function maskCommentsForAugment(source: string): string {
 			}
 			continue;
 		}
-		out += source[i];
+		if (ch === '"' || ch === "'") {
+			// Triple-quoted multiline strings (Dart '''...''' / """..."""):
+			// a run of 3 opens a string that only a matching run of 3 closes.
+			// Treating each quote singly leaves the state machine's parity at
+			// the mercy of the CONTENT (an apostrophe inside the body flipped
+			// it and masked the next real declaration line).
+			if (source[i + 1] === ch && source[i + 2] === ch) {
+				out += ch + ch + ch;
+				i += 2;
+				while (i + 1 < source.length) {
+					if (
+						source[i + 1] === ch &&
+						source[i + 2] === ch &&
+						source[i + 3] === ch
+					) {
+						out += ch + ch + ch;
+						i += 3;
+						break;
+					}
+					out += source[i + 1] === '\n' ? '\n' : ' ';
+					i++;
+				}
+				continue;
+			}
+			quote = ch;
+			out += ch;
+			continue;
+		}
+		out += ch;
 	}
 	return out;
 }
@@ -1212,7 +1280,10 @@ function augmentDartDefs(source: string, defs: FileSymbolFacts['defs']): void {
 }
 
 const rubyMethodDefNameRe = /^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_?!]*)/;
-/** Heredoc opener: `<<~ID`, `<<-ID`, `<<ID`, `<<"ID"`, `<<'ID'` (no space). */
+/** Targeted visibility: `private :a, :b` / `protected :sym`. */
+const rubyTargetedVisibilityRe =
+	/^(private|protected)\s+((?::[A-Za-z_][A-Za-z0-9_?!]*\s*,\s*)*:[A-Za-z_][A-Za-z0-9_?!]*)$/;
+const rubyEndWordRe = /\bend\b/g;
 /**
  * Heredoc opener: `<<~ID`, `<<-ID`, `<<ID`, `<<"ID"`, `<<'ID'`. Context-
  * anchored so the binary shift operator can never open a heredoc: a real
@@ -1223,41 +1294,48 @@ const rubyMethodDefNameRe = /^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_?!]*)/;
 const rubyHeredocOpenRe =
 	/(?:^|[=(,[]\s*|(?:puts|print|raise|return|p)\s+)<<[~-]?['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/;
 
+interface RubyAugmentState {
+	visibility: SymbolVisibilityInfo['visibility'];
+	/** Saved outer-section per enclosing class/module, with the `end` level at entry. */
+	stack: Array<{
+		visibility: SymbolVisibilityInfo['visibility'];
+		atEndLevel: number;
+	}>;
+	/** Unclosed `class`/`module`/`def` bodies (approximated by `end` counting). */
+	endLevel: number;
+	heredocId: string | null;
+}
+
 /**
- * Skips heredoc BODY lines for the line-scoped Ruby augmenter: a line that is
- * literally `private` inside a heredoc must not flip the visibility section,
- * and `def`/`class` text inside heredoc bodies is string data, not code.
- * Only well-formed (terminated) heredocs track correctly; for an unterminated
- * one (invalid Ruby) augmentation silently degrades — tree-sitter's query
- * defs still survive, since they do not pass through this line scanner.
+ * Line-scoped Ruby augmentation. Heredoc BODY lines are skipped (a literal
+ * `private` there must not flip the section; `def`/`class` text there is
+ * string data). Bare `private`/`protected` switch the section until the
+ * enclosing class/module closes — the nesting is restored via an approximate
+ * `end`-keyword balance (imprecise for exotic constructs like modifier-`if`
+ * blocks; conservative direction, documented). Targeted `private :sym` marks
+ * the named method in place and does not switch the section.
  */
 function augmentRubyDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	const lines = source.split(/\r?\n/);
+	const state: RubyAugmentState = {
+		visibility: 'public',
+		stack: [],
+		endLevel: 0,
+		heredocId: null,
+	};
 	let offset = 0;
-	let currentVisibility: SymbolVisibilityInfo['visibility'] = 'public';
-	let heredocId: string | null = null;
 	for (const line of lines) {
 		const trimmed = line.trim();
-		if (heredocId !== null) {
-			if (trimmed === heredocId) heredocId = null;
+		if (state.heredocId !== null) {
+			if (trimmed === state.heredocId) state.heredocId = null;
 		} else {
 			// The opener line itself still carries code (e.g. `QUERY = <<~SQL`
 			// declares a constant) — only the body lines are skipped.
 			const open = trimmed.match(rubyHeredocOpenRe);
-			if (open) heredocId = open[1];
-			augmentRubyLine(
-				trimmed,
-				line,
-				offset,
-				source,
-				defs,
-				(v) => {
-					currentVisibility = v;
-				},
-				() => currentVisibility,
-			);
+			if (open) state.heredocId = open[1];
+			augmentRubyLine(trimmed, line, offset, source, defs, state);
 		}
-		offset += line.length + 1;
+		offset = advanceLineOffset(source, offset, line.length);
 	}
 }
 
@@ -1267,40 +1345,44 @@ function augmentRubyLine(
 	offset: number,
 	source: string,
 	defs: FileSymbolFacts['defs'],
-	setVisibility: (v: SymbolVisibilityInfo['visibility']) => void,
-	getVisibility: () => SymbolVisibilityInfo['visibility'],
+	state: RubyAugmentState,
 ): void {
-	// Bare `private` / `protected` statements switch the section for the
-	// rest of the class body (an AST `call`, not a modifier — hence this
-	// line-scoped tracking rather than a query). The `private :sym` form
-	// targets ONE method and deliberately does NOT switch the section.
 	if (trimmed === 'private' || trimmed === 'protected') {
-		setVisibility(trimmed);
+		state.visibility = trimmed;
+	}
+	// `private :a, :b` retro-marks the named methods without switching the
+	// section for later declarations.
+	const targeted = trimmed.match(rubyTargetedVisibilityRe);
+	if (targeted) {
+		const visibility = targeted[1] as SymbolVisibilityInfo['visibility'];
+		for (const name of targeted[2].split(',').map((part) => part.trim())) {
+			const sym = name.replace(/^:/, '');
+			for (let i = defs.length - 1; i >= 0; i--) {
+				const d = defs[i];
+				if (d.name === sym && d.startLine <= lineNumberAt(source, offset)) {
+					d.exported = false;
+					d.visibilityInfo = symbolVisibilityInfo(visibility, false, 'unknown');
+					break;
+				}
+			}
+		}
 	}
 	const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
-	if (moduleMatch) {
-		setVisibility('public');
-		addRegexDef(
-			defs,
-			source,
-			moduleMatch[1],
-			'type',
-			offset + line.indexOf(moduleMatch[0]),
-			offset + line.length,
-			'public',
-			true,
-			'module_public',
-		);
-	}
 	const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
-	if (classMatch) {
-		setVisibility('public');
+	if (moduleMatch || classMatch) {
+		state.stack.push({
+			visibility: state.visibility,
+			atEndLevel: state.endLevel,
+		});
+		state.visibility = 'public';
+		state.endLevel++;
+		const name = (moduleMatch ?? classMatch)![1];
 		addRegexDef(
 			defs,
 			source,
-			classMatch[1],
-			'class',
-			offset + line.indexOf(classMatch[0]),
+			name,
+			moduleMatch ? 'type' : 'class',
+			offset + line.indexOf((moduleMatch ?? classMatch)![0]),
 			offset + line.length,
 			'public',
 			true,
@@ -1323,10 +1405,11 @@ function augmentRubyLine(
 	}
 	const methodMatch = trimmed.match(rubyMethodDefNameRe);
 	if (methodMatch) {
+		state.endLevel++;
 		const isSingleton = Boolean(methodMatch[1]);
 		const shortName = methodMatch[2];
 		const name = isSingleton ? `self.${shortName}` : shortName;
-		const visibility = isSingleton ? 'public' : getVisibility();
+		const visibility = isSingleton ? 'public' : state.visibility;
 		const exported = visibility !== 'private' && !shortName.startsWith('_');
 		addRegexDef(
 			defs,
@@ -1340,12 +1423,27 @@ function augmentRubyLine(
 			exported ? 'module_public' : 'unknown',
 		);
 	}
+	// Approximate `end` balance: when the count falls back to a frame's entry
+	// level, that class/module has closed — restore its outer section.
+	rubyEndWordRe.lastIndex = 0;
+	const ends = trimmed.match(rubyEndWordRe)?.length ?? 0;
+	if (ends > 0) {
+		state.endLevel -= ends;
+		while (
+			state.stack.length > 0 &&
+			state.endLevel <= state.stack[state.stack.length - 1].atEndLevel
+		) {
+			state.visibility = state.stack.pop()!.visibility;
+		}
+	}
 }
 
 const phpNamespaceRe = /\bnamespace\s+([^;{]+)\s*[;{]/g;
-const phpTypeRe = /\b(trait|class|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+const phpTypeRe = /\b(trait|class|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g;
+// The modifier group is bounded {0,6}: an unbounded star here is quadratic on
+// adversarial modifier runs (measured ~8s at 1MB — PR #2361 PRR-012).
 const phpFunctionRe =
-	/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	/\b(?:(public|protected|private|static|final|abstract)\s+){0,6}function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
 
 function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
 	const masked = maskCommentsForAugment(source);
@@ -1380,7 +1478,7 @@ function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
 			defs,
 			source,
 			m[2],
-			m[1] === 'class' ? 'class' : 'interface',
+			m[1] === 'class' ? 'class' : m[1] === 'enum' ? 'enum' : 'interface',
 			m.index,
 			declarationEnd(masked, m.index),
 			'public',
@@ -1425,6 +1523,13 @@ function augmentPhpDefs(source: string, defs: FileSymbolFacts['defs']): void {
 /**
  * Line-based import fallback for grammars whose import statements the
  * tree-sitter capture can miss (multi-directive lines, unusual node shapes).
+ * Lexical-context aware: detection runs against a comment+string-masked copy
+ * so import-shaped text inside literals cannot match (ruby heredoc bodies are
+ * skipped with the same tracker the augmenter uses; php `use` lines inside a
+ * brace depth > 0 are class-body trait inclusions, not imports). Dart/php
+ * statements are ';'-terminated, so unterminated lines are joined with their
+ * continuations before parsing — a multiline `show` clause yields the same
+ * entry the query path produces and collapses in the semantic dedup.
  * Entries carry startLine/endLine and are deduplicated against query-captured
  * imports by the semantic key in buildFacts.
  */
@@ -1436,27 +1541,119 @@ function fallbackImportsForSource(
 		index: number;
 		entry: FileSymbolFacts['imports'][0];
 	}> = [];
+	if (grammarId !== 'dart' && grammarId !== 'ruby' && grammarId !== 'php') {
+		return entries;
+	}
+	const masked = maskCommentsForAugment(source);
 	const lines = source.split(/\r?\n/);
+	const maskedLines = masked.split(/\r?\n/);
 	let offset = 0;
-	for (const line of lines) {
-		const trimmed = line.trim();
-		const startLine = lineNumberAt(source, offset);
-		let parsed: FileSymbolFacts['imports'][0] | null = null;
-		if (grammarId === 'dart') {
-			parsed = parseDartImport(trimmed);
-		} else if (grammarId === 'ruby') {
-			parsed = parseRubyRequire(trimmed);
-		} else if (grammarId === 'php') {
-			parsed = parsePhpUse(trimmed);
-		}
-		if (parsed) {
+	let heredocId: string | null = null;
+	let braceDepth = 0;
+	let pending: {
+		startOffset: number;
+		startLine: number;
+		text: string;
+		lines: number;
+	} | null = null;
+	const flushPending = (endLine: number) => {
+		if (!pending) return;
+		let parsed:
+			| FileSymbolFacts['imports'][0]
+			| FileSymbolFacts['imports']
+			| null = null;
+		if (grammarId === 'dart') parsed = parseDartImport(pending.text);
+		else if (grammarId === 'php') parsed = parsePhpUse(pending.text);
+		for (const entry of parsed
+			? Array.isArray(parsed)
+				? parsed
+				: [parsed]
+			: []) {
 			entries.push({
-				index: offset,
-				entry: { ...parsed, startLine, endLine: startLine },
+				index: pending.startOffset,
+				entry: { ...entry, startLine: pending.startLine, endLine },
 			});
 		}
-		offset += line.length + 1;
+		pending = null;
+	};
+	for (let li = 0; li < lines.length; li++) {
+		const line = lines[li];
+		const trimmed = line.trim();
+		const maskedTrimmed = maskedLines[li]?.trim() ?? '';
+		const startLine = lineNumberAt(source, offset);
+
+		if (grammarId === 'ruby') {
+			if (heredocId !== null) {
+				if (maskedTrimmed === heredocId) heredocId = null;
+			} else {
+				const open = maskedTrimmed.match(rubyHeredocOpenRe);
+				if (open) heredocId = open[1];
+				else {
+					const parsed = parseRubyRequire(trimmed);
+					if (parsed) {
+						entries.push({
+							index: offset,
+							entry: { ...parsed, startLine, endLine: startLine },
+						});
+					}
+				}
+			}
+			offset = advanceLineOffset(source, offset, line.length);
+			continue;
+		}
+
+		// dart/php: track brace depth on the MASKED line so braces inside
+		// strings cannot skew it.
+		if (grammarId === 'php') {
+			for (const ch of maskedLines[li] ?? '') {
+				if (ch === '{') braceDepth++;
+				else if (ch === '}') braceDepth = Math.max(0, braceDepth - 1);
+			}
+		}
+
+		if (pending) {
+			pending.text += ` ${trimmed}`;
+			pending.lines++;
+			if (trimmed.includes(';') || pending.lines > 10) {
+				flushPending(startLine);
+			} else if (trimmed === '') {
+				pending = null; // blank line aborts an unterminated buffer
+			}
+			offset = advanceLineOffset(source, offset, line.length);
+			continue;
+		}
+
+		const startsStatement =
+			grammarId === 'dart'
+				? /^(import|export)\s/.test(maskedTrimmed)
+				: /^use\s/.test(maskedTrimmed);
+		// php `use` inside a class/trait body is a trait inclusion, not an import
+		const inClassBody = grammarId === 'php' && braceDepth > 0;
+		if (startsStatement && !inClassBody) {
+			if (trimmed.includes(';')) {
+				let parsed:
+					| FileSymbolFacts['imports'][0]
+					| FileSymbolFacts['imports']
+					| null = null;
+				if (grammarId === 'dart') parsed = parseDartImport(trimmed);
+				else if (grammarId === 'php') parsed = parsePhpUse(trimmed);
+				for (const entry of parsed
+					? Array.isArray(parsed)
+						? parsed
+						: [parsed]
+					: []) {
+					entries.push({
+						index: offset,
+						entry: { ...entry, startLine, endLine: startLine },
+					});
+				}
+			} else {
+				pending = { startOffset: offset, startLine, text: trimmed, lines: 1 };
+			}
+		}
+		offset = advanceLineOffset(source, offset, line.length);
 	}
+	flushPending(lineNumberAt(source, offset));
 	return entries;
 }
 
@@ -2141,7 +2338,9 @@ function parseSwiftImport(text: string): FileSymbolFacts['imports'][0] | null {
 	return { specifier: m[2]!, importType: 'namespace', bindings: [] };
 }
 
-function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
+function parseDartImport(
+	text: string,
+): FileSymbolFacts['imports'][0] | FileSymbolFacts['imports'] | null {
 	const t = text.trim();
 	// import 'foo';
 	// import 'foo' as bar;   — namespace-prefix access, not a named binding
@@ -2185,7 +2384,7 @@ function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
 			.split(',')
 			.map((part) => part.trim())
 			.filter(Boolean);
-		return {
+		const primary: FileSymbolFacts['imports'][0] = {
 			specifier: importMatch[1],
 			importType: !alias && shown && shown.length > 0 ? 'named' : 'namespace',
 			bindings:
@@ -2193,6 +2392,17 @@ function parseDartImport(text: string): FileSymbolFacts['imports'][0] | null {
 					? shown.map((name) => ({ imported: name, local: name }))
 					: [],
 		};
+		// Conditional imports (`import 'a' if (cond) 'b';`) resolve to the
+		// configured URI at RUNTIME; both URIs are recorded so either target
+		// can carry an edge (PR #2361 PRR-007).
+		const conditional = clause?.match(/\bif\s*\([^)]*\)\s*['"]([^'"]+)['"]/);
+		if (conditional) {
+			return [
+				primary,
+				{ specifier: conditional[1], importType: 'namespace', bindings: [] },
+			];
+		}
+		return primary;
 	}
 	return null;
 }
@@ -2397,3 +2607,15 @@ function isEsMGrammar(grammarId: string): boolean {
 		grammarId === 'javascript'
 	);
 }
+
+/**
+ * DI seam for direct parser tests — the import parsers are module-private by
+ * design; tests exercise them through this seam instead of `mock.module`,
+ * which leaks across Bun's shared test-runner process (@see AGENTS.md
+ * invariant #7; PR #2361 review R10/PRR-017).
+ */
+export const _internals = {
+	parseDartImport,
+	parseRubyRequire,
+	parsePhpUse,
+};

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -673,6 +673,12 @@ export function resolveModuleSpecifier(
 								'.jsx',
 								'.mjs',
 								'.cjs',
+								'.rb',
+								'.rake',
+								'.gemspec',
+								'.dart',
+								'.php',
+								'.phtml',
 								'.json',
 							]
 						: [
@@ -686,6 +692,12 @@ export function resolveModuleSpecifier(
 								'.pyw',
 								'.rs',
 								'.go',
+								'.rb',
+								'.rake',
+								'.gemspec',
+								'.dart',
+								'.php',
+								'.phtml',
 								'.json',
 							];
 				let found: string | null = null;
@@ -1123,6 +1135,19 @@ function parseFileImports(
 	if (ext === '.cs' || ext === '.csx') {
 		return parseCSharpFileImports(rawContent);
 	}
+	if (ext === '.dart') {
+		return parseDartFileImports(rawContent);
+	}
+	if (ext === '.rb' || ext === '.rake' || ext === '.gemspec') {
+		return parseRubyFileImports(rawContent);
+	}
+	if (
+		ext === '.php' ||
+		ext === '.phtml' ||
+		sourceFile?.endsWith('.blade.php')
+	) {
+		return parsePhpFileImports(rawContent);
+	}
 
 	const imports: ParsedImport[] = [];
 	const content = stripComments(rawContent);
@@ -1314,6 +1339,87 @@ function parseCSharpFileImports(rawContent: string): ParsedImport[] {
 					{ imported: finalDottedSegment(specifier), local: alias },
 				])
 			: makeParsedImport(specifier, 'namespace', []);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+/**
+ * Regex import fallback for Dart (see {@link parseCSharpFileImports}).
+ * `hide` clauses are intentionally unhandled — the import is still recorded
+ * as a namespace import (all symbols minus hidden ones), which is correct
+ * for graph purposes.
+ */
+function parseDartFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^[ \t]*(import|export)[ \t]+['"]([^'"]+)['"]([^;\n]*)/gm,
+	)) {
+		const clause = match[3];
+		const shown = clause
+			?.match(/\bshow\s+([^;]+)/)?.[1]
+			.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const alias = clause?.match(/\bas\s+\w+/);
+		// A prefix (`as p`) makes the import namespace-qualified with no named
+		// binding, even when a show/hide clause follows.
+		const bindings =
+			!alias && shown && shown.length > 0
+				? shown.map((name) => ({ imported: name, local: name }))
+				: [];
+		const parsed = makeParsedImport(
+			match[2],
+			bindings.length > 0 ? 'named' : 'namespace',
+			bindings,
+			match[1] === 'export',
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+/**
+ * Regex import fallback for Ruby require/require_relative. `require_relative`
+ * resolves against the requiring file's directory, so the specifier is
+ * normalized to './name' when no explicit relative prefix is present.
+ */
+function parseRubyFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^[ \t]*(require_relative|require)[ \t]+['"]([^'"]+)['"]/gm,
+	)) {
+		const relative = match[1] === 'require_relative';
+		const specifier =
+			relative && !match[2].startsWith('.') ? `./${match[2]}` : match[2];
+		const parsed = makeParsedImport(
+			specifier,
+			relative ? 'default' : 'namespace',
+			[],
+		);
+		if (parsed) imports.push(parsed);
+	}
+	return imports;
+}
+
+/**
+ * Regex import fallback for PHP `use` declarations. Grouped `use A\B, C\D;`
+ * forms are a known limitation (the whole group is skipped); FQN specifiers
+ * are recorded as-is — mapping them to workspace files requires composer
+ * PSR-4 awareness, which is out of scope (#1531 "where practical").
+ */
+function parsePhpFileImports(rawContent: string): ParsedImport[] {
+	const imports: ParsedImport[] = [];
+	for (const match of rawContent.matchAll(
+		/^[ \t]*use[ \t]+(?:(?:function|const)[ \t]+)?([^;\s]+)(?:[ \t]+as[ \t]+(\w+))?[ \t]*;?[ \t]*\r?$/gim,
+	)) {
+		const imported = match[1].split('\\').pop() ?? match[1];
+		const bindings = match[2] ? [{ imported, local: match[2] }] : [];
+		const parsed = makeParsedImport(
+			match[1],
+			bindings.length > 0 ? 'named' : 'namespace',
+			bindings,
+		);
 		if (parsed) imports.push(parsed);
 	}
 	return imports;
@@ -2134,6 +2240,12 @@ const RANGE_WIDENED_GRAMMARS = new Set([
 	'csharp',
 	'cpp',
 	'swift',
+	// Dynamic-language hardening (#1531): member defs (Ruby methods, PHP
+	// methods) are non-exported at file level but must still carry spans for
+	// context_pack; widening admits them into exportRanges only.
+	'dart',
+	'ruby',
+	'php',
 ]);
 
 /**

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -22,8 +22,11 @@ import * as logger from '../../utils/logger';
 import { containsControlChars } from '../../utils/path-security';
 import { yieldToEventLoop } from '../../utils/timeout';
 import {
+	extractDartSymbols,
 	extractGoSymbols,
+	extractPhpSymbols,
 	extractPythonSymbols,
+	extractRubySymbols,
 	extractRustSymbols,
 	extractTSSymbols,
 } from '../symbols';
@@ -63,7 +66,13 @@ export const _internals: {
 	extractPythonSymbols: typeof extractPythonSymbols;
 	extractRustSymbols: typeof extractRustSymbols;
 	extractGoSymbols: typeof extractGoSymbols;
+	extractDartSymbols: typeof extractDartSymbols;
+	extractRubySymbols: typeof extractRubySymbols;
+	extractPhpSymbols: typeof extractPhpSymbols;
 	parseFileImports: typeof parseFileImports;
+	parseDartFileImports: typeof parseDartFileImports;
+	parseRubyFileImports: typeof parseRubyFileImports;
+	parsePhpFileImports: typeof parsePhpFileImports;
 	extractFileOntology: typeof extractFileOntology;
 	stripComments: typeof stripComments;
 	computeUsedSymbols: typeof computeUsedSymbols;
@@ -75,7 +84,13 @@ export const _internals: {
 	extractPythonSymbols,
 	extractRustSymbols,
 	extractGoSymbols,
+	extractDartSymbols,
+	extractRubySymbols,
+	extractPhpSymbols,
 	parseFileImports,
+	parseDartFileImports,
+	parseRubyFileImports,
+	parsePhpFileImports,
 	extractFileOntology,
 	stripComments,
 	computeUsedSymbols,
@@ -659,9 +674,25 @@ export function resolveModuleSpecifier(
 			// Try to resolve the extensionless path to a real file.
 			// TypeScript/JavaScript imports commonly omit extensions: import { foo } from './utils'
 			// We need to find the actual file: ./utils.ts, ./utils.js, etc.
+			// The importer's OWN language family probes first: a Ruby
+			// `require_relative 'foo'` must not resolve to a sibling foo.ts
+			// when foo.rb exists (PR #2361 review R3).
 			if (!existsSync(resolved)) {
-				const EXTENSIONS =
-					path.extname(sourceFile).toLowerCase() === '.pyw'
+				const importerExt = path.extname(sourceFile).toLowerCase();
+				const FAMILY_FIRST: Record<string, readonly string[]> = {
+					'.rb': ['.rb'],
+					'.rake': ['.rb'],
+					'.gemspec': ['.rb'],
+					'.dart': ['.dart'],
+					'.php': ['.php'],
+					'.phtml': ['.php'],
+					'.py': ['.py'],
+					'.pyw': ['.pyw'],
+					'.rs': ['.rs'],
+					'.go': ['.go'],
+				};
+				const BASE =
+					importerExt === '.pyw'
 						? [
 								'.pyw',
 								'.py',
@@ -673,13 +704,6 @@ export function resolveModuleSpecifier(
 								'.jsx',
 								'.mjs',
 								'.cjs',
-								'.rb',
-								'.rake',
-								'.gemspec',
-								'.dart',
-								'.php',
-								'.phtml',
-								'.json',
 							]
 						: [
 								'.ts',
@@ -692,14 +716,18 @@ export function resolveModuleSpecifier(
 								'.pyw',
 								'.rs',
 								'.go',
-								'.rb',
-								'.rake',
-								'.gemspec',
-								'.dart',
-								'.php',
-								'.phtml',
-								'.json',
 							];
+				const EXTENSIONS = [
+					...(FAMILY_FIRST[importerExt] ?? []),
+					...BASE,
+					'.rb',
+					'.rake',
+					'.gemspec',
+					'.dart',
+					'.php',
+					'.phtml',
+					'.json',
+				].filter((ext, i, all) => all.indexOf(ext) === i);
 				let found: string | null = null;
 				for (const ext of EXTENSIONS) {
 					const candidate = resolved + ext;
@@ -1352,8 +1380,10 @@ function parseCSharpFileImports(rawContent: string): ParsedImport[] {
  */
 function parseDartFileImports(rawContent: string): ParsedImport[] {
 	const imports: ParsedImport[] = [];
+	// `[^;]*` (not `[^;\n]*`) so a show list split across lines is captured
+	// whole — matching the symbol-graph parser's clause handling.
 	for (const match of rawContent.matchAll(
-		/^[ \t]*(import|export)[ \t]+['"]([^'"]+)['"]([^;\n]*)/gm,
+		/^[ \t]*(import|export)[ \t]+['"]([^'"]+)['"]([^;]*)/gm,
 	)) {
 		const clause = match[3];
 		const shown = clause
@@ -2348,6 +2378,23 @@ export function scanFile(
 			({ exports, exportLines } = collectExports(
 				_internals.extractGoSymbols(relativePath, absoluteRoot),
 			));
+		} else if (ext === '.dart') {
+			// Dynamic-language hardening (#1531): the AST fail-open path must
+			// not lose export metadata for the new languages (PR #2361 R9).
+			const relativePath = path.relative(absoluteRoot, filePath);
+			({ exports, exportLines } = collectExports(
+				_internals.extractDartSymbols(relativePath, absoluteRoot),
+			));
+		} else if (ext === '.rb' || ext === '.rake' || ext === '.gemspec') {
+			const relativePath = path.relative(absoluteRoot, filePath);
+			({ exports, exportLines } = collectExports(
+				_internals.extractRubySymbols(relativePath, absoluteRoot),
+			));
+		} else if (ext === '.php' || ext === '.phtml') {
+			const relativePath = path.relative(absoluteRoot, filePath);
+			({ exports, exportLines } = collectExports(
+				_internals.extractPhpSymbols(relativePath, absoluteRoot),
+			));
 		}
 
 		// Parse imports to get specifiers with types
@@ -3128,6 +3175,23 @@ export function buildWorkspaceGraph(
 				const relativePath = path.relative(absoluteRoot, filePath);
 				({ exports, exportLines } = collectExports(
 					_internals.extractGoSymbols(relativePath, absoluteRoot),
+				));
+			} else if (ext === '.dart') {
+				// Dynamic-language hardening (#1531): the AST fail-open path must
+				// not lose export metadata for the new languages (PR #2361 R9).
+				const relativePath = path.relative(absoluteRoot, filePath);
+				({ exports, exportLines } = collectExports(
+					_internals.extractDartSymbols(relativePath, absoluteRoot),
+				));
+			} else if (ext === '.rb' || ext === '.rake' || ext === '.gemspec') {
+				const relativePath = path.relative(absoluteRoot, filePath);
+				({ exports, exportLines } = collectExports(
+					_internals.extractRubySymbols(relativePath, absoluteRoot),
+				));
+			} else if (ext === '.php' || ext === '.phtml') {
+				const relativePath = path.relative(absoluteRoot, filePath);
+				({ exports, exportLines } = collectExports(
+					_internals.extractPhpSymbols(relativePath, absoluteRoot),
 				));
 			}
 

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -638,13 +638,56 @@ export function extractGoSymbols(filePath: string, cwd: string): SymbolInfo[] {
 
 // ============ Dart / Ruby / PHP Extraction (issue #1531) ============
 
+/**
+ * Single-slot memo of line-start offsets for the most recent source:
+ * `lineNumberAt` is called once or more per extracted def; a naive forward
+ * scan is O(file) per call and O(defs × bytes) per file (PR #2361 PRR-018).
+ * Extractors process one file per call, so a one-entry cache is sufficient
+ * and trivially bounded. Binary search over the cached offsets makes each
+ * lookup O(log lines).
+ */
+let memoSource: string | null = null;
+let memoStarts: number[] = [0];
+
+function lineStartsOf(content: string): number[] {
+	if (memoSource !== content) {
+		const starts = [0];
+		for (let i = 0; i < content.length; i++) {
+			if (content[i] === '\n') starts.push(i + 1);
+		}
+		memoSource = content;
+		memoStarts = starts;
+	}
+	return memoStarts;
+}
+
 /** 1-based line number of the character at `index`. */
 function lineNumberAt(content: string, index: number): number {
-	let line = 1;
-	for (let i = 0; i < index && i < content.length; i++) {
-		if (content[i] === '\n') line++;
+	const starts = lineStartsOf(content);
+	let lo = 0;
+	let hi = starts.length - 1;
+	while (lo < hi) {
+		const mid = (lo + hi + 1) >> 1;
+		if (starts[mid] <= index) lo = mid;
+		else hi = mid - 1;
 	}
-	return line;
+	return lo + 1;
+}
+
+/**
+ * Byte offset just past the line starting at `offset` of `lineLength`,
+ * accounting for the ACTUAL separator width (CRLF consumes two bytes —
+ * issue #1526 bug class, PR #2361 PRR-001).
+ */
+function advanceLineOffset(
+	source: string,
+	offset: number,
+	lineLength: number,
+): number {
+	const after = offset + lineLength;
+	if (source[after] === '\r' && source[after + 1] === '\n') return after + 2;
+	if (source[after] === '\n' || source[after] === '\r') return after + 1;
+	return after;
 }
 
 function lineTextAt(content: string, index: number): string {
@@ -671,17 +714,34 @@ function findMatchingBrace(content: string, openIndex: number): number | null {
 }
 
 /**
- * Conservative comment mask for regex scanning: replaces `//`, `#`, and
- * block comments with spaces, preserving newlines (and thus offsets/line
- * structure) so `lineNumberAt`/`lineTextAt` stay accurate against the
- * original text. Quote-awareness is intentionally minimal — this is a
- * best-effort filter for declaration regexes, not a lexer.
+ * Conservative lexical mask for regex scanning: replaces `//`, `#`, and
+ * block comments with spaces AND blanks single/double-quoted string CONTENTS
+ * (delimiters kept), preserving newlines (and thus offsets/line structure)
+ * so `lineNumberAt`/`lineTextAt` stay accurate against the original text.
+ * Braces/semicolons inside literals therefore never reach the structural
+ * scans. Best-effort filter, not a lexer; heredocs are handled separately.
  */
 function stripLineCommentsForScan(content: string): string {
 	let out = '';
 	let inBlock = false;
+	let quote: '"' | "'" | null = null;
 	for (let i = 0; i < content.length; i++) {
+		const ch = content[i];
 		const two = content.substring(i, i + 2);
+		if (quote !== null) {
+			if (ch === '\\') {
+				out += '  ';
+				i++;
+				continue;
+			}
+			if (ch === quote) {
+				quote = null;
+				out += ch;
+			} else {
+				out += ch === '\n' ? '\n' : ' ';
+			}
+			continue;
+		}
 		if (!inBlock && two === '/*') {
 			inBlock = true;
 			out += '  ';
@@ -694,11 +754,11 @@ function stripLineCommentsForScan(content: string): string {
 				out += '  ';
 				i++;
 			} else {
-				out += content[i] === '\n' ? '\n' : ' ';
+				out += ch === '\n' ? '\n' : ' ';
 			}
 			continue;
 		}
-		if (two === '//' || content[i] === '#') {
+		if (two === '//' || ch === '#') {
 			// Line comment: mask the marker and everything to end of line.
 			out += two === '//' ? '  ' : ' ';
 			if (two === '//') i++;
@@ -708,7 +768,32 @@ function stripLineCommentsForScan(content: string): string {
 			}
 			continue;
 		}
-		out += content[i];
+		if (ch === '"' || ch === "'") {
+			// Triple-quoted multiline strings (Dart '''...''' / """..."""):
+			// a run of 3 opens a string that only a matching run of 3 closes.
+			if (ch === content[i + 1] && ch === content[i + 2]) {
+				out += ch + ch + ch;
+				i += 2;
+				while (i + 1 < content.length) {
+					if (
+						content[i + 1] === ch &&
+						content[i + 2] === ch &&
+						content[i + 3] === ch
+					) {
+						out += ch + ch + ch;
+						i += 3;
+						break;
+					}
+					out += content[i + 1] === '\n' ? '\n' : ' ';
+					i++;
+				}
+				continue;
+			}
+			quote = ch;
+			out += ch;
+			continue;
+		}
+		out += ch;
 	}
 	return out;
 }
@@ -732,10 +817,12 @@ function sortSymbols(symbols: SymbolInfo[]): SymbolInfo[] {
 }
 
 /**
- * Dart symbols: classes/mixins/enums/extensions and top-level functions.
- * Visibility is the `_`-prefix convention. Method bodies inside classes are
- * skipped — the function regex only fires on type-position patterns that
- * survive the keyword skip lists (see #1681 review round 3).
+ * Dart symbols: classes/mixins/enums/extensions and functions. Visibility is
+ * the `_`-prefix convention. Functions declared INSIDE a type body are
+ * emitted as qualified `TypeName.member` method symbols (mirroring the Swift
+ * extractor's naming) instead of being mislabeled as top-level functions;
+ * the qualification also keeps same-named members of different classes from
+ * collapsing in the name:kind dedup.
  */
 export function extractDartSymbols(
 	filePath: string,
@@ -746,6 +833,7 @@ export function extractDartSymbols(
 	const content = stripLineCommentsForScan(raw);
 	const symbols: SymbolInfo[] = [];
 	const seen = new Set<string>();
+	const typeBodies: Array<{ start: number; end: number; name: string }> = [];
 	// `extension type` (Dart 3) must match before bare `extension`; the
 	// `(?!on\b)` lookahead skips unnamed extensions; `typedef` is a type def.
 	for (const match of content.matchAll(
@@ -754,6 +842,12 @@ export function extractDartSymbols(
 		const kindWord = match[1].trim().split(/\s+/).pop() ?? match[1];
 		const kind: SymbolInfo['kind'] =
 			kindWord === 'enum' ? 'enum' : kindWord === 'class' ? 'class' : 'type';
+		const bodyStart = content.indexOf('{', match.index);
+		const bodyEnd =
+			bodyStart === -1 ? null : findMatchingBrace(content, bodyStart);
+		if (bodyStart !== -1 && bodyEnd !== null) {
+			typeBodies.push({ start: bodyStart, end: bodyEnd, name: match[2] });
+		}
 		addUniqueSymbol(symbols, seen, {
 			name: match[2],
 			kind,
@@ -777,6 +871,8 @@ export function extractDartSymbols(
 		'yield',
 		'case',
 		'catch',
+		// `void Function(int)` is a function-TYPE reference, not a declaration
+		'Function',
 	]);
 	const KEYWORD_TYPE_SKIP = new Set([
 		'return',
@@ -793,9 +889,12 @@ export function extractDartSymbols(
 	for (const match of content.matchAll(dartFunctionRe)) {
 		if (KEYWORD_NAME_SKIP.has(match[1])) continue;
 		if (KEYWORD_TYPE_SKIP.has(match[0].split(/\s+/)[0])) continue;
+		const enclosing = typeBodies.find(
+			(body) => match.index >= body.start && match.index <= body.end,
+		);
 		addUniqueSymbol(symbols, seen, {
-			name: match[1],
-			kind: 'function',
+			name: enclosing ? `${enclosing.name}.${match[1]}` : match[1],
+			kind: enclosing ? 'method' : 'function',
 			exported: !match[1].startsWith('_'),
 			signature: lineTextAt(raw, match.index),
 			line: lineNumberAt(raw, match.index),
@@ -806,9 +905,11 @@ export function extractDartSymbols(
 
 /**
  * Ruby symbols: modules, classes, constants, and `def` methods with
- * `private`/`protected` section tracking. Singleton methods keep their
- * `self.` qualification in the name. Dynamic constructs (`define_method`,
- * `send`, metaprogramming) are invisible to this scanner by design.
+ * `private`/`protected` section tracking. A nested class/module saves and
+ * restores the outer section (approximate `end`-balance tracking); targeted
+ * `private :sym` marks the named method. Singleton methods keep their `self.`
+ * qualification in the name. Dynamic constructs (`define_method`, `send`,
+ * metaprogramming) are invisible to this scanner by design.
  */
 export function extractRubySymbols(
 	filePath: string,
@@ -818,8 +919,14 @@ export function extractRubySymbols(
 	if (raw === null) return [];
 	const symbols: SymbolInfo[] = [];
 	const seen = new Set<string>();
+	const byName = new Map<string, SymbolInfo>();
 	let offset = 0;
 	let currentVisibility: 'public' | 'protected' | 'private' = 'public';
+	const visibilityStack: Array<{
+		visibility: 'public' | 'protected' | 'private';
+		atEndLevel: number;
+	}> = [];
+	let endLevel = 0;
 	let heredocId: string | null = null;
 	for (const line of raw.split(/\r?\n/)) {
 		const trimmed = line.trim();
@@ -839,15 +946,33 @@ export function extractRubySymbols(
 			if (trimmed === 'private' || trimmed === 'protected') {
 				currentVisibility = trimmed;
 			}
+			// `private :a, :b` marks the named methods without switching the section.
+			const targeted = trimmed.match(
+				/^(private|protected)\s+((?::[A-Za-z_][A-Za-z0-9_?!]*\s*,\s*)*:[A-Za-z_][A-Za-z0-9_?!]*)$/,
+			);
+			if (targeted) {
+				for (const part of targeted[2].split(',')) {
+					const sym = byName.get(part.trim().replace(/^:/, ''));
+					if (sym) {
+						sym.exported = false;
+					}
+				}
+			}
 			const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
 			const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
 			if (moduleMatch || classMatch) {
+				visibilityStack.push({
+					visibility: currentVisibility,
+					atEndLevel: endLevel,
+				});
 				currentVisibility = 'public';
+				endLevel++;
 			}
 			const constMatch = trimmed.match(/^([A-Z][A-Za-z0-9_]*)\s*=/);
 			const methodMatch = trimmed.match(
 				/^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_?!]*)/,
 			);
+			if (methodMatch) endLevel++;
 			const lineIndex = offset + Math.max(0, line.indexOf(trimmed));
 			if (moduleMatch || classMatch || constMatch || methodMatch) {
 				const singleton = Boolean(methodMatch?.[1]);
@@ -858,7 +983,7 @@ export function extractRubySymbols(
 					constMatch?.[1] ??
 					(singleton && shortName ? `self.${shortName}` : shortName!);
 				const visibility = singleton ? 'public' : currentVisibility;
-				addUniqueSymbol(symbols, seen, {
+				const candidate: SymbolInfo = {
 					name,
 					kind: moduleMatch
 						? 'type'
@@ -872,10 +997,22 @@ export function extractRubySymbols(
 						: true,
 					signature: trimmed.substring(0, 100),
 					line: lineNumberAt(raw, lineIndex),
-				});
+				};
+				addUniqueSymbol(symbols, seen, candidate);
+				byName.set(name, candidate);
+			}
+			const ends = trimmed.match(/\bend\b/g)?.length ?? 0;
+			if (ends > 0) {
+				endLevel -= ends;
+				while (
+					visibilityStack.length > 0 &&
+					endLevel <= visibilityStack[visibilityStack.length - 1].atEndLevel
+				) {
+					currentVisibility = visibilityStack.pop()!.visibility;
+				}
 			}
 		}
-		offset += line.length + 1;
+		offset = advanceLineOffset(raw, offset, line.length);
 	}
 	return sortSymbols(symbols);
 }
@@ -905,7 +1042,7 @@ export function extractPhpSymbols(filePath: string, cwd: string): SymbolInfo[] {
 		});
 	}
 	for (const match of content.matchAll(
-		/\b(?:final\s+|abstract\s+)?(class|interface|trait)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+		/\b(?:final\s+|abstract\s+|readonly\s+)?(class|interface|trait|enum)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
 	)) {
 		const bodyStart = content.indexOf('{', match.index);
 		const bodyEnd =
@@ -915,14 +1052,21 @@ export function extractPhpSymbols(filePath: string, cwd: string): SymbolInfo[] {
 		}
 		addUniqueSymbol(symbols, seen, {
 			name: match[2],
-			kind: match[1] === 'class' ? 'class' : 'interface',
+			kind:
+				match[1] === 'class'
+					? 'class'
+					: match[1] === 'enum'
+						? 'enum'
+						: 'interface',
 			exported: !match[2].startsWith('_'),
 			signature: lineTextAt(raw, match.index),
 			line: lineNumberAt(raw, match.index),
 		});
 	}
+	// Modifier group bounded {0,6}: an unbounded star is quadratic on
+	// adversarial modifier runs (PR #2361 PRR-012).
 	for (const match of content.matchAll(
-		/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+		/\b(?:(public|protected|private|static|final|abstract)\s+){0,6}function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
 	)) {
 		const insideType = typeRanges.some(
 			(range) => match.index >= range.start && match.index <= range.end,

--- a/src/tools/symbols.ts
+++ b/src/tools/symbols.ts
@@ -42,6 +42,12 @@ const SYMBOL_EXTENSIONS = new Set([
 	'.pyw',
 	'.rs',
 	'.go',
+	'.dart',
+	'.rb',
+	'.rake',
+	'.gemspec',
+	'.php',
+	'.phtml',
 ]);
 
 // Directories to skip during workspace scanning
@@ -630,6 +636,310 @@ export function extractGoSymbols(filePath: string, cwd: string): SymbolInfo[] {
 	});
 }
 
+// ============ Dart / Ruby / PHP Extraction (issue #1531) ============
+
+/** 1-based line number of the character at `index`. */
+function lineNumberAt(content: string, index: number): number {
+	let line = 1;
+	for (let i = 0; i < index && i < content.length; i++) {
+		if (content[i] === '\n') line++;
+	}
+	return line;
+}
+
+function lineTextAt(content: string, index: number): string {
+	const lineStart = content.lastIndexOf('\n', Math.max(0, index - 1)) + 1;
+	const lineEnd = content.indexOf('\n', lineStart);
+	return content
+		.substring(lineStart, lineEnd === -1 ? content.length : lineEnd)
+		.trim()
+		.substring(0, 120);
+}
+
+function findMatchingBrace(content: string, openIndex: number): number | null {
+	if (content[openIndex] !== '{') return null;
+	let depth = 0;
+	for (let i = openIndex; i < content.length; i++) {
+		const ch = content[i];
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+	return null;
+}
+
+/**
+ * Conservative comment mask for regex scanning: replaces `//`, `#`, and
+ * block comments with spaces, preserving newlines (and thus offsets/line
+ * structure) so `lineNumberAt`/`lineTextAt` stay accurate against the
+ * original text. Quote-awareness is intentionally minimal — this is a
+ * best-effort filter for declaration regexes, not a lexer.
+ */
+function stripLineCommentsForScan(content: string): string {
+	let out = '';
+	let inBlock = false;
+	for (let i = 0; i < content.length; i++) {
+		const two = content.substring(i, i + 2);
+		if (!inBlock && two === '/*') {
+			inBlock = true;
+			out += '  ';
+			i++;
+			continue;
+		}
+		if (inBlock) {
+			if (two === '*/') {
+				inBlock = false;
+				out += '  ';
+				i++;
+			} else {
+				out += content[i] === '\n' ? '\n' : ' ';
+			}
+			continue;
+		}
+		if (two === '//' || content[i] === '#') {
+			// Line comment: mask the marker and everything to end of line.
+			out += two === '//' ? '  ' : ' ';
+			if (two === '//') i++;
+			while (i + 1 < content.length && content[i + 1] !== '\n') {
+				out += ' ';
+				i++;
+			}
+			continue;
+		}
+		out += content[i];
+	}
+	return out;
+}
+
+function addUniqueSymbol(
+	symbols: SymbolInfo[],
+	seen: Set<string>,
+	candidate: SymbolInfo,
+): void {
+	const key = `${candidate.name}:${candidate.kind}`;
+	if (seen.has(key)) return;
+	seen.add(key);
+	symbols.push(candidate);
+}
+
+function sortSymbols(symbols: SymbolInfo[]): SymbolInfo[] {
+	return symbols.sort((a, b) => {
+		if (a.line !== b.line) return a.line - b.line;
+		return a.name.localeCompare(b.name);
+	});
+}
+
+/**
+ * Dart symbols: classes/mixins/enums/extensions and top-level functions.
+ * Visibility is the `_`-prefix convention. Method bodies inside classes are
+ * skipped — the function regex only fires on type-position patterns that
+ * survive the keyword skip lists (see #1681 review round 3).
+ */
+export function extractDartSymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const content = stripLineCommentsForScan(raw);
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	// `extension type` (Dart 3) must match before bare `extension`; the
+	// `(?!on\b)` lookahead skips unnamed extensions; `typedef` is a type def.
+	for (const match of content.matchAll(
+		/\b(extension\s+type|class|mixin|enum|extension|typedef)\s+(?!on\b)([A-Za-z_][A-Za-z0-9_]*)/g,
+	)) {
+		const kindWord = match[1].trim().split(/\s+/).pop() ?? match[1];
+		const kind: SymbolInfo['kind'] =
+			kindWord === 'enum' ? 'enum' : kindWord === 'class' ? 'class' : 'type';
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind,
+			exported: !match[2].startsWith('_'),
+			signature: lineTextAt(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	const dartFunctionRe =
+		/\b(?:void|[A-Za-z_][A-Za-z0-9_<>,?]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+	const KEYWORD_NAME_SKIP = new Set([
+		'if',
+		'for',
+		'while',
+		'switch',
+		'return',
+		'else',
+		'throw',
+		'new',
+		'await',
+		'yield',
+		'case',
+		'catch',
+	]);
+	const KEYWORD_TYPE_SKIP = new Set([
+		'return',
+		'else',
+		'throw',
+		'new',
+		'await',
+		'yield',
+		'case',
+		'catch',
+		'final',
+		'const',
+	]);
+	for (const match of content.matchAll(dartFunctionRe)) {
+		if (KEYWORD_NAME_SKIP.has(match[1])) continue;
+		if (KEYWORD_TYPE_SKIP.has(match[0].split(/\s+/)[0])) continue;
+		addUniqueSymbol(symbols, seen, {
+			name: match[1],
+			kind: 'function',
+			exported: !match[1].startsWith('_'),
+			signature: lineTextAt(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return sortSymbols(symbols);
+}
+
+/**
+ * Ruby symbols: modules, classes, constants, and `def` methods with
+ * `private`/`protected` section tracking. Singleton methods keep their
+ * `self.` qualification in the name. Dynamic constructs (`define_method`,
+ * `send`, metaprogramming) are invisible to this scanner by design.
+ */
+export function extractRubySymbols(
+	filePath: string,
+	cwd: string,
+): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	let offset = 0;
+	let currentVisibility: 'public' | 'protected' | 'private' = 'public';
+	let heredocId: string | null = null;
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (heredocId !== null) {
+			// Heredoc body: string data, not code — a literal `private` here
+			// must not flip the visibility section.
+			if (trimmed === heredocId) heredocId = null;
+		} else {
+			// The opener line itself still carries code (`QUERY = <<~SQL`).
+			// Context-anchored: binary shift (`arr <<item`, `x << y`) never
+			// opens a heredoc — only line start, `=`/`(`/`,`/`[`, or a
+			// value-position keyword (puts/print/raise/return/p) does.
+			const open = trimmed.match(
+				/(?:^|[=(,[]\s*|(?:puts|print|raise|return|p)\s+)<<[~-]?['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/,
+			);
+			if (open) heredocId = open[1];
+			if (trimmed === 'private' || trimmed === 'protected') {
+				currentVisibility = trimmed;
+			}
+			const moduleMatch = trimmed.match(/^module\s+([A-Z][A-Za-z0-9_:]*)/);
+			const classMatch = trimmed.match(/^class\s+([A-Z][A-Za-z0-9_:]*)/);
+			if (moduleMatch || classMatch) {
+				currentVisibility = 'public';
+			}
+			const constMatch = trimmed.match(/^([A-Z][A-Za-z0-9_]*)\s*=/);
+			const methodMatch = trimmed.match(
+				/^def\s+(?:(self)\.)?([A-Za-z_][A-Za-z0-9_?!]*)/,
+			);
+			const lineIndex = offset + Math.max(0, line.indexOf(trimmed));
+			if (moduleMatch || classMatch || constMatch || methodMatch) {
+				const singleton = Boolean(methodMatch?.[1]);
+				const shortName = methodMatch?.[2];
+				const name =
+					moduleMatch?.[1] ??
+					classMatch?.[1] ??
+					constMatch?.[1] ??
+					(singleton && shortName ? `self.${shortName}` : shortName!);
+				const visibility = singleton ? 'public' : currentVisibility;
+				addUniqueSymbol(symbols, seen, {
+					name,
+					kind: moduleMatch
+						? 'type'
+						: classMatch
+							? 'class'
+							: constMatch
+								? 'const'
+								: 'method',
+					exported: methodMatch
+						? visibility !== 'private' && !(shortName ?? '').startsWith('_')
+						: true,
+					signature: trimmed.substring(0, 100),
+					line: lineNumberAt(raw, lineIndex),
+				});
+			}
+		}
+		offset += line.length + 1;
+	}
+	return sortSymbols(symbols);
+}
+
+/**
+ * PHP symbols: namespaces, traits/interfaces/classes, functions and methods
+ * with visibility modifiers. Dynamic constructs (variable functions/classes,
+ * variable variables, Blade directives in `.blade.php`) are best-effort
+ * only — see docs/php-laravel.md.
+ */
+export function extractPhpSymbols(filePath: string, cwd: string): SymbolInfo[] {
+	const raw = readValidatedSourceFile(filePath, cwd);
+	if (raw === null) return [];
+	const content = stripLineCommentsForScan(raw);
+	const symbols: SymbolInfo[] = [];
+	const seen = new Set<string>();
+	const typeRanges: Array<{ start: number; end: number }> = [];
+	for (const match of content.matchAll(
+		/\bnamespace\s+([A-Za-z_\\][A-Za-z0-9_\\]*)\s*[;{]/g,
+	)) {
+		addUniqueSymbol(symbols, seen, {
+			name: match[1],
+			kind: 'type',
+			exported: true,
+			signature: lineTextAt(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	for (const match of content.matchAll(
+		/\b(?:final\s+|abstract\s+)?(class|interface|trait)\s+([A-Za-z_][A-Za-z0-9_]*)/g,
+	)) {
+		const bodyStart = content.indexOf('{', match.index);
+		const bodyEnd =
+			bodyStart === -1 ? null : findMatchingBrace(content, bodyStart);
+		if (bodyStart !== -1 && bodyEnd !== null) {
+			typeRanges.push({ start: bodyStart, end: bodyEnd });
+		}
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind: match[1] === 'class' ? 'class' : 'interface',
+			exported: !match[2].startsWith('_'),
+			signature: lineTextAt(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	for (const match of content.matchAll(
+		/\b(?:(public|protected|private|static|final|abstract)\s+)*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g,
+	)) {
+		const insideType = typeRanges.some(
+			(range) => match.index >= range.start && match.index <= range.end,
+		);
+		const modifiers = match[0].slice(0, match[0].indexOf('function'));
+		const visibility = modifiers.match(/\b(public|protected|private)\b/)?.[1];
+		addUniqueSymbol(symbols, seen, {
+			name: match[2],
+			kind: insideType ? 'method' : 'function',
+			exported: visibility !== 'private' && !match[2].startsWith('_'),
+			signature: lineTextAt(raw, match.index),
+			line: lineNumberAt(raw, match.index),
+		});
+	}
+	return sortSymbols(symbols);
+}
+
 // ============ Workspace File Discovery ============
 
 /**
@@ -722,6 +1032,18 @@ function searchWorkspaceSymbols(
 			case '.go':
 				syms = extractGoSymbols(relFile, cwd);
 				break;
+			case '.dart':
+				syms = _internals.extractDartSymbols(relFile, cwd);
+				break;
+			case '.rb':
+			case '.rake':
+			case '.gemspec':
+				syms = _internals.extractRubySymbols(relFile, cwd);
+				break;
+			case '.php':
+			case '.phtml':
+				syms = _internals.extractPhpSymbols(relFile, cwd);
+				break;
 			default:
 				continue;
 		}
@@ -774,8 +1096,9 @@ export const symbols: ToolDefinition = createSwarmTool({
 	description:
 		'Extract all exported symbols from a source file: functions with signatures, ' +
 		'classes with public members, interfaces, types, enums, constants. ' +
-		'Supports TypeScript/JavaScript, Python, Rust, and Go. Use for architect planning, ' +
-		'designer scaffolding, and understanding module public API surface.',
+		'Supports TypeScript/JavaScript, Python, Rust, Go, Dart, Ruby, and PHP. ' +
+		'Use for architect planning, designer scaffolding, and understanding module ' +
+		'public API surface.',
 	args: {
 		file: z
 			.string()
@@ -925,11 +1248,23 @@ export const symbols: ToolDefinition = createSwarmTool({
 			case '.go':
 				syms = extractGoSymbols(file, cwd);
 				break;
+			case '.dart':
+				syms = _internals.extractDartSymbols(file, cwd);
+				break;
+			case '.rb':
+			case '.rake':
+			case '.gemspec':
+				syms = _internals.extractRubySymbols(file, cwd);
+				break;
+			case '.php':
+			case '.phtml':
+				syms = _internals.extractPhpSymbols(file, cwd);
+				break;
 			default:
 				return JSON.stringify(
 					{
 						file,
-						error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .pyw, .rs, .go`,
+						error: `Unsupported file extension: ${ext}. Supported: .ts, .tsx, .js, .jsx, .mjs, .cjs, .py, .pyw, .rs, .go, .dart, .rb, .rake, .gemspec, .php, .phtml`,
 						symbols: [],
 					},
 					null,
@@ -957,3 +1292,14 @@ export const symbols: ToolDefinition = createSwarmTool({
 		);
 	},
 });
+
+/**
+ * DI seam for testability — tests substitute via `_internals.fn` rather than
+ * `mock.module`, which leaks across Bun's shared test-runner process.
+ * @see AGENTS.md invariant #7
+ */
+export const _internals = {
+	extractDartSymbols,
+	extractRubySymbols,
+	extractPhpSymbols,
+};

--- a/tests/unit/lang/language-extraction-coverage.test.ts
+++ b/tests/unit/lang/language-extraction-coverage.test.ts
@@ -114,25 +114,26 @@ const EXPECTATIONS: Record<string, Expectation> = {
 			'A bare Swift `import M` binds a whole module; named bindings require a kind-qualified import (`import class M.C`).',
 	},
 	dart: {
-		source: "import 'm.dart';\nclass C { void m() {} }\n",
+		// A `show` clause is the only import form that binds names (a bare or
+		// aliased Dart import binds a namespace/prefix).
+		source: "import 'm.dart' show A;\nclass C { void m() {} }\n",
 		expectMethods: false,
-		expectBindings: false,
+		expectBindings: true,
 		reason:
-			'Dart hardening is issue #1531. A bare Dart import binds no named symbol without a `show` clause.',
+			'Dart class members are not def-captured as methods: the tree-sitter path captures top-level function_signature defs and class/mixin/enum/extension types; augmentation (#1531) adds no member defs. Bindings come from `show` clauses.',
 	},
 	ruby: {
 		source: "require 'm'\nclass C\n  def m\n  end\nend\n",
-		expectMethods: false,
+		expectMethods: true,
 		expectBindings: false,
 		reason:
-			'Ruby hardening is issue #1531. `require` loads a file and binds no name, and members are not re-typed to method.',
+			'Ruby require/require_relative load whole files and bind no names (module-level require semantics); mixin inclusion (include/extend) is not an import edge in this extractor. Methods are typed via the #1531 augmentation layer.',
 	},
 	php: {
-		source: '<?php\nuse M\\A;\nclass C { public function m() {} }\n',
-		expectMethods: false,
-		expectBindings: false,
-		reason:
-			'PHP hardening is issue #1531. Members are not re-typed to method today.',
+		source:
+			'<?php\nuse M\\A as Alias;\nclass C { public function m() { Alias::x(); } }\n',
+		expectMethods: true,
+		expectBindings: true,
 	},
 };
 

--- a/tests/unit/lang/symbol-graph-dart.test.ts
+++ b/tests/unit/lang/symbol-graph-dart.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function def(
+	facts: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>,
+	name: string,
+) {
+	return facts.defs.find((item) => item.name === name);
+}
+
+describe('extractFileSymbols — dart hardening (#1531)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('captures import/export directives and underscore-private API convention', async () => {
+		const source = `import './src/helper.dart' as helper;
+import './src/util.dart' show pick, omit;
+export './src/public_api.dart' show PublicApi;
+
+class PublicWidget {}
+mixin Renderable {}
+enum Mode { fast }
+extension StrExt on String {}
+void _hidden() {}
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		// alias import: namespace prefix access, no fake named binding
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './src/helper.dart',
+				importType: 'namespace',
+				bindings: [],
+			}),
+		);
+		// show import: named bindings for the shown symbols
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './src/util.dart',
+				importType: 'named',
+				bindings: [
+					{ imported: 'pick', local: 'pick' },
+					{ imported: 'omit', local: 'omit' },
+				],
+			}),
+		);
+		// export directive: a re-export edge with exported bindings
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './src/public_api.dart',
+				reExport: true,
+				exportedBindings: [{ imported: 'PublicApi', exported: 'PublicApi' }],
+			}),
+		);
+		expect(def(facts!, 'PublicWidget')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, 'Renderable')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+		expect(def(facts!, 'Mode')).toMatchObject({
+			kind: 'enum',
+			exported: true,
+		});
+		expect(def(facts!, 'StrExt')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+		expect(def(facts!, '_hidden')).toMatchObject({
+			kind: 'function',
+			exported: false,
+		});
+	});
+
+	test('body refs survive while refs inside import/export directives are dropped', async () => {
+		const source = `import './a.dart' show Alpha;
+export './b.dart' show Beta;
+
+class Uses {
+	void go() {
+		Alpha.run();
+	}
+}
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		// 'Alpha' must appear as a body ref (inside go), not only on the import line
+		const bodyAlpha = facts!.refs.find((r) => r.identifier === 'Alpha');
+		expect(bodyAlpha).toBeDefined();
+		// ...but only once: the import-line occurrence is filtered, not duplicated
+		expect(facts!.refs.filter((r) => r.identifier === 'Alpha')).toHaveLength(1);
+	});
+
+	test('identical import statements collapse; distinct show-sets stay distinct', async () => {
+		const source = `import 'package:a/a.dart' as a;
+import 'package:a/a.dart' as b;
+import 'x.dart' show One;
+import 'x.dart' show Two;
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		const specifiers = facts!.imports.map((i) => i.specifier);
+		// two alias imports of the same URI are one semantic namespace import
+		expect(specifiers.filter((s) => s === 'package:a/a.dart')).toHaveLength(1);
+		// show-sets differ → both remain
+		const shown = facts!.imports.filter((i) => i.specifier === 'x.dart');
+		expect(shown).toHaveLength(2);
+		expect(
+			shown.map((i) => i.bindings.map((b) => b.imported).join(',')),
+		).toContain('One');
+		expect(
+			shown.map((i) => i.bindings.map((b) => b.imported).join(',')),
+		).toContain('Two');
+	});
+
+	test('commented-out declarations are not augmented', async () => {
+		const source = `// class Ghost {}
+// enum Phantom { x }
+class Real {}
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'Ghost')).toBeUndefined();
+		expect(def(facts!, 'Phantom')).toBeUndefined();
+		expect(def(facts!, 'Real')).toMatchObject({ kind: 'class' });
+	});
+
+	test('Dart 3 extension types, unnamed extensions, and typedefs', async () => {
+		const source = `extension type Meters(int value) {}
+extension on String {
+	void shout() {}
+}
+sealed class Node {}
+base class Leaf extends Node {}
+typedef Callback = void Function(int);
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		// `extension type` must yield the TYPE's name — not a bogus def named
+		// `type` from a bare `extension` match (reviewer finding R1)
+		expect(def(facts!, 'Meters')).toMatchObject({ kind: 'type' });
+		expect(def(facts!, 'type')).toBeUndefined();
+		// unnamed `extension on X` carries no name — no def named `on`
+		expect(def(facts!, 'on')).toBeUndefined();
+		// Dart 3 class modifiers still capture the class name
+		expect(def(facts!, 'Node')).toMatchObject({ kind: 'class' });
+		expect(def(facts!, 'Leaf')).toMatchObject({ kind: 'class' });
+		// typedef aliases are type defs
+		expect(def(facts!, 'Callback')).toMatchObject({ kind: 'type' });
+	});
+
+	test('alias combined with show/hide clauses stays a namespace import', async () => {
+		const source = `import 'pkg.dart' as p show Alpha, Beta;
+import 'pkg2.dart' as q hide Gamma;
+`;
+
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: 'pkg.dart',
+				importType: 'namespace',
+				bindings: [],
+			}),
+		);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: 'pkg2.dart',
+				importType: 'namespace',
+				bindings: [],
+			}),
+		);
+	});
+});

--- a/tests/unit/lang/symbol-graph-dart.test.ts
+++ b/tests/unit/lang/symbol-graph-dart.test.ts
@@ -181,3 +181,93 @@ import 'pkg2.dart' as q hide Gamma;
 		);
 	});
 });
+
+describe('extractFileSymbols — dart hardening round 2 (#2361 review)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('multiline show clause yields ONE import with all bindings (PRR-002)', async () => {
+		const source = `import 'x.dart' show Alpha
+    , Beta;
+void main() {}
+`;
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toHaveLength(1);
+		expect(facts!.imports[0]).toMatchObject({
+			specifier: 'x.dart',
+			importType: 'named',
+			bindings: [
+				{ imported: 'Alpha', local: 'Alpha' },
+				{ imported: 'Beta', local: 'Beta' },
+			],
+		});
+	});
+
+	test('conditional import records both URIs (PRR-007)', async () => {
+		const source = `import 'platform.dart' if (dart.library.io) 'io.dart';
+void main() {}
+`;
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'platform.dart' }),
+		);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'io.dart' }),
+		);
+	});
+
+	test('bare import stays a namespace import with no bindings (R10)', async () => {
+		const facts = await extractFileSymbols('dart', "import 'm.dart';\n");
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toEqual([
+			{ specifier: 'm.dart', importType: 'namespace', bindings: [] },
+		]);
+	});
+
+	test('CRLF sources produce identical dart defs to LF', async () => {
+		const lf = `class Model {}
+mixin Renderable {}
+void main() {}
+`;
+		const crlf = lf.replace(/\n/g, '\r\n');
+		const lfFacts = await extractFileSymbols('dart', lf);
+		const crlfFacts = await extractFileSymbols('dart', crlf);
+		expect(crlfFacts!.defs).toEqual(lfFacts!.defs);
+	});
+
+	test('import-shaped text inside a multiline string is not an edge (R4)', async () => {
+		const source = `var doc = '''
+import 'phantom.dart';
+''';
+import 'real.dart';
+`;
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(
+			facts!.imports.filter((i) => i.specifier.includes('phantom')),
+		).toHaveLength(0);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'real.dart' }),
+		);
+	});
+
+	test('triple-quoted strings with inner apostrophes do not flip the mask (round 3)', async () => {
+		const source = `var doc = '''
+it's here
+import 'phantom.dart';
+''';
+import 'real2.dart';
+`;
+		const facts = await extractFileSymbols('dart', source);
+		expect(facts).not.toBeNull();
+		expect(
+			facts!.imports.filter((i) => i.specifier.includes('phantom')),
+		).toHaveLength(0);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'real2.dart' }),
+		);
+	});
+});

--- a/tests/unit/lang/symbol-graph-parser-internals.test.ts
+++ b/tests/unit/lang/symbol-graph-parser-internals.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'bun:test';
+import { _internals } from '../../../src/lang/symbol-graph';
+import { _internals as builderInternals } from '../../../src/tools/repo-graph/builder';
+
+const { parseDartImport, parseRubyRequire, parsePhpUse } = _internals;
+
+describe('parseDartImport (direct, via _internals seam — PR #2361 R10)', () => {
+	test('bare import is namespace with no bindings', () => {
+		expect(parseDartImport("import 'foo.dart';")).toEqual({
+			specifier: 'foo.dart',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('empty specifier is rejected', () => {
+		expect(parseDartImport("import '';")).toBeNull();
+	});
+
+	test('alias import is namespace with no fake named binding', () => {
+		expect(parseDartImport("import 'foo.dart' as f;")).toEqual({
+			specifier: 'foo.dart',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('show import produces named bindings', () => {
+		expect(parseDartImport("import 'foo.dart' show A, B;")).toEqual({
+			specifier: 'foo.dart',
+			importType: 'named',
+			bindings: [
+				{ imported: 'A', local: 'A' },
+				{ imported: 'B', local: 'B' },
+			],
+		});
+	});
+
+	test('multiline show clause parses whole (statement joined by caller)', () => {
+		expect(parseDartImport("import 'x.dart' show Alpha\n    , Beta;")).toEqual({
+			specifier: 'x.dart',
+			importType: 'named',
+			bindings: [
+				{ imported: 'Alpha', local: 'Alpha' },
+				{ imported: 'Beta', local: 'Beta' },
+			],
+		});
+	});
+
+	test('alias combined with show stays namespace', () => {
+		expect(parseDartImport("import 'x.dart' as p show Alpha, Beta;")).toEqual({
+			specifier: 'x.dart',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('deferred import is a namespace import of the URI', () => {
+		expect(parseDartImport("import 'x.dart' deferred as y;")).toEqual({
+			specifier: 'x.dart',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('conditional import records BOTH URIs', () => {
+		expect(
+			parseDartImport("import 'x.dart' if (dart.library.io) 'io.dart';"),
+		).toEqual([
+			{ specifier: 'x.dart', importType: 'namespace', bindings: [] },
+			{ specifier: 'io.dart', importType: 'namespace', bindings: [] },
+		]);
+	});
+
+	test('export directive is a re-export edge with exported bindings', () => {
+		expect(parseDartImport("export 'api.dart' show PublicApi;")).toEqual({
+			specifier: 'api.dart',
+			importType: 'named',
+			bindings: [{ imported: 'PublicApi', local: 'PublicApi' }],
+			reExport: true,
+			exportedBindings: [{ imported: 'PublicApi', exported: 'PublicApi' }],
+		});
+	});
+
+	test('non-import text is rejected', () => {
+		expect(parseDartImport('void main() {}')).toBeNull();
+		expect(parseDartImport('')).toBeNull();
+	});
+});
+
+describe('parseRubyRequire (direct)', () => {
+	test('require is a namespace import', () => {
+		expect(parseRubyRequire("require 'json'")).toEqual({
+			specifier: 'json',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('require_relative without a prefix is normalized relative', () => {
+		expect(parseRubyRequire("require_relative 'helper'")).toEqual({
+			specifier: './helper',
+			importType: 'default',
+			bindings: [],
+		});
+	});
+
+	test('require_relative with an explicit ./ prefix is not double-prefixed', () => {
+		expect(parseRubyRequire("require_relative './helper'")).toEqual({
+			specifier: './helper',
+			importType: 'default',
+			bindings: [],
+		});
+	});
+
+	test('require_relative with ../ stays relative', () => {
+		expect(parseRubyRequire("require_relative '../lib/helper'")).toEqual({
+			specifier: '../lib/helper',
+			importType: 'default',
+			bindings: [],
+		});
+	});
+
+	test('bare specifier text (no require keyword) is rejected', () => {
+		expect(parseRubyRequire('json')).toBeNull();
+	});
+});
+
+describe('parsePhpUse (direct)', () => {
+	test('aliased use binds the short name', () => {
+		expect(parsePhpUse('use App\\Models\\User as U;')).toEqual({
+			specifier: 'App\\Models\\User',
+			importType: 'named',
+			bindings: [{ imported: 'User', local: 'U' }],
+		});
+	});
+
+	test('non-aliased use is a namespace import with no bindings', () => {
+		expect(parsePhpUse('use App\\Models\\User;')).toEqual({
+			specifier: 'App\\Models\\User',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('use function / use const prefixes are accepted', () => {
+		expect(parsePhpUse('use function App\\helpers;')).toEqual({
+			specifier: 'App\\helpers',
+			importType: 'namespace',
+			bindings: [],
+		});
+	});
+
+	test('grouped use is skipped entirely (documented limitation)', () => {
+		expect(parsePhpUse('use A\\B, C\\D;')).toBeNull();
+	});
+
+	test('non-use text is rejected', () => {
+		expect(parsePhpUse('$x = 1;')).toBeNull();
+	});
+});
+
+describe('builder sync-path file import parsers (direct)', () => {
+	test('parseDartFileImports captures multiline show and re-exports', () => {
+		const parsed = builderInternals.parseDartFileImports(
+			"import 'x.dart' show Alpha\n    , Beta;\nexport 'api.dart' show P;\n",
+		);
+		expect(parsed).toHaveLength(2);
+		expect(parsed[0]).toMatchObject({
+			specifier: 'x.dart',
+			importType: 'named',
+			importedSymbols: ['Alpha', 'Beta'],
+		});
+		expect(parsed[1]).toMatchObject({
+			specifier: 'api.dart',
+			reExport: true,
+		});
+	});
+
+	test('parseRubyFileImports normalizes require_relative', () => {
+		const parsed = builderInternals.parseRubyFileImports(
+			"require_relative 'helper'\nrequire 'json'\n",
+		);
+		expect(parsed[0]).toMatchObject({
+			specifier: './helper',
+			importType: 'default',
+		});
+		expect(parsed[1]).toMatchObject({
+			specifier: 'json',
+			importType: 'namespace',
+		});
+	});
+
+	test('parsePhpFileImports parses aliased and skips grouped use', () => {
+		const parsed = builderInternals.parsePhpFileImports(
+			'use A\\B as C;\nuse X\\Y, Z\\W;\n',
+		);
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0]).toMatchObject({
+			specifier: 'A\\B',
+			importType: 'named',
+			importedSymbols: ['B'],
+		});
+	});
+});
+
+describe('regex time budgets for the dynamic-language parsers (PRR-019)', () => {
+	test('bounded php modifier star stays fast on adversarial modifier runs', () => {
+		const re =
+			/\b(?:(public|protected|private|static|final|abstract)\s+){0,6}function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+		const hostile = 'public '.repeat(32_768); // ~230KB
+		const t0 = performance.now();
+		let count = 0;
+		for (const _ of hostile.matchAll(re)) count++;
+		const ms = performance.now() - t0;
+		// the unbounded star measured ~7s at this size; the bound keeps it
+		// comfortably under a second (measured ~5-15ms)
+		expect(ms).toBeLessThan(1000);
+		expect(count).toBe(0);
+	});
+
+	test('extractFileSymbols stays bounded on a hostile php modifier file', async () => {
+		const hostile = '<?php\n' + 'public '.repeat(32_768) + '\n';
+		const t0 = performance.now();
+		const facts = await extractFileSymbolsForTime('php', hostile);
+		const ms = performance.now() - t0;
+		expect(ms).toBeLessThan(2000);
+		expect(facts).toBeDefined();
+	}, 10_000);
+});
+
+async function extractFileSymbolsForTime(grammarId: string, source: string) {
+	const { extractFileSymbols } = await import('../../../src/lang/symbol-graph');
+	return extractFileSymbols(grammarId, source);
+}

--- a/tests/unit/lang/symbol-graph-php.test.ts
+++ b/tests/unit/lang/symbol-graph-php.test.ts
@@ -147,3 +147,107 @@ class Real {}
 		expect(def(facts!, 'Real')).toMatchObject({ kind: 'class' });
 	});
 });
+
+describe('extractFileSymbols — php hardening round 2 (#2361 review)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('PHP 8.1 enums are captured as enum defs (R8)', async () => {
+		const source = `<?php
+namespace App;
+enum Suit: string {
+	case Hearts = 'h';
+	public function color(): string { return 'red'; }
+}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'Suit')).toMatchObject({ kind: 'enum', exported: true });
+		expect(def(facts!, 'color')).toMatchObject({ kind: 'method' });
+	});
+
+	test('trait `use` inside a class body is not an import edge (R5)', async () => {
+		const source = `<?php
+trait Loggable {}
+class Service {
+	use Loggable;
+	public function run() {}
+}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toHaveLength(0);
+	});
+
+	test('string literals with braces/semicolons do not corrupt spans (PRR-011)', async () => {
+		const source = `<?php
+class Service {
+	public function sep($x = '};') { $y = 1; }
+	public function brace($s = '{') { $z = 2; }
+	public function render() {
+		$glue = '}';
+		return $glue;
+	}
+}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		// render spans its whole declaration (5→8), not truncated at the
+		// string brace nor inflated to the class end
+		expect(def(facts!, 'render')).toMatchObject({
+			kind: 'method',
+			startLine: 5,
+			endLine: 8,
+		});
+		// sep/brace spans stay on their own signature lines
+		const sep = def(facts!, 'sep');
+		const brace = def(facts!, 'brace');
+		expect(sep!.endLine).toBeLessThanOrEqual(3);
+		expect(brace!.endLine).toBeLessThanOrEqual(4);
+		expect(sep!.kind).toBe('method');
+		expect(brace!.kind).toBe('method');
+	});
+
+	test('`#` line comments are masked before augmentation (PRR-020)', async () => {
+		const source = `<?php
+# class GhostHash {}
+# trait PhantomHash {}
+class RealHash {}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'GhostHash')).toBeUndefined();
+		expect(def(facts!, 'PhantomHash')).toBeUndefined();
+		expect(def(facts!, 'RealHash')).toMatchObject({ kind: 'class' });
+	});
+
+	test('CRLF sources produce identical php defs to LF', async () => {
+		const lf = `<?php
+namespace AppServices;
+trait Logs {}
+class Service {
+	function run() {}
+}
+`;
+		const crlf = lf.replace(/\n/g, '\r\n');
+		const lfFacts = await extractFileSymbols('php', lf);
+		const crlfFacts = await extractFileSymbols('php', crlf);
+		expect(crlfFacts!.defs).toEqual(lfFacts!.defs);
+	});
+
+	test('`use` inside a function body string is not an import (lexical mask)', async () => {
+		const source = `<?php
+$doc = 'use Fake\\Import;';
+use RealThing;
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'RealThing' }),
+		);
+		expect(
+			facts!.imports.filter((i) => i.specifier.includes('Fake')),
+		).toHaveLength(0);
+	});
+});

--- a/tests/unit/lang/symbol-graph-php.test.ts
+++ b/tests/unit/lang/symbol-graph-php.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function def(
+	facts: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>,
+	name: string,
+) {
+	return facts.defs.find((item) => item.name === name);
+}
+
+describe('extractFileSymbols — php hardening (#1531)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('captures namespaces, traits, functions, classes, and method visibility', async () => {
+		const source = `<?php
+namespace App\\Services;
+use App\\Models\\User as U;
+
+trait Logs {}
+class Service {
+	function run(U $user) {}
+	static function build() {}
+	final protected function flush() {}
+	private function hidden() {}
+}
+function helper() {}
+`;
+
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'App\\Services')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+		expect(def(facts!, 'Logs')).toMatchObject({
+			kind: 'interface',
+			exported: true,
+		});
+		expect(def(facts!, 'Service')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, 'run')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'build')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+		expect(def(facts!, 'flush')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'protected' },
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			kind: 'method',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		expect(def(facts!, 'helper')).toMatchObject({
+			kind: 'function',
+			exported: true,
+		});
+		// aliased use binds the SHORT name — what body expressions spell
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: 'App\\Models\\User',
+				bindings: [{ imported: 'User', local: 'U' }],
+			}),
+		);
+	});
+
+	test('body refs survive while refs inside use declarations are dropped', async () => {
+		const source = `<?php
+use App\\Models\\User as U;
+
+function main() {
+	U::find(1);
+}
+`;
+
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		const uRefs = facts!.refs.filter((r) => r.identifier === 'U');
+		expect(uRefs).toHaveLength(1);
+		expect(uRefs[0].enclosingDecl).toBe('main');
+	});
+
+	test('function_exists and other builtin calls are not defs', async () => {
+		const source = `<?php
+if (function_exists('mb_strlen')) {
+	call_user_func_array('trim', []);
+}
+function real_fn() {}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		// `function\s+` requires whitespace, so `function_exists(` cannot match
+		expect(def(facts!, 'function_exists')).toBeUndefined();
+		expect(def(facts!, 'call_user_func_array')).toBeUndefined();
+		expect(def(facts!, 'real_fn')).toMatchObject({ kind: 'function' });
+	});
+
+	test('namespace brace form is captured', async () => {
+		const source = `<?php
+namespace App\\Http {
+	function handle() {}
+}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'App\\Http')).toMatchObject({
+			kind: 'type',
+			exported: true,
+		});
+	});
+
+	test('unterminated class body at EOF still yields bounded def lines', async () => {
+		const source = `<?php
+class Dangling {
+	function m() {}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		const cls = def(facts!, 'Dangling');
+		expect(cls).toBeDefined();
+		expect(cls!.startLine).toBeGreaterThan(0);
+		expect(cls!.endLine).toBeGreaterThanOrEqual(cls!.startLine);
+	});
+
+	test('commented-out declarations are not augmented', async () => {
+		const source = `<?php
+// class Ghost {}
+/* trait Phantom {} */
+class Real {}
+`;
+		const facts = await extractFileSymbols('php', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'Ghost')).toBeUndefined();
+		expect(def(facts!, 'Phantom')).toBeUndefined();
+		expect(def(facts!, 'Real')).toMatchObject({ kind: 'class' });
+	});
+});

--- a/tests/unit/lang/symbol-graph-ruby.test.ts
+++ b/tests/unit/lang/symbol-graph-ruby.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { clearParserCache } from '../../../src/lang/runtime';
+import { extractFileSymbols } from '../../../src/lang/symbol-graph';
+
+function def(
+	facts: NonNullable<Awaited<ReturnType<typeof extractFileSymbols>>>,
+	name: string,
+) {
+	return facts.defs.find((item) => item.name === name);
+}
+
+describe('extractFileSymbols — ruby hardening (#1531)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('captures require_relative, modules, constants, singleton methods, and private methods', async () => {
+		const source = `require_relative 'helper'
+
+module Api
+	VERSION = '1'
+	class Client
+		def call
+			Helper.run
+		end
+
+		private
+
+		def hidden
+		end
+
+		def self.build
+			new
+		end
+	end
+
+	class Other
+		def visible
+		end
+	end
+end
+`;
+
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: './helper',
+				importType: 'default',
+			}),
+		);
+		expect(def(facts!, 'Api')).toMatchObject({ kind: 'type', exported: true });
+		expect(def(facts!, 'VERSION')).toMatchObject({
+			kind: 'const',
+			exported: true,
+		});
+		expect(def(facts!, 'Client')).toMatchObject({
+			kind: 'class',
+			exported: true,
+		});
+		expect(def(facts!, 'call')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+		expect(def(facts!, 'hidden')).toMatchObject({
+			kind: 'method',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		// singleton methods keep their self. qualification
+		expect(def(facts!, 'self.build')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+		// a new class body resets the visibility section to public
+		expect(def(facts!, 'visible')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+	});
+
+	test('require (non-relative) stays a namespace import', async () => {
+		const facts = await extractFileSymbols('ruby', "require 'json'\n");
+		expect(facts).not.toBeNull();
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({
+				specifier: 'json',
+				importType: 'namespace',
+			}),
+		);
+	});
+
+	test('heredoc bodies do not flip visibility or create defs; opener consts survive', async () => {
+		const source = `QUERY = <<~SQL
+private
+def ghost_method
+class Ghost
+SQL
+class Repo
+	def after
+	end
+
+	private
+
+	def secret
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		// the heredoc opener line still declares its constant
+		expect(def(facts!, 'QUERY')).toMatchObject({ kind: 'const' });
+		// heredoc BODY lines are string data, not code
+		expect(def(facts!, 'ghost_method')).toBeUndefined();
+		expect(def(facts!, 'Ghost')).toBeUndefined();
+		// a literal `private` inside the heredoc must NOT flip the section:
+		// `after` (declared before the real `private`) is public, and `secret`
+		// (after it) is private
+		expect(def(facts!, 'after')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+		expect(def(facts!, 'secret')).toMatchObject({
+			kind: 'method',
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+	});
+
+	test('shift operators (`arr <<item`, `x << y`) never open heredocs', async () => {
+		const source = `class Bits
+	def build(list)
+		list <<item
+		x = 2 <<3
+	end
+end
+class After
+	def alive
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		// A spurious heredoc would swallow every following augmented def —
+		// `After`/`alive` surviving proves the operators did not open one.
+		expect(def(facts!, 'Bits')).toMatchObject({ kind: 'class' });
+		expect(def(facts!, 'build')).toMatchObject({ kind: 'method' });
+		expect(def(facts!, 'After')).toMatchObject({ kind: 'class' });
+		expect(def(facts!, 'alive')).toMatchObject({
+			kind: 'method',
+			exported: true,
+		});
+	});
+
+	test('`private :symbol` targets one method and does not flip the section', async () => {
+		const source = `class C
+	def a
+	end
+
+	private :a
+
+	def b
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		// `b` is still public — the symbol-argument form is per-method only
+		expect(def(facts!, 'b')).toMatchObject({
+			kind: 'method',
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+	});
+
+	test('question/bang method names are captured', async () => {
+		const source = `class Doc
+	def valid?
+	end
+
+	def save!
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'valid?')).toMatchObject({ kind: 'method' });
+		expect(def(facts!, 'save!')).toMatchObject({ kind: 'method' });
+	});
+
+	test('end keyword inside a string literal does not affect defs', async () => {
+		const source = `class C
+	def phrase
+		"tail end"
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'C')).toMatchObject({ kind: 'class' });
+		expect(def(facts!, 'phrase')).toMatchObject({ kind: 'method' });
+		// exactly one def per name — augmentation upserted, not duplicated
+		expect(facts!.defs.filter((d) => d.name === 'phrase')).toHaveLength(1);
+	});
+});

--- a/tests/unit/lang/symbol-graph-ruby.test.ts
+++ b/tests/unit/lang/symbol-graph-ruby.test.ts
@@ -204,3 +204,151 @@ end
 		expect(facts!.defs.filter((d) => d.name === 'phrase')).toHaveLength(1);
 	});
 });
+
+describe('extractFileSymbols — ruby hardening round 2 (#2361 review)', () => {
+	beforeEach(() => {
+		clearParserCache();
+	});
+
+	test('CRLF sources produce identical defs to LF (issue #1526 class)', async () => {
+		const lf = `module Api
+	VERSION = '1'
+	class Client
+		def call
+		end
+
+		private
+
+		def hidden
+		end
+	end
+end
+`;
+		const crlf = lf.replace(/\n/g, '\r\n');
+		const lfFacts = await extractFileSymbols('ruby', lf);
+		const crlfFacts = await extractFileSymbols('ruby', crlf);
+		expect(crlfFacts).not.toBeNull();
+		expect(lfFacts).not.toBeNull();
+		// no duplicates, identical spans — the pre-fix CRLF run produced a
+		// second drifted Client/call def pair
+		expect(crlfFacts!.defs).toEqual(lfFacts!.defs);
+		expect(new Set(crlfFacts!.defs.map((d) => d.name)).size).toBe(
+			crlfFacts!.defs.length,
+		);
+	});
+
+	test('nested class/module restores the outer private section on close (R1)', async () => {
+		const source = `class Outer
+	private
+
+	class Inner
+		def inner_m
+		end
+	end
+
+	def outer_m
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		// Inner opens a fresh public section...
+		expect(def(facts!, 'inner_m')).toMatchObject({ exported: true });
+		// ...and closing it restores Outer's private section
+		expect(def(facts!, 'outer_m')).toMatchObject({
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+	});
+
+	test('targeted `private :sym` marks the named method only (R1)', async () => {
+		const source = `class C
+	def a
+	end
+
+	def b
+	end
+
+	private :a
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'a')).toMatchObject({
+			exported: false,
+			visibilityInfo: { visibility: 'private' },
+		});
+		expect(def(facts!, 'b')).toMatchObject({
+			exported: true,
+			visibilityInfo: { visibility: 'public' },
+		});
+	});
+
+	test('`protected` sections are tracked like private', async () => {
+		const source = `class C
+	protected
+
+	def guarded
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		// protected mirrors the PHP precedent: precise visibility, still an
+		// exported member (only `private` is non-exported)
+		expect(def(facts!, 'guarded')).toMatchObject({
+			exported: true,
+			visibilityInfo: { visibility: 'protected' },
+		});
+	});
+
+	test('heredoc `<<-` and bare `<<` variants skip bodies too', async () => {
+		const dashSource = `text = <<-EOS
+private
+def ghost
+EOS
+class Real
+	def alive
+	end
+end
+`;
+		const facts = await extractFileSymbols('ruby', dashSource);
+		expect(facts).not.toBeNull();
+		expect(def(facts!, 'ghost')).toBeUndefined();
+		expect(def(facts!, 'alive')).toMatchObject({ exported: true });
+
+		const bareSource = `text = <<EOS
+private
+def phantom
+EOS
+class Real2
+	def alive2
+	end
+end
+`;
+		const facts2 = await extractFileSymbols('ruby', bareSource);
+		expect(facts2).not.toBeNull();
+		expect(def(facts2!, 'phantom')).toBeUndefined();
+		expect(def(facts2!, 'alive2')).toMatchObject({ exported: true });
+	});
+
+	test('import-shaped lines inside heredoc bodies produce no edges (R4)', async () => {
+		const source = `text = <<~EOS
+require 'phantom'
+require_relative 'ghost'
+EOS
+require 'real'
+`;
+		const facts = await extractFileSymbols('ruby', source);
+		expect(facts).not.toBeNull();
+		expect(
+			facts!.imports.filter((i) => i.specifier.includes('phantom')),
+		).toHaveLength(0);
+		expect(
+			facts!.imports.filter((i) => i.specifier.includes('ghost')),
+		).toHaveLength(0);
+		expect(facts!.imports).toContainEqual(
+			expect.objectContaining({ specifier: 'real' }),
+		);
+	});
+});

--- a/tests/unit/lang/symbol-graph.test.ts
+++ b/tests/unit/lang/symbol-graph.test.ts
@@ -1107,15 +1107,13 @@ void main() {
 			facts!.defs[0].startLine,
 		);
 
-		// import: import 'dart:io' as io
+		// import: import 'dart:io' as io — a prefix, not a named binding
 		expect(facts!.imports).toHaveLength(1);
 		expect(facts!.imports[0]).toMatchObject({
 			specifier: 'dart:io',
-			importType: 'named',
+			importType: 'namespace',
 		});
-		expect(facts!.imports[0].bindings).toEqual([
-			{ imported: 'dart:io', local: 'io' },
-		]);
+		expect(facts!.imports[0].bindings).toEqual([]);
 
 		// ref: io.stdout... inside main → enclosingDecl = 'main'
 		const ioRef = facts!.refs.find((r) => r.identifier === 'io');
@@ -1143,11 +1141,12 @@ end
 		const facts = await extractFileSymbols('ruby', source);
 		expect(facts).not.toBeNull();
 
-		// def: main method
+		// def: main method — augmentation re-types ruby `def` (#1531)
 		expect(facts!.defs).toHaveLength(1);
 		expect(facts!.defs[0]).toMatchObject({
 			name: 'main',
-			kind: 'function',
+			kind: 'method',
+			exported: true,
 		});
 		expect(facts!.defs[0].startLine).toBeGreaterThan(0);
 		expect(facts!.defs[0].endLine).toBeGreaterThanOrEqual(
@@ -1208,7 +1207,7 @@ function main() {
 			importType: 'named',
 		});
 		expect(facts!.imports[0].bindings).toEqual([
-			{ imported: 'Ns\\Foo', local: 'F' },
+			{ imported: 'Foo', local: 'F' },
 		]);
 
 		// ref: F::bar() inside main → enclosingDecl = 'main'

--- a/tests/unit/tools/repo-map-dart-ruby-php.test.ts
+++ b/tests/unit/tools/repo-map-dart-ruby-php.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { repo_map } from '../../../src/tools/repo-map';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let root: string;
+
+async function callRepoMap(args: Record<string, unknown>): Promise<any> {
+	type Executable = {
+		execute: (
+			args: Record<string, unknown>,
+			ctx: { directory: string },
+		) => Promise<string | { output: string }>;
+	};
+	const out = await (repo_map as unknown as Executable).execute(args, {
+		directory: root,
+	});
+	return JSON.parse(typeof out === 'string' ? out : out.output);
+}
+
+function write(rel: string, content: string): void {
+	const full = path.join(root, rel);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+beforeEach(() => {
+	root = canonicalMkdtemp('repo-map-dart-ruby-php-');
+});
+
+afterEach(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('repo_map dart/ruby/php context surfaces (#1531)', () => {
+	test('build resolves dart alias imports as namespace edges, not fake symbol imports', async () => {
+		write(
+			'helper.dart',
+			`void run() {}
+`,
+		);
+		write(
+			'main.dart',
+			`import './helper.dart' as helper;
+
+void main() {
+	helper.run();
+}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const graph = JSON.parse(
+			fs.readFileSync(path.join(root, '.swarm', 'repo-graph.json'), 'utf-8'),
+		);
+		const mainNode = Object.values(graph.nodes).find(
+			(node: any) => node.moduleName === 'main.dart',
+		) as any;
+		expect(mainNode.imports).toContain('./helper.dart');
+		expect(graph.edges).toContainEqual(
+			expect.objectContaining({
+				importSpecifier: './helper.dart',
+				importType: 'namespace',
+				importedSymbols: [],
+			}),
+		);
+		expect(graph.edges).not.toContainEqual(
+			expect.objectContaining({
+				importSpecifier: './helper.dart',
+				importedSymbols: ['./helper.dart'],
+			}),
+		);
+	});
+
+	test('ruby require_relative resolves to the target file and context_pack returns class/singleton spans', async () => {
+		write(
+			'helper.rb',
+			`module Helper
+	def self.run
+	end
+end
+`,
+		);
+		write(
+			'billing.rb',
+			`require_relative 'helper'
+
+module Billing
+class Service
+  def self.build; end
+  private
+  def token; end
+end
+end
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const graph = JSON.parse(
+			fs.readFileSync(path.join(root, '.swarm', 'repo-graph.json'), 'utf-8'),
+		);
+		const billing = Object.values(graph.nodes).find(
+			(node: any) => node.moduleName === 'billing.rb',
+		) as any;
+		expect(billing.imports).toContain('./helper');
+
+		const classContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'billing.rb',
+			symbol: 'Service',
+			top_n: 3,
+		});
+		expect(classContext.success).toBe(true);
+		expect(classContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'billing.rb',
+				symbol: 'Service',
+				startLine: 4,
+			}),
+		);
+
+		// Singleton methods are keyed by their literal `self.`-prefixed name.
+		const methodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'billing.rb',
+			symbol: 'self.build',
+			top_n: 3,
+		});
+		expect(methodContext.success).toBe(true);
+		expect(methodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'billing.rb',
+				symbol: 'self.build',
+				startLine: 5,
+			}),
+		);
+	});
+
+	test('context_pack returns PHP trait and method spans from the tool path', async () => {
+		write(
+			'Service.php',
+			`<?php
+namespace App\\Services;
+trait Logs {}
+class Service {
+	function run() {}
+	static function build() {}
+}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const traitContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'Logs',
+			top_n: 3,
+		});
+		expect(traitContext.success).toBe(true);
+		expect(traitContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'Logs',
+				startLine: 3,
+			}),
+		);
+
+		const methodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'run',
+			top_n: 3,
+		});
+		expect(methodContext.success).toBe(true);
+		expect(methodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'run',
+				startLine: 5,
+			}),
+		);
+
+		const staticMethodContext = await callRepoMap({
+			action: 'context_pack',
+			file: 'Service.php',
+			symbol: 'build',
+			top_n: 3,
+		});
+		expect(staticMethodContext.success).toBe(true);
+		expect(staticMethodContext.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'Service.php',
+				symbol: 'build',
+				startLine: 6,
+			}),
+		);
+	});
+
+	test('context_pack returns dart type spans', async () => {
+		write(
+			'model.dart',
+			`class Model {}
+mixin Renderable {}
+`,
+		);
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'model.dart',
+			symbol: 'Renderable',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'model.dart',
+				symbol: 'Renderable',
+				startLine: 2,
+			}),
+		);
+	});
+});

--- a/tests/unit/tools/repo-map-dart-ruby-php.test.ts
+++ b/tests/unit/tools/repo-map-dart-ruby-php.test.ts
@@ -230,3 +230,83 @@ mixin Renderable {}
 		);
 	});
 });
+
+describe('repo_map dart/ruby/php round 2 (#2361 review)', () => {
+	test('require_relative resolves the .rb sibling, not a same-basename .ts (R3)', async () => {
+		write('helper.rb', 'module Helper\n\tdef self.run\n\tend\nend\n');
+		write('helper.ts', 'export const helper = 1;\n');
+		write('main.rb', "require_relative 'helper'\n");
+
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+
+		const graph = JSON.parse(
+			fs.readFileSync(path.join(root, '.swarm', 'repo-graph.json'), 'utf-8'),
+		);
+		const mainNode = Object.values(graph.nodes).find(
+			(node: any) => node.moduleName === 'main.rb',
+		) as any;
+		expect(mainNode.imports).toContain('./helper');
+		const edge = (graph.edges as any[]).find(
+			(e) => e.importSpecifier === './helper',
+		);
+		// the edge must target the RUBY file, not helper.ts
+		expect(edge.target).toContain('helper.rb');
+		expect(edge.target).not.toContain('helper.ts');
+	});
+
+	test('context_pack serves a private dart symbol span (PRR-027)', async () => {
+		write(
+			'model.dart',
+			`class Public {}
+void _hidden() {}
+`,
+		);
+		const build = await callRepoMap({ action: 'build' });
+		expect(build.success).toBe(true);
+		const context = await callRepoMap({
+			action: 'context_pack',
+			file: 'model.dart',
+			symbol: '_hidden',
+			top_n: 3,
+		});
+		expect(context.success).toBe(true);
+		expect(context.spans).toContainEqual(
+			expect.objectContaining({
+				file: 'model.dart',
+				symbol: '_hidden',
+				startLine: 2,
+			}),
+		);
+	});
+
+	test('AST fail-open preserves export metadata for php (R9)', async () => {
+		write(
+			'Failing.php',
+			`<?php
+namespace App;
+class Kept {
+	public function run() {}
+}
+`,
+		);
+		// Force the async tree-sitter path to fail via the builder's seam so
+		// the sync fallback (scanFile) must supply exports.
+		const builder = await import('../../../src/tools/repo-graph/builder');
+		const original = builder._internals.extractFileSymbols;
+		builder._internals.extractFileSymbols = (() =>
+			Promise.resolve(null)) as typeof original;
+		try {
+			const graph = await builder.buildWorkspaceGraphAsync(root, {
+				maxFiles: 10,
+			});
+			const node = Object.values(graph.nodes).find(
+				(n: any) => n.moduleName === 'Failing.php',
+			) as any;
+			expect(node).toBeDefined();
+			expect(node.exports).toContain('Kept');
+		} finally {
+			builder._internals.extractFileSymbols = original;
+		}
+	});
+});

--- a/tests/unit/tools/symbols-dart-ruby-php.test.ts
+++ b/tests/unit/tools/symbols-dart-ruby-php.test.ts
@@ -237,3 +237,127 @@ class Real {}
 		);
 	});
 });
+
+describe('symbols tool — dart/ruby/php extractors round 2 (#2361 review)', () => {
+	test('dart: class members are qualified TypeName.method, not top-level functions (R6)', () => {
+		write(
+			'members.dart',
+			`class Foo {
+  void bar() {}
+  static void staticBaz() {}
+}
+void topLevel() {}
+`,
+		);
+
+		const symbols = extractDartSymbols('members.dart', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Foo.bar', kind: 'method' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Foo.staticBaz', kind: 'method' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'topLevel', kind: 'function' }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'bar', kind: 'function' }),
+		);
+	});
+
+	test('dart: same-named members of different classes do not collapse (R7)', () => {
+		write(
+			'twins.dart',
+			`class A {
+  void run() {}
+}
+class B {
+  void run() {}
+}
+`,
+		);
+
+		const symbols = extractDartSymbols('twins.dart', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'A.run', kind: 'method' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'B.run', kind: 'method' }),
+		);
+	});
+
+	test('dart: `void Function(int)` type references are not symbols (PRR-006)', () => {
+		write('fnref.dart', 'typedef Cb = void Function(int);\nvoid real() {}\n');
+		const symbols = extractDartSymbols('fnref.dart', root);
+		expect(symbols.find((s) => s.name === 'Function')).toBeUndefined();
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'real', kind: 'function' }),
+		);
+	});
+
+	test('ruby: CRLF sources report correct line numbers (PRR-001)', () => {
+		write(
+			'crlf.rb',
+			[
+				'module Billing',
+				'class Service',
+				'  def work; end',
+				'end',
+				'end',
+				'',
+			].join('\r\n'),
+		);
+		const symbols = extractRubySymbols('crlf.rb', root);
+		const service = symbols.find((s) => s.name === 'Service');
+		const work = symbols.find((s) => s.name === 'work');
+		expect(service?.line).toBe(2);
+		expect(work?.line).toBe(3);
+	});
+
+	test('php: enums are extracted (R8)', () => {
+		write('suit.php', "<?php\nenum Suit: string {\n\tcase Hearts = 'h';\n}\n");
+		const symbols = extractPhpSymbols('suit.php', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Suit', kind: 'enum', exported: true }),
+		);
+	});
+
+	test('ruby: nested class restores outer private section (R1 parity)', () => {
+		write(
+			'nested.rb',
+			[
+				'class Outer',
+				'  private',
+				'  class Inner',
+				'    def inner_m; end',
+				'  end',
+				'  def outer_m; end',
+				'end',
+				'',
+			].join('\n'),
+		);
+		const symbols = extractRubySymbols('nested.rb', root);
+		expect(symbols.find((s) => s.name === 'inner_m')?.exported).toBe(true);
+		expect(symbols.find((s) => s.name === 'outer_m')?.exported).toBe(false);
+	});
+
+	test('php: string literals do not corrupt brace ranges', () => {
+		write(
+			'glue.php',
+			[
+				'<?php',
+				'class S {',
+				'  public function render() {',
+				"    $glue = '}';",
+				'    return $glue;',
+				'  }',
+				'  public function other() {}',
+				'}',
+				'',
+			].join('\n'),
+		);
+		const symbols = extractPhpSymbols('glue.php', root);
+		expect(symbols.find((s) => s.name === 'other')?.kind).toBe('method');
+		expect(symbols.find((s) => s.name === 'render')?.kind).toBe('method');
+	});
+});

--- a/tests/unit/tools/symbols-dart-ruby-php.test.ts
+++ b/tests/unit/tools/symbols-dart-ruby-php.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	extractDartSymbols,
+	extractPhpSymbols,
+	extractRubySymbols,
+} from '../../../src/tools/symbols';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let root: string;
+
+function write(rel: string, content: string): void {
+	const full = path.join(root, rel);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf-8');
+}
+
+beforeEach(() => {
+	root = canonicalMkdtemp('symbols-dart-ruby-php-');
+});
+
+afterEach(() => {
+	fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('symbols tool — dart/ruby/php extractors (#1531)', () => {
+	test('dart: types and functions with `_` privacy filtering', () => {
+		write(
+			'model.dart',
+			`class Foo {
+  void bar() {}
+  final int _privateField = 0;
+}
+
+mixin Helper {}
+enum Mode { fast }
+void _hidden() {}
+void visible() {}
+`,
+		);
+
+		const symbols = extractDartSymbols('model.dart', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Foo', kind: 'class', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Helper', kind: 'type', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Mode', kind: 'enum', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'visible',
+				kind: 'function',
+				exported: true,
+			}),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: '_privateField' }),
+		);
+		expect(symbols.find((s) => s.name === '_hidden')?.exported).toBe(false);
+	});
+
+	test('dart: control-flow and call expressions are not functions', () => {
+		write(
+			'flow.dart',
+			`void main() {
+  if (ready()) {}
+  return helper();
+  final x = make();
+}
+`,
+		);
+
+		const symbols = extractDartSymbols('flow.dart', root);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'ready' }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'helper' }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'make' }),
+		);
+		expect(symbols).not.toContainEqual(expect.objectContaining({ name: 'if' }));
+	});
+
+	test('dart: extension types, unnamed extensions, typedefs, Dart 3 modifiers', () => {
+		write(
+			'modern.dart',
+			`extension type Meters(int value) {}
+extension on String {}
+sealed class Node {}
+typedef Callback = void Function(int);
+`,
+		);
+
+		const symbols = extractDartSymbols('modern.dart', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Meters', kind: 'type' }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'type' }),
+		);
+		expect(symbols).not.toContainEqual(expect.objectContaining({ name: 'on' }));
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Node', kind: 'class' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Callback', kind: 'type' }),
+		);
+	});
+
+	test('ruby: modules, classes, constants, methods, visibility sections', () => {
+		write(
+			'service.rb',
+			`module Billing
+VERSION = '1'
+class Service
+  def self.build; end
+  private
+  def token; end
+  def _internal; end
+end
+class Other
+  def visible; end
+end
+end
+`,
+		);
+
+		const symbols = extractRubySymbols('service.rb', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'Billing',
+				kind: 'type',
+				exported: true,
+			}),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'VERSION', kind: 'const' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Service', kind: 'class' }),
+		);
+		// singleton methods keep the self. qualification and stay public
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'self.build',
+				kind: 'method',
+				exported: true,
+			}),
+		);
+		// private-section methods are not exported
+		expect(symbols.find((s) => s.name === 'token')?.exported).toBe(false);
+		expect(symbols.find((s) => s.name === '_internal')?.exported).toBe(false);
+		// a new class body resets the section to public
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'visible',
+				kind: 'method',
+				exported: true,
+			}),
+		);
+	});
+
+	test('php: namespaces, traits, classes, methods with visibility', () => {
+		write(
+			'Service.php',
+			`<?php
+namespace App\\Billing;
+trait Logs {}
+class Service {
+  function run() {}
+  static function build() {}
+  private function token() {}
+}
+function helper() {}
+`,
+		);
+
+		const symbols = extractPhpSymbols('Service.php', root);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'App\\Billing',
+				kind: 'type',
+				exported: true,
+			}),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Logs', kind: 'interface' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Service', kind: 'class' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'run', kind: 'method', exported: true }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'build',
+				kind: 'method',
+				exported: true,
+			}),
+		);
+		expect(symbols.find((s) => s.name === 'token')?.exported).toBe(false);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({
+				name: 'helper',
+				kind: 'function',
+				exported: true,
+			}),
+		);
+	});
+
+	test('php: commented-out declarations are skipped', () => {
+		write(
+			'ghost.php',
+			`<?php
+// class Ghost {}
+/* function phantom() {} */
+class Real {}
+`,
+		);
+
+		const symbols = extractPhpSymbols('ghost.php', root);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'Ghost' }),
+		);
+		expect(symbols).not.toContainEqual(
+			expect.objectContaining({ name: 'phantom' }),
+		);
+		expect(symbols).toContainEqual(
+			expect.objectContaining({ name: 'Real', kind: 'class' }),
+		);
+	});
+});


### PR DESCRIPTION
# feat(symbol-graph): harden Dart, Ruby, and PHP symbol graph support

Closes #1531

## Summary

Ports the Dart/Ruby/PHP subset of the reviewed-but-stranded PR #1681 (which
was merged only into the side branch `codex/issues-1527-1528-symbol-graph` and
never reached main) onto current main, adapted to the post-#1530 architecture:

- **`src/lang/symbol-graph.ts`** — regex augmentation layer
  (`augmentNativeDynamicDefs`, comment-masked) adds facts the tree-sitter
  queries can't express: Dart class/mixin/enum/extension/typedef types
  including Dart 3 forms (`extension type`, unnamed `extension on X` skipped,
  `base`/`final`/`interface`/`sealed`/`abstract` modifiers); Ruby modules,
  constants, `def`-typed methods with bare `private`/`protected` section
  tracking (reset on class/module; `private :sym` is per-method; heredoc
  bodies skipped with context-anchored openers so binary `<<` never opens
  one); PHP namespaces (`;` and brace forms), traits, and methods with
  `public`/`protected`/`private` visibility modifiers and `_`-prefix privacy.
  Import parsers fixed: Dart `export` directives → re-export edges with
  exported bindings, `show` → named bindings, `as` prefix (incl. `as`+`show`/
  `hide` combos) → namespace with no fake binding; Ruby `require_relative`
  normalizes to `./x`; PHP aliased `use` binds the SHORT name (F-002). Adds a
  line-based import fallback plus semantic dedup so query and fallback paths
  yield one import fact per statement; dart/php import-ancestor ref filtering
  (`namespace_use_clause`, `library_export`, `export_directive`); def endLine
  clamping for widened-range validation.
- **`src/tools/repo-graph/builder.ts`** — `dart`/`ruby`/`php` join
  `RANGE_WIDENED_GRAMMARS` so `context_pack` serves member spans instead of
  placeholders; sync-path `parseFileImports` branches for the three languages
  (`parseDart/Ruby/PhpFileImports`); relative resolution probes
  `.rb`/`.rake`/`.gemspec`/`.dart`/`.php`/`.phtml`.
- **`src/tools/symbols.ts`** — new `extractDartSymbols`/`extractRubySymbols`/
  `extractPhpSymbols` regex extractors behind an `_internals` DI seam; the
  `symbols` tool now supports `.dart`, `.rb`, `.rake`, `.gemspec`, `.php`,
  `.phtml` (description + dispatch switches + error message updated).
- **Tests** — 5 new files: `symbol-graph-dart.test.ts` (6),
  `symbol-graph-ruby.test.ts` (7), `symbol-graph-php.test.ts` (6),
  `symbols-dart-ruby-php.test.ts` (6), `repo-map-dart-ruby-php.test.ts` (4) —
  including adversarial rows (Dart 3 forms, heredoc bodies, shift-operator
  non-heredocs, alias+show combos, commented-out declarations, unterminated
  braces at EOF, builtin-call false positives). Coverage-test opt-outs for
  dart/ruby/php flipped to positive, honest expectations
  (`language-extraction-coverage.test.ts`); dart/ruby/php query expectations
  updated in `symbol-graph.test.ts` (net −1 line; over-cap files must not
  grow).
- **Docs** — "Dynamic language limitations (Dart, Ruby, PHP)" section in
  `docs/repo-graph-symbol-graph.md` (incl. `self.`-prefixed singleton naming,
  Flutter widget caveats, PHP `use`/PSR-4 boundaries, Blade caveats, heredoc
  semantics), stale exportRanges table fixed, `docs/php-laravel.md` Blade
  caveats, release fragment
  `docs/releases/pending/1531-dart-ruby-php-symbol-graph.md`.

## Root cause context

The original #1531 implementation (PR #1681) was completed and reviewed but
merged into a side branch that never landed on main; the dependency #1530
(C/C++/Swift) was re-implemented separately in the meantime. This PR ports
the issue-scoped subset and reconciles with main's newer architecture
(`RANGE_WIDENED_GRAMMARS` instead of #1681's "methods exported=true" flip,
which would have contradicted main's tested "methods are not promoted into
file-level exports" invariant).

## Invariant audit

- 1 (plugin init): not touched — the changed modules add pure
  functions/constants only; no new top-level I/O, no init-path awaits
  (`git diff origin/main..HEAD` contains no changes to `src/index.ts` or any
  registration/init path).
- 2 (runtime portability): not touched — no `bun:` imports or `Bun.*` calls
  added (`grep -n "bun:" src/lang/symbol-graph.ts src/tools/symbols.ts
  src/tools/repo-graph/builder.ts` → 0 hits); default export shape unchanged.
- 3 (subprocesses): not touched — no spawn/child_process additions
  (`git diff origin/main..HEAD | xargs grep -nE "spawn\(|spawnSync\("` → 0
  hits); extraction is pure regex + shipped tree-sitter WASM.
- 4 (.swarm containment): not touched in product code — no new `.swarm/`
  writes; tests write only to `canonicalMkdtemp` external temp dirs
  (`scripts/check-test-tmpdir.sh` → "All new/changed test temp roots are
  external and canonicalized").
- 5 (plan durability): not touched — no plan/ledger code paths.
- 6 (test_runner safety): not touched — no test-runner changes.
- 7 (test writing): touched — all new tests are `bun:test`; **zero**
  `mock.module` usage (new files use direct imports +
  `clearParserCache`/exported extractors; the symbols extractors sit behind
  the new `_internals` seam per invariant 7); temp paths via
  `canonicalMkdtemp` (no raw `os.tmpdir()`/`mkdtempSync` —
  `check-test-tmpdir.sh` clean); all new files under 500 lines
  (`check:test-file-cap` → 0 new-file, 0 ratchet violations; the combined
  extraction suite was split by language to meet FR-006).
- 8 (session state): touched — a single-slot, content-keyed line-start memo in src/tools/symbols.ts (bounded by design: one entry, no growth); no session-keyed state.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched (help surface only) — the `symbols` tool's
  description now lists the supported languages; no new tool, command, agent,
  or TOOL_NAMES entry (tool set unchanged: 126 tools coherent per
  `bun run scripts/check-tool-registration.ts` → "passed"); drift check clean
  (`bun run drift:check` → "No drift detected").
- 12 (release/cache): touched — release fragment added at
  `docs/releases/pending/1531-dart-ruby-php-symbol-graph.md` (no version
  computed; `package.json`/`CHANGELOG.md`/`.release-please-manifest.json`
  untouched; `check:pending-fragment` → OK).

## Test plan

Commands run locally on the PR head (all green):

- `bun run typecheck` → clean
- `bun test tests/unit/lang/` → 858 pass, 0 fail (39 files)
- `bun test tests/unit/tools/repo-graph.test.ts tests/unit/tools/repo-graph-*.test.ts`
  → 511 pass, 0 fail (44 files — includes the #1530 cpp/swift guards)
- `bun test tests/unit/tools/repo-map*.test.ts tests/unit/tools/symbols*.test.ts`
  → 179 tests, 0 fail (8 files)
- `bun test tests/unit/lang/php-backend.test.ts tests/unit/lang/laravel-fixture.test.ts
  tests/unit/lang/framework-detector.test.ts` → 53 pass, 0 fail (PHP/Laravel
  acceptance)
- New suites: 29 tests, 0 fail across the five new files
- All CI quality-job gates run locally and passing (mock-cleanup,
  invariants, tool-registration, runtime-src-refs, events, retention,
  cross-contamination, test-clock, test-file-cap, pending-fragment,
  gate-portability, bare-spawn, test-tmpdir, bash-portability, biome on
  src+tests, swarm-model node --test)
- Issue-repro script: 19/19 acceptance checks PASS (was 13 FAIL before)

Closes #1531


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




---

## Review round 2 (feedback fixes, commit a49dcd78)

Closes all findings from the swarm PR review and the maintainer review. Headline fixes:

- **CRLF-correct line arithmetic** for the ruby/php/dart line scanners — CRLF and LF sources now produce identical facts (previously CRLF ruby files drifted one byte per line, creating duplicate defs with wrong persisted spans; the #1526 bug class, verified as a regression vs. base).
- **Bounded PHP modifier quantifier** — the unbounded star measured ~7.2-8s (quadratic backtracking) at 230KB-1MB hostile input; now 4-14ms, with timing-budget regression tests.
- **String-literal-aware masking** incl. Dart triple-quoted strings — braces/semicolons/import-shaped text inside literals (even with inner apostrophes) no longer corrupt spans or create false edges.
- **Ruby visibility**: nested class/module sections save/restore via end-balance; targeted `private :a, :b` marks named methods; `protected` pinned.
- **PHP**: 8.1 enums (query + augment + symbols tool); class-body trait `use` no longer a false import edge.
- **Dart**: symbols tool members qualified `TypeName.member` (kind `method`) — no same-name collapse across classes; conditional imports record both URIs; multiline `show` clauses parse whole and dedup to one entry.
- **Importer-language-aware resolution**: ruby `require_relative 'foo'` resolves `foo.rb` over a sibling `foo.ts`.
- **AST fail-open preserves exports** for dart/ruby/php (sync collector extended + seam-forced failure test).
- **_internals seams** for the import parsers + new tests (direct parser tests, CRLF/enum/nested/trait/conditional/qualified-member/heredoc/#-comment regressions, redos timing).
- Docs: limitations section updated for all round-2 behaviors; 11 stale line pointers fixed.

Full ledger with per-item dispositions (including rejected findings with evidence) maintained in the review workspace.
