### PR TITLE
fix(status): #2104 follow-through — status help surface + init-bound maintenance tests

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,6 +48,15 @@ Tasks: 3/5 complete
 Agents: 11 registered
 ```
 
+When `hooks.background_subagents` is enabled (default `false`), status additionally renders a
+**Background Work** section: delegation counts by status (pending, running,
+completed-unconsumed, consumed, stale, cancelled, error, ingestion_error), active coder
+reservations with their generation and lease state (active / expired / protected-legacy), the
+durable maintenance summary (last ok, last failure, last lock contention), and a
+`Source: validated recovery (bounded scan)` provenance label. Corrupt or over-bound stores
+render a `⚠ State uncertain: …` line instead of partially-trusted counts. Disabled
+configurations see no section and schedule no maintenance.
+
 ### `/swarm learning [--json] [--phase N] [--timeout-ms N]`
 
 Show aggregate learning metrics computed from `.swarm/knowledge-events.jsonl` and the knowledge store:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,7 +50,7 @@ Agents: 11 registered
 
 When `hooks.background_subagents` is enabled (default `false`), status additionally renders a
 **Background Work** section: delegation counts by status (pending, running,
-completed-unconsumed, consumed, stale, cancelled, error, ingestion_error), active coder
+completed (unconsumed), consumed, stale, cancelled, error, ingestion_error), active coder
 reservations with their generation and lease state (active / expired / protected-legacy), the
 durable maintenance summary (last ok, last failure, last lock contention), and a
 `Source: validated recovery (bounded scan)` provenance label. Corrupt or over-bound stores

--- a/docs/releases/pending/2104-background-reclaimable-retryable-visible.md
+++ b/docs/releases/pending/2104-background-reclaimable-retryable-visible.md
@@ -59,7 +59,7 @@ durable delegation-owner scan, so deleting the file cannot over-admit a live tas
 ### Opt-in `/swarm status` background-work section
 
 When `hooks.background_subagents` is enabled, `/swarm status` now shows delegation counts
-(pending, running, completed-unconsumed, consumed, stale, cancelled, error, ingestion_error),
+(pending, running, completed (unconsumed), consumed, stale, cancelled, error, ingestion_error),
 active reservations with their generation and lease state (active / expired / protected-legacy),
 the durable maintenance summary (last ok, last failure, last lock contention), and a
 provenance label. All reads are bounded (recovery scan + bounded reservation store + health

--- a/docs/releases/pending/2104-status-help-and-init-tests.md
+++ b/docs/releases/pending/2104-status-help-and-init-tests.md
@@ -1,0 +1,26 @@
+## Follow-through for issue #2104: status help + init-bound acceptance tests
+
+Documentation- and test-only follow-through on the background-work visibility shipped for
+issue #2104. No runtime behavior changes — the opt-in status section itself landed earlier in
+this release cycle.
+
+### `/swarm status` help now mentions the opt-in section
+
+The `status` command (and its deprecated `info` alias) description now reads "Show current
+swarm state (plus background-work health when hooks.background_subagents is enabled)", and
+`docs/commands.md` documents what the opt-in Background Work section shows: delegation counts
+by status, active coder reservations with generation/lease state, the durable maintenance
+summary, and the `Source: validated recovery (bounded scan)` provenance label — with typed
+`⚠ State uncertain: …` output when a store is corrupt or over its recovery bound. Disabled
+(default) configurations still see no section and schedule no maintenance.
+
+### Init-bound acceptance tests for the #2104 maintenance wiring
+
+New tests pin the post-init maintenance contract from the issue's acceptance list: the
+deferred post-init pass is registered only when `hooks.background_subagents` is enabled, runs
+strictly after plugin-server resolution on the wrapper-owned post-resolution queue, and fails
+open when maintenance storage is corrupt (the failure is recorded durably in the health
+artifact's maintenance ring instead of surfacing at init). A third test drives a terminal
+session event through the real plugin event hook and proves the session-close maintenance
+point fires. The deferred task is now named (`backgroundMaintenancePostInitTask`) so the
+wiring stays addressable by tests, matching the existing deferred-task pattern.

--- a/src/commands/registry-type.test.ts
+++ b/src/commands/registry-type.test.ts
@@ -188,7 +188,9 @@ describe('CommandEntry type', () => {
 		it('resolveCommand should find known commands', () => {
 			const result = resolveCommand(['status']);
 			expect(result).not.toBeNull();
-			expect(result!.entry.description).toBe('Show current swarm state');
+			expect(result!.entry.description).toBe(
+				'Show current swarm state (plus background-work health when hooks.background_subagents is enabled)',
+			);
 		});
 
 		it('resolveCommand should find compound commands', () => {

--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -383,7 +383,9 @@ describe('resolveCommand works with aliased commands', () => {
 	test('resolveCommand resolves primary command', () => {
 		const result = resolveCommand(['status']);
 		expect(result).not.toBeNull();
-		expect(result!.entry.description).toBe('Show current swarm state');
+		expect(result!.entry.description).toBe(
+			'Show current swarm state (plus background-work health when hooks.background_subagents is enabled)',
+		);
 	});
 
 	test('resolveCommand resolves compound command', () => {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -442,7 +442,8 @@ export const COMMAND_REGISTRY = {
 	status: {
 		handler: async (ctx) =>
 			handleStatusCommand(ctx.directory, ctx.agents, ctx.sessionID),
-		description: 'Show current swarm state',
+		description:
+			'Show current swarm state (plus background-work health when hooks.background_subagents is enabled)',
 		category: 'core',
 		clashesWithNativeCcCommand: '/status',
 		toolPolicy: 'agent',
@@ -858,7 +859,8 @@ export const COMMAND_REGISTRY = {
 	info: {
 		handler: async (ctx) =>
 			handleStatusCommand(ctx.directory, ctx.agents, ctx.sessionID),
-		description: 'Show current swarm state',
+		description:
+			'Show current swarm state (plus background-work health when hooks.background_subagents is enabled)',
 		category: 'core',
 		aliasOf: 'status',
 		deprecated: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -961,8 +961,12 @@ async function initializeOpenCodeSwarm(
 		(config.hooks as Record<string, unknown> | undefined)
 			?.background_subagents === true
 	) {
-		postResolutionTasks.push(() => {
-			void withTimeout(
+		postResolutionTasks.push(function backgroundMaintenancePostInitTask() {
+			// Returned (not `void`ed) so the task is awaitable like
+			// regenerateMemoryReflectionTask — tests and any future awaiter of
+			// the post-resolution queue can observe completion. The scheduler
+			// already treats tasks as void | Promise<void>.
+			return withTimeout(
 				import('./background/pending-delegations.js').then((m) =>
 					m.maintainBackgroundDelegations(ctx.directory, {
 						lockTimeoutMs: 5_000,
@@ -973,15 +977,17 @@ async function initializeOpenCodeSwarm(
 				new Error(
 					`background maintenance exceeded ${BACKGROUND_MAINTENANCE_INIT_TIMEOUT_MS}ms post-init budget; continuing without it (other maintenance points remain)`,
 				),
-			).catch((err: unknown) => {
-				const msg = err instanceof Error ? err.message : String(err);
-				log(
-					'post-init background maintenance timed out or failed (non-fatal)',
-					{
-						error: msg,
-					},
-				);
-			});
+			)
+				.catch((err: unknown) => {
+					const msg = err instanceof Error ? err.message : String(err);
+					log(
+						'post-init background maintenance timed out or failed (non-fatal)',
+						{
+							error: msg,
+						},
+					);
+				})
+				.then(() => undefined);
 		});
 	}
 

--- a/tests/unit/commands/registry.test.ts
+++ b/tests/unit/commands/registry.test.ts
@@ -54,13 +54,11 @@ describe('CommandRegistry types and structure', () => {
 			).toBeGreaterThan(0);
 		}
 	});
-
 	test('loop help resolves its plugin-owned protocol from the bundled skill root', () => {
 		const details = COMMAND_REGISTRY.loop.details ?? '';
 		expect(details).toContain('.swarm/bundled-skills/loop/SKILL.md');
 		expect(details).not.toContain('.opencode/skills/loop/SKILL.md');
 	});
-
 	test('entries with subcommandOf are subcommands', () => {
 		for (const [name, entry] of Object.entries(COMMAND_REGISTRY)) {
 			const cmdEntry = entry as CommandEntry;

--- a/tests/unit/commands/registry.test.ts
+++ b/tests/unit/commands/registry.test.ts
@@ -235,7 +235,9 @@ describe('resolveCommand()', () => {
 		test('resolves single-token command "status"', () => {
 			const result = resolveCommand(['status']);
 			expect(result).not.toBeNull();
-			expect(result!.entry.description).toBe('Show current swarm state');
+			expect(result!.entry.description).toBe(
+				'Show current swarm state (plus background-work health when hooks.background_subagents is enabled)',
+			);
 			expect(result!.remainingArgs).toEqual([]);
 		});
 

--- a/tests/unit/index-background-maintenance-init.test.ts
+++ b/tests/unit/index-background-maintenance-init.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import OpenCodeSwarm, {
-	overrideIndexInternalsForTest,
-} from '../../src/index';
-import { canonicalMkdtemp } from '../helpers/tmpdir';
+import OpenCodeSwarm, { overrideIndexInternalsForTest } from '../../src/index';
+import { resetSwarmState } from '../../src/state';
 import { createIsolatedTestEnv } from '../helpers/isolated-test-env';
+import { canonicalMkdtemp } from '../helpers/tmpdir';
 
 /**
  * Issue #2104 acceptance coverage for the plugin-init maintenance wiring:
@@ -49,13 +48,28 @@ function writeProjectConfig(directory: string, hooks: unknown): void {
 	);
 }
 
+/** Write a GLOBAL (XDG) config with no project config present. */
+function writeGlobalConfigOnly(configDir: string, hooks: unknown): void {
+	fs.mkdirSync(path.join(configDir, 'opencode'), { recursive: true });
+	fs.writeFileSync(
+		path.join(configDir, 'opencode', 'opencode-swarm.json'),
+		JSON.stringify({
+			quiet: true,
+			version_check: false,
+			hooks,
+		}),
+	);
+}
+
 function healthArtifactPath(directory: string): string {
 	return path.join(directory, '.swarm', HEALTH_ARTIFACT);
 }
 
-function readMaintenanceSection(
-	directory: string,
-): { lastRunAt: number; lastOkAt: number | null; lastFailure: { reason: string; at: number } | null } | null {
+function readMaintenanceSection(directory: string): {
+	lastRunAt: number;
+	lastOkAt: number | null;
+	lastFailure: { reason: string; at: number } | null;
+} | null {
 	const raw = fs.readFileSync(healthArtifactPath(directory), 'utf-8');
 	const parsed = JSON.parse(raw) as {
 		maintenance?: {
@@ -99,15 +113,20 @@ async function bootWithCapturedTasks(directory: string): Promise<{
 
 describe('issue #2104 background maintenance init wiring', () => {
 	let directory = '';
+	let configDir = '';
 	let cleanupIsolatedEnv: () => void = () => {};
 
 	beforeEach(() => {
-		cleanupIsolatedEnv = createIsolatedTestEnv().cleanup;
+		const isolated = createIsolatedTestEnv();
+		configDir = isolated.configDir;
+		cleanupIsolatedEnv = isolated.cleanup;
+		resetSwarmState();
 		directory = makeProject();
 		fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
 	});
 
 	afterEach(() => {
+		resetSwarmState();
 		fs.rmSync(directory, { recursive: true, force: true });
 		cleanupIsolatedEnv();
 		cleanupIsolatedEnv = () => {};
@@ -141,6 +160,8 @@ describe('issue #2104 background maintenance init wiring', () => {
 		expect(maintenance).not.toBeNull();
 		expect(maintenance!.lastRunAt).toBeGreaterThan(0);
 		expect(maintenance!.lastFailure).not.toBeNull();
+		// A failure observation must not record a success stamp.
+		expect(maintenance!.lastOkAt).toBeNull();
 	});
 
 	test('P5 is not scheduled when hooks.background_subagents is disabled', async () => {
@@ -163,11 +184,22 @@ describe('issue #2104 background maintenance init wiring', () => {
 		).toBeUndefined();
 	});
 
+	test('P5 is scheduled when only the XDG global config enables it', async () => {
+		// No project config: the loader deep-merges the XDG global config, so a
+		// global hooks.background_subagents:true must enable the deferred pass.
+		writeGlobalConfigOnly(configDir, { background_subagents: true });
+		const { scheduledTasks } = await bootWithCapturedTasks(directory);
+		expect(
+			scheduledTasks.find(
+				(task) => task.name === 'backgroundMaintenancePostInitTask',
+			),
+		).toBeDefined();
+	});
+
 	test('P3 fires maintenance from the event hook on session.deleted', async () => {
 		writeProjectConfig(directory, { background_subagents: true });
-		const { serverResult, scheduledTasks } = await bootWithCapturedTasks(
-			directory,
-		);
+		const { serverResult, scheduledTasks } =
+			await bootWithCapturedTasks(directory);
 
 		// The scheduler is captured, so only the session-close maintenance
 		// point can write the artifact from here.
@@ -189,5 +221,7 @@ describe('issue #2104 background maintenance init wiring', () => {
 		const maintenance = readMaintenanceSection(directory);
 		expect(maintenance).not.toBeNull();
 		expect(maintenance!.lastRunAt).toBeGreaterThan(0);
+		// Empty stores ⇒ the P3 pass completes ok and stamps lastOkAt.
+		expect(maintenance!.lastOkAt).not.toBeNull();
 	});
 });

--- a/tests/unit/index-background-maintenance-init.test.ts
+++ b/tests/unit/index-background-maintenance-init.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import OpenCodeSwarm, {
+	overrideIndexInternalsForTest,
+} from '../../src/index';
+import { canonicalMkdtemp } from '../helpers/tmpdir';
+import { createIsolatedTestEnv } from '../helpers/isolated-test-env';
+
+/**
+ * Issue #2104 acceptance coverage for the plugin-init maintenance wiring:
+ *
+ * - the deferred post-init maintenance pass (P5) is registered ONLY when
+ *   `hooks.background_subagents` is enabled, and runs strictly after
+ *   server() resolution on the wrapper-owned post-resolution queue;
+ * - it fails open when maintenance storage is corrupt — the failure is
+ *   recorded durably in the health artifact's maintenance ring instead of
+ *   surfacing at init;
+ * - the session-close maintenance point (P3) fires from the real plugin
+ *   event hook on a terminal session event.
+ *
+ * Every test captures `schedulePostResolutionTasks` so the unref'd timer
+ * never runs: a scheduled task executes only when the test invokes it, which
+ * is what makes the before/after artifact assertions deterministic and keeps
+ * P5 writes distinguishable from P3 writes.
+ */
+
+interface CapturedTask {
+	name?: string;
+	run: () => void | Promise<void>;
+}
+
+const HEALTH_ARTIFACT = 'background-delegations-health.json';
+const RESERVATION_STORE = 'background-coder-reservations.json';
+
+function makeProject(): string {
+	return canonicalMkdtemp('index-bg-maintenance-');
+}
+
+function writeProjectConfig(directory: string, hooks: unknown): void {
+	fs.mkdirSync(path.join(directory, '.opencode'), { recursive: true });
+	fs.writeFileSync(
+		path.join(directory, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify({
+			quiet: true,
+			version_check: false,
+			hooks,
+		}),
+	);
+}
+
+function healthArtifactPath(directory: string): string {
+	return path.join(directory, '.swarm', HEALTH_ARTIFACT);
+}
+
+function readMaintenanceSection(
+	directory: string,
+): { lastRunAt: number; lastOkAt: number | null; lastFailure: { reason: string; at: number } | null } | null {
+	const raw = fs.readFileSync(healthArtifactPath(directory), 'utf-8');
+	const parsed = JSON.parse(raw) as {
+		maintenance?: {
+			lastRunAt: number;
+			lastOkAt: number | null;
+			lastFailure: { reason: string; at: number } | null;
+		};
+	};
+	return parsed.maintenance ?? null;
+}
+
+async function bootWithCapturedTasks(directory: string): Promise<{
+	serverResult: Awaited<ReturnType<typeof OpenCodeSwarm.server>>;
+	scheduledTasks: CapturedTask[];
+}> {
+	const scheduledTasks: CapturedTask[] = [];
+	const restore = overrideIndexInternalsForTest({
+		schedulePostResolutionTasks: (tasks) => {
+			for (const task of tasks) {
+				scheduledTasks.push({
+					name: (task as { name?: string }).name,
+					run: task,
+				});
+			}
+		},
+	});
+	try {
+		const serverResult = await OpenCodeSwarm.server({
+			client: {} as never,
+			project: {} as never,
+			directory,
+			worktree: directory,
+			serverUrl: new URL('http://localhost:3000'),
+			$: {} as never,
+		});
+		return { serverResult, scheduledTasks };
+	} finally {
+		restore();
+	}
+}
+
+describe('issue #2104 background maintenance init wiring', () => {
+	let directory = '';
+	let cleanupIsolatedEnv: () => void = () => {};
+
+	beforeEach(() => {
+		cleanupIsolatedEnv = createIsolatedTestEnv().cleanup;
+		directory = makeProject();
+		fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(directory, { recursive: true, force: true });
+		cleanupIsolatedEnv();
+		cleanupIsolatedEnv = () => {};
+	});
+
+	test('P5 is deferred, opt-in, and fails open on a corrupt reservation store', async () => {
+		writeProjectConfig(directory, { background_subagents: true });
+		fs.writeFileSync(
+			path.join(directory, '.swarm', RESERVATION_STORE),
+			'{ not valid json',
+		);
+
+		const { scheduledTasks } = await bootWithCapturedTasks(directory);
+
+		// Deferred: the queue received work, but nothing has run yet — plugin
+		// registration already resolved and no maintenance artifact exists.
+		expect(scheduledTasks.length).toBeGreaterThan(0);
+		expect(fs.existsSync(healthArtifactPath(directory))).toBe(false);
+
+		const maintenanceTask = scheduledTasks.find(
+			(task) => task.name === 'backgroundMaintenancePostInitTask',
+		);
+		expect(maintenanceTask).toBeDefined();
+
+		// Fail-open: a corrupt store must not throw out of the deferred task.
+		await maintenanceTask!.run();
+
+		// The failure is durably recorded instead of surfacing at init.
+		expect(fs.existsSync(healthArtifactPath(directory))).toBe(true);
+		const maintenance = readMaintenanceSection(directory);
+		expect(maintenance).not.toBeNull();
+		expect(maintenance!.lastRunAt).toBeGreaterThan(0);
+		expect(maintenance!.lastFailure).not.toBeNull();
+	});
+
+	test('P5 is not scheduled when hooks.background_subagents is disabled', async () => {
+		writeProjectConfig(directory, { background_subagents: false });
+		const { scheduledTasks } = await bootWithCapturedTasks(directory);
+		expect(
+			scheduledTasks.find(
+				(task) => task.name === 'backgroundMaintenancePostInitTask',
+			),
+		).toBeUndefined();
+	});
+
+	test('P5 is not scheduled when hooks.background_subagents is omitted', async () => {
+		writeProjectConfig(directory, {});
+		const { scheduledTasks } = await bootWithCapturedTasks(directory);
+		expect(
+			scheduledTasks.find(
+				(task) => task.name === 'backgroundMaintenancePostInitTask',
+			),
+		).toBeUndefined();
+	});
+
+	test('P3 fires maintenance from the event hook on session.deleted', async () => {
+		writeProjectConfig(directory, { background_subagents: true });
+		const { serverResult, scheduledTasks } = await bootWithCapturedTasks(
+			directory,
+		);
+
+		// The scheduler is captured, so only the session-close maintenance
+		// point can write the artifact from here.
+		expect(fs.existsSync(healthArtifactPath(directory))).toBe(false);
+		expect(
+			scheduledTasks.find(
+				(task) => task.name === 'backgroundMaintenancePostInitTask',
+			),
+		).toBeDefined();
+
+		await serverResult.event?.({
+			event: {
+				type: 'session.deleted',
+				properties: { sessionID: 'closing-parent' },
+			},
+		});
+
+		expect(fs.existsSync(healthArtifactPath(directory))).toBe(true);
+		const maintenance = readMaintenanceSection(directory);
+		expect(maintenance).not.toBeNull();
+		expect(maintenance!.lastRunAt).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
# Follow-through for #2104: /swarm status help surface + init-bound maintenance acceptance tests

Reference-only for #2104 (closed as completed 2026-08-26; the main implementation shipped in #2357). This PR is documentation- and test-only follow-through from an end-to-end audit of #2357 — no runtime behavior change.

## Summary

An end-to-end audit of the merged #2104 implementation found it complete except two residual gaps, which this PR closes:

1. **`/swarm status` help now mentions the opt-in background-work section** (the issue's "Update /swarm status help if its output contract changes" line). The `status` command and its deprecated `info` alias descriptions now read "Show current swarm state (plus background-work health when hooks.background_subagents is enabled)", and `docs/commands.md` documents exactly what the section renders (status counts, reservation generation/lease state, maintenance summary, `Source: validated recovery (bounded scan)` provenance, typed `⚠ State uncertain: …` under corrupt/over-bound stores, and nothing when disabled) — wording mirrors the renderer.
2. **The missing init-bound acceptance test row** ("Plugin initialization still returns under the existing startup bound when maintenance storage is slow, corrupt, locked, or unavailable") is now pinned by `tests/unit/index-background-maintenance-init.test.ts`: the deferred post-init maintenance pass is opt-in (project config, XDG-global config, disabled, and omitted-key variants), lives on the wrapper-owned post-resolution queue (never the `server()`-resolution path), and fails open against a corrupt reservation store with the failure recorded durably in the health artifact's maintenance ring (`lastFailure` set, `lastOkAt` null). A further test proves the session-close maintenance point fires from the real plugin event hook on `session.deleted` (ok observation, `lastOkAt` stamped).

Supporting change: the deferred task is now named (`backgroundMaintenancePostInitTask`) and returns its bounded promise chain — the exact shape of the existing `regenerateMemoryReflectionTask` precedent — so the post-resolution queue is awaitable. The scheduler already treats tasks as `void | Promise<void>`; runtime behavior is unchanged.

Audit note: a per-record typed staleness reason was deliberately NOT added — `BackgroundDelegationRecordSchema` is `.strict()`, so any new record field fails closed on older readers under rollback, violating the issue's own "Rollback must leave unknown new fields harmless" requirement. The migration-safe reading (typed `status: 'stale'` + the maintenance facts ring) is what #2357 shipped.

## Review history

- Initial head `0f4aeb40` failed CI (`quality`: biome ci import-order/format violations in the new test file → `unit` skipped → BLOCKED) despite locally-green `bun run lint` (that script omits biome's assist/format checks — `lint:ci`/`biome ci .` is the CI-equivalent gate). A full swarm-pr-review run (6 base lanes + 11 risk-family micro lanes + 2 reviewer shards + 2 critic passes) confirmed that HIGH finding plus LOW advisories; head `0dc26b7a` fixes all of them: biome compliance, the renderer-exact "completed (unconsumed)" label (docs + release fragment), `lastOkAt` assertions, `resetSwarmState` isolation, and the XDG-global-config enablement test. Seven other candidates were disproved with evidence (see `.zcode/pr-review/prr-2372-20260826/review-report.md` in the working session).

## Invariant audit

- 1 (plugin init): touched — named/awaitable P5 deferred task; tests prove the pass is opt-in (project + XDG-global + disabled + omitted), deferred off the `server()`-resolution path (artifact asserted absent before the captured task runs), and fail-open on corrupt storage.
- 2 (runtime portability): touched — src/index.ts edited (no import/export shape change); `node --input-type=module -e "await import('./dist/index.js')"` verified on the initial head; CI re-validates via the unit/package-check jobs.
- 3 (subprocesses): not touched — no spawn changes.
- 4 (.swarm containment): not touched — tests use `canonicalMkdtemp` temp dirs; no new runtime paths.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — targeted per-file `bun test` invocations only.
- 7 (test writing): touched — bun:test file (227 lines < 500), DI via `overrideIndexInternalsForTest` (no `mock.module`), `canonicalMkdtemp` + `createIsolatedTestEnv` + `resetSwarmState` isolation; registry pin tests updated to the new description string.
- 8 (session state): not touched in production; tests now reset module state around boots.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched (command description only) — registry/help/architect-prompt suites pass; `bun run drift:check` clean.
- 12 (release/cache): touched — pending fragment `docs/releases/pending/2104-status-help-and-init-tests.md` (unique slug, no version edits; release-please owns versions).

## Test plan

Latest head `0dc26b7a` (all run locally on Windows/Git Bash; CI re-runs the same gates):

- `bunx biome ci .` → exit 0 (the exact CI quality-gate command; the initial head's local `bun run lint` pass was insufficient — see Review history)
- `bun test tests/unit/index-background-maintenance-init.test.ts` → 5 pass, 0 fail
- `bun run typecheck` → exit 0
- Registry/help/architect suites (10 files) → 250 pass at the initial head; pin/help files re-run at this head (195 pass across 6 files)
- #2104 regression suites (queue/worker/pending-delegations*/lease/maintenance/completion-observer*/background-coder-reservations*/delegation-health/status-service*/delegation-gate-background*) → 243 pass at the initial head (no production-code change since except the two description strings and the named task)

## Review evidence

Implementation review (Kimi K2.7, fresh context): APPROVE on the initial diff, no blockers. Final closure critic (Kimi K3, fresh context): APPROVE. Post-fix: independent reviewer (Kimi K2.7) verified all five feedback fixes in source; final critic (Kimi K3) verified all coverage checks — their execution-only caveats are satisfied by the recorded live runs above (biome ci exit 0, 5/5 tests, tsc exit 0).
