### PR TITLE
fix(skills): rename resume skill slug to swarm-resume to unshadow /resume (#2379)

### DIFF
--- a/.claude/skills/editing-skills/SKILL.md
+++ b/.claude/skills/editing-skills/SKILL.md
@@ -22,7 +22,7 @@ OpenCode and Claude Code surfaces. Classify first, then edit.
 Look the slug up in `src/config/skill-mirrors.ts`:
 
 - **MIRRORED_ARCHITECT_MODE_SKILLS** (brainstorm, specify, clarify-spec,
-  resume, clarify, discover, consult, pre-phase-briefing, council, deep-dive,
+  swarm-resume, clarify, discover, consult, pre-phase-briefing, council, deep-dive,
   deep-research, issue-ingest, plan, critic-gate, design-docs): `.opencode`
   and `.claude` copies must stay **byte-identical**.
   Any edit is a dual-tree edit — apply the identical change to both files.

--- a/.claude/skills/swarm-resume/SKILL.md
+++ b/.claude/skills/swarm-resume/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: swarm-resume
 audience: swarm-plugin
 description: >
   Full execution protocol for MODE: RESUME -- continuing an existing approved plan safely from current state.

--- a/.opencode/skills/swarm-resume/SKILL.md
+++ b/.opencode/skills/swarm-resume/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: swarm-resume
 audience: swarm-plugin
 description: >
   Full execution protocol for MODE: RESUME -- continuing an existing approved plan safely from current state.

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -513,7 +513,7 @@ evidence as trustworthy only within that cooperative-agent threat model. Strong
 integrity against a same-user adversarial process would require a protected
 trust root outside the workspace.
 
-**Session-reset worktree resilience (FR-004):** `.swarm-worktrees/` directories created by parallel lanes must be reconciled on session resume/reset. `provisionWorktree` in `src/worktree/core.ts` implements idempotent provisioning: if a branch exists but is not checked out in any active worktree, it is adopted; if it is active elsewhere, an error is returned. `reset-session.ts` wipes `.swarm-worktrees/` and orphan branches. The resume skill explicitly calls out reconciliation as the first step. This prevents stale worktrees from causing provisioning failures or silent git state corruption when a session resumes after reset.
+**Session-reset worktree resilience (FR-004):** `.swarm-worktrees/` directories created by parallel lanes must be reconciled on session resume/reset. `provisionWorktree` in `src/worktree/core.ts` implements idempotent provisioning: if a branch exists but is not checked out in any active worktree, it is adopted; if it is active elsewhere, an error is returned. `reset-session.ts` wipes `.swarm-worktrees/` and orphan branches. The swarm-resume skill (slug `resume` before the #2379 rename) explicitly calls out reconciliation as the first step. This prevents stale worktrees from causing provisioning failures or silent git state corruption when a session resumes after reset.
 
 **Anti-pattern:**
 

--- a/docs/releases/pending/2379-resume-skill-slug-rename.md
+++ b/docs/releases/pending/2379-resume-skill-slug-rename.md
@@ -1,0 +1,36 @@
+# resume skill renamed to swarm-resume — `/resume` no longer fires the swarm protocol
+
+## What changed
+
+- The internal architect-MODE "resume plan" protocol skill was renamed from
+  the slug `resume` to `swarm-resume` (`.opencode/skills/swarm-resume/` and
+  `.claude/skills/swarm-resume/`).
+- The bundled runtime copy now materializes at
+  `.swarm/bundled-skills/swarm-resume/SKILL.md`, and the sync automatically
+  removes the stale `.swarm/bundled-skills/resume/` directory left over in
+  existing projects.
+- A new regression guard test fails CI if any repo-shipped native skill slug
+  shadows a Claude Code built-in slash command
+  (`CLAUDE_CODE_NATIVE_COMMANDS`), so this class of collision cannot ship
+  again unnoticed.
+
+## Why
+
+Both OpenCode and Claude Code expose every native skill directory as the
+slash command `/<slug>`. Typing `/resume` in a Claude Code session therefore
+invoked this plugin's plan-resumption protocol instead of Claude Code's
+built-in conversation resume (issue #2379). `swarm-resume` follows the
+existing `swarm-` plugin-surface namespace (`swarm-pr-review`,
+`swarm-ci-monitor`, …), which no host built-in can shadow.
+
+## Migration notes
+
+- Typing `/resume` now reaches your host's built-in conversation resume
+  again. The swarm protocol is unaffected: the architect still auto-enters
+  MODE: RESUME when `.swarm/plan.md` has incomplete tasks — nothing about the
+  mode's behavior changed, only the user-facing skill slug.
+- If you maintain a custom prompt or note that references
+  `file:.swarm/bundled-skills/resume/SKILL.md`, update it to
+  `file:.swarm/bundled-skills/swarm-resume/SKILL.md`. The architect's
+  skill-loading protocol reports `SKILL_LOAD_FAILED` on a missing path, so a
+  stale custom reference fails loudly rather than silently.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		".opencode/skills/brainstorm",
 		".opencode/skills/specify",
 		".opencode/skills/clarify-spec",
-		".opencode/skills/resume",
+		".opencode/skills/swarm-resume",
 		".opencode/skills/clarify",
 		".opencode/skills/discover",
 		".opencode/skills/consult",

--- a/scripts/ci/quarantined-integration-tests.txt
+++ b/scripts/ci/quarantined-integration-tests.txt
@@ -4,3 +4,9 @@
 # starting with # are ignored.
 #
 # No active integration quarantines. Issue #1908 requires merge-group proof.
+
+# Refs #2396: skill_improver quota tests refuse to run inside the merge_group
+# integration batch (r.ran false); pass standalone. Merge-group proof: PR #2377
+# run 33109018048 and PR #2387 run 33110714121 failed identically on
+# 2026-08-27 while the standalone file passed on both branches.
+tests/integration/issue-629-skill-improver.test.ts

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -16,7 +16,7 @@ export const REQUIRED_PROJECT_SKILL_SLUGS = [
 	'brainstorm',
 	'specify',
 	'clarify-spec',
-	'resume',
+	'swarm-resume',
 	'clarify',
 	'discover',
 	'consult',

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -808,7 +808,7 @@ Activates when an existing .swarm/plan.md or .swarm/spec.md must be resumed.
 
 Purpose: Reconcile saved workflow state with the current swarm and continue without corrupting ownership.
 
-ACTION: Load skill ${bundledProjectSkillFileReference('resume')} immediately. Follow the protocol defined there.
+ACTION: Load skill ${bundledProjectSkillFileReference('swarm-resume')} immediately. Follow the protocol defined there.
 
 HARD CONSTRAINTS:
 - Preserve existing plan/spec state and reconcile swarm ownership before continuing work.

--- a/src/config/bundled-skills.ts
+++ b/src/config/bundled-skills.ts
@@ -301,15 +301,17 @@ async function copyBundledDirectoryBoundedAsync(
 }
 /**
  * Best-effort removal of retired bundled-slug directories from a project's
- * private runtime root. Bounded (fixed retired list — no directory scanning),
- * contained (each target is verified to sit under `skillsDir` before any
- * delete), symlink-refusing, and fail-open per slug: a removal failure
- * (including Windows EPERM/EACCES, which `force: true` does not swallow)
- * logs and continues without failing the surrounding sync.
+ * private runtime root. Validates its own root (refuses a symlinked
+ * `skillsDir` before any delete), is bounded (fixed retired list — no
+ * directory scanning), contained (each target is verified to sit under
+ * `skillsDir` before any delete), symlink-refusing, and fail-open per slug:
+ * a removal failure (including Windows EPERM/EACCES, which `force: true`
+ * does not swallow) logs and continues without failing the surrounding sync.
  */
 async function removeRetiredBundledSkillDirsAsync(
 	skillsDir: string,
 ): Promise<void> {
+	if (!(await ensureNotSymlinkedDirectoryAsync(skillsDir))) return;
 	const safeRoot = path.resolve(skillsDir);
 	for (const slug of RETIRED_BUNDLED_PROJECT_SKILLS) {
 		try {
@@ -343,6 +345,15 @@ async function performBundledProjectSkillSyncAsync(
 	packageRoot: string,
 	quiet: boolean,
 ): Promise<void> {
+	// Tracks whether `skillsDir` passed its symlink/directory guards. The
+	// retired-dir cleanup below must ONLY run on that validated path: running
+	// it unconditionally (e.g. via a bare `finally`) would also fire on the
+	// guard early-returns above, where `skillsDir` may be a symlink and a
+	// recursive rm could follow it outside the project (PR #2387 review
+	// finding F-003). Inside the validated region the cleanup must also run
+	// when the copy loop throws, so a failed copy can never leave the stale
+	// retired directory behind.
+	let skillsDirValidated = false;
 	try {
 		const sourceRoot = path.join(packageRoot, '.opencode', 'skills');
 		const swarmDir = path.join(projectDirectory, '.swarm');
@@ -352,6 +363,7 @@ async function performBundledProjectSkillSyncAsync(
 		}
 		if (!(await ensureNotSymlinkedDirectoryAsync(swarmDir))) return;
 		if (!(await ensureNotSymlinkedDirectoryAsync(skillsDir))) return;
+		skillsDirValidated = true;
 		for (const slug of BUNDLED_PROJECT_SKILLS) {
 			const sourceDir = path.join(sourceRoot, slug);
 			const sourceSkill = path.join(sourceDir, 'SKILL.md');
@@ -371,11 +383,6 @@ async function performBundledProjectSkillSyncAsync(
 				slug: bundledProjectSkillFileReference(slug),
 			});
 		}
-		// Retired slugs (renamed away in past releases) have no copy loop entry,
-		// so remove their stale materialized directories separately. Fail-open
-		// per slug inside the helper; a cleanup failure must never surface as a
-		// sync failure.
-		await removeRetiredBundledSkillDirsAsync(skillsDir);
 	} catch (err) {
 		// Non-fatal: plugin init and command registration must remain fail-open.
 		// The failure IS operator-actionable (the backstop broke): under
@@ -391,6 +398,18 @@ async function performBundledProjectSkillSyncAsync(
 		} else {
 			// biome-ignore lint/suspicious/noConsole: Fallback user-facing warning when bundled skill sync fails non-quietly — cannot use advisoryWarn as it would duplicate the already-raised advisory
 			console.warn(failureMsg);
+		}
+	} finally {
+		// Retired slugs (renamed away in past releases) have no copy loop entry,
+		// so remove their stale materialized directories separately — on the
+		// success path AND after a caught copy failure. Gated on the validated
+		// flag so the guard early-returns above never reach it. Fail-open per
+		// slug inside the helper; a cleanup failure must never surface as a
+		// sync failure.
+		if (skillsDirValidated) {
+			await removeRetiredBundledSkillDirsAsync(
+				path.join(projectDirectory, BUNDLED_PROJECT_SKILL_ROOT),
+			);
 		}
 	}
 }

--- a/src/config/bundled-skills.ts
+++ b/src/config/bundled-skills.ts
@@ -7,7 +7,7 @@ export const BUNDLED_PROJECT_SKILLS = [
 	'brainstorm',
 	'specify',
 	'clarify-spec',
-	'resume',
+	'swarm-resume',
 	'clarify',
 	'discover',
 	'consult',
@@ -48,6 +48,15 @@ export const BUNDLED_PROJECT_SKILLS = [
 	'durable-session-state',
 ] as const;
 export type BundledProjectSkill = (typeof BUNDLED_PROJECT_SKILLS)[number];
+/**
+ * Bundled skill slugs that were retired (renamed away) in shipped releases.
+ * The sync removes their materialized directories from
+ * `.swarm/bundled-skills/` in existing user projects so a rename never leaves
+ * a stale protocol copy behind (issue #2379: `resume` → `swarm-resume`).
+ * A slug must never appear both here and in BUNDLED_PROJECT_SKILLS (asserted
+ * by tests/unit/skills/claude-slug-collision-guard.test.ts).
+ */
+export const RETIRED_BUNDLED_PROJECT_SKILLS = ['resume'] as const;
 /**
  * Project-private runtime location for plugin-owned skills. Repository-native
  * skill roots (`.opencode/skills`, `.claude/skills`, and `.agents/skills`) are
@@ -290,6 +299,45 @@ async function copyBundledDirectoryBoundedAsync(
 		throw err;
 	}
 }
+/**
+ * Best-effort removal of retired bundled-slug directories from a project's
+ * private runtime root. Bounded (fixed retired list — no directory scanning),
+ * contained (each target is verified to sit under `skillsDir` before any
+ * delete), symlink-refusing, and fail-open per slug: a removal failure
+ * (including Windows EPERM/EACCES, which `force: true` does not swallow)
+ * logs and continues without failing the surrounding sync.
+ */
+async function removeRetiredBundledSkillDirsAsync(
+	skillsDir: string,
+): Promise<void> {
+	const safeRoot = path.resolve(skillsDir);
+	for (const slug of RETIRED_BUNDLED_PROJECT_SKILLS) {
+		try {
+			const target = path.resolve(safeRoot, slug);
+			const relative = path.relative(safeRoot, target);
+			if (relative.startsWith('..') || path.isAbsolute(relative)) {
+				throw new Error('retired bundled skill path escaped its private root');
+			}
+			try {
+				const stat = await fsp.lstat(target);
+				// Skip symlinks (never delete through a link) and non-directories.
+				if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+			} catch (err) {
+				// ENOENT: nothing to clean up — the expected state for projects
+				// that never materialized this slug.
+				if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+				throw err;
+			}
+			await fsp.rm(target, { recursive: true, force: true });
+			log('removed retired bundled skill', { slug });
+		} catch (err) {
+			log('could not remove retired bundled skill (continuing)', {
+				slug,
+				message: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+}
 async function performBundledProjectSkillSyncAsync(
 	projectDirectory: string,
 	packageRoot: string,
@@ -323,6 +371,11 @@ async function performBundledProjectSkillSyncAsync(
 				slug: bundledProjectSkillFileReference(slug),
 			});
 		}
+		// Retired slugs (renamed away in past releases) have no copy loop entry,
+		// so remove their stale materialized directories separately. Fail-open
+		// per slug inside the helper; a cleanup failure must never surface as a
+		// sync failure.
+		await removeRetiredBundledSkillDirsAsync(skillsDir);
 	} catch (err) {
 		// Non-fatal: plugin init and command registration must remain fail-open.
 		// The failure IS operator-actionable (the backstop broke): under

--- a/src/config/skill-mirrors.ts
+++ b/src/config/skill-mirrors.ts
@@ -48,9 +48,13 @@ export const MIRRORED_ARCHITECT_MODE_SKILLS: Array<{
 		canonical: '.opencode',
 	},
 	{
-		slug: 'resume',
-		opencodePath: '.opencode/skills/resume/SKILL.md',
-		claudePath: '.claude/skills/resume/SKILL.md',
+		// Slug renamed from `resume` (issue #2379): both hosts expose native
+		// skill directories as `/<slug>` slash commands, so the bare slug
+		// shadowed Claude Code's built-in `/resume` conversation command. The
+		// internal MODE label stays `RESUME`; only the user-facing slug moved.
+		slug: 'swarm-resume',
+		opencodePath: '.opencode/skills/swarm-resume/SKILL.md',
+		claudePath: '.claude/skills/swarm-resume/SKILL.md',
 		canonical: '.opencode',
 	},
 	{

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -95,7 +95,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/commands/handoff.ts:48 (pre-#2035)',
 			'src/commands/handoff.ts:79 (pre-#2035)',
 			'src/memory/local-jsonl-provider.ts:1171',
-			'src/config/bundled-skills.ts:241',
+			'src/config/bundled-skills.ts:250',
 		],
 	},
 	{

--- a/tests/unit/agents/architect-mode-skill-helpers.ts
+++ b/tests/unit/agents/architect-mode-skill-helpers.ts
@@ -27,7 +27,7 @@ const MODE_PROTOCOL_INSERTIONS = [
 	},
 	{
 		nextMarker: '### MODE: CLARIFY',
-		protocol: readSkill('resume'),
+		protocol: readSkill('swarm-resume'),
 	},
 	{
 		nextMarker: '### MODE: DISCOVER',

--- a/tests/unit/config/bundled-skills-retired-cleanup.test.ts
+++ b/tests/unit/config/bundled-skills-retired-cleanup.test.ts
@@ -6,7 +6,15 @@
  * per the test-file-split protocol.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from 'bun:test';
 import * as fs from 'node:fs';
 import * as realFsPromises from 'node:fs/promises';
 import * as path from 'node:path';
@@ -15,7 +23,19 @@ import {
 	BUNDLED_PROJECT_SKILL_ROOT,
 	syncBundledProjectSkillsIfMissingAsync,
 } from '../../../src/config/bundled-skills';
+import {
+	clearDeferredWarnings,
+	getDeferredWarnings,
+} from '../../../src/services/warning-buffer';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+// Capture the REAL rm at module scope, BEFORE any mock.module runs. Passing
+// `realFsPromises.rm` directly inside the mock factory's delegate branch is
+// self-referential: mock.module mutates the live namespace binding, so the
+// captured namespace's `rm` IS the mock by call time and the delegate branch
+// re-enters itself forever (PR #2387 review finding F-002). The repo
+// precedent is tests/helpers/prod-store-tripwire.ts.
+const realRm = realFsPromises.rm.bind(realFsPromises);
 
 function writePackageSkill(
 	packageRoot: string,
@@ -23,8 +43,13 @@ function writePackageSkill(
 	body = 'canonical skill\n',
 ): void {
 	const skillDir = path.join(packageRoot, '.opencode', 'skills', slug);
-	fs.mkdirSync(skillDir, { recursive: true });
+	fs.mkdirSync(path.join(skillDir, 'references'), { recursive: true });
 	fs.writeFileSync(path.join(skillDir, 'SKILL.md'), body, 'utf-8');
+	fs.writeFileSync(
+		path.join(skillDir, 'references', 'review-protocol-v8.2.md'),
+		'protocol\n',
+		'utf-8',
+	);
 }
 
 describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)', () => {
@@ -32,9 +57,12 @@ describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)',
 	let packageRoot: string;
 	let cleanupProject: () => void;
 	let cleanupPackage: () => void;
+	let warnOutput: string[];
+	let warnSpy: ReturnType<typeof spyOn>;
 
 	beforeEach(() => {
 		_test_exports.resetBundledProjectSkillSyncCache();
+		clearDeferredWarnings();
 		({ dir: projectDir, cleanup: cleanupProject } = createSafeTestDir(
 			'swarm-bundled-skill-retired-project-',
 		));
@@ -43,16 +71,32 @@ describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)',
 		));
 		writePackageSkill(packageRoot);
 		writePackageSkill(packageRoot, 'design-docs', 'design docs skill\n');
+		warnOutput = [];
+		warnSpy = spyOn(console, 'warn').mockImplementation(
+			(...args: unknown[]) => {
+				warnOutput.push(args.map(String).join(' '));
+			},
+		);
 	});
 
 	afterEach(() => {
+		warnSpy.mockRestore();
 		mock.restore();
+		clearDeferredWarnings();
 		cleanupProject();
 		cleanupPackage();
 	});
 
 	const retiredDir = () =>
 		path.join(projectDir, BUNDLED_PROJECT_SKILL_ROOT, 'resume');
+
+	const activeSkillPath = () =>
+		path.join(
+			projectDir,
+			BUNDLED_PROJECT_SKILL_ROOT,
+			'codebase-review-swarm',
+			'SKILL.md',
+		);
 
 	test('removes a stale retired bundled-slug directory during sync', async () => {
 		fs.mkdirSync(retiredDir(), { recursive: true });
@@ -65,17 +109,38 @@ describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)',
 		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
 		expect(fs.existsSync(retiredDir())).toBe(false);
+		expect(fs.readFileSync(activeSkillPath(), 'utf-8')).toBe(
+			'canonical skill\n',
+		);
+	});
+
+	test('cleanup still runs when the copy loop fails mid-sync', async () => {
+		// PR #2387 review finding F-003: the cleanup runs in a finally gated on
+		// the validated skillsDir, so a copy failure (here: a file where the
+		// references directory belongs) must not leave the stale retired
+		// directory behind.
+		fs.mkdirSync(retiredDir(), { recursive: true });
+		fs.writeFileSync(path.join(retiredDir(), 'SKILL.md'), 'legacy\n', 'utf-8');
+		const blocked = path.join(
+			projectDir,
+			BUNDLED_PROJECT_SKILL_ROOT,
+			'codebase-review-swarm',
+			'references',
+		);
+		fs.mkdirSync(path.dirname(blocked), { recursive: true });
+		fs.writeFileSync(blocked, 'not a directory\n', 'utf-8');
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		// The copy failure surfaces its advisory as designed (non-quiet call →
+		// legacy console.warn routing, matching bundled-skills-async.test.ts)...
 		expect(
-			fs.readFileSync(
-				path.join(
-					projectDir,
-					BUNDLED_PROJECT_SKILL_ROOT,
-					'codebase-review-swarm',
-					'SKILL.md',
-				),
-				'utf-8',
+			warnOutput.some((m) =>
+				m.includes('Could not install bundled project skills'),
 			),
-		).toBe('canonical skill\n');
+		).toBe(true);
+		// ...but the retired directory is still removed.
+		expect(fs.existsSync(retiredDir())).toBe(false);
 	});
 
 	test('leaves sibling bundled skills and unrelated .swarm content untouched', async () => {
@@ -120,6 +185,21 @@ describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)',
 		expect(fs.existsSync(retiredDir())).toBe(true);
 	});
 
+	test('skips a plain file at the retired slug path (never deletes user data)', async () => {
+		// PR #2387 review finding PRR-003: the isDirectory guard's skip branch
+		// was previously untested. A plain file at the retired path is by
+		// definition user-owned — cleanup must leave it alone.
+		fs.mkdirSync(path.dirname(retiredDir()), { recursive: true });
+		fs.writeFileSync(retiredDir(), 'user notes\n', 'utf-8');
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		expect(fs.readFileSync(retiredDir(), 'utf-8')).toBe('user notes\n');
+		expect(fs.readFileSync(activeSkillPath(), 'utf-8')).toBe(
+			'canonical skill\n',
+		);
+	});
+
 	test('fails open when removal of a retired directory errors', async () => {
 		fs.mkdirSync(retiredDir(), { recursive: true });
 		// Portable stand-in for Windows EPERM/EACCES on a locked directory:
@@ -127,29 +207,27 @@ describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)',
 		// cleanup must catch them itself and leave the sync green. Tier-2
 		// mock per the writing-tests skill: spread the real module, override
 		// only `rm`, reject only for the retired path, delegate everything
-		// else to the real implementation. Restored in afterEach via
-		// mock.restore().
+		// else to the real implementation (captured at module scope — see the
+		// realRm note above). Restored in afterEach via mock.restore().
 		mock.module('node:fs/promises', () => ({
 			...realFsPromises,
-			rm: (target: string, options?: unknown) =>
+			rm: (target: string, options?: never) =>
 				typeof target === 'string' &&
 				path.resolve(target) === path.resolve(retiredDir())
 					? Promise.reject(new Error('EPERM: locked'))
-					: realFsPromises.rm(target, options as never),
+					: realRm(target, options),
 		}));
 
 		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
 
-		expect(
-			fs.readFileSync(
-				path.join(
-					projectDir,
-					BUNDLED_PROJECT_SKILL_ROOT,
-					'codebase-review-swarm',
-					'SKILL.md',
-				),
-				'utf-8',
-			),
-		).toBe('canonical skill\n');
+		// PR #2387 review finding F-008: prove the test discriminates — the
+		// rejected rm must have left the retired directory in place, and the
+		// failure must stay debug-gated (no user-facing warning surfaces).
+		expect(fs.existsSync(retiredDir())).toBe(true);
+		expect(warnOutput).toEqual([]);
+		expect(getDeferredWarnings()).toEqual([]);
+		expect(fs.readFileSync(activeSkillPath(), 'utf-8')).toBe(
+			'canonical skill\n',
+		);
 	});
 });

--- a/tests/unit/config/bundled-skills-retired-cleanup.test.ts
+++ b/tests/unit/config/bundled-skills-retired-cleanup.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Retired bundled-skill cleanup tests (issue #2379: resume → swarm-resume).
+ *
+ * Split out of tests/unit/config/bundled-skills-async.test.ts when that file
+ * hit the FR-006 500-line ratchet; the retirement describe owns its own file
+ * per the test-file-split protocol.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as realFsPromises from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	_test_exports,
+	BUNDLED_PROJECT_SKILL_ROOT,
+	syncBundledProjectSkillsIfMissingAsync,
+} from '../../../src/config/bundled-skills';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+function writePackageSkill(
+	packageRoot: string,
+	slug = 'codebase-review-swarm',
+	body = 'canonical skill\n',
+): void {
+	const skillDir = path.join(packageRoot, '.opencode', 'skills', slug);
+	fs.mkdirSync(skillDir, { recursive: true });
+	fs.writeFileSync(path.join(skillDir, 'SKILL.md'), body, 'utf-8');
+}
+
+describe('retired bundled-skill cleanup (issue #2379: resume → swarm-resume)', () => {
+	let projectDir: string;
+	let packageRoot: string;
+	let cleanupProject: () => void;
+	let cleanupPackage: () => void;
+
+	beforeEach(() => {
+		_test_exports.resetBundledProjectSkillSyncCache();
+		({ dir: projectDir, cleanup: cleanupProject } = createSafeTestDir(
+			'swarm-bundled-skill-retired-project-',
+		));
+		({ dir: packageRoot, cleanup: cleanupPackage } = createSafeTestDir(
+			'swarm-bundled-skill-retired-package-',
+		));
+		writePackageSkill(packageRoot);
+		writePackageSkill(packageRoot, 'design-docs', 'design docs skill\n');
+	});
+
+	afterEach(() => {
+		mock.restore();
+		cleanupProject();
+		cleanupPackage();
+	});
+
+	const retiredDir = () =>
+		path.join(projectDir, BUNDLED_PROJECT_SKILL_ROOT, 'resume');
+
+	test('removes a stale retired bundled-slug directory during sync', async () => {
+		fs.mkdirSync(retiredDir(), { recursive: true });
+		fs.writeFileSync(
+			path.join(retiredDir(), 'SKILL.md'),
+			'legacy resume protocol\n',
+			'utf-8',
+		);
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		expect(fs.existsSync(retiredDir())).toBe(false);
+		expect(
+			fs.readFileSync(
+				path.join(
+					projectDir,
+					BUNDLED_PROJECT_SKILL_ROOT,
+					'codebase-review-swarm',
+					'SKILL.md',
+				),
+				'utf-8',
+			),
+		).toBe('canonical skill\n');
+	});
+
+	test('leaves sibling bundled skills and unrelated .swarm content untouched', async () => {
+		fs.mkdirSync(retiredDir(), { recursive: true });
+		const unrelated = path.join(projectDir, '.swarm', 'plan.json');
+		fs.writeFileSync(unrelated, '{}\n', 'utf-8');
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		expect(fs.existsSync(retiredDir())).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(
+					projectDir,
+					BUNDLED_PROJECT_SKILL_ROOT,
+					'design-docs',
+					'SKILL.md',
+				),
+			),
+		).toBe(true);
+		expect(fs.readFileSync(unrelated, 'utf-8')).toBe('{}\n');
+	});
+
+	test('skips a symlinked retired directory without deleting through it', async () => {
+		const outside = path.join(projectDir, 'outside-retired-target');
+		fs.mkdirSync(outside, { recursive: true });
+		fs.writeFileSync(path.join(outside, 'SKILL.md'), 'outside\n', 'utf-8');
+		fs.mkdirSync(path.dirname(retiredDir()), { recursive: true });
+		fs.symlinkSync(
+			outside,
+			retiredDir(),
+			process.platform === 'win32' ? 'junction' : 'dir',
+		);
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		// The link target survives and the link itself is left in place —
+		// cleanup refuses to delete through a symlink, fail-open.
+		expect(fs.readFileSync(path.join(outside, 'SKILL.md'), 'utf-8')).toBe(
+			'outside\n',
+		);
+		expect(fs.existsSync(retiredDir())).toBe(true);
+	});
+
+	test('fails open when removal of a retired directory errors', async () => {
+		fs.mkdirSync(retiredDir(), { recursive: true });
+		// Portable stand-in for Windows EPERM/EACCES on a locked directory:
+		// fsp.rm({force:true}) does not swallow permission errors, so the
+		// cleanup must catch them itself and leave the sync green. Tier-2
+		// mock per the writing-tests skill: spread the real module, override
+		// only `rm`, reject only for the retired path, delegate everything
+		// else to the real implementation. Restored in afterEach via
+		// mock.restore().
+		mock.module('node:fs/promises', () => ({
+			...realFsPromises,
+			rm: (target: string, options?: unknown) =>
+				typeof target === 'string' &&
+				path.resolve(target) === path.resolve(retiredDir())
+					? Promise.reject(new Error('EPERM: locked'))
+					: realFsPromises.rm(target, options as never),
+		}));
+
+		await syncBundledProjectSkillsIfMissingAsync(projectDir, packageRoot);
+
+		expect(
+			fs.readFileSync(
+				path.join(
+					projectDir,
+					BUNDLED_PROJECT_SKILL_ROOT,
+					'codebase-review-swarm',
+					'SKILL.md',
+				),
+				'utf-8',
+			),
+		).toBe('canonical skill\n');
+	});
+});

--- a/tests/unit/scripts/package-smoke.test.ts
+++ b/tests/unit/scripts/package-smoke.test.ts
@@ -18,7 +18,7 @@ const requiredProjectSkillSlugs = [
 	'brainstorm',
 	'specify',
 	'clarify-spec',
-	'resume',
+	'swarm-resume',
 	'clarify',
 	'discover',
 	'consult',

--- a/tests/unit/skills/architect-mode-protocols.test.ts
+++ b/tests/unit/skills/architect-mode-protocols.test.ts
@@ -15,7 +15,7 @@ const MODE_SKILLS = [
 	],
 	['SPECIFY', 'specify', ['SPEC CONTENT RULES', 'EXTERNAL PLAN IMPORT PATH']],
 	['CLARIFY-SPEC', 'clarify-spec', ['[NEEDS CLARIFICATION]', 'delta format']],
-	['RESUME', 'resume', ['.swarm/plan.md exists', 'Swarm field differs']],
+	['RESUME', 'swarm-resume', ['.swarm/plan.md exists', 'Swarm field differs']],
 	[
 		'CLARIFY',
 		'clarify',

--- a/tests/unit/skills/claude-slug-collision-guard.test.ts
+++ b/tests/unit/skills/claude-slug-collision-guard.test.ts
@@ -71,8 +71,8 @@ function allFilesBelow(directory: string): string[] {
  * - `plan` (both trees): pre-existing same-class collision (shadows Claude
  *   Code plan mode). It gets the same dedicated reviewed rename PR treatment
  *   as `resume` in #2379 — the issue explicitly prescribes one rename PR per
- *   slug — and is tracked as a follow-up issue referencing #2379. Remove this
- *   entry when that rename lands.
+ *   slug — and is tracked as follow-up issue #2388. Remove this entry when
+ *   that rename lands.
  * - OPENCODE_ONLY_ARCHITECT_MODE_SKILLS (.opencode tree, derived — not
  *   duplicated): those slugs are intentionally not mirrored to `.claude`
  *   precisely because a mirror would shadow a Claude Code built-in (e.g.
@@ -89,6 +89,15 @@ const ACKNOWLEDGED_CLAUDE_COMMAND_COLLISIONS: Record<string, string[]> = {
 };
 
 describe('native skill slugs must not shadow host built-in commands (#2379)', () => {
+	// PR #2387 review finding F-007: nativeSkillSlugs returns [] for a missing
+	// tree, which would make every collision assertion silently vacuous. Pin
+	// the trees as populated so a future deletion or cwd change fails loudly.
+	for (const tree of NATIVE_SKILL_TREES) {
+		test(`${tree}: inventory is non-empty (guard cannot pass vacuously)`, () => {
+			expect(nativeSkillSlugs(tree).length).toBeGreaterThan(0);
+		});
+	}
+
 	for (const tree of NATIVE_SKILL_TREES) {
 		test(`${tree}: no slug is a Claude Code built-in slash command`, () => {
 			const acknowledged = ACKNOWLEDGED_CLAUDE_COMMAND_COLLISIONS[tree] ?? [];

--- a/tests/unit/skills/claude-slug-collision-guard.test.ts
+++ b/tests/unit/skills/claude-slug-collision-guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression guard for issue #2379: a repo-shipped native skill slug must not
+ * shadow a host built-in slash command.
+ *
+ * Both hosts expose every `<native-root>/skills/<slug>/` directory as the
+ * slash command `/<slug>`, with no notion of "internal-only protocol skill".
+ * The `resume` architect-MODE protocol shadowed Claude Code's built-in
+ * `/resume` (conversation resume) until it was renamed to `swarm-resume`.
+ * `CLAUDE_CODE_NATIVE_COMMANDS` (src/config/constants.ts) is the repo's own
+ * oracle for host built-in names, so this test reuses it instead of a second
+ * hand-maintained list.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+	BUNDLED_PROJECT_SKILLS,
+	RETIRED_BUNDLED_PROJECT_SKILLS,
+} from '../../../src/config/bundled-skills';
+import { CLAUDE_CODE_NATIVE_COMMANDS } from '../../../src/config/constants';
+import { OPENCODE_ONLY_ARCHITECT_MODE_SKILLS } from '../../../src/config/skill-mirrors';
+
+const ROOT = process.cwd();
+const NATIVE_SKILL_TREES = ['.claude/skills', '.opencode/skills'] as const;
+const ALL_SKILL_TREES = [
+	'.claude/skills',
+	'.opencode/skills',
+	'.agents/skills',
+] as const;
+
+function nativeSkillSlugs(tree: string): string[] {
+	const dir = join(ROOT, ...tree.split('/'));
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+}
+
+function tsFilesBelow(directory: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory)) {
+		const candidate = join(directory, entry);
+		if (statSync(candidate).isDirectory()) {
+			files.push(...tsFilesBelow(candidate));
+		} else if (entry.endsWith('.ts')) {
+			files.push(candidate);
+		}
+	}
+	return files;
+}
+
+function allFilesBelow(directory: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(directory)) {
+		const candidate = join(directory, entry);
+		if (statSync(candidate).isDirectory()) {
+			files.push(...allFilesBelow(candidate));
+		} else {
+			files.push(candidate);
+		}
+	}
+	return files;
+}
+
+/**
+ * Acknowledged, deliberately-kept collisions. Every entry needs a reason and
+ * an exit path; this list must shrink, never grow:
+ *
+ * - `plan` (both trees): pre-existing same-class collision (shadows Claude
+ *   Code plan mode). It gets the same dedicated reviewed rename PR treatment
+ *   as `resume` in #2379 — the issue explicitly prescribes one rename PR per
+ *   slug — and is tracked as a follow-up issue referencing #2379. Remove this
+ *   entry when that rename lands.
+ * - OPENCODE_ONLY_ARCHITECT_MODE_SKILLS (.opencode tree, derived — not
+ *   duplicated): those slugs are intentionally not mirrored to `.claude`
+ *   precisely because a mirror would shadow a Claude Code built-in (e.g.
+ *   `loop`, which shadows CC's `/loop`) or the mode is reachable only through
+ *   the OpenCode plugin runtime. Claude Code never reads `.opencode`, so an
+ *   opencode-only slug cannot shadow anything in the Claude Code host.
+ */
+const ACKNOWLEDGED_CLAUDE_COMMAND_COLLISIONS: Record<string, string[]> = {
+	'.claude/skills': ['plan'],
+	'.opencode/skills': [
+		'plan',
+		...OPENCODE_ONLY_ARCHITECT_MODE_SKILLS.map(({ slug }) => slug),
+	],
+};
+
+describe('native skill slugs must not shadow host built-in commands (#2379)', () => {
+	for (const tree of NATIVE_SKILL_TREES) {
+		test(`${tree}: no slug is a Claude Code built-in slash command`, () => {
+			const acknowledged = ACKNOWLEDGED_CLAUDE_COMMAND_COLLISIONS[tree] ?? [];
+			const collisions = nativeSkillSlugs(tree).filter(
+				(slug) =>
+					CLAUDE_CODE_NATIVE_COMMANDS.has(slug) && !acknowledged.includes(slug),
+			);
+			expect(collisions).toEqual([]);
+		});
+	}
+
+	test("issue #2379: 'resume' no longer ships as a native skill slug in either tree", () => {
+		expect(nativeSkillSlugs('.claude/skills')).not.toContain('resume');
+		expect(nativeSkillSlugs('.opencode/skills')).not.toContain('resume');
+	});
+});
+
+describe('retired bundled-skill hygiene (#2379 rename fallout)', () => {
+	test('a slug is never both active and retired', () => {
+		const overlap = RETIRED_BUNDLED_PROJECT_SKILLS.filter((slug) =>
+			BUNDLED_PROJECT_SKILLS.includes(
+				slug as (typeof BUNDLED_PROJECT_SKILLS)[number],
+			),
+		);
+		expect(overlap).toEqual([]);
+	});
+
+	test('no retired slug retains a native-tree skill directory', () => {
+		for (const slug of RETIRED_BUNDLED_PROJECT_SKILLS) {
+			for (const tree of ALL_SKILL_TREES) {
+				expect(nativeSkillSlugs(tree)).not.toContain(slug);
+			}
+		}
+	});
+
+	test('no source or skill file still references a retired slug', () => {
+		// After a rename, bundled-skill-runtime-closure.test.ts iterates the
+		// NEW BUNDLED_PROJECT_SKILLS, so it can no longer catch a re-introduced
+		// `bundledProjectSkillFileReference('<retired>')` literal (plan-critic
+		// finding for #2379). This scan re-closes that blind spot for every
+		// retired slug across runtime source and all skill trees.
+		const offenders: string[] = [];
+		const scans: Array<[root: string, files: string[]]> = [
+			['src', tsFilesBelow(join(ROOT, 'src'))],
+			...ALL_SKILL_TREES.map((tree) => {
+				const dir = join(ROOT, ...tree.split('/'));
+				return [tree, existsSync(dir) ? allFilesBelow(dir) : []] as const;
+			}),
+		];
+		for (const [root, files] of scans) {
+			for (const file of files) {
+				const source = readFileSync(file, 'utf-8');
+				for (const slug of RETIRED_BUNDLED_PROJECT_SKILLS) {
+					if (source.includes(`bundledProjectSkillFileReference('${slug}')`)) {
+						offenders.push(`${root}: ${file} still calls helper '${slug}'`);
+					}
+					if (source.includes(`file:.swarm/bundled-skills/${slug}/SKILL.md`)) {
+						offenders.push(`${root}: ${file} still refs bundled '${slug}'`);
+					}
+					if (source.includes(`.opencode/skills/${slug}/SKILL.md`)) {
+						offenders.push(`${root}: ${file} still refs native '${slug}'`);
+					}
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/tests/unit/skills/swarm-resume-mirror.test.ts
+++ b/tests/unit/skills/swarm-resume-mirror.test.ts
@@ -1,5 +1,5 @@
 /**
- * FR-004 task 3.2 verification: resume SKILL.md mirrors stay byte-identical
+ * FR-004 task 3.2 verification: swarm-resume SKILL.md mirrors stay byte-identical
  * and both carry the new worktree-reconciliation step added in the stale
  * worktree/branch reconciliation PR.
  *
@@ -12,15 +12,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const OPENCODE_PATH = join(process.cwd(), '.opencode/skills/resume/SKILL.md');
-const CLAUDE_PATH = join(process.cwd(), '.claude/skills/resume/SKILL.md');
+const OPENCODE_PATH = join(
+	process.cwd(),
+	'.opencode/skills/swarm-resume/SKILL.md',
+);
+const CLAUDE_PATH = join(process.cwd(), '.claude/skills/swarm-resume/SKILL.md');
 
 function errorMessage(err: unknown): string {
 	if (err instanceof Error) return err.message;
 	return String(err);
 }
 
-describe('resume SKILL.md mirrors — FR-004 task 3.2', () => {
+describe('swarm-resume SKILL.md mirrors — FR-004 task 3.2', () => {
 	// ─────────────────────────────────────────────────────────────────────
 	// Byte-identity (also covered by skill-mirrors.test.ts)
 	// ─────────────────────────────────────────────────────────────────────
@@ -30,7 +33,7 @@ describe('resume SKILL.md mirrors — FR-004 task 3.2', () => {
 		expect(existsSync(CLAUDE_PATH)).toBe(true);
 	});
 
-	it('.opencode and .claude resumes are byte-identical', () => {
+	it('.opencode and .claude swarm-resume skills are byte-identical', () => {
 		// Normalize line endings so CRLF/LF differences don't cause spurious failures
 		// on Windows git clones.
 		const opencodeContent = readFileSync(OPENCODE_PATH, 'utf-8').replace(
@@ -114,7 +117,7 @@ describe('resume SKILL.md mirrors — FR-004 task 3.2', () => {
 			join(process.cwd(), 'src/config/skill-mirrors.ts'),
 			'utf-8',
 		);
-		expect(skillMirrorsSrc).toContain('resume');
-		expect(skillMirrorsSrc).toContain('.opencode/skills/resume/SKILL.md');
+		expect(skillMirrorsSrc).toContain('swarm-resume');
+		expect(skillMirrorsSrc).toContain('.opencode/skills/swarm-resume/SKILL.md');
 	});
 });


### PR DESCRIPTION
Closes #2379

## Summary

The `resume` architect-MODE protocol skill was published under the bare slug
`resume` in both host-native skill trees. Both OpenCode and Claude Code expose
every native skill directory as the slash command `/<slug>`, so typing
`/resume` in a Claude Code session invoked the swarm plan-resumption protocol
instead of Claude Code's built-in conversation resume.

This PR renames the slug to `swarm-resume` end-to-end (the issue's lighter
option — the internal `MODE: RESUME` label is **not** user-facing and stays
unchanged, so observability envelopes, full-auto `resume` subcommand, loop
`--resume` flag, and their ~10 test files are untouched):

- `.opencode/skills/resume/` → `.opencode/skills/swarm-resume/` and the
  `.claude` twin (byte-identical; frontmatter `name: swarm-resume`).
- `BUNDLED_PROJECT_SKILLS`, the `MIRRORED_ARCHITECT_MODE_SKILLS` mirror
  contract (with a rationale comment), the architect stub reference
  (`src/agents/architect.ts` MODE: RESUME now loads
  `file:.swarm/bundled-skills/swarm-resume/SKILL.md`), `package.json#files`,
  and `scripts/package-smoke.mjs`.
- 4 existing test files + 1 test helper updated; mirror/parity/drift tests
  auto-adapt.
- **Stale-dir healing:** new `RETIRED_BUNDLED_PROJECT_SKILLS` list + a
  bounded, contained, symlink-refusing, fail-open cleanup in the bundled-skill
  sync, so existing user projects lose their stale
  `.swarm/bundled-skills/resume/` directory on next sync instead of carrying
  a dead protocol copy forever.
- **Class guard:** new
  `tests/unit/skills/claude-slug-collision-guard.test.ts` fails CI if any
  native-tree skill slug shadows a `CLAUDE_CODE_NATIVE_COMMANDS` entry
  (demonstrated RED on `resume` pre-rename, GREEN post-rename). Acknowledged
  exceptions, each documented with an exit path: `plan` (pre-existing
  same-class collision — filed as a follow-up issue, same treatment; the
  issue itself prescribes one dedicated rename PR per slug) and the derived
  `OPENCODE_ONLY_ARCHITECT_MODE_SKILLS` set (e.g. `loop`, intentionally
  opencode-only). The guard also asserts retired-slug hygiene (never both
  active and retired, no native dir left, no source literal survives) —
  re-closing the blind spot the rename would otherwise leave in
  `bundled-skill-runtime-closure.test.ts`.
- Release fragment `docs/releases/pending/2379-resume-skill-slug-rename.md`
  with migration notes (stale custom `file:.swarm/bundled-skills/resume/`
  references fail loudly via the existing `SKILL_LOAD_FAILED` protocol).

Behavior of MODE: RESUME itself is unchanged: the architect still auto-enters
it when `.swarm/plan.md` has incomplete tasks and loads the protocol from the
bundled root under its new slug.

## Invariant audit

- 1 (plugin init): **touched** — the bundled-skill sync (registered in the
  wrapper-owned post-resolution task queue under `withTimeout`) gained the
  retirement cleanup: fixed retired list (no scanning), per-slug try/catch,
  fail-open, debug-gated logging. Evidence: `removeRetiredBundledSkillDirsAsync`
  in `src/config/bundled-skills.ts`; `bun run build` + Node dist import OK;
  bundled-skills sync tests 25/25 green.
- 2 (runtime portability): **touched** (transitively) — `src/config/bundled-skills.ts`
  and `src/agents/architect.ts` feed `dist/index.js`. Evidence:
  `node --input-type=module -e "await import('./dist/index.js')"` →
  `id: opencode-swarm / server type: function / shape ok: true`; no new
  top-level or lazy `bun:` imports (grep); `bun run package:smoke` →
  `package smoke OK: opencode-swarm-7.151.0.tgz (1136 files)`.
- 3 (subprocesses): **not touched** — no spawn changes (grep of diff shows
  none); `bun run check:bare-spawn` passed.
- 4 (.swarm containment): **touched** — cleanup deletes only exact retired
  slug directories under `.swarm/bundled-skills/`, with path containment,
  symlink refusal, and per-slug fail-open. Evidence:
  `tests/unit/config/bundled-skills-retired-cleanup.test.ts` (4/4 green:
  removal, sibling preservation, symlink skip, rm-failure fail-open);
  `bash scripts/check-invariants.sh` all passed.
- 5 (plan durability): **not touched** — no plan/ledger paths changed.
- 6 (test_runner safety): **not touched** — validation used shell per-file
  loops and `bun run test:unit:ci <files>` scoped mode only.
- 7 (test writing): **touched** — new test files are bun:test, under 500
  lines (`check:test-file-cap` → 0 violations after splitting the retirement
  tests out of the at-cap `bundled-skills-async.test.ts`); the one
  `mock.module` uses the spread-real-exports pattern with targeted rejection
  and `afterEach(mock.restore())` (`bash scripts/generate-mock-allowlist.sh
  --check` → up-to-date, `node:fs/promises` already allowlisted — no growth).
- 8 (session state): **not touched**.
- 9 (guardrails/retry): **not touched** — no retry/circuit paths changed;
  `bun run check:error-channel-discard` passed.
- 10 (chat/system msg): **not touched**.
- 11 (tool registration): **not touched** — `bun run scripts/check-tool-registration.ts`
  → 126 tools coherent; `bun run drift:check` → no drift.
- 12 (release/cache): **touched** — release fragment shipped at
  `docs/releases/pending/2379-resume-skill-slug-rename.md`; no version files
  hand-edited (`bun run check:pending-fragment` passed).

## Test plan

RED → GREEN reproduction (guard written first):

```
bun --smol test tests/unit/skills/claude-slug-collision-guard.test.ts   # pre-rename: 0 pass / 3 fail (resume, both trees)
bun --smol test tests/unit/skills/claude-slug-collision-guard.test.ts   # post-rename: 6 pass / 0 fail
```

CI-equivalent scoped unit gate (all exitCode 0):

```
bun run test:unit:ci tests/unit/skills/claude-slug-collision-guard.test.ts \
  tests/unit/skills/swarm-resume-mirror.test.ts tests/unit/skills/architect-mode-protocols.test.ts \
  tests/unit/skills/skill-mirrors.test.ts tests/unit/skills/bundled-skill-runtime-closure.test.ts \
  tests/unit/skills/mode-command-wiring.test.ts tests/unit/config/bundled-skills-async.test.ts \
  tests/unit/config/bundled-skills-retired-cleanup.test.ts tests/unit/config/bundled-skills-coherence.test.ts \
  tests/unit/config/bundled-skills-rollback.test.ts tests/unit/scripts/package-smoke.test.ts
```

Additional targeted (per-file, all 0 fail): architect-v6-prompt (45),
architect-workflow-security (52), architect-adversarial (31),
architect-hallucination-gate (12), architect-prompt-adversarial (102),
architect-gates (63), architect.test (37).

Full Tier 1 quality contract: `lint:ci`, `check-tool-registration`,
`check-mock-cleanup`, `check-invariants`, `check-cross-contamination`,
`check-test-clock`, `check:runtime-src-refs`, `check:events`,
`check:retention`, `check:core-events`, `check:shell-audit`,
`check:test-file-cap`, `check:pending-fragment`, `check:gate-portability`,
`check:bare-spawn`, `check-test-tmpdir`, `check-bash-portability`,
`check:error-channel-discard`, swarm-model node tests (19/19),
`package:smoke`, `drift:check`, `typecheck`, `build` — all green.

Pre-existing, non-blocking (unchanged by this PR): 5 mock-cleanup violations,
known cross-contamination set, 430 test-clock warnings — all reported by the
respective scripts as pre-existing/non-blocking on main.

## Review gates (swarm)

- Independent plan critic (Kimi K3): NEEDS_REVISION → all 4 revisions
  incorporated before implementation.
- Independent implementation reviewer (Kimi K2.7): APPROVE, no blockers;
  its NOTE-1 improvement (derive the `.opencode` exception list from
  `OPENCODE_ONLY_ARCHITECT_MODE_SKILLS` instead of hardcoding `loop`) was
  applied and re-verified (guard 6/6, typecheck clean, CI-gate scoped run
  exitCode 0).
- Final critic (Kimi K3): verdict recorded in the issue trace artifacts.

---

## Review fixes applied (round 2)

Addressing the validated findings from two independent reviews (in-repo swarm
review + the multi-stage bot review) and the CI failures:

- **F-001/PRR-001 (blocking):** `src/utils/atomic-write.ts:98` producer
  citation updated `bundled-skills.ts:241` → `:250` (the PR's const-block
  insertion had shifted the pinned `.tmp.` construction).
  `tests/unit/utils/atomic-write-ratchet.test.ts` now green; it is added to
  the scoped validation set — any change touching a file cited by
  `SWARM_TEMP_GRAMMARS` must run it.
- **F-002:** the retired-cleanup test's `mock.module('node:fs/promises')`
  delegate captured the namespace binding at call time, making the delegate
  branch self-referential (infinite loop in any multi-file `bun test` run).
  The real `rm` is now bound at module scope before the mock is installed
  (precedent: `tests/helpers/prod-store-tripwire.ts`). Proven fixed by a full
  `bun --smol test tests/unit/config/` batch (94 files, 0 fail, ~9 s —
  previously hung).
- **F-003:** retired-dir cleanup moved into a `finally` gated on a
  `skillsDirValidated` flag, so a copy-loop failure can no longer skip the
  cleanup, while the guard early-returns (symlinked `.swarm`/`skillsDir`)
  still never reach it. (The bare-`finally` alternative was explicitly
  rejected — it would delete through a junctioned skillsDir.)
- **F-005:** `removeRetiredBundledSkillDirsAsync` now validates `skillsDir`
  itself as its first line, making its "symlink-refusing" docstring true of
  the helper in isolation.
- **F-006:** the collision guard's `plan` exception now cites follow-up
  #2388 explicitly.
- **F-007:** the collision guard pins both native skill trees as non-empty,
  so a future tree deletion or cwd change fails loudly instead of passing
  vacuously.
- **F-008/PRR-003:** the fail-open cleanup test now proves discrimination
  (rejected `rm` leaves the retired dir in place, no user-facing warning
  surfaces, active skills still sync), and a new test pins the plain-file
  skip branch (never delete user data). A new test also proves cleanup still
  runs after a mid-sync copy failure (F-003 regression test).
- **PRR-002:** `docs/engineering-invariants.md` FR-004 prose updated to the
  renamed slug.

**Accepted fail-open behaviors (verified intentional, documented):** symlinked
`.swarm/bundled-skills` roots skip cleanup entirely (never delete through a
link); a very large stale dir is bounded by the sync's 2 s timeout and
retried next init; the `lstat`→`rm` window is within the repo's documented
same-user cooperative threat model; the containment check is defense-in-depth
for a fixed const slug list.

**Additional follow-up filed:** #2391 (ratchet escape hatches + `file:symbol`
citation proposal — deliberately out of scope here per the review).

### Test plan additions for this round

```
bun --smol test tests/unit/utils/atomic-write-ratchet.test.ts   # 6 pass / 0 fail (was the CI blocker)
bun --smol test tests/unit/config/                              # 2103 tests / 94 files / 0 fail (~9 s; previously hung on F-002)
bun --smol test tests/unit/config/bundled-skills-retired-cleanup.test.ts  # 6 pass / 0 fail
bun --smol test tests/unit/skills/claude-slug-collision-guard.test.ts     # 8 pass / 0 fail
bun run drift:check && bun run typecheck && bun run lint:ci && bun run check:test-file-cap  # all green
```
