### PR TITLE
feat(repo-graph): add trustworthy symbol edge metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,11 +92,13 @@ actions include:
   limitations.
 - `context_pack` returns a token-budgeted, symbol-level source slice (definition
   + transitive callers/callees) built on tree-sitter extraction across all **12**
-  first-class languages (schema 1.2.0). See `docs/repo-graph-symbol-graph.md` for
-  design and limitations.
+  first-class languages. Schema 1.5.0 adds stable IDs, relationship kind,
+  confidence, resolution provenance, and hashed source evidence while retaining
+  schema 1.2.0 edge compatibility. See `docs/repo-graph-symbol-graph.md`.
 - `graph_health` returns graph freshness plus bounded extraction diagnostics,
   including stale files, symbol-extraction failures, unresolved relative imports,
-  oversized files, unsupported files, binary skips, and unreadable skips.
+  oversized files, unsupported files, binary skips, unreadable skips, and
+  advisory low-confidence/unresolved SymbolEdge v2 counts.
 
 The ontology extractor is intentionally conservative. It records detected facts
 and "detected missing guard" findings; it does not claim formal security proofs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ actions include:
   at graph schema 1.1.0; see `docs/repo-graph-call-graph.md` for scope and
   limitations.
 - `context_pack` returns a token-budgeted, symbol-level source slice (definition
-  + transitive callers/callees) built on tree-sitter extraction across all **12**
+  + transitive callers/callees) built on tree-sitter extraction across all **13**
   first-class languages. Schema 1.5.0 adds stable IDs, relationship kind,
   confidence, resolution provenance, and hashed source evidence while retaining
   schema 1.2.0 edge compatibility. See `docs/repo-graph-symbol-graph.md`.

--- a/docs/releases/pending/1532-symbol-edge-v2.md
+++ b/docs/releases/pending/1532-symbol-edge-v2.md
@@ -1,0 +1,16 @@
+# Trustworthy SymbolEdge v2 graph facts
+
+Repo-graph symbol edges now carry deterministic endpoint and edge IDs,
+relationship kind, advisory confidence, resolution provenance, and bounded
+hashed source evidence. `graph_health` reports low-confidence and unresolved v2
+facts without blocking traversal.
+
+Existing schema 1.2.0 four-field edges remain readable and usable by
+`context_pack`. They are normalized conservatively and reported as unscored
+until the graph is rebuilt; malformed or semantically inconsistent v2 records
+are rejected on both load and save.
+
+No migration step is required. Rebuild with `repo_map action="build"` to populate
+v2 metadata for an existing repository graph. This change is additive and has no
+breaking configuration changes or known caveats beyond the documented
+best-effort limits of static symbol extraction.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -1,6 +1,7 @@
-# repo-graph: symbol-level call graph & context packing (schema 1.2.0)
+# repo-graph: symbol-level graph facts & context packing (schemas 1.2.0–1.5.0)
 
-> Status: implemented (schema 1.2.0). Origin: follow-up to issue #1409 / PR #1468 (schema 1.1.0).
+> Status: implemented. Schema 1.2.0 introduced traversal coordinates; schema
+> 1.5.0 adds stable identity, confidence, resolution, and evidence.
 > Audience: contributors implementing the next slice of structural intelligence in opencode-swarm.
 
 For the broader graph-backed repository memory contract, support matrix,
@@ -167,6 +168,13 @@ export interface SymbolEdge {
   fromSymbol: string;  // enclosing top-level decl, or '<module>' for module-scope refs
   toFile: string;      // resolved target path
   toSymbol: string;    // exported symbol referenced
+  id?: string;         // stable SHA-256 edge identity (1.5.0)
+  fromId?: string;     // stable source symbol identity
+  toId?: string;       // stable target symbol identity
+  kind?: 'CALLS' | 'REFERENCES' | 'USES_TYPE' | 'INSTANTIATES' | 'IMPLEMENTS' | 'OVERRIDES';
+  confidence?: number; // advisory 0..1
+  resolution?: 'exact' | 'import_binding' | 'same_file_scope' | 'unique_name' | 'type_resolved' | 'lsp' | 'scip' | 'heuristic' | 'unresolved';
+  evidence?: Array<{ file: string; line: number; column?: number; snippetHash: string; extractor: string }>;
 }
 
 // Result types for the new query
@@ -181,7 +189,38 @@ export interface ContextPackResult {
 }
 ```
 
-`GRAPH_SCHEMA_VERSION` (now `'1.4.0'` at `types.ts:52`; this design originally bumped it to `'1.2.0'`). Every new query
+### Schema 1.5.0 confidence, identity, and provenance
+
+New async builds retain the four legacy coordinates and add a complete v2 fact.
+Symbol IDs hash a canonical repository label, workspace-relative path, qualified
+name, and the graph identity role (`symbol` or `module`). Paths use forward
+slashes and NFC Unicode while preserving case, so Linux case-distinct files do
+not collide. The repository label comes from the canonical workspace basename;
+renaming that directory intentionally changes the repository identity.
+
+Current tree-sitter extraction proves a reference through an import binding but
+does not prove call or type semantics. It therefore emits `kind: REFERENCES`,
+`resolution: import_binding`, and confidence `0.9` when a real source line is
+available. If an extractor supplies no honest line, the edge remains traversable
+with confidence `0`, resolution `unresolved`, and empty evidence. It never
+invents a location. Evidence contains only a relative path, position, extractor,
+and SHA-256 logical-line hash—never source text.
+
+Confidence below `0.5` is reported as low confidence by `graph_health`; it does
+not block traversal or agent behavior. `unresolvedSymbolEdgeCount` reports only
+complete v2 facts whose resolution is `unresolved`. Legacy four-field edges are
+still normalized and traversed, but are unscored; health emits a rebuild note
+instead of falsely counting every old edge as low-confidence or unresolved.
+
+On load and save, complete v2 IDs are recomputed from canonical coordinates and
+must match the persisted values. Partial v2 records, unknown enums, confidence
+outside 0..1, unsafe evidence, and semantic ID mismatches are corruption. A
+schema 1.2.0 graph remains readable; normalization is in-memory until an
+existing caller explicitly saves it, and neither its schema version nor legacy
+coordinates are rewritten.
+
+Schema 1.2.0 originally introduced these coordinates; the current
+`GRAPH_SCHEMA_VERSION` is `1.5.0`. Context queries still
 self-gates with `isSchemaVersionAtLeast(graph.schema_version, '1.2.0')` and returns
 `{ schemaSupported: false, note: 'rebuild with repo_map action="build"' }` on older
 graphs (the `getDeadExports` pattern, `query.ts:257`).
@@ -530,7 +569,7 @@ Recorded rather than fixed, with the measurement behind each:
 ## Usage
 
 ```text
-repo_map { "action": "build" }                                  # populates 1.2.0 symbol data (async build)
+repo_map { "action": "build" }                                  # populates 1.5.0 symbol facts (async build)
 repo_map { "action": "graph_health" }                           # freshness + extraction diagnostics
 repo_map { "action": "callers", "file": "src/foo.ts", "symbol": "doThing" }
 repo_map { "action": "context_pack", "file": "src/foo.ts", "symbol": "doThing", "max_depth": 2, "top_n": 40 }

--- a/docs/repo-memory-graph-plan.md
+++ b/docs/repo-memory-graph-plan.md
@@ -9,7 +9,7 @@
 
 Repository memory is the graph-backed context-reduction layer that lets agents
 ask targeted structural questions before opening broad file sets. It builds on
-the native `repo_map` tool, `.swarm/repo-graph.json`, graph schema `1.2.0`,
+the native `repo_map` tool, `.swarm/repo-graph.json`, graph schema `1.5.0`,
 `exportRanges`, `symbolEdges`, and `context_pack`, then adds a durable contract
 for provenance, freshness, confidence, truncation, warnings, and graph-first
 retrieval.
@@ -36,13 +36,16 @@ including `importers`, `dependencies`, `blast_radius`, `localization`,
 `key_files`, `ontology`, `package_boundaries`, `preflight_packet`, `callers`,
 `dead_exports`, `context_pack`, and `graph_health`.
 
-Current schema `1.2.0` is additive:
+Current schema `1.5.0` is additive:
 
 | Schema | Added fields | Compatibility rule |
 | --- | --- | --- |
 | `1.0.0` | file nodes, file edges, graph metadata | Must continue to load when structurally valid. |
 | `1.1.0` | `GraphEdge.usedSymbols`, `GraphNode.exportLines` | Optional fields; symbol-usage queries self-gate when absent. |
 | `1.2.0` | `GraphNode.exportRanges`, `RepoGraph.symbolEdges` | Optional fields; `context_pack` returns `schemaSupported: false` and a rebuild note on older graphs. |
+| `1.3.0` | `GraphEdge.targetKind` | Optional node/asset target classification; older graphs use a safe extension fallback. |
+| `1.4.0` | `GraphNode.sizeBytes`, `GraphNode.mtimeMs` | Optional freshness witnesses; older graphs require rebuild before certification. |
+| `1.5.0` | `RepoGraph.repoRootId`, SymbolEdge stable IDs, kind, confidence, resolution, evidence | Additive fields; legacy four-field edges normalize in memory and remain traversable but unscored. |
 | additive diagnostics | `RepoGraph.diagnostics` | Optional on every schema version; `graph_health` reports empty diagnostics with a rebuild note for old graphs. |
 
 The loader validates that a graph is structurally safe enough to read. Query

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -114,6 +114,10 @@ export type {
 	RouteMethod,
 	SecurityFact,
 	SymbolEdge,
+	SymbolEdgeEvidence,
+	SymbolEdgeKind,
+	SymbolEdgeResolution,
+	SymbolIdentityKind,
 	SymbolReference,
 } from './repo-graph/types';
 export {

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -843,6 +843,21 @@ interface ScanStats {
 	_absoluteRoot?: string;
 }
 
+function symbolEdgeValidationFailure(
+	file: string,
+	language: string,
+): RepoGraphDiagnostics {
+	return {
+		extractionFailures: [
+			{
+				file,
+				language,
+				reason: 'symbol_edge_validation_failed',
+			},
+		],
+	};
+}
+
 /**
  * Fully-populated diagnostics shape used during a build. `Required<>` would
  * make `walkTruncationReason` (a `'budget' | 'cap'` union with no `undefined`)
@@ -2492,15 +2507,17 @@ export async function scanFileAsync(
 	filePath: string,
 	absoluteRoot: string,
 	maxFileSize: number,
-	hasManifest?: (relDir: string) => boolean,
+	hasManifest: ((relDir: string) => boolean) | undefined,
+	repoRootId: string,
 ): Promise<AsyncScanResult> {
+	const moduleName = toModuleName(filePath, absoluteRoot);
+	const grammarId = getLanguage(filePath);
 	let content: string;
 	let fileStats: fsSync.Stats;
 
 	try {
 		fileStats = await fsPromises.stat(filePath);
 		if (fileStats.size > maxFileSize) {
-			const moduleName = toModuleName(filePath, absoluteRoot);
 			return {
 				node: null,
 				edges: [],
@@ -2526,7 +2543,6 @@ export async function scanFileAsync(
 
 	// Skip binary files
 	if (isBinaryContent(content)) {
-		const moduleName = toModuleName(filePath, absoluteRoot);
 		return {
 			node: null,
 			edges: [],
@@ -2541,7 +2557,6 @@ export async function scanFileAsync(
 		};
 	}
 
-	const grammarId = getLanguage(filePath);
 	const facts = await _internals.extractFileSymbols(grammarId, content);
 
 	// Fail-open: tree-sitter unavailable or timed out → minimal node
@@ -2737,7 +2752,6 @@ export async function scanFileAsync(
 	// Derive imports list from tree-sitter facts
 	const imports = facts.imports.map((i) => i.specifier);
 
-	const moduleName = toModuleName(filePath, absoluteRoot);
 	const language = grammarId;
 
 	const node: GraphNode = {
@@ -2824,8 +2838,8 @@ export async function scanFileAsync(
 	// binding, resolve that binding's specifier to a target file and emit
 	// a symbol→symbol edge.
 	const symbolEdges: SymbolEdge[] = [];
-	const repoRootId = deriveRepoRootId(absoluteRoot);
 	const sourceLines = content.split(/\r?\n/);
+	let symbolEdgeValidationFailed = false;
 	const evidenceForLine = (line: number | undefined) => {
 		if (!Number.isInteger(line) || (line ?? 0) < 1) return [];
 		const snippet = sourceLines[(line as number) - 1];
@@ -2878,23 +2892,27 @@ export async function scanFileAsync(
 		seenSymbolEdgeKeys.add(key);
 
 		const evidence = evidenceForLine(ref.line);
-		symbolEdges.push(
-			createSymbolEdgeV2(
-				{
-					fromFile: filePath,
-					fromSymbol,
-					toFile: resolvedTarget,
-					toSymbol: mapping.imported,
-				},
-				absoluteRoot,
-				repoRootId,
-				{
-					confidence: evidence.length > 0 ? 0.9 : 0,
-					resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
-					evidence,
-				},
-			),
-		);
+		try {
+			symbolEdges.push(
+				createSymbolEdgeV2(
+					{
+						fromFile: filePath,
+						fromSymbol,
+						toFile: resolvedTarget,
+						toSymbol: mapping.imported,
+					},
+					absoluteRoot,
+					repoRootId,
+					{
+						confidence: evidence.length > 0 ? 0.9 : 0,
+						resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
+						evidence,
+					},
+				),
+			);
+		} catch {
+			symbolEdgeValidationFailed = true;
+		}
 	}
 	for (const imp of facts.imports) {
 		const packageInitBindings =
@@ -2931,32 +2949,44 @@ export async function scanFileAsync(
 			seenSymbolEdgeKeys.add(key);
 
 			const evidence = evidenceForLine(imp.startLine);
-			symbolEdges.push(
-				createSymbolEdgeV2(
-					{
-						fromFile: filePath,
-						fromSymbol: binding.exported,
-						toFile: resolvedTarget,
-						toSymbol: binding.imported,
-					},
-					absoluteRoot,
-					repoRootId,
-					{
-						confidence: evidence.length > 0 ? 0.9 : 0,
-						resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
-						evidence,
-					},
-				),
-			);
+			try {
+				symbolEdges.push(
+					createSymbolEdgeV2(
+						{
+							fromFile: filePath,
+							fromSymbol: binding.exported,
+							toFile: resolvedTarget,
+							toSymbol: binding.imported,
+						},
+						absoluteRoot,
+						repoRootId,
+						{
+							confidence: evidence.length > 0 ? 0.9 : 0,
+							resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
+							evidence,
+						},
+					),
+				);
+			} catch {
+				symbolEdgeValidationFailed = true;
+			}
 		}
 	}
+	const diagnostics: RepoGraphDiagnostics | undefined =
+		unresolvedImports.length > 0 || symbolEdgeValidationFailed
+			? {
+					...(unresolvedImports.length > 0 ? { unresolvedImports } : {}),
+					...(symbolEdgeValidationFailed
+						? symbolEdgeValidationFailure(moduleName, language)
+						: {}),
+				}
+			: undefined;
 
 	return {
 		node,
 		edges,
 		symbolEdges,
-		diagnostics:
-			unresolvedImports.length > 0 ? { unresolvedImports } : undefined,
+		diagnostics,
 	};
 }
 
@@ -3392,8 +3422,9 @@ export async function buildWorkspaceGraphAsync(
 		);
 	}
 
+	const repoRootId = deriveRepoRootId(absoluteRoot);
 	const graph = createEmptyGraph(workspaceRoot);
-	graph.repoRootId = deriveRepoRootId(absoluteRoot);
+	graph.repoRootId = repoRootId;
 	const stats: ScanStats = {
 		filesScanned: 0,
 		skippedDirs: 0,
@@ -3448,12 +3479,30 @@ export async function buildWorkspaceGraphAsync(
 	const symbolEdgesById = new Map<string, SymbolEdge>();
 	let processedSinceYield = 0;
 	for (const filePath of sourceFiles) {
-		const result = await scanFileAsync(
-			filePath,
-			absoluteRoot,
-			maxFileSize,
-			hasManifest,
-		);
+		let result: AsyncScanResult;
+		try {
+			result = await scanFileAsync(
+				filePath,
+				absoluteRoot,
+				maxFileSize,
+				hasManifest,
+				repoRootId,
+			);
+		} catch {
+			mergeDiagnostics(
+				diagnostics,
+				symbolEdgeValidationFailure(
+					toModuleName(filePath, absoluteRoot),
+					getLanguage(filePath),
+				),
+			);
+			stats.skippedFiles++;
+			processedSinceYield++;
+			if (processedSinceYield % ASYNC_SCAN_YIELD_INTERVAL === 0) {
+				await yieldToEventLoop();
+			}
+			continue;
+		}
 		mergeDiagnostics(diagnostics, result.diagnostics);
 		if (result.inputWitness) {
 			pushInputWitness(
@@ -3491,19 +3540,36 @@ export async function buildWorkspaceGraphAsync(
 				}
 				// Aggregate symbolEdges across all files (dedup)
 				for (const symbolEdge of result.symbolEdges) {
-					const key = symbolEdge.id as string;
+					const key = symbolEdge.id as string | undefined;
+					if (!key) {
+						mergeDiagnostics(
+							diagnostics,
+							symbolEdgeValidationFailure(
+								result.node.moduleName,
+								result.node.language,
+							),
+						);
+						continue;
+					}
 					const existing = symbolEdgesById.get(key);
-					symbolEdgesById.set(
-						key,
-						existing
-							? mergeSymbolEdges(
-									existing,
-									symbolEdge,
-									absoluteRoot,
-									deriveRepoRootId(absoluteRoot),
-								)
-							: symbolEdge,
-					);
+					if (!existing) {
+						symbolEdgesById.set(key, symbolEdge);
+						continue;
+					}
+					try {
+						symbolEdgesById.set(
+							key,
+							mergeSymbolEdges(existing, symbolEdge, absoluteRoot, repoRootId),
+						);
+					} catch {
+						mergeDiagnostics(
+							diagnostics,
+							symbolEdgeValidationFailure(
+								result.node.moduleName,
+								result.node.language,
+							),
+						);
+					}
 				}
 				stats.filesScanned++;
 			}

--- a/src/tools/repo-graph/builder.ts
+++ b/src/tools/repo-graph/builder.ts
@@ -32,6 +32,12 @@ import {
 } from '../symbols';
 import { extractFileOntology, maskMultilineStringLiterals } from './ontology';
 import { safeRealpathSync } from './safe-realpath';
+import {
+	createSymbolEdgeV2,
+	deriveRepoRootId,
+	hashSymbolEdgeSnippet,
+	mergeSymbolEdges,
+} from './symbol-edge';
 import type {
 	BuildWorkspaceGraphOptions,
 	GraphEdge,
@@ -2818,6 +2824,21 @@ export async function scanFileAsync(
 	// binding, resolve that binding's specifier to a target file and emit
 	// a symbol→symbol edge.
 	const symbolEdges: SymbolEdge[] = [];
+	const repoRootId = deriveRepoRootId(absoluteRoot);
+	const sourceLines = content.split(/\r?\n/);
+	const evidenceForLine = (line: number | undefined) => {
+		if (!Number.isInteger(line) || (line ?? 0) < 1) return [];
+		const snippet = sourceLines[(line as number) - 1];
+		if (snippet === undefined) return [];
+		return [
+			{
+				file: moduleName,
+				line: line as number,
+				snippetHash: hashSymbolEdgeSnippet(snippet),
+				extractor: `tree-sitter/${grammarId}`,
+			},
+		];
+	};
 	const localToImported = new Map<
 		string,
 		{ specifier: string; imported: string }
@@ -2856,12 +2877,24 @@ export async function scanFileAsync(
 		if (seenSymbolEdgeKeys.has(key)) continue;
 		seenSymbolEdgeKeys.add(key);
 
-		symbolEdges.push({
-			fromFile: filePath,
-			fromSymbol,
-			toFile: resolvedTarget,
-			toSymbol: mapping.imported,
-		});
+		const evidence = evidenceForLine(ref.line);
+		symbolEdges.push(
+			createSymbolEdgeV2(
+				{
+					fromFile: filePath,
+					fromSymbol,
+					toFile: resolvedTarget,
+					toSymbol: mapping.imported,
+				},
+				absoluteRoot,
+				repoRootId,
+				{
+					confidence: evidence.length > 0 ? 0.9 : 0,
+					resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
+					evidence,
+				},
+			),
+		);
 	}
 	for (const imp of facts.imports) {
 		const packageInitBindings =
@@ -2897,12 +2930,24 @@ export async function scanFileAsync(
 			if (seenSymbolEdgeKeys.has(key)) continue;
 			seenSymbolEdgeKeys.add(key);
 
-			symbolEdges.push({
-				fromFile: filePath,
-				fromSymbol: binding.exported,
-				toFile: resolvedTarget,
-				toSymbol: binding.imported,
-			});
+			const evidence = evidenceForLine(imp.startLine);
+			symbolEdges.push(
+				createSymbolEdgeV2(
+					{
+						fromFile: filePath,
+						fromSymbol: binding.exported,
+						toFile: resolvedTarget,
+						toSymbol: binding.imported,
+					},
+					absoluteRoot,
+					repoRootId,
+					{
+						confidence: evidence.length > 0 ? 0.9 : 0,
+						resolution: evidence.length > 0 ? 'import_binding' : 'unresolved',
+						evidence,
+					},
+				),
+			);
 		}
 	}
 
@@ -3057,6 +3102,7 @@ export function buildWorkspaceGraph(
 
 	// Create graph with original workspaceRoot form (not absolute path)
 	const graph = createEmptyGraph(workspaceRoot);
+	graph.repoRootId = deriveRepoRootId(absoluteRoot);
 	const stats: ScanStats = {
 		filesScanned: 0,
 		skippedDirs: 0,
@@ -3347,6 +3393,7 @@ export async function buildWorkspaceGraphAsync(
 	}
 
 	const graph = createEmptyGraph(workspaceRoot);
+	graph.repoRootId = deriveRepoRootId(absoluteRoot);
 	const stats: ScanStats = {
 		filesScanned: 0,
 		skippedDirs: 0,
@@ -3398,8 +3445,7 @@ export async function buildWorkspaceGraphAsync(
 	// scan interval bounds event-loop monopolization even when symbol extraction
 	// or its fail-open fallback resolves synchronously (issues #704 and #1144).
 	const seenEdges = new Set<string>();
-	const seenSymbolEdges = new Set<string>();
-	const allSymbolEdges: SymbolEdge[] = [];
+	const symbolEdgesById = new Map<string, SymbolEdge>();
 	let processedSinceYield = 0;
 	for (const filePath of sourceFiles) {
 		const result = await scanFileAsync(
@@ -3445,18 +3491,19 @@ export async function buildWorkspaceGraphAsync(
 				}
 				// Aggregate symbolEdges across all files (dedup)
 				for (const symbolEdge of result.symbolEdges) {
-					const key =
-						symbolEdge.fromFile +
-						'\u0000' +
-						symbolEdge.fromSymbol +
-						'\u0000' +
-						symbolEdge.toFile +
-						'\u0000' +
-						symbolEdge.toSymbol;
-					if (!seenSymbolEdges.has(key)) {
-						seenSymbolEdges.add(key);
-						allSymbolEdges.push(symbolEdge);
-					}
+					const key = symbolEdge.id as string;
+					const existing = symbolEdgesById.get(key);
+					symbolEdgesById.set(
+						key,
+						existing
+							? mergeSymbolEdges(
+									existing,
+									symbolEdge,
+									absoluteRoot,
+									deriveRepoRootId(absoluteRoot),
+								)
+							: symbolEdge,
+					);
 				}
 				stats.filesScanned++;
 			}
@@ -3477,8 +3524,8 @@ export async function buildWorkspaceGraphAsync(
 	};
 
 	// Attach symbolEdges when present (schema >= 1.2.0); keep additive.
-	if (allSymbolEdges.length > 0) {
-		graph.symbolEdges = allSymbolEdges;
+	if (symbolEdgesById.size > 0) {
+		graph.symbolEdges = [...symbolEdgesById.values()];
 	}
 	// AFTER symbolEdges are attached: the reconciler prunes symbol edges whose
 	// endpoints have no node, so it has to run once both edge collections exist.

--- a/src/tools/repo-graph/incremental.ts
+++ b/src/tools/repo-graph/incremental.ts
@@ -37,6 +37,7 @@ import { resetQueryCache } from './query';
 import { getGraphPath, loadGraph, saveGraph } from './storage';
 import {
 	deriveRepoRootId,
+	isCompleteSymbolEdge,
 	mergeSymbolEdges,
 	normalizeSymbolEdge,
 } from './symbol-edge';
@@ -281,6 +282,27 @@ function scanDiagnostics(
 	};
 }
 
+function appendExtractionFailure(
+	diagnostics: RepoGraphDiagnostics | undefined,
+	failure: { file: string; language: string; reason: string },
+): RepoGraphDiagnostics {
+	const extractionFailures = diagnostics?.extractionFailures ?? [];
+	if (
+		extractionFailures.some(
+			(entry) =>
+				entry.file === failure.file &&
+				entry.language === failure.language &&
+				entry.reason === failure.reason,
+		)
+	) {
+		return diagnostics ?? {};
+	}
+	return {
+		...(diagnostics ?? {}),
+		extractionFailures: [...extractionFailures, failure],
+	};
+}
+
 function isEnoent(error: unknown): boolean {
 	return (
 		error instanceof Error &&
@@ -505,11 +527,33 @@ async function applyAsyncFileUpdates(
 			continue;
 		}
 
-		const result = await _internals.scanFileAsync(
-			rawFilePath,
-			absoluteRoot,
-			maxFileSize,
-			hasManifest,
+		const repoRootId =
+			graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
+		graph.repoRootId = repoRootId;
+		let result: Awaited<ReturnType<typeof _internals.scanFileAsync>>;
+		try {
+			result = await _internals.scanFileAsync(
+				rawFilePath,
+				absoluteRoot,
+				maxFileSize,
+				hasManifest,
+				repoRootId,
+			);
+		} catch {
+			replaceFileDiagnostics(graph, fileDiagnosticName, {
+				extractionFailures: [
+					{
+						file: fileDiagnosticName,
+						language: path.extname(rawFilePath).slice(1) || 'unknown',
+						reason: 'symbol_edge_validation_failed',
+					},
+				],
+			});
+			continue;
+		}
+		let replacementDiagnostics = scanDiagnostics(
+			result.diagnostics,
+			result.inputWitness,
 		);
 
 		if (result.node) {
@@ -579,40 +623,58 @@ async function applyAsyncFileUpdates(
 				if (!graph.symbolEdges) {
 					graph.symbolEdges = [];
 				}
-				const repoRootId =
-					graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
-				graph.repoRootId = repoRootId;
-				graph.symbolEdges = graph.symbolEdges.map((edge) =>
-					normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId),
-				);
-				const existingById = new Map(
-					graph.symbolEdges.map((edge, index) => [edge.id as string, index]),
-				);
+				const existingById = new Map<string, number>();
+				graph.symbolEdges.forEach((edge, index) => {
+					if (isCompleteSymbolEdge(edge)) {
+						existingById.set(edge.id, index);
+					}
+				});
 				for (const symbolEdge of result.symbolEdges) {
-					const normalized = normalizeSymbolEdge(
-						symbolEdge,
-						graph.workspaceRoot,
-						repoRootId,
-					);
-					const existingIndex = existingById.get(normalized.id);
-					if (existingIndex === undefined) {
-						graph.symbolEdges.push(normalized);
-						existingById.set(normalized.id, graph.symbolEdges.length - 1);
-					} else {
-						graph.symbolEdges[existingIndex] = mergeSymbolEdges(
-							graph.symbolEdges[existingIndex] as SymbolEdge,
-							normalized,
+					let normalized: ReturnType<typeof normalizeSymbolEdge>;
+					try {
+						normalized = normalizeSymbolEdge(
+							symbolEdge,
 							graph.workspaceRoot,
 							repoRootId,
 						);
+					} catch {
+						replacementDiagnostics = appendExtractionFailure(
+							replacementDiagnostics,
+							{
+								file: fileDiagnosticName,
+								language: result.node.language,
+								reason: 'symbol_edge_validation_failed',
+							},
+						);
+						continue;
+					}
+					const normalizedId = normalized.id;
+					const existingIndex = existingById.get(normalizedId);
+					if (existingIndex === undefined) {
+						graph.symbolEdges.push(normalized);
+						existingById.set(normalizedId, graph.symbolEdges.length - 1);
+					} else {
+						try {
+							graph.symbolEdges[existingIndex] = mergeSymbolEdges(
+								graph.symbolEdges[existingIndex] as SymbolEdge,
+								normalized,
+								graph.workspaceRoot,
+								repoRootId,
+							);
+						} catch {
+							replacementDiagnostics = appendExtractionFailure(
+								replacementDiagnostics,
+								{
+									file: fileDiagnosticName,
+									language: result.node.language,
+									reason: 'symbol_edge_validation_failed',
+								},
+							);
+						}
 					}
 				}
 			}
-			replaceFileDiagnostics(
-				graph,
-				fileDiagnosticName,
-				scanDiagnostics(result.diagnostics, result.inputWitness),
-			);
+			replaceFileDiagnostics(graph, fileDiagnosticName, replacementDiagnostics);
 		} else {
 			const definitelyUnindexable =
 				(result.diagnostics?.oversizedFiles?.length ?? 0) > 0 ||

--- a/src/tools/repo-graph/incremental.ts
+++ b/src/tools/repo-graph/incremental.ts
@@ -35,6 +35,11 @@ import { clearCache, getCachedMtime } from './cache';
 import { writeFingerprint } from './freshness';
 import { resetQueryCache } from './query';
 import { getGraphPath, loadGraph, saveGraph } from './storage';
+import {
+	deriveRepoRootId,
+	mergeSymbolEdges,
+	normalizeSymbolEdge,
+} from './symbol-edge';
 import type {
 	BuildWorkspaceGraphOptions,
 	GraphEdge,
@@ -574,17 +579,32 @@ async function applyAsyncFileUpdates(
 				if (!graph.symbolEdges) {
 					graph.symbolEdges = [];
 				}
-				const existingKeys = new Set(
-					graph.symbolEdges.map(
-						(se) =>
-							`${se.fromFile}\u0000${se.fromSymbol}\u0000${se.toFile}\u0000${se.toSymbol}`,
-					),
+				const repoRootId =
+					graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
+				graph.repoRootId = repoRootId;
+				graph.symbolEdges = graph.symbolEdges.map((edge) =>
+					normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId),
+				);
+				const existingById = new Map(
+					graph.symbolEdges.map((edge, index) => [edge.id as string, index]),
 				);
 				for (const symbolEdge of result.symbolEdges) {
-					const key = `${symbolEdge.fromFile}\u0000${symbolEdge.fromSymbol}\u0000${symbolEdge.toFile}\u0000${symbolEdge.toSymbol}`;
-					if (!existingKeys.has(key)) {
-						graph.symbolEdges.push(symbolEdge);
-						existingKeys.add(key);
+					const normalized = normalizeSymbolEdge(
+						symbolEdge,
+						graph.workspaceRoot,
+						repoRootId,
+					);
+					const existingIndex = existingById.get(normalized.id);
+					if (existingIndex === undefined) {
+						graph.symbolEdges.push(normalized);
+						existingById.set(normalized.id, graph.symbolEdges.length - 1);
+					} else {
+						graph.symbolEdges[existingIndex] = mergeSymbolEdges(
+							graph.symbolEdges[existingIndex] as SymbolEdge,
+							normalized,
+							graph.workspaceRoot,
+							repoRootId,
+						);
 					}
 				}
 			}

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -6,6 +6,12 @@ import {
 } from '../../utils/path-security';
 import { isAssetEdge } from './builder';
 import type { FreshnessProbe } from './freshness';
+import {
+	deriveRepoRootId,
+	isCompleteSymbolEdge,
+	LOW_CONFIDENCE_SYMBOL_EDGE_THRESHOLD,
+	normalizeSymbolEdge,
+} from './symbol-edge';
 import type {
 	BlastRadiusResult,
 	CallerReference,
@@ -259,6 +265,7 @@ export function getGraphHealth(
 			unreadableFiles: [],
 			validationSkippedFiles: [],
 			lowConfidenceEdgeCount: 0,
+			unresolvedSymbolEdgeCount: 0,
 			walkTruncated: false,
 			walkTruncationReason: null,
 			incrementalFallbacks: 0,
@@ -269,6 +276,13 @@ export function getGraphHealth(
 	}
 
 	const diagnostics = graph.diagnostics as Record<string, unknown> | undefined;
+	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
+	const rawSymbolEdges = graph.symbolEdges ?? [];
+	const completeSymbolEdges = rawSymbolEdges
+		.filter(isCompleteSymbolEdge)
+		.map((edge) => normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId));
+	const legacySymbolEdgeCount =
+		rawSymbolEdges.length - completeSymbolEdges.length;
 	const fresh = probeState === 'clean';
 	const staleFiles = getProbeStaleFiles(
 		probe,
@@ -291,6 +305,11 @@ export function getGraphHealth(
 	if (!diagnostics) {
 		notes.push(
 			'Graph has no recorded diagnostics. Rebuild with repo_map action="build" to collect health details.',
+		);
+	}
+	if (legacySymbolEdgeCount > 0) {
+		notes.push(
+			`${legacySymbolEdgeCount} legacy symbol edge(s) have no confidence or resolution metadata; rebuild the graph to score them.`,
 		);
 	}
 	const binaryFiles = sanitizePathList(diagnostics?.binaryFiles);
@@ -348,11 +367,18 @@ export function getGraphHealth(
 			diagnostics?.validationSkippedFiles,
 		),
 		lowConfidenceEdgeCount:
-			typeof diagnostics?.lowConfidenceEdgeCount === 'number' &&
-			Number.isFinite(diagnostics.lowConfidenceEdgeCount) &&
-			diagnostics.lowConfidenceEdgeCount > 0
-				? Math.floor(diagnostics.lowConfidenceEdgeCount)
-				: 0,
+			completeSymbolEdges.length > 0
+				? completeSymbolEdges.filter(
+						(edge) => edge.confidence < LOW_CONFIDENCE_SYMBOL_EDGE_THRESHOLD,
+					).length
+				: typeof diagnostics?.lowConfidenceEdgeCount === 'number' &&
+						Number.isFinite(diagnostics.lowConfidenceEdgeCount) &&
+						diagnostics.lowConfidenceEdgeCount > 0
+					? Math.floor(diagnostics.lowConfidenceEdgeCount)
+					: 0,
+		unresolvedSymbolEdgeCount: completeSymbolEdges.filter(
+			(edge) => edge.resolution === 'unresolved',
+		).length,
 		walkTruncated,
 		walkTruncationReason,
 		incrementalFallbacks,
@@ -747,7 +773,10 @@ export function getContextPack(
 	// reverse (incoming callers), keyed by normalized file + symbol.
 	const forward = new Map<string, SymbolEdge[]>();
 	const reverse = new Map<string, SymbolEdge[]>();
-	const symbolEdges = graph.symbolEdges ?? [];
+	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
+	const symbolEdges = (graph.symbolEdges ?? []).map((edge) =>
+		normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId),
+	);
 	for (const edge of symbolEdges) {
 		const fromKey = `${normalizeGraphPath(edge.fromFile)}\0${edge.fromSymbol}`;
 		const toKey = `${normalizeGraphPath(edge.toFile)}\0${edge.toSymbol}`;

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -7,10 +7,8 @@ import {
 import { isAssetEdge } from './builder';
 import type { FreshnessProbe } from './freshness';
 import {
-	deriveRepoRootId,
 	isCompleteSymbolEdge,
 	LOW_CONFIDENCE_SYMBOL_EDGE_THRESHOLD,
-	normalizeSymbolEdge,
 } from './symbol-edge';
 import type {
 	BlastRadiusResult,
@@ -276,11 +274,8 @@ export function getGraphHealth(
 	}
 
 	const diagnostics = graph.diagnostics as Record<string, unknown> | undefined;
-	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
 	const rawSymbolEdges = graph.symbolEdges ?? [];
-	const completeSymbolEdges = rawSymbolEdges
-		.filter(isCompleteSymbolEdge)
-		.map((edge) => normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId));
+	const completeSymbolEdges = rawSymbolEdges.filter(isCompleteSymbolEdge);
 	const legacySymbolEdgeCount =
 		rawSymbolEdges.length - completeSymbolEdges.length;
 	const fresh = probeState === 'clean';
@@ -773,10 +768,7 @@ export function getContextPack(
 	// reverse (incoming callers), keyed by normalized file + symbol.
 	const forward = new Map<string, SymbolEdge[]>();
 	const reverse = new Map<string, SymbolEdge[]>();
-	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
-	const symbolEdges = (graph.symbolEdges ?? []).map((edge) =>
-		normalizeSymbolEdge(edge, graph.workspaceRoot, repoRootId),
-	);
+	const symbolEdges = graph.symbolEdges ?? [];
 	for (const edge of symbolEdges) {
 		const fromKey = `${normalizeGraphPath(edge.fromFile)}\0${edge.fromSymbol}`;
 		const toKey = `${normalizeGraphPath(edge.toFile)}\0${edge.toSymbol}`;

--- a/src/tools/repo-graph/storage.ts
+++ b/src/tools/repo-graph/storage.ts
@@ -24,7 +24,11 @@ import {
 } from './cache';
 import { type FreshnessOptions, writeFingerprint } from './freshness';
 import { safeRealpathSync } from './safe-realpath';
-import { deriveRepoRootId, normalizeSymbolEdge } from './symbol-edge';
+import {
+	deriveRepoRootId,
+	hasSymbolEdgeV2Fields,
+	normalizeSymbolEdge,
+} from './symbol-edge';
 import type { RepoGraph } from './types';
 import {
 	createEmptyGraph,
@@ -80,37 +84,66 @@ export const _internals: {
 	writeFingerprint,
 };
 
-function validateLoadedGraph(parsed: RepoGraph): void {
+function corruption(message: string, cause?: unknown): Error {
+	return Object.assign(new Error(message), { code: 'CORRUPTION', cause });
+}
+
+function resolveTrustedWorkspaceRoot(workspace: string): string {
+	const resolved = path.resolve(workspace);
+	const trusted = _internals.safeRealpathSync(resolved, resolved);
+	if (trusted === null) {
+		throw corruption(`Workspace realpath security check failed: ${workspace}`);
+	}
+	return trusted;
+}
+
+function bindGraphToWorkspace(graph: RepoGraph, workspace: string): void {
+	if (
+		typeof graph.workspaceRoot !== 'string' ||
+		graph.workspaceRoot.length === 0 ||
+		containsControlChars(graph.workspaceRoot)
+	) {
+		throw corruption('repo-graph.json missing or invalid workspaceRoot');
+	}
+	const trustedWorkspace = resolveTrustedWorkspaceRoot(workspace);
+	const persistedWorkspace = path.resolve(graph.workspaceRoot);
+	const trustedPersisted = _internals.safeRealpathSync(
+		persistedWorkspace,
+		persistedWorkspace,
+	);
+	if (trustedPersisted === null) {
+		throw corruption(
+			`repo-graph.json workspaceRoot realpath security check failed: ${graph.workspaceRoot}`,
+		);
+	}
+	if (path.normalize(trustedPersisted) !== path.normalize(trustedWorkspace)) {
+		throw corruption(
+			`repo-graph.json workspaceRoot mismatch: ${graph.workspaceRoot}`,
+		);
+	}
+	graph.workspaceRoot = trustedWorkspace;
+	graph.repoRootId = deriveRepoRootId(trustedWorkspace);
+}
+
+function validateLoadedGraph(parsed: RepoGraph, workspace: string): void {
 	if (!parsed.schema_version) {
-		throw Object.assign(new Error('repo-graph.json missing schema_version'), {
-			code: 'CORRUPTION',
-		});
+		throw corruption('repo-graph.json missing schema_version');
 	}
 	if (!parsed.nodes || typeof parsed.nodes !== 'object') {
-		throw Object.assign(new Error('repo-graph.json missing or invalid nodes'), {
-			code: 'CORRUPTION',
-		});
+		throw corruption('repo-graph.json missing or invalid nodes');
 	}
 	if (!Array.isArray(parsed.edges)) {
-		throw Object.assign(new Error('repo-graph.json missing or invalid edges'), {
-			code: 'CORRUPTION',
-		});
+		throw corruption('repo-graph.json missing or invalid edges');
 	}
 	for (const [key, node] of Object.entries(parsed.nodes)) {
 		if (!key || typeof key !== 'string') {
-			throw Object.assign(
-				new Error('repo-graph.json contains invalid node key'),
-				{ code: 'CORRUPTION' },
-			);
+			throw corruption('repo-graph.json contains invalid node key');
 		}
 		try {
 			validateGraphNode(node);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : 'Invalid node structure';
-			throw Object.assign(
-				new Error(`repo-graph.json node validation failed: ${msg}`),
-				{ code: 'CORRUPTION' },
-			);
+			throw corruption(`repo-graph.json node validation failed: ${msg}`);
 		}
 	}
 	for (const edge of parsed.edges) {
@@ -118,10 +151,7 @@ function validateLoadedGraph(parsed: RepoGraph): void {
 			validateGraphEdge(edge);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : 'Invalid edge structure';
-			throw Object.assign(
-				new Error(`repo-graph.json edge validation failed: ${msg}`),
-				{ code: 'CORRUPTION' },
-			);
+			throw corruption(`repo-graph.json edge validation failed: ${msg}`);
 		}
 	}
 	if (
@@ -132,49 +162,38 @@ function validateLoadedGraph(parsed: RepoGraph): void {
 		typeof parsed.metadata.nodeCount !== 'number' ||
 		typeof parsed.metadata.edgeCount !== 'number'
 	) {
-		throw Object.assign(
-			new Error('repo-graph.json missing or invalid metadata'),
-			{ code: 'CORRUPTION' },
-		);
+		throw corruption('repo-graph.json missing or invalid metadata');
 	}
 	if (parsed.symbolEdges !== undefined) {
 		if (!Array.isArray(parsed.symbolEdges)) {
-			throw Object.assign(
-				new Error('repo-graph.json symbolEdges must be an array'),
-				{ code: 'CORRUPTION' },
-			);
+			throw corruption('repo-graph.json symbolEdges must be an array');
 		}
 	}
+	bindGraphToWorkspace(parsed, workspace);
 	normalizeGraphSymbolEdges(parsed);
 }
 
 function normalizeGraphSymbolEdges(graph: RepoGraph): void {
-	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
-	if (
-		typeof repoRootId !== 'string' ||
-		repoRootId.length === 0 ||
-		repoRootId.length > 512 ||
-		containsControlChars(repoRootId)
-	) {
-		throw Object.assign(
-			new Error('repo-graph.json contains invalid repoRootId'),
-			{
-				code: 'CORRUPTION',
-			},
-		);
-	}
+	const repoRootId = deriveRepoRootId(graph.workspaceRoot);
 	graph.repoRootId = repoRootId;
 	if (!graph.symbolEdges) return;
-	try {
-		graph.symbolEdges = graph.symbolEdges.map((entry) =>
-			normalizeSymbolEdge(entry, graph.workspaceRoot, repoRootId),
-		);
-	} catch (cause) {
-		throw Object.assign(
-			new Error('repo-graph.json contains invalid symbolEdges entry'),
-			{ code: 'CORRUPTION', cause },
-		);
+	const normalized = [];
+	for (const entry of graph.symbolEdges) {
+		try {
+			const validated = normalizeSymbolEdge(
+				entry,
+				graph.workspaceRoot,
+				repoRootId,
+			);
+			normalized.push(hasSymbolEdgeV2Fields(entry) ? validated : entry);
+		} catch (cause) {
+			throw corruption(
+				'repo-graph.json contains invalid symbolEdges entry',
+				cause,
+			);
+		}
 	}
+	graph.symbolEdges = normalized;
 }
 
 // ============ Safe Load/Save Operations ============
@@ -262,7 +281,7 @@ export async function loadGraph(workspace: string): Promise<RepoGraph | null> {
 				code: 'CORRUPTION',
 			});
 		}
-		validateLoadedGraph(parsed);
+		validateLoadedGraph(parsed, workspace);
 
 		// Update cache with current file mtime
 		setCachedGraph(normalized, parsed, stats.mtimeMs);
@@ -317,7 +336,7 @@ export function loadGraphSync(workspace: string): RepoGraph | null {
 				code: 'CORRUPTION',
 			});
 		}
-		validateLoadedGraph(parsed);
+		validateLoadedGraph(parsed, workspace);
 		setCachedGraph(normalized, parsed, stats.mtimeMs);
 		return parsed;
 	} catch (error: unknown) {
@@ -389,6 +408,7 @@ export async function saveGraph(
 			`Graph workspaceRoot mismatch: graph was built for "${graph.workspaceRoot}" but save was called for "${workspace}"`,
 		);
 	}
+	graph.repoRootId = deriveRepoRootId(realWorkspace);
 
 	// Normalize legacy edges and reject structurally or semantically invalid v2
 	// facts before any write. This is the same trust boundary used by both loaders.

--- a/src/tools/repo-graph/storage.ts
+++ b/src/tools/repo-graph/storage.ts
@@ -13,7 +13,6 @@ import { validateSwarmPath } from '../../hooks/utils';
 import * as logger from '../../utils/logger';
 import {
 	containsControlChars,
-	containsPathTraversal,
 	validateSymlinkBoundary,
 } from '../../utils/path-security';
 import {
@@ -25,6 +24,7 @@ import {
 } from './cache';
 import { type FreshnessOptions, writeFingerprint } from './freshness';
 import { safeRealpathSync } from './safe-realpath';
+import { deriveRepoRootId, normalizeSymbolEdge } from './symbol-edge';
 import type { RepoGraph } from './types';
 import {
 	createEmptyGraph,
@@ -144,31 +144,36 @@ function validateLoadedGraph(parsed: RepoGraph): void {
 				{ code: 'CORRUPTION' },
 			);
 		}
-		for (const entry of parsed.symbolEdges) {
-			if (
-				typeof entry !== 'object' ||
-				entry === null ||
-				typeof entry.fromFile !== 'string' ||
-				typeof entry.fromSymbol !== 'string' ||
-				typeof entry.toFile !== 'string' ||
-				typeof entry.toSymbol !== 'string' ||
-				entry.fromFile === '' ||
-				entry.fromSymbol === '' ||
-				entry.toFile === '' ||
-				entry.toSymbol === '' ||
-				containsControlChars(entry.fromFile) ||
-				containsControlChars(entry.fromSymbol) ||
-				containsControlChars(entry.toFile) ||
-				containsControlChars(entry.toSymbol) ||
-				containsPathTraversal(entry.fromFile) ||
-				containsPathTraversal(entry.toFile)
-			) {
-				throw Object.assign(
-					new Error('repo-graph.json contains invalid symbolEdges entry'),
-					{ code: 'CORRUPTION' },
-				);
-			}
-		}
+	}
+	normalizeGraphSymbolEdges(parsed);
+}
+
+function normalizeGraphSymbolEdges(graph: RepoGraph): void {
+	const repoRootId = graph.repoRootId ?? deriveRepoRootId(graph.workspaceRoot);
+	if (
+		typeof repoRootId !== 'string' ||
+		repoRootId.length === 0 ||
+		repoRootId.length > 512 ||
+		containsControlChars(repoRootId)
+	) {
+		throw Object.assign(
+			new Error('repo-graph.json contains invalid repoRootId'),
+			{
+				code: 'CORRUPTION',
+			},
+		);
+	}
+	graph.repoRootId = repoRootId;
+	if (!graph.symbolEdges) return;
+	try {
+		graph.symbolEdges = graph.symbolEdges.map((entry) =>
+			normalizeSymbolEdge(entry, graph.workspaceRoot, repoRootId),
+		);
+	} catch (cause) {
+		throw Object.assign(
+			new Error('repo-graph.json contains invalid symbolEdges entry'),
+			{ code: 'CORRUPTION', cause },
+		);
 	}
 }
 
@@ -384,6 +389,10 @@ export async function saveGraph(
 			`Graph workspaceRoot mismatch: graph was built for "${graph.workspaceRoot}" but save was called for "${workspace}"`,
 		);
 	}
+
+	// Normalize legacy edges and reject structurally or semantically invalid v2
+	// facts before any write. This is the same trust boundary used by both loaders.
+	normalizeGraphSymbolEdges(graph);
 
 	const normalized = normalizedWorkspace;
 

--- a/src/tools/repo-graph/symbol-edge.ts
+++ b/src/tools/repo-graph/symbol-edge.ts
@@ -1,0 +1,302 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import {
+	containsControlChars,
+	containsPathTraversal,
+} from '../../utils/path-security';
+import {
+	SYMBOL_EDGE_KIND_VALUES,
+	SYMBOL_EDGE_RESOLUTION_VALUES,
+	type SymbolEdge,
+	type SymbolEdgeEvidence,
+	type SymbolEdgeKind,
+	type SymbolEdgeResolution,
+	type SymbolIdentityKind,
+} from './types';
+
+export const LOW_CONFIDENCE_SYMBOL_EDGE_THRESHOLD = 0.5;
+export const MAX_SYMBOL_EDGE_EVIDENCE = 16;
+
+const MAX_EVIDENCE_PATH_LENGTH = 1024;
+const MAX_EXTRACTOR_LENGTH = 128;
+const MAX_SYMBOL_NAME_LENGTH = 512;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const KIND_SET = new Set<string>(SYMBOL_EDGE_KIND_VALUES);
+const RESOLUTION_SET = new Set<string>(SYMBOL_EDGE_RESOLUTION_VALUES);
+const V2_KEYS = [
+	'id',
+	'fromId',
+	'toId',
+	'kind',
+	'confidence',
+	'resolution',
+	'evidence',
+] as const;
+
+function canonicalText(value: string): string {
+	return value.normalize('NFC');
+}
+
+function canonicalPath(value: string): string {
+	const normalized = canonicalText(value)
+		.replace(/\\/g, '/')
+		.replace(/\/{2,}/g, '/')
+		.replace(/^(?:\.\/)+/, '')
+		.replace(/\/$/, '');
+	return normalized.replace(
+		/^([A-Z]):\//,
+		(_, drive: string) => `${drive.toLowerCase()}:/`,
+	);
+}
+
+function digest(parts: readonly string[]): string {
+	return createHash('sha256')
+		.update(parts.join('\u0000'), 'utf8')
+		.digest('hex');
+}
+
+export function deriveRepoRootId(workspaceRoot: string): string {
+	const canonical = canonicalPath(workspaceRoot);
+	const segments = canonical.split('/').filter(Boolean);
+	const label = canonicalText(segments.at(-1) ?? 'repository');
+	return label || 'repository';
+}
+
+export function relativeSymbolPath(
+	workspaceRoot: string,
+	filePath: string,
+): string {
+	const root = canonicalPath(path.resolve(workspaceRoot));
+	const file = canonicalPath(path.resolve(filePath));
+	const prefix = `${root}/`;
+	return file.startsWith(prefix) ? file.slice(prefix.length) : file;
+}
+
+export function createStableSymbolId(
+	repoRootId: string,
+	relativePath: string,
+	qualifiedName: string,
+	identityKind: SymbolIdentityKind,
+): string {
+	return digest([
+		canonicalText(repoRootId),
+		canonicalPath(relativePath),
+		canonicalText(qualifiedName),
+		identityKind,
+	]);
+}
+
+export function createStableSymbolEdgeId(
+	fromId: string,
+	toId: string,
+	kind: SymbolEdgeKind,
+): string {
+	return digest([fromId, toId, kind]);
+}
+
+export function hashSymbolEdgeSnippet(snippet: string): string {
+	return digest([canonicalText(snippet.replace(/\r$/, ''))]);
+}
+
+export function isCompleteSymbolEdge(edge: SymbolEdge): boolean {
+	return V2_KEYS.every((key) => edge[key] !== undefined);
+}
+
+function hasAnyV2Field(edge: SymbolEdge): boolean {
+	return V2_KEYS.some((key) => edge[key] !== undefined);
+}
+
+function identityKind(symbol: string): SymbolIdentityKind {
+	return symbol === '<module>' ? 'module' : 'symbol';
+}
+
+function computedIds(
+	edge: Pick<SymbolEdge, 'fromFile' | 'fromSymbol' | 'toFile' | 'toSymbol'>,
+	workspaceRoot: string,
+	repoRootId: string,
+	kind: SymbolEdgeKind,
+): { fromId: string; toId: string; id: string } {
+	const fromId = createStableSymbolId(
+		repoRootId,
+		relativeSymbolPath(workspaceRoot, edge.fromFile),
+		edge.fromSymbol,
+		identityKind(edge.fromSymbol),
+	);
+	const toId = createStableSymbolId(
+		repoRootId,
+		relativeSymbolPath(workspaceRoot, edge.toFile),
+		edge.toSymbol,
+		identityKind(edge.toSymbol),
+	);
+	return { fromId, toId, id: createStableSymbolEdgeId(fromId, toId, kind) };
+}
+
+function validateCoordinate(
+	name: string,
+	value: unknown,
+): asserts value is string {
+	const maxLength = name.endsWith('File') ? 4096 : MAX_SYMBOL_NAME_LENGTH;
+	if (
+		typeof value !== 'string' ||
+		value.length === 0 ||
+		value.length > maxLength ||
+		containsControlChars(value)
+	) {
+		throw new Error(`invalid ${name}`);
+	}
+}
+
+function validateEvidence(
+	evidence: unknown,
+): asserts evidence is SymbolEdgeEvidence[] {
+	if (!Array.isArray(evidence) || evidence.length > MAX_SYMBOL_EDGE_EVIDENCE) {
+		throw new Error('invalid evidence');
+	}
+	for (const item of evidence) {
+		if (typeof item !== 'object' || item === null) {
+			throw new Error('invalid evidence entry');
+		}
+		const entry = item as Partial<SymbolEdgeEvidence>;
+		if (
+			typeof entry.file !== 'string' ||
+			entry.file.length === 0 ||
+			entry.file.length > MAX_EVIDENCE_PATH_LENGTH ||
+			entry.file.startsWith('/') ||
+			/^[A-Za-z]:[/\\]/.test(entry.file) ||
+			containsControlChars(entry.file) ||
+			containsPathTraversal(entry.file) ||
+			!Number.isInteger(entry.line) ||
+			(entry.line ?? 0) < 1 ||
+			(entry.column !== undefined &&
+				(!Number.isInteger(entry.column) || entry.column < 1)) ||
+			typeof entry.snippetHash !== 'string' ||
+			!SHA256_PATTERN.test(entry.snippetHash) ||
+			typeof entry.extractor !== 'string' ||
+			entry.extractor.length === 0 ||
+			entry.extractor.length > MAX_EXTRACTOR_LENGTH ||
+			containsControlChars(entry.extractor)
+		) {
+			throw new Error('invalid evidence entry');
+		}
+	}
+}
+
+function evidenceKey(entry: SymbolEdgeEvidence): string {
+	return [
+		canonicalPath(entry.file),
+		entry.line,
+		entry.column ?? 0,
+		entry.snippetHash,
+		canonicalText(entry.extractor),
+	].join('\u0000');
+}
+
+export function mergeSymbolEdgeEvidence(
+	left: readonly SymbolEdgeEvidence[],
+	right: readonly SymbolEdgeEvidence[],
+): SymbolEdgeEvidence[] {
+	const byKey = new Map<string, SymbolEdgeEvidence>();
+	for (const entry of [...left, ...right]) {
+		byKey.set(evidenceKey(entry), entry);
+	}
+	return [...byKey.entries()]
+		.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+		.slice(0, MAX_SYMBOL_EDGE_EVIDENCE)
+		.map(([, entry]) => entry);
+}
+
+export function normalizeSymbolEdge(
+	edge: SymbolEdge,
+	workspaceRoot: string,
+	repoRootId: string,
+): SymbolEdge & Required<Pick<SymbolEdge, (typeof V2_KEYS)[number]>> {
+	validateCoordinate('fromFile', edge.fromFile);
+	validateCoordinate('fromSymbol', edge.fromSymbol);
+	validateCoordinate('toFile', edge.toFile);
+	validateCoordinate('toSymbol', edge.toSymbol);
+	if (
+		containsPathTraversal(edge.fromFile) ||
+		containsPathTraversal(edge.toFile)
+	) {
+		throw new Error('invalid symbol edge path');
+	}
+
+	const anyV2 = hasAnyV2Field(edge);
+	if (anyV2 && !isCompleteSymbolEdge(edge)) {
+		throw new Error('partial SymbolEdge v2 fields');
+	}
+	const kind = (edge.kind ?? 'REFERENCES') as SymbolEdgeKind;
+	const resolution = (edge.resolution ?? 'unresolved') as SymbolEdgeResolution;
+	const confidence = edge.confidence ?? 0;
+	const evidence = edge.evidence ?? [];
+	if (!KIND_SET.has(kind)) throw new Error('invalid symbol edge kind');
+	if (!RESOLUTION_SET.has(resolution)) {
+		throw new Error('invalid symbol edge resolution');
+	}
+	if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+		throw new Error('invalid symbol edge confidence');
+	}
+	validateEvidence(evidence);
+
+	const ids = computedIds(edge, workspaceRoot, repoRootId, kind);
+	if (
+		anyV2 &&
+		(edge.fromId !== ids.fromId || edge.toId !== ids.toId || edge.id !== ids.id)
+	) {
+		throw new Error('symbol edge stable ID mismatch');
+	}
+	return {
+		...edge,
+		...ids,
+		kind,
+		confidence,
+		resolution,
+		evidence: mergeSymbolEdgeEvidence([], evidence),
+	};
+}
+
+export function createSymbolEdgeV2(
+	edge: Pick<SymbolEdge, 'fromFile' | 'fromSymbol' | 'toFile' | 'toSymbol'>,
+	workspaceRoot: string,
+	repoRootId: string,
+	options: {
+		kind?: SymbolEdgeKind;
+		confidence: number;
+		resolution: SymbolEdgeResolution;
+		evidence: SymbolEdgeEvidence[];
+	},
+): SymbolEdge {
+	const kind = options.kind ?? 'REFERENCES';
+	const ids = computedIds(edge, workspaceRoot, repoRootId, kind);
+	return normalizeSymbolEdge(
+		{ ...edge, ...ids, kind, ...options },
+		workspaceRoot,
+		repoRootId,
+	);
+}
+
+export function mergeSymbolEdges(
+	left: SymbolEdge,
+	right: SymbolEdge,
+	workspaceRoot: string,
+	repoRootId: string,
+): SymbolEdge {
+	const a = normalizeSymbolEdge(left, workspaceRoot, repoRootId);
+	const b = normalizeSymbolEdge(right, workspaceRoot, repoRootId);
+	if (a.id !== b.id) throw new Error('cannot merge different symbol edges');
+	const resolutionRank = (value: SymbolEdgeResolution) =>
+		SYMBOL_EDGE_RESOLUTION_VALUES.indexOf(value);
+	const preferred =
+		a.confidence > b.confidence ||
+		(a.confidence === b.confidence &&
+			resolutionRank(a.resolution) <= resolutionRank(b.resolution))
+			? a
+			: b;
+	return {
+		...a,
+		confidence: Math.max(a.confidence, b.confidence),
+		resolution: preferred.resolution,
+		evidence: mergeSymbolEdgeEvidence(a.evidence, b.evidence),
+	};
+}

--- a/src/tools/repo-graph/symbol-edge.ts
+++ b/src/tools/repo-graph/symbol-edge.ts
@@ -68,7 +68,7 @@ export function relativeSymbolPath(
 	filePath: string,
 ): string {
 	const root = canonicalPath(path.resolve(workspaceRoot));
-	const file = canonicalPath(path.resolve(filePath));
+	const file = canonicalPath(path.resolve(workspaceRoot, filePath));
 	const prefix = `${root}/`;
 	return file.startsWith(prefix) ? file.slice(prefix.length) : file;
 }
@@ -99,12 +99,30 @@ export function hashSymbolEdgeSnippet(snippet: string): string {
 	return digest([canonicalText(snippet.replace(/\r$/, ''))]);
 }
 
-export function isCompleteSymbolEdge(edge: SymbolEdge): boolean {
+export function isCompleteSymbolEdge(
+	edge: SymbolEdge,
+): edge is SymbolEdge & Required<Pick<SymbolEdge, (typeof V2_KEYS)[number]>> {
 	return V2_KEYS.every((key) => edge[key] !== undefined);
 }
 
-function hasAnyV2Field(edge: SymbolEdge): boolean {
+export function hasSymbolEdgeV2Fields(edge: SymbolEdge): boolean {
 	return V2_KEYS.some((key) => edge[key] !== undefined);
+}
+
+function resolveTrustedCoordinate(
+	name: 'fromFile' | 'toFile',
+	value: string,
+	workspaceRoot: string,
+): string {
+	const resolvedWorkspace = canonicalPath(path.resolve(workspaceRoot));
+	const resolvedValue = canonicalPath(path.resolve(workspaceRoot, value));
+	if (
+		resolvedValue !== resolvedWorkspace &&
+		!resolvedValue.startsWith(`${resolvedWorkspace}/`)
+	) {
+		throw new Error(`invalid ${name}`);
+	}
+	return path.resolve(workspaceRoot, value);
 }
 
 function identityKind(symbol: string): SymbolIdentityKind {
@@ -222,10 +240,16 @@ export function normalizeSymbolEdge(
 		throw new Error('invalid symbol edge path');
 	}
 
-	const anyV2 = hasAnyV2Field(edge);
+	const anyV2 = hasSymbolEdgeV2Fields(edge);
 	if (anyV2 && !isCompleteSymbolEdge(edge)) {
 		throw new Error('partial SymbolEdge v2 fields');
 	}
+	const fromFile = anyV2
+		? resolveTrustedCoordinate('fromFile', edge.fromFile, workspaceRoot)
+		: edge.fromFile;
+	const toFile = anyV2
+		? resolveTrustedCoordinate('toFile', edge.toFile, workspaceRoot)
+		: edge.toFile;
 	const kind = (edge.kind ?? 'REFERENCES') as SymbolEdgeKind;
 	const resolution = (edge.resolution ?? 'unresolved') as SymbolEdgeResolution;
 	const confidence = edge.confidence ?? 0;
@@ -239,7 +263,12 @@ export function normalizeSymbolEdge(
 	}
 	validateEvidence(evidence);
 
-	const ids = computedIds(edge, workspaceRoot, repoRootId, kind);
+	const ids = computedIds(
+		{ ...edge, fromFile, toFile },
+		workspaceRoot,
+		repoRootId,
+		kind,
+	);
 	if (
 		anyV2 &&
 		(edge.fromId !== ids.fromId || edge.toId !== ids.toId || edge.id !== ids.id)
@@ -248,6 +277,8 @@ export function normalizeSymbolEdge(
 	}
 	return {
 		...edge,
+		fromFile,
+		toFile,
 		...ids,
 		kind,
 		confidence,

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -48,8 +48,12 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * source read. The content-freshness sidecar requires both witnesses before
  * it will certify a graph; older graphs remain readable but are intentionally
  * treated as needing a rebuild before certification.
+ *
+ * 1.5.0 adds an optional graph-level `repoRootId` plus additive SymbolEdge v2
+ * identity, kind, confidence, resolution, and evidence fields. Legacy 1.2.0
+ * four-coordinate symbol edges remain readable and are normalized in memory.
  */
-export const GRAPH_SCHEMA_VERSION = '1.4.0';
+export const GRAPH_SCHEMA_VERSION = '1.5.0';
 
 /**
  * Compare dotted numeric version strings (e.g. '1.1.0' >= '1.1.0').
@@ -332,6 +336,45 @@ export interface SymbolReference {
  * than {@link GraphEdge} (which tracks file-level imports) and enable
  * precise context-packing and symbol navigation queries.
  */
+export const SYMBOL_EDGE_KIND_VALUES = [
+	'CALLS',
+	'REFERENCES',
+	'USES_TYPE',
+	'INSTANTIATES',
+	'IMPLEMENTS',
+	'OVERRIDES',
+] as const;
+export type SymbolEdgeKind = (typeof SYMBOL_EDGE_KIND_VALUES)[number];
+
+export const SYMBOL_EDGE_RESOLUTION_VALUES = [
+	'exact',
+	'import_binding',
+	'same_file_scope',
+	'unique_name',
+	'type_resolved',
+	'lsp',
+	'scip',
+	'heuristic',
+	'unresolved',
+] as const;
+export type SymbolEdgeResolution =
+	(typeof SYMBOL_EDGE_RESOLUTION_VALUES)[number];
+
+export type SymbolIdentityKind = 'symbol' | 'module';
+
+export interface SymbolEdgeEvidence {
+	/** Workspace-relative source path; source text itself is never persisted. */
+	file: string;
+	/** 1-based source line. */
+	line: number;
+	/** Optional 1-based source column. */
+	column?: number;
+	/** SHA-256 of the NFC-normalized logical source line. */
+	snippetHash: string;
+	/** Extractor that produced the fact, for example `tree-sitter/typescript`. */
+	extractor: string;
+}
+
 export interface SymbolEdge {
 	/** Resolved absolute path of the source file (matches `GraphNode.filePath` keys). */
 	fromFile: string;
@@ -341,6 +384,20 @@ export interface SymbolEdge {
 	toFile: string;
 	/** Exported symbol referenced in the target file. */
 	toSymbol: string;
+	/** Stable SHA-256 identity of this edge (schema >= 1.5.0). */
+	id?: string;
+	/** Stable SHA-256 identity of the source symbol. */
+	fromId?: string;
+	/** Stable SHA-256 identity of the target symbol. */
+	toId?: string;
+	/** Relationship kind. Current tree-sitter extraction emits REFERENCES. */
+	kind?: SymbolEdgeKind;
+	/** Advisory confidence in the inclusive range 0..1. */
+	confidence?: number;
+	/** How the relationship was resolved. */
+	resolution?: SymbolEdgeResolution;
+	/** Bounded provenance records. Empty only when no honest location exists. */
+	evidence?: SymbolEdgeEvidence[];
 }
 
 /**
@@ -506,6 +563,7 @@ export interface GraphHealthResult {
 	unreadableFiles: string[];
 	validationSkippedFiles: string[];
 	lowConfidenceEdgeCount: number;
+	unresolvedSymbolEdgeCount: number;
 	walkTruncated: boolean;
 	walkTruncationReason: 'budget' | 'cap' | null;
 	incrementalFallbacks: number;
@@ -560,6 +618,8 @@ export interface RepoGraph {
 	schema_version: string;
 	/** Workspace root directory */
 	workspaceRoot: string;
+	/** Root-independent repository label used to scope stable symbol IDs. */
+	repoRootId?: string;
 	/** Graph nodes keyed by resolved file path */
 	nodes: Record<string, GraphNode>;
 	/** Graph edges representing dependencies */

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -138,7 +138,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/evidence/manager.ts:288',
 			'src/evidence/manager.ts:456',
 			'src/tools/sast-baseline.ts:106',
-			'src/tools/repo-graph/storage.ts:406',
+			'src/tools/repo-graph/storage.ts:426',
 			'src/memory/reflection-service.ts:547 (pre-#2035)',
 			'src/hooks/review-receipt.ts:608',
 			'src/hooks/review-receipt.ts:674',

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -138,7 +138,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/evidence/manager.ts:288',
 			'src/evidence/manager.ts:456',
 			'src/tools/sast-baseline.ts:106',
-			'src/tools/repo-graph/storage.ts:397',
+			'src/tools/repo-graph/storage.ts:406',
 			'src/memory/reflection-service.ts:547 (pre-#2035)',
 			'src/hooks/review-receipt.ts:608',
 			'src/hooks/review-receipt.ts:674',

--- a/tests/unit/hooks/audit-log.test.ts
+++ b/tests/unit/hooks/audit-log.test.ts
@@ -22,10 +22,6 @@ import {
 	redactPath,
 } from '../../../src/hooks/guardrails/audit-log';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 async function mkTempDir(): Promise<string> {
 	return mkdtemp(join(tmpdir(), 'audit-log-test-'));
 }

--- a/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
+++ b/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
@@ -108,6 +108,19 @@ describe('repo-graph: Java import/symbol resolution + ontology + context pack (i
 			(e) => e.toSymbol === 'Repo' && e.toFile === repoNode.filePath,
 		);
 		expect(symEdge).toBeDefined();
+		expect(symEdge).toEqual(
+			expect.objectContaining({
+				id: expect.stringMatching(/^[a-f0-9]{64}$/),
+				fromId: expect.stringMatching(/^[a-f0-9]{64}$/),
+				toId: expect.stringMatching(/^[a-f0-9]{64}$/),
+				kind: 'REFERENCES',
+				resolution: 'import_binding',
+				evidence: [
+					expect.objectContaining({ file: 'com/example/OrderService.java' }),
+				],
+			}),
+		);
+		expect(symEdge?.confidence).toBeGreaterThan(0);
 	});
 
 	test('criterion 4: package boundary is the dotted Java package, not the path segment', async () => {
@@ -237,6 +250,12 @@ describe('repo-graph: Kotlin import/symbol resolution + ontology (issue #1529)',
 				fromSymbol: 'run',
 				toFile: widgetNode.filePath,
 				toSymbol: 'Widget',
+				id: expect.stringMatching(/^[a-f0-9]{64}$/),
+				fromId: expect.stringMatching(/^[a-f0-9]{64}$/),
+				toId: expect.stringMatching(/^[a-f0-9]{64}$/),
+				kind: 'REFERENCES',
+				resolution: 'import_binding',
+				evidence: [expect.objectContaining({ file: 'com/example/Service.kt' })],
 			}),
 		);
 	});

--- a/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
+++ b/tests/unit/tools/repo-graph-jvm-dotnet.test.ts
@@ -231,12 +231,14 @@ describe('repo-graph: Kotlin import/symbol resolution + ontology (issue #1529)',
 		const graph = await buildWorkspaceGraphAsync(tempDir);
 		const serviceNode = nodeFor(graph, 'com/example/Service.kt');
 		const widgetNode = nodeFor(graph, 'com/example/helper/Widget.kt');
-		expect(graph.symbolEdges ?? []).toContainEqual({
-			fromFile: serviceNode.filePath,
-			fromSymbol: 'run',
-			toFile: widgetNode.filePath,
-			toSymbol: 'Widget',
-		});
+		expect(graph.symbolEdges ?? []).toContainEqual(
+			expect.objectContaining({
+				fromFile: serviceNode.filePath,
+				fromSymbol: 'run',
+				toFile: widgetNode.filePath,
+				toSymbol: 'Widget',
+			}),
+		);
 	});
 });
 

--- a/tests/unit/tools/repo-graph-symbol-edge-v2-resilience.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2-resilience.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	loadGraph,
+	saveGraph,
+	updateGraphForFiles,
+} from '../../../src/tools/repo-graph';
+import { _internals as builderInternals } from '../../../src/tools/repo-graph/builder';
+import { REPO_GRAPH_FINGERPRINT_FILENAME } from '../../../src/tools/repo-graph/freshness';
+import { _internals as incrementalInternals } from '../../../src/tools/repo-graph/incremental';
+import {
+	createSymbolEdgeV2,
+	deriveRepoRootId,
+	hashSymbolEdgeSnippet,
+} from '../../../src/tools/repo-graph/symbol-edge';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('SymbolEdge v2 resilience — issue #1532 review findings', () => {
+	let workspace: string;
+	let originalExtractFileSymbols: typeof builderInternals.extractFileSymbols;
+	let originalIncrementalScanFileAsync: typeof incrementalInternals.scanFileAsync;
+
+	beforeEach(() => {
+		workspace = canonicalMkdtemp('repo-graph-edge-v2-resilience-');
+		originalExtractFileSymbols = builderInternals.extractFileSymbols;
+		originalIncrementalScanFileAsync = incrementalInternals.scanFileAsync;
+	});
+
+	afterEach(() => {
+		builderInternals.extractFileSymbols = originalExtractFileSymbols;
+		incrementalInternals.scanFileAsync = originalIncrementalScanFileAsync;
+		clearCache(workspace);
+		fs.rmSync(workspace, { recursive: true, force: true });
+	});
+
+	function write(relPath: string, content: string): string {
+		const full = path.join(workspace, relPath);
+		fs.mkdirSync(path.dirname(full), { recursive: true });
+		fs.writeFileSync(full, content);
+		return full;
+	}
+
+	test('async builder keeps valid nodes and records a diagnostic when one symbol edge is malformed', async () => {
+		write('dep.ts', 'export function target() { return 1; }\n');
+		write(
+			'caller.ts',
+			'import { target } from "./dep";\nexport function caller() { return target(); }\n',
+		);
+		originalExtractFileSymbols = builderInternals.extractFileSymbols;
+		builderInternals.extractFileSymbols = async (grammar, content) => {
+			const facts = await originalExtractFileSymbols(grammar, content);
+			if (!content.includes('export function caller')) {
+				return facts;
+			}
+			if (!facts) return facts;
+			return {
+				...facts,
+				imports: [
+					{
+						...facts.imports[0],
+						bindings: [{ imported: 'x'.repeat(513), local: 'target' }],
+					},
+				],
+			};
+		};
+
+		const graph = await buildWorkspaceGraphAsync(workspace);
+		expect(Object.keys(graph.nodes)).toHaveLength(2);
+		expect(graph.symbolEdges ?? []).toHaveLength(0);
+		expect(graph.edges).toContainEqual(
+			expect.objectContaining({ importSpecifier: './dep' }),
+		);
+		expect(graph.diagnostics?.extractionFailures).toContainEqual({
+			file: 'caller.ts',
+			language: 'typescript',
+			reason: 'symbol_edge_validation_failed',
+		});
+	});
+
+	test('incremental update persists/fingerprints the graph when a malformed symbol edge is skipped', async () => {
+		const depPath = write('dep.ts', 'export function target() { return 1; }\n');
+		const callerPath = write(
+			'caller.ts',
+			'import { target } from "./dep";\nexport function caller() { return target(); }\n',
+		);
+		await saveGraph(workspace, await buildWorkspaceGraphAsync(workspace));
+
+		fs.writeFileSync(
+			callerPath,
+			'import { target } from "./dep";\nexport function caller() { return target() + 1; }\n',
+		);
+		builderInternals.extractFileSymbols = async (grammar, content) => {
+			const facts = await originalExtractFileSymbols(grammar, content);
+			if (!content.includes('target() + 1')) {
+				return facts;
+			}
+			if (!facts) return facts;
+			return {
+				...facts,
+				refs: [
+					{ identifier: 'target', enclosingDecl: 'x'.repeat(513), line: 2 },
+				],
+			};
+		};
+
+		const updated = await updateGraphForFiles(workspace, [callerPath]);
+		expect(Object.keys(updated.nodes)).toHaveLength(2);
+		expect(updated.edges).toContainEqual(
+			expect.objectContaining({ source: callerPath, target: depPath }),
+		);
+		expect(updated.symbolEdges ?? []).toHaveLength(0);
+		expect(updated.diagnostics?.extractionFailures).toContainEqual({
+			file: 'caller.ts',
+			language: 'typescript',
+			reason: 'symbol_edge_validation_failed',
+		});
+		expect(
+			fs.existsSync(
+				path.join(workspace, '.swarm', REPO_GRAPH_FINGERPRINT_FILENAME),
+			),
+		).toBe(true);
+		const reloaded = await loadGraph(workspace);
+		expect(reloaded?.diagnostics?.extractionFailures).toContainEqual({
+			file: 'caller.ts',
+			language: 'typescript',
+			reason: 'symbol_edge_validation_failed',
+		});
+	});
+
+	test('incremental update merges duplicate incoming v2 edges and preserves both evidence records', async () => {
+		write('dep.ts', 'export function target() { return 1; }\n');
+		const callerPath = write(
+			'caller.ts',
+			'import { target } from "./dep";\nexport function caller() { return target(); }\n',
+		);
+		await saveGraph(workspace, await buildWorkspaceGraphAsync(workspace));
+
+		const realScanFileAsync = originalIncrementalScanFileAsync;
+		incrementalInternals.scanFileAsync = async (
+			filePath,
+			absoluteRoot,
+			maxFileSize,
+			hasManifest,
+			repoRootId,
+		) => {
+			const scanned = await realScanFileAsync(
+				filePath,
+				absoluteRoot,
+				maxFileSize,
+				hasManifest,
+				repoRootId,
+			);
+			if (!filePath.endsWith('caller.ts')) {
+				return scanned;
+			}
+			const resolvedRepoRootId = repoRootId ?? deriveRepoRootId(absoluteRoot);
+			const coordinates = {
+				fromFile: callerPath,
+				fromSymbol: 'caller',
+				toFile: path.join(workspace, 'dep.ts'),
+				toSymbol: 'target',
+			};
+			return {
+				...scanned,
+				symbolEdges: [
+					createSymbolEdgeV2(coordinates, absoluteRoot, resolvedRepoRootId, {
+						confidence: 0.9,
+						resolution: 'import_binding',
+						evidence: [
+							{
+								file: 'caller.ts',
+								line: 2,
+								snippetHash: hashSymbolEdgeSnippet('return target();'),
+								extractor: 'tree-sitter/typescript',
+							},
+						],
+					}),
+					createSymbolEdgeV2(coordinates, absoluteRoot, resolvedRepoRootId, {
+						confidence: 0.8,
+						resolution: 'import_binding',
+						evidence: [
+							{
+								file: 'caller.ts',
+								line: 3,
+								snippetHash: hashSymbolEdgeSnippet('return target();'),
+								extractor: 'tree-sitter/typescript',
+							},
+						],
+					}),
+				],
+			};
+		};
+
+		const updated = await updateGraphForFiles(workspace, [callerPath]);
+		const edge = updated.symbolEdges?.find(
+			(candidate) =>
+				candidate.fromFile === callerPath && candidate.toSymbol === 'target',
+		);
+		expect(edge).toBeDefined();
+		expect(edge?.evidence.map((entry) => entry.line)).toEqual([2, 3]);
+	});
+
+	test('incremental update replaces a legacy source edge instead of duplicating it', async () => {
+		// Before the fix, a schema-1.2 edge was excluded from the v2 ID index and
+		// remained beside the newly extracted v2 edge after the source file changed.
+		const depPath = write('dep.ts', 'export function target() { return 1; }\n');
+		const callerPath = write(
+			'caller.ts',
+			'import { target } from "./dep";\nexport function caller() { return target(); }\n',
+		);
+		const graph = await buildWorkspaceGraphAsync(workspace);
+		const generated = graph.symbolEdges?.find(
+			(edge) => edge.fromFile === callerPath && edge.toFile === depPath,
+		);
+		expect(generated).toBeDefined();
+		if (!generated) throw new Error('expected generated symbol edge');
+		graph.schema_version = '1.2.0';
+		graph.symbolEdges = [
+			{
+				fromFile: generated.fromFile,
+				fromSymbol: generated.fromSymbol,
+				toFile: generated.toFile,
+				toSymbol: generated.toSymbol,
+			},
+		];
+		await saveGraph(workspace, graph);
+
+		fs.writeFileSync(
+			callerPath,
+			'import { target } from "./dep";\nexport function caller() { return target() + 1; }\n',
+		);
+		const updated = await updateGraphForFiles(workspace, [callerPath]);
+		const callerEdges = (updated.symbolEdges ?? []).filter(
+			(edge) => edge.fromFile === callerPath,
+		);
+		expect(callerEdges).toHaveLength(1);
+		expect(callerEdges[0]).toEqual(
+			expect.objectContaining({
+				id: expect.stringMatching(/^[a-f0-9]{64}$/),
+				confidence: expect.any(Number),
+			}),
+		);
+	});
+});

--- a/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	clearCache,
+	loadGraph,
+	type RepoGraph,
+	saveGraph,
+} from '../../../src/tools/repo-graph';
+import {
+	createSymbolEdgeV2,
+	deriveRepoRootId,
+	hashSymbolEdgeSnippet,
+} from '../../../src/tools/repo-graph/symbol-edge';
+
+type SymbolEdge = NonNullable<RepoGraph['symbolEdges']>[number];
+
+describe('SymbolEdge v2 persistence validation — issue #1532', () => {
+	let workspace: string;
+
+	beforeEach(() => {
+		workspace = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-edge-v2-store-')),
+		);
+		fs.mkdirSync(path.join(workspace, '.swarm'), { recursive: true });
+	});
+
+	afterEach(() => {
+		clearCache(workspace);
+		fs.rmSync(workspace, { recursive: true, force: true });
+	});
+
+	function coordinates(): Pick<
+		SymbolEdge,
+		'fromFile' | 'fromSymbol' | 'toFile' | 'toSymbol'
+	> {
+		return {
+			fromFile: path.join(workspace, 'caller.ts'),
+			fromSymbol: 'caller',
+			toFile: path.join(workspace, 'dep.ts'),
+			toSymbol: 'target',
+		};
+	}
+
+	function graphWith(edge: SymbolEdge, schema = '1.5.0'): RepoGraph {
+		return {
+			schema_version: schema,
+			workspaceRoot: workspace,
+			repoRootId: deriveRepoRootId(workspace),
+			nodes: {},
+			edges: [],
+			symbolEdges: [edge],
+			metadata: {
+				generatedAt: new Date(0).toISOString(),
+				generator: 'test',
+				nodeCount: 0,
+				edgeCount: 0,
+			},
+		};
+	}
+
+	function validEdge(): SymbolEdge {
+		return createSymbolEdgeV2(
+			coordinates(),
+			workspace,
+			deriveRepoRootId(workspace),
+			{
+				confidence: 0.9,
+				resolution: 'import_binding',
+				evidence: [
+					{
+						file: 'caller.ts',
+						line: 2,
+						snippetHash: hashSymbolEdgeSnippet('target();'),
+						extractor: 'tree-sitter/typescript',
+					},
+				],
+			},
+		);
+	}
+
+	function writeRaw(graph: RepoGraph): void {
+		fs.writeFileSync(
+			path.join(workspace, '.swarm', 'repo-graph.json'),
+			JSON.stringify(graph),
+		);
+		clearCache(workspace);
+	}
+
+	test.each([
+		['unknown kind', { kind: 'MAYBE' }],
+		['unknown resolution', { resolution: 'guessed' }],
+		['confidence below zero', { confidence: -0.1 }],
+		['confidence above one', { confidence: 1.1 }],
+		['shape-valid mismatched edge id', { id: 'a'.repeat(64) }],
+		['shape-valid mismatched source id', { fromId: 'b'.repeat(64) }],
+		[
+			'unsafe evidence path',
+			{
+				evidence: [
+					{
+						file: '../escape.ts',
+						line: 1,
+						snippetHash: 'c'.repeat(64),
+						extractor: 'test',
+					},
+				],
+			},
+		],
+		[
+			'invalid evidence line',
+			{
+				evidence: [
+					{
+						file: 'caller.ts',
+						line: 0,
+						snippetHash: 'c'.repeat(64),
+						extractor: 'test',
+					},
+				],
+			},
+		],
+		[
+			'invalid evidence hash',
+			{
+				evidence: [
+					{
+						file: 'caller.ts',
+						line: 1,
+						snippetHash: 'nope',
+						extractor: 'test',
+					},
+				],
+			},
+		],
+	] as const)('load rejects %s', async (_name, mutation) => {
+		const edge = { ...validEdge(), ...mutation } as unknown as SymbolEdge;
+		writeRaw(graphWith(edge));
+		await expect(loadGraph(workspace)).rejects.toThrow(
+			'repo-graph.json contains invalid symbolEdges entry',
+		);
+	});
+
+	test('load rejects a partial v2 record', async () => {
+		const partial = { ...coordinates(), confidence: 0.5 } as SymbolEdge;
+		writeRaw(graphWith(partial));
+		await expect(loadGraph(workspace)).rejects.toThrow(
+			'repo-graph.json contains invalid symbolEdges entry',
+		);
+	});
+
+	test('save rejects a shape-valid but semantically inconsistent ID before writing', async () => {
+		const edge = { ...validEdge(), toId: 'd'.repeat(64) };
+		await expect(saveGraph(workspace, graphWith(edge))).rejects.toThrow(
+			'repo-graph.json contains invalid symbolEdges entry',
+		);
+		expect(
+			fs.existsSync(path.join(workspace, '.swarm', 'repo-graph.json')),
+		).toBe(false);
+	});
+
+	test('confidence and provenance survive save/load unchanged', async () => {
+		const edge = validEdge();
+		await saveGraph(workspace, graphWith(edge));
+		clearCache(workspace);
+		const loaded = await loadGraph(workspace);
+		expect(loaded?.symbolEdges?.[0]).toEqual(edge);
+	});
+
+	test('schema 1.2 legacy graph derives root identity and survives explicit save/reload', async () => {
+		const legacy: SymbolEdge = coordinates();
+		const graph = graphWith(legacy, '1.2.0');
+		delete graph.repoRootId;
+		writeRaw(graph);
+
+		const loaded = await loadGraph(workspace);
+		expect(loaded?.schema_version).toBe('1.2.0');
+		expect(loaded?.repoRootId).toBe(deriveRepoRootId(workspace));
+		expect(loaded?.symbolEdges?.[0]).toEqual(
+			expect.objectContaining(coordinates()),
+		);
+		expect(loaded?.symbolEdges?.[0].resolution).toBe('unresolved');
+		if (!loaded) throw new Error('expected legacy graph');
+
+		await saveGraph(workspace, loaded);
+		clearCache(workspace);
+		const reloaded = await loadGraph(workspace);
+		expect(reloaded?.schema_version).toBe('1.2.0');
+		expect(reloaded?.repoRootId).toBe(deriveRepoRootId(workspace));
+		expect(reloaded?.symbolEdges?.[0]).toEqual(loaded.symbolEdges?.[0]);
+	});
+});

--- a/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import {
 	clearCache,
+	getGraphHealth,
 	loadGraph,
 	type RepoGraph,
 	saveGraph,
@@ -179,7 +180,12 @@ describe('SymbolEdge v2 persistence validation — issue #1532', () => {
 		expect(loaded?.symbolEdges?.[0]).toEqual(
 			expect.objectContaining(coordinates()),
 		);
-		expect(loaded?.symbolEdges?.[0].resolution).toBe('unresolved');
+		expect(loaded?.symbolEdges?.[0].resolution).toBeUndefined();
+		expect(
+			getGraphHealth(loaded!).notes.some((note) =>
+				note.includes('legacy symbol edge'),
+			),
+		).toBe(true);
 		if (!loaded) throw new Error('expected legacy graph');
 
 		await saveGraph(workspace, loaded);
@@ -188,5 +194,138 @@ describe('SymbolEdge v2 persistence validation — issue #1532', () => {
 		expect(reloaded?.schema_version).toBe('1.2.0');
 		expect(reloaded?.repoRootId).toBe(deriveRepoRootId(workspace));
 		expect(reloaded?.symbolEdges?.[0]).toEqual(loaded.symbolEdges?.[0]);
+	});
+
+	test('load binds workspaceRoot and repoRootId to the active workspace', async () => {
+		const graph = graphWith(validEdge());
+		graph.workspaceRoot = path.relative(process.cwd(), workspace);
+		graph.repoRootId = 'forged-root';
+		writeRaw(graph);
+
+		const loaded = await loadGraph(workspace);
+		expect(loaded?.workspaceRoot).toBe(workspace);
+		expect(loaded?.repoRootId).toBe(deriveRepoRootId(workspace));
+	});
+
+	test('load rejects a graph whose persisted workspaceRoot targets another workspace', async () => {
+		const foreignWorkspace = canonicalMkdtemp('repo-graph-edge-v2-foreign-');
+		try {
+			const graph = graphWith(validEdge());
+			graph.workspaceRoot = foreignWorkspace;
+			writeRaw(graph);
+			await expect(loadGraph(workspace)).rejects.toThrow(
+				'repo-graph.json workspaceRoot mismatch',
+			);
+		} finally {
+			fs.rmSync(foreignWorkspace, { recursive: true, force: true });
+		}
+	});
+
+	test('createSymbolEdgeV2 accepts exact schema boundaries', () => {
+		const repoRootId = deriveRepoRootId(workspace);
+		const exactFilePath = `${workspace}${path.sep}${'f'.repeat(
+			4096 - workspace.length - path.sep.length,
+		)}`;
+		const edge = createSymbolEdgeV2(
+			{
+				fromFile: exactFilePath,
+				fromSymbol: 's'.repeat(512),
+				toFile: path.join(workspace, 'dep.ts'),
+				toSymbol: 't'.repeat(512),
+			},
+			workspace,
+			repoRootId,
+			{
+				confidence: 1,
+				resolution: 'import_binding',
+				evidence: [
+					{
+						file: 'e'.repeat(1024),
+						line: 1,
+						snippetHash: 'a'.repeat(64),
+						extractor: 'x'.repeat(128),
+					},
+				],
+			},
+		);
+		expect(edge.fromSymbol).toHaveLength(512);
+		expect(edge.toSymbol).toHaveLength(512);
+		expect(edge.fromFile.length).toBe(4096);
+		expect(edge.evidence[0]?.file).toHaveLength(1024);
+		expect(edge.evidence[0]?.extractor).toHaveLength(128);
+	});
+
+	test.each([
+		[
+			'symbol over 512 chars',
+			() => ({
+				fromSymbol: 's'.repeat(513),
+			}),
+			'invalid fromSymbol',
+		],
+		[
+			'path over 4096 chars',
+			() => ({
+				fromFile: `${workspace}${path.sep}${'f'.repeat(
+					4097 - workspace.length - path.sep.length,
+				)}`,
+			}),
+			'invalid fromFile',
+		],
+		[
+			'evidence path over 1024 chars',
+			() => ({
+				evidence: [
+					{
+						file: 'e'.repeat(1025),
+						line: 1,
+						snippetHash: 'a'.repeat(64),
+						extractor: 'test',
+					},
+				],
+			}),
+			'invalid evidence entry',
+		],
+		[
+			'extractor over 128 chars',
+			() => ({
+				evidence: [
+					{
+						file: 'caller.ts',
+						line: 1,
+						snippetHash: 'a'.repeat(64),
+						extractor: 'x'.repeat(129),
+					},
+				],
+			}),
+			'invalid evidence entry',
+		],
+		[
+			'too many evidence entries',
+			() => ({
+				evidence: Array.from({ length: 17 }, (_, index) => ({
+					file: `caller-${index}.ts`,
+					line: 1,
+					snippetHash: 'a'.repeat(64),
+					extractor: 'test',
+				})),
+			}),
+			'invalid evidence',
+		],
+		[
+			'NaN confidence',
+			() => ({ confidence: Number.NaN }),
+			'invalid symbol edge confidence',
+		],
+	] as const)('createSymbolEdgeV2 rejects %s', (_name, mutation, message) => {
+		const repoRootId = deriveRepoRootId(workspace);
+		expect(() =>
+			createSymbolEdgeV2(coordinates(), workspace, repoRootId, {
+				confidence: 0.9,
+				resolution: 'import_binding',
+				evidence: [],
+				...mutation(),
+			}),
+		).toThrow(message);
 	});
 });

--- a/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2-validation.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
@@ -14,6 +13,7 @@ import {
 	deriveRepoRootId,
 	hashSymbolEdgeSnippet,
 } from '../../../src/tools/repo-graph/symbol-edge';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 type SymbolEdge = NonNullable<RepoGraph['symbolEdges']>[number];
 
@@ -21,9 +21,7 @@ describe('SymbolEdge v2 persistence validation — issue #1532', () => {
 	let workspace: string;
 
 	beforeEach(() => {
-		workspace = fs.realpathSync(
-			fs.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-edge-v2-store-')),
-		);
+		workspace = canonicalMkdtemp('repo-graph-edge-v2-store-');
 		fs.mkdirSync(path.join(workspace, '.swarm'), { recursive: true });
 	});
 

--- a/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+	buildWorkspaceGraphAsync,
+	clearCache,
+	getContextPack,
+	getGraphHealth,
+	loadGraph,
+	type RepoGraph,
+} from '../../../src/tools/repo-graph';
+import { _internals as builderInternals } from '../../../src/tools/repo-graph/builder';
+import {
+	createStableSymbolId,
+	createSymbolEdgeV2,
+	deriveRepoRootId,
+	hashSymbolEdgeSnippet,
+	mergeSymbolEdges,
+} from '../../../src/tools/repo-graph/symbol-edge';
+
+describe('SymbolEdge v2 — issue #1532 regression', () => {
+	let workspace: string;
+	let originalExtractFileSymbols: typeof builderInternals.extractFileSymbols;
+
+	beforeEach(() => {
+		workspace = fs.realpathSync(
+			fs.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-edge-v2-')),
+		);
+		originalExtractFileSymbols = builderInternals.extractFileSymbols;
+	});
+
+	afterEach(() => {
+		clearCache(workspace);
+		builderInternals.extractFileSymbols = originalExtractFileSymbols;
+		fs.rmSync(workspace, { recursive: true, force: true });
+	});
+
+	test('async builder emits trustworthy v2 facts on real symbol edges', async () => {
+		fs.writeFileSync(
+			path.join(workspace, 'dep.ts'),
+			'export function target() { return 1; }\n',
+		);
+		fs.writeFileSync(
+			path.join(workspace, 'caller.ts'),
+			'import { target } from "./dep";\nexport function caller() { return target(); }\n',
+		);
+
+		const graph = await buildWorkspaceGraphAsync(workspace);
+		const edge = graph.symbolEdges?.find(
+			(candidate) =>
+				candidate.fromFile.endsWith('caller.ts') &&
+				candidate.toSymbol === 'target',
+		) as (Record<string, unknown> & { evidence?: unknown[] }) | undefined;
+
+		expect(edge).toBeDefined();
+		expect(edge?.id).toMatch(/^[a-f0-9]{64}$/);
+		expect(edge?.fromId).toMatch(/^[a-f0-9]{64}$/);
+		expect(edge?.toId).toMatch(/^[a-f0-9]{64}$/);
+		expect(edge?.kind).toBe('REFERENCES');
+		expect(edge?.confidence).toBeGreaterThan(0);
+		expect(edge?.confidence).toBeLessThanOrEqual(1);
+		expect(edge?.resolution).toBe('import_binding');
+		expect(edge?.evidence).toHaveLength(1);
+		expect(edge?.evidence?.[0]).toEqual(
+			expect.objectContaining({
+				file: 'caller.ts',
+				line: 2,
+				extractor: 'tree-sitter/typescript',
+			}),
+		);
+	});
+
+	test('storage rejects a partially populated malformed v2 edge', async () => {
+		const graphPath = path.join(workspace, '.swarm', 'repo-graph.json');
+		fs.mkdirSync(path.dirname(graphPath), { recursive: true });
+		const graph: RepoGraph = {
+			schema_version: '1.5.0',
+			workspaceRoot: workspace,
+			nodes: {},
+			edges: [],
+			symbolEdges: [
+				{
+					fromFile: path.join(workspace, 'caller.ts'),
+					fromSymbol: 'caller',
+					toFile: path.join(workspace, 'dep.ts'),
+					toSymbol: 'target',
+					confidence: 2,
+				} as RepoGraph['symbolEdges'][number],
+			],
+			metadata: {
+				generatedAt: new Date().toISOString(),
+				generator: 'test',
+				nodeCount: 0,
+				edgeCount: 0,
+			},
+		};
+		fs.writeFileSync(graphPath, JSON.stringify(graph));
+
+		await expect(loadGraph(workspace)).rejects.toThrow(
+			'repo-graph.json contains invalid symbolEdges entry',
+		);
+	});
+
+	test('graph health derives low-confidence and unresolved counts from edges', () => {
+		const repoRootId = deriveRepoRootId(workspace);
+		const edge = createSymbolEdgeV2(
+			{
+				fromFile: path.join(workspace, 'caller.ts'),
+				fromSymbol: 'caller',
+				toFile: path.join(workspace, 'dep.ts'),
+				toSymbol: 'target',
+			},
+			workspace,
+			repoRootId,
+			{
+				confidence: 0.25,
+				resolution: 'unresolved',
+				evidence: [],
+			},
+		);
+		const graph: RepoGraph = {
+			schema_version: '1.5.0',
+			workspaceRoot: workspace,
+			repoRootId,
+			nodes: {},
+			edges: [],
+			symbolEdges: [edge],
+			metadata: {
+				generatedAt: new Date().toISOString(),
+				generator: 'test',
+				nodeCount: 0,
+				edgeCount: 0,
+			},
+		};
+
+		const health = getGraphHealth(graph) as unknown as Record<string, unknown>;
+		expect(health.lowConfidenceEdgeCount).toBe(1);
+		expect(health.unresolvedSymbolEdgeCount).toBe(1);
+	});
+
+	test('stable IDs normalize roots, separators, drive case, and Unicode without folding path case', () => {
+		const windowsRoot = deriveRepoRootId('C:\\work\\cafe\u0301-repo');
+		const posixRoot = deriveRepoRootId('/mnt/work/caf\u00e9-repo');
+		expect(windowsRoot).toBe(posixRoot);
+
+		const windowsId = createStableSymbolId(
+			windowsRoot,
+			'src\\caf\u00e9.ts',
+			're\u0301sume\u0301',
+			'symbol',
+		);
+		const posixId = createStableSymbolId(
+			posixRoot,
+			'src/caf\u00e9.ts',
+			'r\u00e9sum\u00e9',
+			'symbol',
+		);
+		expect(windowsId).toBe(posixId);
+		expect(
+			createStableSymbolId(
+				posixRoot,
+				'src/CAF\u00c9.ts',
+				'r\u00e9sum\u00e9',
+				'symbol',
+			),
+		).not.toBe(posixId);
+	});
+
+	test('snippet hashing is stable across CRLF/LF logical lines', () => {
+		expect(hashSymbolEdgeSnippet('return target();\r')).toBe(
+			hashSymbolEdgeSnippet('return target();'),
+		);
+	});
+
+	test('duplicate evidence merges deterministically regardless of input order', () => {
+		const repoRootId = deriveRepoRootId(workspace);
+		const coordinates = {
+			fromFile: path.join(workspace, 'caller.ts'),
+			fromSymbol: 'caller',
+			toFile: path.join(workspace, 'dep.ts'),
+			toSymbol: 'target',
+		};
+		const evidenceA = {
+			file: 'caller.ts',
+			line: 2,
+			snippetHash: hashSymbolEdgeSnippet('target();'),
+			extractor: 'tree-sitter/typescript',
+		};
+		const evidenceB = { ...evidenceA, line: 4 };
+		const a = createSymbolEdgeV2(coordinates, workspace, repoRootId, {
+			confidence: 0.9,
+			resolution: 'import_binding',
+			evidence: [evidenceA],
+		});
+		const b = createSymbolEdgeV2(coordinates, workspace, repoRootId, {
+			confidence: 0.8,
+			resolution: 'import_binding',
+			evidence: [evidenceB],
+		});
+		expect(mergeSymbolEdges(a, b, workspace, repoRootId)).toEqual(
+			mergeSymbolEdges(b, a, workspace, repoRootId),
+		);
+	});
+
+	test('equal-confidence duplicates choose resolution deterministically', () => {
+		const repoRootId = deriveRepoRootId(workspace);
+		const coordinates = {
+			fromFile: path.join(workspace, 'caller.ts'),
+			fromSymbol: 'caller',
+			toFile: path.join(workspace, 'dep.ts'),
+			toSymbol: 'target',
+		};
+		const unresolved = createSymbolEdgeV2(coordinates, workspace, repoRootId, {
+			confidence: 0.9,
+			resolution: 'unresolved',
+			evidence: [],
+		});
+		const resolved = createSymbolEdgeV2(coordinates, workspace, repoRootId, {
+			confidence: 0.9,
+			resolution: 'import_binding',
+			evidence: [],
+		});
+
+		const merged = mergeSymbolEdges(
+			unresolved,
+			resolved,
+			workspace,
+			repoRootId,
+		);
+		expect(merged.resolution).toBe('import_binding');
+		expect(
+			mergeSymbolEdges(resolved, unresolved, workspace, repoRootId),
+		).toEqual(merged);
+	});
+
+	test('legacy edges remain traversable and unscored in health', () => {
+		const caller = path.join(workspace, 'caller.ts');
+		const dep = path.join(workspace, 'dep.ts');
+		const graph: RepoGraph = {
+			schema_version: '1.2.0',
+			workspaceRoot: workspace,
+			nodes: {
+				[caller.replace(/\\/g, '/')]: {
+					filePath: caller,
+					moduleName: 'caller.ts',
+					exports: ['caller'],
+					exportRanges: { caller: { startLine: 1, endLine: 2 } },
+					imports: ['./dep'],
+					language: 'typescript',
+					mtime: new Date(0).toISOString(),
+				},
+				[dep.replace(/\\/g, '/')]: {
+					filePath: dep,
+					moduleName: 'dep.ts',
+					exports: ['target'],
+					exportRanges: { target: { startLine: 1, endLine: 1 } },
+					imports: [],
+					language: 'typescript',
+					mtime: new Date(0).toISOString(),
+				},
+			},
+			edges: [],
+			symbolEdges: [
+				{
+					fromFile: caller,
+					fromSymbol: 'caller',
+					toFile: dep,
+					toSymbol: 'target',
+				},
+			],
+			metadata: {
+				generatedAt: new Date(0).toISOString(),
+				generator: 'test',
+				nodeCount: 2,
+				edgeCount: 0,
+			},
+		};
+
+		expect(getContextPack(graph, 'dep.ts', 'target').spans).toHaveLength(2);
+		const health = getGraphHealth(graph);
+		expect(health.lowConfidenceEdgeCount).toBe(0);
+		expect(health.unresolvedSymbolEdgeCount).toBe(0);
+		expect(
+			health.notes.some((note) => note.includes('legacy symbol edge')),
+		).toBe(true);
+	});
+
+	test('missing direct-reference line retains an honest unresolved edge', async () => {
+		fs.writeFileSync(
+			path.join(workspace, 'dep.ts'),
+			'export const target = 1;\n',
+		);
+		fs.writeFileSync(
+			path.join(workspace, 'caller.ts'),
+			'import { target } from "./dep";\nexport const caller = target;\n',
+		);
+		builderInternals.extractFileSymbols = async (_grammar, content) =>
+			content.includes('caller')
+				? {
+						defs: [
+							{
+								name: 'caller',
+								kind: 'const',
+								exported: true,
+								startLine: 2,
+								endLine: 2,
+							},
+						],
+						imports: [
+							{
+								specifier: './dep',
+								importType: 'named',
+								bindings: [{ imported: 'target', local: 'target' }],
+							},
+						],
+						refs: [{ identifier: 'target', enclosingDecl: 'caller' }],
+					}
+				: {
+						defs: [
+							{
+								name: 'target',
+								kind: 'const',
+								exported: true,
+								startLine: 1,
+								endLine: 1,
+							},
+						],
+						imports: [],
+						refs: [],
+					};
+
+		const graph = await buildWorkspaceGraphAsync(workspace);
+		const edge = graph.symbolEdges?.[0];
+		expect(edge?.confidence).toBe(0);
+		expect(edge?.resolution).toBe('unresolved');
+		expect(edge?.evidence).toEqual([]);
+	});
+});

--- a/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
@@ -197,9 +197,12 @@ describe('SymbolEdge v2 — issue #1532 regression', () => {
 			resolution: 'import_binding',
 			evidence: [evidenceB],
 		});
-		expect(mergeSymbolEdges(a, b, workspace, repoRootId)).toEqual(
-			mergeSymbolEdges(b, a, workspace, repoRootId),
-		);
+		const merged = mergeSymbolEdges(a, b, workspace, repoRootId);
+		expect(merged).toEqual(mergeSymbolEdges(b, a, workspace, repoRootId));
+		expect(merged.evidence).toEqual([
+			expect.objectContaining({ line: 2 }),
+			expect.objectContaining({ line: 4 }),
+		]);
 	});
 
 	test('equal-confidence duplicates choose resolution deterministically', () => {

--- a/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-v2.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
@@ -19,15 +18,14 @@ import {
 	hashSymbolEdgeSnippet,
 	mergeSymbolEdges,
 } from '../../../src/tools/repo-graph/symbol-edge';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 describe('SymbolEdge v2 — issue #1532 regression', () => {
 	let workspace: string;
 	let originalExtractFileSymbols: typeof builderInternals.extractFileSymbols;
 
 	beforeEach(() => {
-		workspace = fs.realpathSync(
-			fs.mkdtempSync(path.join(os.tmpdir(), 'repo-graph-edge-v2-')),
-		);
+		workspace = canonicalMkdtemp('repo-graph-edge-v2-');
 		originalExtractFileSymbols = builderInternals.extractFileSymbols;
 	});
 
@@ -90,7 +88,7 @@ describe('SymbolEdge v2 — issue #1532 regression', () => {
 				} as RepoGraph['symbolEdges'][number],
 			],
 			metadata: {
-				generatedAt: new Date().toISOString(),
+				generatedAt: new Date(0).toISOString(),
 				generator: 'test',
 				nodeCount: 0,
 				edgeCount: 0,
@@ -128,7 +126,7 @@ describe('SymbolEdge v2 — issue #1532 regression', () => {
 			edges: [],
 			symbolEdges: [edge],
 			metadata: {
-				generatedAt: new Date().toISOString(),
+				generatedAt: new Date(0).toISOString(),
 				generator: 'test',
 				nodeCount: 0,
 				edgeCount: 0,


### PR DESCRIPTION
Closes #1532

## Summary
- Add additive SymbolEdge v2 metadata with stable repository-scoped endpoint and edge IDs, relationship kind, confidence, resolution provenance, and bounded hashed evidence.
- Make async and incremental graph production fail-open per malformed edge, retain valid nodes, emit bounded diagnostics, and avoid repeated full-array normalization on hot paths.
- Harden persisted graph trust boundaries: bind workspaceRoot/repoRootId to the active workspace, reject off-root or inconsistent v2 coordinates, preserve schema 1.2 legacy edges as traversable/unscored, and replace legacy source edges during incremental migration.
- Strengthen JVM/.NET assertions, evidence merge and boundary coverage, documentation, and regression tests for resilience and persistence behavior.

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization or startup await path changed; production build completed.
- 2 (runtime portability): not touched - no runtime loader, entrypoint, or bundle-shape changes; Node dist import passed.
- 3 (subprocesses): not touched - no subprocess code changed.
- 4 (.swarm containment): touched - storage binds persisted workspaceRoot to the active workspace and rejects foreign roots; persistence/containment tests passed.
- 5 (plan durability): not touched - no plan ledger, projection, or checkpoint code changed.
- 6 (test_runner safety): not touched - validation used explicit shell test commands and per-file repo-graph loops; no broad test_runner scope was used.
- 7 (test writing): touched - bun:test coverage uses canonical temp directories, DI seams, bounded files, resilience fixtures, and exact boundary assertions; test-file-cap passed.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no guardrail, retry, or circuit behavior changed.
- 10 (chat/system msg): not touched - no chat hook or message transformation changed.
- 11 (tool registration): not touched - existing repo_map tool registration is unchanged; invariant checks passed.
- 12 (release/cache): touched - required pending release fragment is present; generated dist/ was not staged.

## Test plan
- `bun run typecheck`
- `bun run lint:ci`
- `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- Full repo-graph unit sweep: 586/586 tests across 49 files
- Focused SymbolEdge v2/resilience/JVM/.NET suite: 69/69 tests; final post-doc focused suite: 35/35 tests
- `bun run check:test-file-cap`, `scripts/check-test-clock.sh`, `scripts/check-test-tmpdir.sh`, `scripts/check-mock-cleanup.sh`, `scripts/check-invariants.sh`
- `bun run check:runtime-src-refs`, `check:events`, `check:retention`, `check:core-events`, `check:pending-fragment`, `check:gate-portability`, `check:bare-spawn`, `check:error-channel-discard`, `check:memory-recall`, and `scripts/check-bash-portability.sh`
- `git diff --check`
- `package:smoke` previously reached packaging but timed out on this Windows host during npm cache/install (`EPERM`/`ETIMEDOUT`); CI package-check is authoritative.
