### PR TITLE
fix(build): prefer repository-safe build commands

### DIFF
--- a/docs/releases/pending/2303-build-discovery-runtime-safety.md
+++ b/docs/releases/pending/2303-build-discovery-runtime-safety.md
@@ -4,4 +4,6 @@ Build checks now honor repository-defined package scripts before language-profil
 
 Plugin-generated TypeScript/JavaScript build, typecheck, and test commands no longer use `npx` fallbacks that can download similarly named registry packages. Undeclared tools are resolved only from the existing PATH or the repository's `node_modules/.bin` directory, including Windows `.cmd` shims.
 
+Build-check evidence now distinguishes projects with no supported build files from projects whose required toolchain is unavailable. Profile-only skips include structured required-command diagnostics, while unrelated runtime failures are suppressed when no matching build file exists.
+
 No migration is required for projects that declare scripts or local tool dependencies. Projects that previously relied on the plugin implicitly downloading undeclared tools must add the dependency locally or define the corresponding package script.

--- a/docs/releases/pending/2303-build-discovery-runtime-safety.md
+++ b/docs/releases/pending/2303-build-discovery-runtime-safety.md
@@ -1,0 +1,7 @@
+# Safe repository-first build discovery
+
+Build checks now honor repository-defined package scripts before language-profile fallbacks. An available Bun runtime remains the default preference when a project does not declare `packageManager`; explicit package-manager declarations are respected and unavailable runtimes are reported as structured, non-failing environment skips.
+
+Plugin-generated TypeScript/JavaScript build, typecheck, and test commands no longer use `npx` fallbacks that can download similarly named registry packages. Undeclared tools are resolved only from the existing PATH or the repository's `node_modules/.bin` directory, including Windows `.cmd` shims.
+
+No migration is required for projects that declare scripts or local tool dependencies. Projects that previously relied on the plugin implicitly downloading undeclared tools must add the dependency locally or define the corresponding package script.

--- a/src/build/command-resolution.ts
+++ b/src/build/command-resolution.ts
@@ -1,0 +1,53 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface ResolvedCommand {
+	argv: string[];
+	shellCommand: string;
+}
+
+function splitCommand(command: string): string[] {
+	return command.trim().split(/\s+/).filter(Boolean);
+}
+
+/** Resolve a plugin-generated command without invoking a package downloader. */
+export function resolveLocalCommand(
+	command: string,
+	workingDir: string,
+	isAvailable: (binary: string) => boolean,
+	platform: NodeJS.Platform = process.platform,
+): ResolvedCommand | null {
+	const tokens = splitCommand(command);
+	if (tokens.length === 0) return null;
+	const [binary, ...args] = tokens;
+	if (['npx', 'bunx', 'pnpx'].includes(binary)) return null;
+	if (binary.includes('/') || binary.includes('\\')) return null;
+
+	const executable = platform === 'win32' ? `${binary}.cmd` : binary;
+	const relative =
+		platform === 'win32'
+			? path.win32.join('node_modules', '.bin', executable)
+			: path.posix.join('node_modules', '.bin', executable);
+	if (
+		fs.existsSync(path.join(workingDir, 'node_modules', '.bin', executable)) &&
+		isAvailable('node')
+	) {
+		const shellPath = platform === 'win32' ? relative : `./${relative}`;
+		return {
+			argv: [path.join(workingDir, relative), ...args],
+			shellCommand: [shellPath, ...args].join(' '),
+		};
+	}
+	return isAvailable(binary) ? { argv: tokens, shellCommand: command } : null;
+}
+
+export function resolveLocalNodeTool(
+	tool: string,
+	args: string[],
+	workingDir: string,
+	platform: NodeJS.Platform = process.platform,
+): string[] | null {
+	const executable = platform === 'win32' ? `${tool}.cmd` : tool;
+	const absolute = path.join(workingDir, 'node_modules', '.bin', executable);
+	return fs.existsSync(absolute) ? [absolute, ...args] : null;
+}

--- a/src/build/command-resolution.ts
+++ b/src/build/command-resolution.ts
@@ -6,8 +6,132 @@ export interface ResolvedCommand {
 	shellCommand: string;
 }
 
-function splitCommand(command: string): string[] {
-	return command.trim().split(/\s+/).filter(Boolean);
+interface LocalCommandCandidate {
+	absolute: string;
+	relative: string;
+	requiresNode: boolean;
+}
+
+const WINDOWS_LOCAL_SHIM_CANDIDATES: ReadonlyArray<{
+	suffix: string;
+	requiresNode: boolean;
+}> = [
+	{ suffix: '.cmd', requiresNode: true },
+	{ suffix: '.exe', requiresNode: false },
+	{ suffix: '.bat', requiresNode: true },
+	{ suffix: '.ps1', requiresNode: true },
+	{ suffix: '', requiresNode: true },
+];
+
+/**
+ * Tokenize a generated command into argv without invoking a shell. Supports
+ * single and double quotes for grouping, but never interprets shell
+ * metacharacters.
+ */
+export function tokenizeCommand(command: string): string[] {
+	const out: string[] = [];
+	let buf = '';
+	let quote: '"' | "'" | null = null;
+	for (const ch of command.trim()) {
+		if (quote) {
+			if (ch === quote) {
+				quote = null;
+			} else {
+				buf += ch;
+			}
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			quote = ch as '"' | "'";
+			continue;
+		}
+		if (ch === ' ' || ch === '\t') {
+			if (buf.length > 0) {
+				out.push(buf);
+				buf = '';
+			}
+			continue;
+		}
+		buf += ch;
+	}
+	if (buf.length > 0) out.push(buf);
+	return out;
+}
+
+function findCommandSuffixStart(command: string): number {
+	let quote: '"' | "'" | null = null;
+	let sawTokenChar = false;
+	for (let i = 0; i < command.length; i++) {
+		const ch = command[i];
+		if (quote) {
+			if (ch === quote) {
+				quote = null;
+			} else {
+				sawTokenChar = true;
+			}
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			quote = ch as '"' | "'";
+			sawTokenChar = true;
+			continue;
+		}
+		if ((ch === ' ' || ch === '\t') && sawTokenChar) {
+			return i;
+		}
+		if (ch !== ' ' && ch !== '\t') {
+			sawTokenChar = true;
+		}
+	}
+	return command.length;
+}
+
+function resolveLocalCandidate(
+	binary: string,
+	workingDir: string,
+	platform: NodeJS.Platform = process.platform,
+	isAvailable?: (binary: string) => boolean,
+): LocalCommandCandidate | null {
+	const candidates =
+		platform === 'win32'
+			? WINDOWS_LOCAL_SHIM_CANDIDATES
+			: [{ suffix: '', requiresNode: true }];
+	for (const candidate of candidates) {
+		const executable = `${binary}${candidate.suffix}`;
+		const absolute = path.join(workingDir, 'node_modules', '.bin', executable);
+		if (!fs.existsSync(absolute)) continue;
+		if (candidate.requiresNode && isAvailable && !isAvailable('node')) continue;
+		const relative =
+			platform === 'win32'
+				? path.win32.join('node_modules', '.bin', executable)
+				: path.posix.join('node_modules', '.bin', executable);
+		return {
+			absolute,
+			relative,
+			requiresNode: candidate.requiresNode,
+		};
+	}
+	return null;
+}
+
+function hasAnyLocalCandidate(
+	binary: string,
+	workingDir: string,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	const candidates =
+		platform === 'win32'
+			? WINDOWS_LOCAL_SHIM_CANDIDATES
+			: [{ suffix: '', requiresNode: true }];
+	for (const candidate of candidates) {
+		const executable = `${binary}${candidate.suffix}`;
+		if (
+			fs.existsSync(path.join(workingDir, 'node_modules', '.bin', executable))
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /** Resolve a plugin-generated command without invoking a package downloader. */
@@ -17,27 +141,27 @@ export function resolveLocalCommand(
 	isAvailable: (binary: string) => boolean,
 	platform: NodeJS.Platform = process.platform,
 ): ResolvedCommand | null {
-	const tokens = splitCommand(command);
+	const tokens = tokenizeCommand(command);
 	if (tokens.length === 0) return null;
 	const [binary, ...args] = tokens;
 	if (['npx', 'bunx', 'pnpx'].includes(binary)) return null;
 	if (binary.includes('/') || binary.includes('\\')) return null;
-
-	const executable = platform === 'win32' ? `${binary}.cmd` : binary;
-	const relative =
-		platform === 'win32'
-			? path.win32.join('node_modules', '.bin', executable)
-			: path.posix.join('node_modules', '.bin', executable);
-	if (
-		fs.existsSync(path.join(workingDir, 'node_modules', '.bin', executable)) &&
-		isAvailable('node')
-	) {
-		const shellPath = platform === 'win32' ? relative : `./${relative}`;
+	const trimmed = command.trim();
+	const local = resolveLocalCandidate(
+		binary,
+		workingDir,
+		platform,
+		isAvailable,
+	);
+	if (local) {
+		const shellPath =
+			platform === 'win32' ? local.relative : `./${local.relative}`;
 		return {
-			argv: [path.join(workingDir, relative), ...args],
-			shellCommand: [shellPath, ...args].join(' '),
+			argv: [local.absolute, ...args],
+			shellCommand: `${shellPath}${trimmed.slice(findCommandSuffixStart(trimmed))}`,
 		};
 	}
+	if (hasAnyLocalCandidate(binary, workingDir, platform)) return null;
 	return isAvailable(binary) ? { argv: tokens, shellCommand: command } : null;
 }
 
@@ -46,8 +170,12 @@ export function resolveLocalNodeTool(
 	args: string[],
 	workingDir: string,
 	platform: NodeJS.Platform = process.platform,
+	isAvailable?: (binary: string) => boolean,
 ): string[] | null {
-	const executable = platform === 'win32' ? `${tool}.cmd` : tool;
-	const absolute = path.join(workingDir, 'node_modules', '.bin', executable);
-	return fs.existsSync(absolute) ? [absolute, ...args] : null;
+	const local = resolveLocalCandidate(tool, workingDir, platform, isAvailable);
+	if (local) return [local.absolute, ...args];
+	// FB-001: PATH fallback is allowed only for callers that already own an
+	// explicit availability probe; repository-local shims still win first.
+	if (hasAnyLocalCandidate(tool, workingDir, platform)) return null;
+	return isAvailable?.(tool) ? [tool, ...args] : null;
 }

--- a/src/build/command-resolution.ts
+++ b/src/build/command-resolution.ts
@@ -172,11 +172,15 @@ export function resolveLocalNodeTool(
 	platform: NodeJS.Platform = process.platform,
 	isAvailable?: (binary: string) => boolean,
 ): string[] | null {
-	// A repository-local node tool is already the caller's explicit execution
-	// target; do not probe the ambient PATH for `node` before returning it.
-	// This preserves the local-tool contract and avoids resolution depending on
-	// a concurrently changing process CWD in test hosts.
-	const local = resolveLocalCandidate(tool, workingDir, platform);
+	// POSIX shims remain authoritative without a second PATH probe; Windows
+	// callers pass their availability probe so node-backed `.cmd`/`.bat` shims
+	// are rejected when the required runtime is absent.
+	const local = resolveLocalCandidate(
+		tool,
+		workingDir,
+		platform,
+		platform === 'win32' ? isAvailable : undefined,
+	);
 	if (local) return [local.absolute, ...args];
 	// FB-001: PATH fallback is allowed only for callers that already own an
 	// explicit availability probe; repository-local shims still win first.

--- a/src/build/command-resolution.ts
+++ b/src/build/command-resolution.ts
@@ -172,7 +172,11 @@ export function resolveLocalNodeTool(
 	platform: NodeJS.Platform = process.platform,
 	isAvailable?: (binary: string) => boolean,
 ): string[] | null {
-	const local = resolveLocalCandidate(tool, workingDir, platform, isAvailable);
+	// A repository-local node tool is already the caller's explicit execution
+	// target; do not probe the ambient PATH for `node` before returning it.
+	// This preserves the local-tool contract and avoids resolution depending on
+	// a concurrently changing process CWD in test hosts.
+	const local = resolveLocalCandidate(tool, workingDir, platform);
 	if (local) return [local.absolute, ...args];
 	// FB-001: PATH fallback is allowed only for callers that already own an
 	// explicit availability probe; repository-local shims still win first.

--- a/src/build/discovery.ts
+++ b/src/build/discovery.ts
@@ -5,6 +5,7 @@ import { detectProjectLanguages } from '../lang/detector';
 import { LANGUAGE_REGISTRY } from '../lang/profiles';
 import { simpleGlobToRegex, warn } from '../utils';
 import { bunSpawnSync } from '../utils/bun-compat';
+import { resolveLocalCommand } from './command-resolution';
 
 // ============ Types ============
 
@@ -17,7 +18,14 @@ export interface BuildCommand {
 
 export interface BuildDiscoveryResult {
 	commands: BuildCommand[];
-	skipped: { ecosystem: string; reason: string }[];
+	skipped: BuildDiscoverySkip[];
+}
+
+export interface BuildDiscoverySkip {
+	ecosystem: string;
+	reason: string;
+	code?: 'environment_unavailable';
+	required_commands?: string[];
 }
 
 export interface BuildDiscoveryOptions {
@@ -39,7 +47,7 @@ const ECOSYSTEMS: EcosystemConfig[] = [
 	{
 		ecosystem: 'node',
 		buildFiles: ['package.json'],
-		toolchainCommands: ['npm', 'yarn', 'pnpm'],
+		toolchainCommands: ['bun', 'npm', 'pnpm', 'yarn'],
 		commands: [
 			{ command: 'npm run build', priority: 30 },
 			{ command: 'npm run typecheck', priority: 20 },
@@ -141,6 +149,7 @@ const ECOSYSTEMS: EcosystemConfig[] = [
  */
 const PROFILE_TO_ECOSYSTEM_NAMES: Record<string, string[]> = {
 	typescript: ['node'],
+	javascript: ['node'],
 	python: ['python'],
 	rust: ['rust'],
 	go: ['go'],
@@ -215,7 +224,7 @@ export function isCommandAvailable(command: string): boolean {
  * Check if any of the toolchain commands are available
  */
 function checkToolchain(commands: string[]): boolean {
-	return commands.some((cmd) => isCommandAvailable(cmd));
+	return commands.some((cmd) => _internals.isCommandAvailable(cmd));
 }
 
 /**
@@ -254,11 +263,15 @@ function findBuildFiles(workingDir: string, patterns: string[]): string | null {
 function getRepoDefinedScripts(
 	workingDir: string,
 	scripts: string[],
-): { script: string; priority: number }[] {
+): {
+	commands: { command: string; priority: number }[];
+	hasScripts: boolean;
+	skip?: BuildDiscoverySkip;
+} {
 	const packageJsonPath = path.join(workingDir, 'package.json');
 
 	if (!fs.existsSync(packageJsonPath)) {
-		return [];
+		return { commands: [], hasScripts: false };
 	}
 
 	try {
@@ -266,23 +279,62 @@ function getRepoDefinedScripts(
 		const pkg = JSON.parse(content);
 
 		if (!pkg.scripts || typeof pkg.scripts !== 'object') {
-			return [];
+			return { commands: [], hasScripts: false };
 		}
 
-		const found: { script: string; priority: number }[] = [];
+		const scriptNames = scripts.filter(
+			(name) =>
+				typeof pkg.scripts[name] === 'string' && pkg.scripts[name].trim(),
+		);
+		if (scriptNames.length === 0) return { commands: [], hasScripts: false };
 
-		for (const scriptName of scripts) {
-			if (pkg.scripts[scriptName]) {
-				found.push({
-					script: `npm run ${scriptName}`,
-					priority: 100, // Repo-defined scripts have highest priority
-				});
-			}
+		const rawPackageManager =
+			typeof pkg.packageManager === 'string'
+				? pkg.packageManager.trim()
+				: undefined;
+		const declared = rawPackageManager?.split('@')[0]?.trim();
+		const supported = ['bun', 'npm', 'pnpm', 'yarn'];
+		const candidates = declared ? [declared] : supported;
+		if (
+			rawPackageManager !== undefined &&
+			(!declared || !supported.includes(declared))
+		) {
+			return {
+				commands: [],
+				hasScripts: true,
+				skip: {
+					ecosystem: 'node',
+					code: 'environment_unavailable',
+					required_commands: declared ? [declared] : [],
+					reason: `Unsupported packageManager: ${rawPackageManager || '(empty)'}`,
+				},
+			};
+		}
+		const manager = candidates.find((candidate) =>
+			_internals.isCommandAvailable(candidate),
+		);
+		if (!manager) {
+			return {
+				commands: [],
+				hasScripts: true,
+				skip: {
+					ecosystem: 'node',
+					code: 'environment_unavailable',
+					required_commands: candidates,
+					reason: `Package manager not available: ${candidates.join(' or ')}`,
+				},
+			};
 		}
 
-		return found;
+		return {
+			hasScripts: true,
+			commands: scriptNames.map((scriptName) => ({
+				command: `${manager} run ${scriptName}`,
+				priority: 100, // Repo-defined scripts have highest priority
+			})),
+		};
 	} catch {
-		return [];
+		return { commands: [], hasScripts: false };
 	}
 }
 
@@ -393,7 +445,7 @@ export async function discoverBuildCommandsFromProfiles(
 	workingDir: string,
 ): Promise<BuildDiscoveryResult> {
 	const commands: BuildCommand[] = [];
-	const skipped: { ecosystem: string; reason: string }[] = [];
+	const skipped: BuildDiscoverySkip[] = [];
 
 	// Get detected profiles sorted by tier (lower tier = higher confidence)
 	const detectedProfiles = await detectProjectLanguages(workingDir);
@@ -425,11 +477,15 @@ export async function discoverBuildCommandsFromProfiles(
 			}
 			// Check if binary is available on PATH
 			// Derive binary name from first word of command string
-			const binaryName = cmd.cmd.split(' ')[0];
-			if (isCommandAvailable(binaryName)) {
+			const resolved = resolveLocalCommand(
+				cmd.cmd,
+				workingDir,
+				_internals.isCommandAvailable,
+			);
+			if (resolved) {
 				commands.push({
 					ecosystem: fullProfile.id,
-					command: cmd.cmd,
+					command: resolved.shellCommand,
 					cwd: workingDir,
 					priority: cmd.priority,
 				});
@@ -477,9 +533,43 @@ export async function discoverBuildCommands(
 	const profileCommands = profileResult.commands;
 	const profileSkipped = profileResult.skipped;
 
-	// Build the set of ecosystem names already covered by profile detection
+	// Build the repo-defined build scripts up front so they can suppress the
+	// generic profile fallback for the same ecosystem. A repository's own build
+	// script is more specific than a language-profile default.
+	const repoDefinedScriptsByEcosystem = new Map<
+		string,
+		{ command: string; priority: number }[]
+	>();
+	const repoScriptSkips: BuildDiscoverySkip[] = [];
+	const repoDeclaredEcosystems = new Set<string>();
+	for (const ecosystem of ECOSYSTEMS) {
+		if (!ecosystem.repoDefinedScripts) continue;
+		const repoResult = getRepoDefinedScripts(
+			workingDir,
+			ecosystem.repoDefinedScripts,
+		);
+		if (repoResult.commands.length > 0) {
+			repoDefinedScriptsByEcosystem.set(
+				ecosystem.ecosystem,
+				repoResult.commands,
+			);
+		}
+		if (repoResult.hasScripts) repoDeclaredEcosystems.add(ecosystem.ecosystem);
+		if (repoResult.skip) repoScriptSkips.push(repoResult.skip);
+	}
+
+	// Filter out profile commands that are shadowed by repo-defined scripts for
+	// the same ecosystem. This preserves the repo's own build entry while still
+	// allowing profiles to cover ecosystems that do not define a local script.
+	const filteredProfileCommands = profileCommands.filter((cmd) => {
+		const ecosystemNames = PROFILE_TO_ECOSYSTEM_NAMES[cmd.ecosystem] ?? [];
+		return ecosystemNames.every((name) => !repoDeclaredEcosystems.has(name));
+	});
+
+	// Build the set of ecosystem names already covered by the remaining profile
+	// detection results.
 	const coveredEcosystems = new Set<string>();
-	for (const cmd of profileCommands) {
+	for (const cmd of filteredProfileCommands) {
 		const ecosystemNames = PROFILE_TO_ECOSYSTEM_NAMES[cmd.ecosystem] ?? [];
 		for (const name of ecosystemNames) {
 			coveredEcosystems.add(name);
@@ -487,11 +577,32 @@ export async function discoverBuildCommands(
 	}
 
 	// ============ Ecosystem-based detection (fallback) ============
-	const commands: BuildCommand[] = [...profileCommands];
-	const skipped: { ecosystem: string; reason: string }[] = [...profileSkipped];
+	const commands: BuildCommand[] = [...filteredProfileCommands];
+	const skipped: BuildDiscoverySkip[] = [...profileSkipped, ...repoScriptSkips];
 
 	// Process each ecosystem, skipping those already covered by profiles
 	for (const ecosystem of ECOSYSTEMS) {
+		const buildFile = findBuildFiles(workingDir, ecosystem.buildFiles);
+		if (!buildFile) continue;
+		const repoScripts = repoDefinedScriptsByEcosystem.get(ecosystem.ecosystem);
+		if (repoScripts && repoScripts.length > 0) {
+			for (const script of repoScripts) {
+				commands.push({
+					ecosystem: ecosystem.ecosystem,
+					command: script.command,
+					cwd: workingDir,
+					priority: script.priority,
+				});
+			}
+			continue;
+		}
+		if (repoDeclaredEcosystems.has(ecosystem.ecosystem)) {
+			// The repository declared relevant scripts, but its explicit/available
+			// package-manager contract could not be satisfied. Preserve the
+			// structured environment skip instead of degrading to a generic command.
+			continue;
+		}
+
 		// Skip if this ecosystem is already handled by profile detection
 		if (coveredEcosystems.has(ecosystem.ecosystem)) {
 			// Still surface the ecosystem in skipped so callers can detect it was found
@@ -506,6 +617,8 @@ export async function discoverBuildCommands(
 		if (!checkToolchain(ecosystem.toolchainCommands)) {
 			skipped.push({
 				ecosystem: ecosystem.ecosystem,
+				code: 'environment_unavailable',
+				required_commands: ecosystem.toolchainCommands,
 				reason: `Toolchain not found: ${ecosystem.toolchainCommands.join(
 					' or ',
 				)} not on PATH`,
@@ -513,33 +626,8 @@ export async function discoverBuildCommands(
 			continue;
 		}
 
-		// Check for build files
-		const buildFile = findBuildFiles(workingDir, ecosystem.buildFiles);
-
-		if (!buildFile) {
-			skipped.push({
-				ecosystem: ecosystem.ecosystem,
-				reason: `No build file found: ${ecosystem.buildFiles.join(', ')}`,
-			});
-			continue;
-		}
-
-		// For Node.js, check for repo-defined scripts first
-		let availableCommands: { command: string; priority: number }[] =
+		const availableCommands: { command: string; priority: number }[] =
 			ecosystem.commands;
-
-		if (ecosystem.repoDefinedScripts) {
-			const repoScripts = getRepoDefinedScripts(
-				workingDir,
-				ecosystem.repoDefinedScripts,
-			);
-			if (repoScripts.length > 0) {
-				availableCommands = repoScripts.map((s) => ({
-					command: s.script,
-					priority: s.priority,
-				}));
-			}
-		}
 
 		// Add commands for this ecosystem
 		for (const cmd of availableCommands) {

--- a/src/build/discovery.ts
+++ b/src/build/discovery.ts
@@ -43,11 +43,14 @@ interface EcosystemConfig {
 	repoDefinedScripts?: string[]; // Scripts that can be defined in repo config
 }
 
+const SUPPORTED_NODE_PACKAGE_MANAGERS = ['bun', 'npm', 'pnpm', 'yarn'] as const;
+const MAX_PACKAGE_MANAGER_EVIDENCE_CHARS = 120;
+
 const ECOSYSTEMS: EcosystemConfig[] = [
 	{
 		ecosystem: 'node',
 		buildFiles: ['package.json'],
-		toolchainCommands: ['bun', 'npm', 'pnpm', 'yarn'],
+		toolchainCommands: [...SUPPORTED_NODE_PACKAGE_MANAGERS],
 		commands: [
 			{ command: 'npm run build', priority: 30 },
 			{ command: 'npm run typecheck', priority: 20 },
@@ -257,6 +260,58 @@ function findBuildFiles(workingDir: string, patterns: string[]): string | null {
 	return null;
 }
 
+function sanitizeEvidenceText(raw: string, maxChars: number): string {
+	let withoutControls = '';
+	for (const char of raw) {
+		const code = char.charCodeAt(0);
+		withoutControls += code < 32 || code === 127 ? ' ' : char;
+	}
+	const normalized = withoutControls.replace(/\s+/g, ' ').trim();
+	if (!normalized) return '(empty)';
+	if (normalized.length <= maxChars) return normalized;
+	if (maxChars <= 3) return normalized.slice(0, maxChars);
+	return `${normalized.slice(0, maxChars - 3)}...`;
+}
+
+function sanitizeRequiredCommand(command: string): string | null {
+	const sanitized = sanitizeEvidenceText(command, 40);
+	return sanitized === '(empty)' ? null : sanitized;
+}
+
+function getBinaryFromCommand(command: string): string {
+	return command.trim().split(/\s+/)[0] ?? '';
+}
+
+function getProfileRequiredCommands(
+	commands: Array<{ cmd: string }>,
+): string[] {
+	const uniqueCommands = new Set<string>();
+	for (const command of commands) {
+		const binary = sanitizeRequiredCommand(getBinaryFromCommand(command.cmd));
+		if (binary) uniqueCommands.add(binary);
+	}
+	return Array.from(uniqueCommands);
+}
+
+function getNoMatchingBuildFilesReason(
+	profileId: string,
+	commands: Array<{ detectFile?: string }>,
+): string {
+	const detectFiles = Array.from(
+		new Set(
+			commands
+				.map((command) => command.detectFile?.trim())
+				.filter((detectFile): detectFile is string => Boolean(detectFile)),
+		),
+	);
+	if (detectFiles.length === 0) {
+		return `No matching build files for profile ${profileId}`;
+	}
+	return `No matching build files for profile ${profileId}: expected ${detectFiles.join(
+		' or ',
+	)}`;
+}
+
 /**
  * Get repo-defined build scripts from package.json
  */
@@ -293,7 +348,10 @@ function getRepoDefinedScripts(
 				? pkg.packageManager.trim()
 				: undefined;
 		const declared = rawPackageManager?.split('@')[0]?.trim();
-		const supported = ['bun', 'npm', 'pnpm', 'yarn'];
+		const supported = [...SUPPORTED_NODE_PACKAGE_MANAGERS];
+		const sanitizedDeclared = declared
+			? sanitizeRequiredCommand(declared)
+			: null;
 		const candidates = declared ? [declared] : supported;
 		if (
 			rawPackageManager !== undefined &&
@@ -305,8 +363,11 @@ function getRepoDefinedScripts(
 				skip: {
 					ecosystem: 'node',
 					code: 'environment_unavailable',
-					required_commands: declared ? [declared] : [],
-					reason: `Unsupported packageManager: ${rawPackageManager || '(empty)'}`,
+					required_commands: sanitizedDeclared ? [sanitizedDeclared] : [],
+					reason: `Unsupported packageManager: ${sanitizeEvidenceText(
+						rawPackageManager,
+						MAX_PACKAGE_MANAGER_EVIDENCE_CHARS,
+					)}`,
 				},
 			};
 		}
@@ -431,6 +492,8 @@ export const _internals: {
 	discoverBuildCommands: typeof discoverBuildCommands;
 	clearToolchainCache: typeof clearToolchainCache;
 	getEcosystems: typeof getEcosystems;
+	detectProjectLanguagesImpl: typeof detectProjectLanguages;
+	getLanguageProfileImpl: typeof LANGUAGE_REGISTRY.get;
 	spawnSyncImpl: typeof bunSpawnSync;
 } = {
 	isCommandAvailable,
@@ -438,6 +501,8 @@ export const _internals: {
 	discoverBuildCommands,
 	clearToolchainCache,
 	getEcosystems,
+	detectProjectLanguagesImpl: detectProjectLanguages,
+	getLanguageProfileImpl: LANGUAGE_REGISTRY.get.bind(LANGUAGE_REGISTRY),
 	spawnSyncImpl: bunSpawnSync,
 };
 
@@ -448,11 +513,12 @@ export async function discoverBuildCommandsFromProfiles(
 	const skipped: BuildDiscoverySkip[] = [];
 
 	// Get detected profiles sorted by tier (lower tier = higher confidence)
-	const detectedProfiles = await detectProjectLanguages(workingDir);
+	const detectedProfiles =
+		await _internals.detectProjectLanguagesImpl(workingDir);
 
 	for (const profile of detectedProfiles) {
 		// Get the full profile from registry
-		const fullProfile = LANGUAGE_REGISTRY.get(profile.id);
+		const fullProfile = _internals.getLanguageProfileImpl(profile.id);
 		if (!fullProfile) {
 			warn(
 				`[build-discovery] profile ${profile.id} not found in registry, skipping`,
@@ -465,16 +531,23 @@ export async function discoverBuildCommandsFromProfiles(
 			(a, b) => b.priority - a.priority,
 		);
 
+		const applicableCommands = sortedCommands.filter((cmd) => {
+			if (!cmd.detectFile) return true;
+			const detectFilePath = path.join(workingDir, cmd.detectFile);
+			return fs.existsSync(detectFilePath);
+		});
+
+		if (applicableCommands.length === 0) {
+			skipped.push({
+				ecosystem: fullProfile.id,
+				reason: getNoMatchingBuildFilesReason(fullProfile.id, sortedCommands),
+			});
+			continue;
+		}
+
 		// Find first available binary
 		let foundCommand = false;
-		for (const cmd of sortedCommands) {
-			// Skip command if its detectFile is specified but not present
-			if (cmd.detectFile) {
-				const detectFilePath = path.join(workingDir, cmd.detectFile);
-				if (!fs.existsSync(detectFilePath)) {
-					continue;
-				}
-			}
+		for (const cmd of applicableCommands) {
 			// Check if binary is available on PATH
 			// Derive binary name from first word of command string
 			const resolved = resolveLocalCommand(
@@ -495,12 +568,13 @@ export async function discoverBuildCommandsFromProfiles(
 		}
 
 		if (!foundCommand) {
-			const triedBinaries = sortedCommands
-				.map((c) => c.name || c.cmd.split(' ')[0])
-				.join(', ');
+			const requiredCommands = getProfileRequiredCommands(applicableCommands);
+			const triedBinaries = requiredCommands.join(', ');
 			const reason = `No binary available for profile ${fullProfile.id}: tried ${triedBinaries}`;
 			skipped.push({
 				ecosystem: fullProfile.id,
+				code: 'environment_unavailable',
+				required_commands: requiredCommands,
 				reason,
 			});
 			warn(

--- a/src/config/evidence-schema.ts
+++ b/src/config/evidence-schema.ts
@@ -285,6 +285,16 @@ export const BuildEvidenceSchema = BaseEvidenceSchema.extend({
 	runs_count: z.number().int(),
 	failed_count: z.number().int(),
 	skipped_reason: z.string().optional(),
+	environment_unavailable: z
+		.array(
+			z.object({
+				ecosystem: z.string(),
+				reason: z.string(),
+				code: z.literal('environment_unavailable'),
+				required_commands: z.array(z.string()).optional(),
+			}),
+		)
+		.optional(),
 });
 export type BuildEvidence = z.infer<typeof BuildEvidenceSchema>;
 

--- a/src/hooks/incremental-verify-local-tool.test.ts
+++ b/src/hooks/incremental-verify-local-tool.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { canonicalMkdtemp } from '../../tests/helpers/tmpdir';
+import { detectTypecheckCommand } from './incremental-verify';
+
+describe('incremental verify local TypeScript resolution (#2303)', () => {
+	let tempDir: string;
+
+	afterEach(() => {
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test('uses the repository-local tsc binary without a package downloader', () => {
+		tempDir = canonicalMkdtemp('incremental-verify-2303-');
+		fs.writeFileSync(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({ dependencies: { typescript: '5.7.3' } }),
+		);
+		fs.writeFileSync(path.join(tempDir, 'tsconfig.json'), '{}');
+		const binDir = path.join(tempDir, 'node_modules', '.bin');
+		fs.mkdirSync(binDir, { recursive: true });
+		const tscName = process.platform === 'win32' ? 'tsc.cmd' : 'tsc';
+		fs.writeFileSync(path.join(binDir, tscName), '');
+
+		expect(detectTypecheckCommand(tempDir)).toEqual({
+			command: [path.join(binDir, tscName), '--noEmit'],
+			language: 'typescript',
+		});
+	});
+});

--- a/src/hooks/incremental-verify.test.ts
+++ b/src/hooks/incremental-verify.test.ts
@@ -428,9 +428,7 @@ describe('detectTypecheckCommand adversarial tests', () => {
 		);
 		fs.writeFileSync(path.join(tmpDir, 'tsconfig.json'), '{}', 'utf8');
 		const result = detectTypecheckCommand(tmpDir);
-		expect(result).not.toBeNull();
-		expect(result!.command).toEqual(['npx', 'tsc', '--noEmit']);
-		expect(result!.language).toBe('typescript');
+		expect(result).toEqual({ command: null, language: 'typescript' });
 	});
 
 	// 11. Go when package.json exists but has no TypeScript markers

--- a/src/hooks/incremental-verify.ts
+++ b/src/hooks/incremental-verify.ts
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { resolveLocalNodeTool } from '../build/command-resolution';
 import type { IncrementalVerifyConfig } from '../config/schema';
 import { getStoredInputArgs } from './guardrails/stored-input-args';
 import { spawnAsync } from './spawn-helper';
@@ -99,7 +100,10 @@ function detectTypecheckCommand(
 				deps?.typescript ||
 				fs.existsSync(path.join(projectDir, 'tsconfig.json'));
 			if (hasTSMarkers) {
-				return { command: ['npx', 'tsc', '--noEmit'], language: 'typescript' };
+				return {
+					command: resolveLocalNodeTool('tsc', ['--noEmit'], projectDir),
+					language: 'typescript',
+				};
 			}
 			// No TS markers — fall through to Go/Rust/Python/C# detection below
 		} catch {

--- a/src/lang/default-backend.ts
+++ b/src/lang/default-backend.ts
@@ -12,6 +12,10 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {
+	resolveLocalCommand,
+	resolveLocalNodeTool,
+} from '../build/command-resolution';
 import { isCommandAvailable } from '../build/discovery';
 import type {
 	BuildCommandSelection,
@@ -53,7 +57,7 @@ function detectFileExists(dir: string, pattern: string): boolean {
 /**
  * Tokenize a string command into an array. Splits on whitespace; respects
  * single and double quotes for argument grouping. Used to convert profile
- * `cmd` strings (which today are written as "npx tsc --noEmit" etc.) into
+ * profile `cmd` strings into
  * the array form `bunSpawn` expects.
  *
  * This deliberately does NOT support shell metacharacters (`;`, `&`, `|`,
@@ -165,28 +169,33 @@ export function defaultBuildTestCommand(
 			return args;
 		}
 		case 'vitest': {
-			const args: string[] = [
-				'npx',
+			const args = resolveLocalNodeTool(
 				'vitest',
-				'run',
-				'--reporter=json',
-				'--outputFile',
-				'.swarm/cache/test-runner-vitest.json',
-			];
+				[
+					'run',
+					'--reporter=json',
+					'--outputFile',
+					'.swarm/cache/test-runner-vitest.json',
+				],
+				dir,
+			);
+			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) args.push(...files);
 			return args;
 		}
 		case 'jest': {
-			const args: string[] = ['npx', 'jest', '--json'];
+			const args = resolveLocalNodeTool('jest', ['--json'], dir);
+			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) args.push(...files);
 			return args;
 		}
 		case 'mocha': {
-			const args: string[] = ['npx', 'mocha'];
+			const args = resolveLocalNodeTool('mocha', [], dir);
+			if (!args) return null;
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) args.push(...files);
 			return args;
@@ -680,12 +689,11 @@ export async function defaultSelectBuildCommand(
 	);
 	for (const cmd of sorted) {
 		if (cmd.detectFile && !detectFileExists(dir, cmd.detectFile)) continue;
-		const argv = tokenizeCommand(cmd.cmd);
-		if (argv.length === 0) continue;
-		if (!isCommandAvailable(argv[0])) continue;
+		const resolved = resolveLocalCommand(cmd.cmd, dir, isCommandAvailable);
+		if (!resolved) continue;
 		return {
 			name: cmd.name,
-			cmd: argv,
+			cmd: resolved.argv,
 			cwd: dir,
 			detectedVia: cmd.detectFile ?? `${profile.id} default`,
 		};

--- a/src/lang/default-backend.ts
+++ b/src/lang/default-backend.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 import {
 	resolveLocalCommand,
 	resolveLocalNodeTool,
+	tokenizeCommand,
 } from '../build/command-resolution';
 import { isCommandAvailable } from '../build/discovery';
 import type {
@@ -54,47 +55,7 @@ function detectFileExists(dir: string, pattern: string): boolean {
 	}
 }
 
-/**
- * Tokenize a string command into an array. Splits on whitespace; respects
- * single and double quotes for argument grouping. Used to convert profile
- * profile `cmd` strings into
- * the array form `bunSpawn` expects.
- *
- * This deliberately does NOT support shell metacharacters (`;`, `&`, `|`,
- * `>`, `<`, backticks, `$()`) — backends with non-trivial commands must
- * override `buildTestCommand`/`selectBuildCommand` to return a custom
- * `cmd: string[]`. Splitting a profile string into words is a 90% case;
- * the 10% override their backend.
- */
-export function tokenizeCommand(cmd: string): string[] {
-	const out: string[] = [];
-	let buf = '';
-	let quote: '"' | "'" | null = null;
-	for (const ch of cmd) {
-		if (quote) {
-			if (ch === quote) {
-				quote = null;
-			} else {
-				buf += ch;
-			}
-			continue;
-		}
-		if (ch === '"' || ch === "'") {
-			quote = ch as '"' | "'";
-			continue;
-		}
-		if (ch === ' ' || ch === '\t') {
-			if (buf.length > 0) {
-				out.push(buf);
-				buf = '';
-			}
-			continue;
-		}
-		buf += ch;
-	}
-	if (buf.length > 0) out.push(buf);
-	return out;
-}
+export { tokenizeCommand } from '../build/command-resolution';
 
 /**
  * Default selectTestFramework: highest-priority framework whose detect
@@ -178,6 +139,8 @@ export function defaultBuildTestCommand(
 					'.swarm/cache/test-runner-vitest.json',
 				],
 				dir,
+				process.platform,
+				isCommandAvailable,
 			);
 			if (!args) return null;
 			if (coverage) args.push('--coverage');
@@ -186,7 +149,13 @@ export function defaultBuildTestCommand(
 			return args;
 		}
 		case 'jest': {
-			const args = resolveLocalNodeTool('jest', ['--json'], dir);
+			const args = resolveLocalNodeTool(
+				'jest',
+				['--json'],
+				dir,
+				process.platform,
+				isCommandAvailable,
+			);
 			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
@@ -194,7 +163,13 @@ export function defaultBuildTestCommand(
 			return args;
 		}
 		case 'mocha': {
-			const args = resolveLocalNodeTool('mocha', [], dir);
+			const args = resolveLocalNodeTool(
+				'mocha',
+				[],
+				dir,
+				process.platform,
+				isCommandAvailable,
+			);
 			if (!args) return null;
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) args.push(...files);

--- a/src/lang/profiles.ts
+++ b/src/lang/profiles.ts
@@ -190,13 +190,13 @@ LANGUAGE_REGISTRY.register({
 			},
 			{
 				name: 'tsc',
-				cmd: 'npx tsc --noEmit',
+				cmd: 'tsc --noEmit',
 				detectFile: 'tsconfig.json',
 				priority: 9,
 			},
 			{
 				name: 'vite build',
-				cmd: 'npx vite build',
+				cmd: 'vite build',
 				detectFile: 'vite.config.ts',
 				priority: 8,
 			},
@@ -217,7 +217,7 @@ LANGUAGE_REGISTRY.register({
 				cmd: 'bun test',
 				priority: 10,
 			},
-			{ name: 'jest', detect: 'jest.config.js', cmd: 'npx jest', priority: 9 },
+			{ name: 'jest', detect: 'jest.config.js', cmd: 'jest', priority: 9 },
 			{
 				// Bun lockfile is the unambiguous signal for a Bun-managed
 				// project — the dispatch path requires this to avoid the
@@ -231,7 +231,7 @@ LANGUAGE_REGISTRY.register({
 			{
 				name: 'mocha',
 				detect: '.mocharc.json',
-				cmd: 'npx mocha',
+				cmd: 'mocha',
 				priority: 7,
 			},
 		],
@@ -253,7 +253,7 @@ LANGUAGE_REGISTRY.register({
 			{
 				name: 'eslint',
 				detect: '.eslintrc.js',
-				cmd: 'npx eslint --fix .',
+				cmd: 'eslint --fix .',
 				priority: 9,
 			},
 		],
@@ -303,13 +303,13 @@ LANGUAGE_REGISTRY.register({
 			},
 			{
 				name: 'tsc',
-				cmd: 'npx tsc --noEmit',
+				cmd: 'tsc --noEmit',
 				detectFile: 'tsconfig.json',
 				priority: 9,
 			},
 			{
 				name: 'vite build',
-				cmd: 'npx vite build',
+				cmd: 'vite build',
 				detectFile: 'vite.config.ts',
 				priority: 8,
 			},
@@ -330,7 +330,7 @@ LANGUAGE_REGISTRY.register({
 				cmd: 'bun test',
 				priority: 10,
 			},
-			{ name: 'jest', detect: 'jest.config.js', cmd: 'npx jest', priority: 9 },
+			{ name: 'jest', detect: 'jest.config.js', cmd: 'jest', priority: 9 },
 			{
 				name: 'bun:test',
 				detect: 'bun.lock',
@@ -340,7 +340,7 @@ LANGUAGE_REGISTRY.register({
 			{
 				name: 'mocha',
 				detect: '.mocharc.json',
-				cmd: 'npx mocha',
+				cmd: 'mocha',
 				priority: 7,
 			},
 		],
@@ -362,7 +362,7 @@ LANGUAGE_REGISTRY.register({
 			{
 				name: 'eslint',
 				detect: '.eslintrc.js',
-				cmd: 'npx eslint --fix .',
+				cmd: 'eslint --fix .',
 				priority: 9,
 			},
 		],

--- a/src/tools/build-check.ts
+++ b/src/tools/build-check.ts
@@ -22,6 +22,8 @@ import { createSwarmTool } from './create-tool';
 export const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
 export const MAX_OUTPUT_BYTES = 10 * 1024; // 10KB
 export const MAX_OUTPUT_LINES = 100;
+const NO_BUILD_FILES_DISCOVERED_REASON =
+	'No build commands discovered (no supported build files found)';
 
 // ============ Types ============
 
@@ -256,7 +258,7 @@ export async function runBuildCheck(
 				.map((s) => `${s.ecosystem}: ${s.reason}`)
 				.join('; ');
 		} else {
-			skipped_reason = 'No build commands discovered (no toolchains found)';
+			skipped_reason = NO_BUILD_FILES_DISCOVERED_REASON;
 		}
 	} else if (failedCount > 0) {
 		verdict = 'fail';

--- a/src/tools/build-check.ts
+++ b/src/tools/build-check.ts
@@ -6,7 +6,11 @@
 
 import type { tool } from '@opencode-ai/plugin';
 import { z } from 'zod';
-import { type BuildCommand, discoverBuildCommands } from '../build/discovery';
+import {
+	type BuildCommand,
+	type BuildDiscoverySkip,
+	discoverBuildCommands,
+} from '../build/discovery';
 import type { BuildEvidence, EvidenceVerdict } from '../config/evidence-schema';
 import { saveEvidence } from '../evidence/manager';
 import { bunSpawn } from '../utils/bun-compat';
@@ -48,6 +52,9 @@ export interface BuildCheckResult {
 		runs_count: number;
 		failed_count: number;
 		skipped_reason?: string;
+		environment_unavailable?: Array<
+			BuildDiscoverySkip & { code: 'environment_unavailable' }
+		>;
 	};
 }
 
@@ -236,9 +243,13 @@ export async function runBuildCheck(
 	// Determine verdict
 	let verdict: EvidenceVerdict;
 	let skipped_reason: string | undefined;
+	const environmentUnavailable = discoveryResult.skipped.filter(
+		(skip): skip is BuildDiscoverySkip & { code: 'environment_unavailable' } =>
+			skip.code === 'environment_unavailable',
+	);
 
 	if (runs.length === 0) {
-		verdict = 'info';
+		verdict = environmentUnavailable.length > 0 ? 'skip' : 'info';
 		// Generate skipped reason
 		if (discoveryResult.skipped.length > 0) {
 			skipped_reason = discoveryResult.skipped
@@ -261,6 +272,8 @@ export async function runBuildCheck(
 			runs_count: runs.length,
 			failed_count: failedCount,
 			skipped_reason,
+			environment_unavailable:
+				environmentUnavailable.length > 0 ? environmentUnavailable : undefined,
 		},
 	};
 }
@@ -318,6 +331,7 @@ export const build_check: ReturnType<typeof tool> = createSwarmTool({
 			runs_count: result.summary.runs_count,
 			failed_count: result.summary.failed_count,
 			skipped_reason: result.summary.skipped_reason,
+			environment_unavailable: result.summary.environment_unavailable,
 		};
 
 		// Save evidence

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { tool } from '@opencode-ai/plugin';
 import { z } from 'zod';
+import { resolveLocalNodeTool } from '../build/command-resolution';
 import { isCommandAvailable } from '../build/discovery';
 import type { NativeTestTarget, TestScope } from '../lang/backend';
 import { buildNativeTargetCommand } from '../lang/default-backend';
@@ -1350,14 +1351,17 @@ function buildTestCommand(
 			return args;
 		}
 		case 'vitest': {
-			const args: string[] = [
-				'npx',
+			const args = resolveLocalNodeTool(
 				'vitest',
-				'run',
-				'--reporter=json',
-				'--outputFile',
-				VITEST_JSON_OUTPUT_RELATIVE_PATH,
-			];
+				[
+					'run',
+					'--reporter=json',
+					'--outputFile',
+					VITEST_JSON_OUTPUT_RELATIVE_PATH,
+				],
+				baseDir,
+			);
+			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail=1');
 			if (scope !== 'all' && files.length > 0) {
@@ -1366,7 +1370,8 @@ function buildTestCommand(
 			return args;
 		}
 		case 'jest': {
-			const args: string[] = ['npx', 'jest', '--json'];
+			const args = resolveLocalNodeTool('jest', ['--json'], baseDir);
+			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) {
@@ -1375,7 +1380,8 @@ function buildTestCommand(
 			return args;
 		}
 		case 'mocha': {
-			const args: string[] = ['npx', 'mocha'];
+			const args = resolveLocalNodeTool('mocha', [], baseDir);
+			if (!args) return null;
 			// Mocha doesn't have built-in coverage, skip if coverage requested
 			if (bail) args.push('--bail');
 			if (scope !== 'all' && files.length > 0) {

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -1360,6 +1360,8 @@ function buildTestCommand(
 					VITEST_JSON_OUTPUT_RELATIVE_PATH,
 				],
 				baseDir,
+				process.platform,
+				_internals.isCommandAvailable,
 			);
 			if (!args) return null;
 			if (coverage) args.push('--coverage');
@@ -1370,7 +1372,13 @@ function buildTestCommand(
 			return args;
 		}
 		case 'jest': {
-			const args = _internals.resolveLocalNodeTool('jest', ['--json'], baseDir);
+			const args = _internals.resolveLocalNodeTool(
+				'jest',
+				['--json'],
+				baseDir,
+				process.platform,
+				_internals.isCommandAvailable,
+			);
 			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
@@ -1380,7 +1388,13 @@ function buildTestCommand(
 			return args;
 		}
 		case 'mocha': {
-			const args = _internals.resolveLocalNodeTool('mocha', [], baseDir);
+			const args = _internals.resolveLocalNodeTool(
+				'mocha',
+				[],
+				baseDir,
+				process.platform,
+				_internals.isCommandAvailable,
+			);
 			if (!args) return null;
 			// Mocha doesn't have built-in coverage, skip if coverage requested
 			if (bail) args.push('--bail');

--- a/src/tools/test-runner.ts
+++ b/src/tools/test-runner.ts
@@ -1351,7 +1351,7 @@ function buildTestCommand(
 			return args;
 		}
 		case 'vitest': {
-			const args = resolveLocalNodeTool(
+			const args = _internals.resolveLocalNodeTool(
 				'vitest',
 				[
 					'run',
@@ -1370,7 +1370,7 @@ function buildTestCommand(
 			return args;
 		}
 		case 'jest': {
-			const args = resolveLocalNodeTool('jest', ['--json'], baseDir);
+			const args = _internals.resolveLocalNodeTool('jest', ['--json'], baseDir);
 			if (!args) return null;
 			if (coverage) args.push('--coverage');
 			if (bail) args.push('--bail');
@@ -1380,7 +1380,7 @@ function buildTestCommand(
 			return args;
 		}
 		case 'mocha': {
-			const args = resolveLocalNodeTool('mocha', [], baseDir);
+			const args = _internals.resolveLocalNodeTool('mocha', [], baseDir);
 			if (!args) return null;
 			// Mocha doesn't have built-in coverage, skip if coverage requested
 			if (bail) args.push('--bail');
@@ -3371,6 +3371,7 @@ export const _internals: {
 	existsSync: typeof fs.existsSync;
 	readdirSync: typeof fs.readdirSync;
 	readFileSync: typeof fs.readFileSync;
+	resolveLocalNodeTool: typeof resolveLocalNodeTool;
 	bunSpawn: typeof bunSpawn;
 	buildNativeTargetCommand: typeof buildNativeTargetCommand;
 	formatNativeHistoryTestFile: typeof formatNativeHistoryTestFile;
@@ -3383,6 +3384,7 @@ export const _internals: {
 	existsSync: fs.existsSync,
 	readdirSync: fs.readdirSync,
 	readFileSync: fs.readFileSync,
+	resolveLocalNodeTool,
 	bunSpawn,
 	buildNativeTargetCommand,
 	formatNativeHistoryTestFile,

--- a/tests/unit/build/command-resolution.test.ts
+++ b/tests/unit/build/command-resolution.test.ts
@@ -71,7 +71,7 @@ describe('local-only command resolution (#2303)', () => {
 			'win32',
 		);
 		expect(result?.shellCommand).toBe(
-			path.join('node_modules', '.bin', 'tsc.cmd') + ' --noEmit',
+			'node_modules\\.bin\\tsc.cmd --noEmit',
 		);
 		expect(result?.shellCommand).not.toContain(dir);
 	});

--- a/tests/unit/build/command-resolution.test.ts
+++ b/tests/unit/build/command-resolution.test.ts
@@ -161,6 +161,13 @@ describe('local-only command resolution (#2303)', () => {
 		).toEqual([path.join(dir, 'node_modules', '.bin', 'eslint'), '.']);
 	});
 
+	test('FB-001 rejects a Windows node shim when node is unavailable', () => {
+		const { dir } = fixtureWithExecutables(['tsc.cmd']);
+		expect(
+			resolveLocalNodeTool('tsc', ['--noEmit'], dir, 'win32', () => false),
+		).toBeNull();
+	});
+
 	test('FB-001 falls back to PATH for node tools only when the caller explicitly allows it', () => {
 		// Previous code had no PATH fallback at all for the node-tool helper, so
 		// default-backend/test-runner callers could not honor existing PATH tools.

--- a/tests/unit/build/command-resolution.test.ts
+++ b/tests/unit/build/command-resolution.test.ts
@@ -70,9 +70,7 @@ describe('local-only command resolution (#2303)', () => {
 			(binary) => binary === 'node',
 			'win32',
 		);
-		expect(result?.shellCommand).toBe(
-			'node_modules\\.bin\\tsc.cmd --noEmit',
-		);
+		expect(result?.shellCommand).toBe('node_modules\\.bin\\tsc.cmd --noEmit');
 		expect(result?.shellCommand).not.toContain(dir);
 	});
 

--- a/tests/unit/build/command-resolution.test.ts
+++ b/tests/unit/build/command-resolution.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import {
 	resolveLocalCommand,
 	resolveLocalNodeTool,
+	tokenizeCommand,
 } from '../../../src/build/command-resolution';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
@@ -29,6 +30,17 @@ describe('local-only command resolution (#2303)', () => {
 		const executable = platform === 'win32' ? `${tool}.cmd` : tool;
 		fs.writeFileSync(path.join(binDir, executable), '');
 		return { dir, executable };
+	}
+
+	function fixtureWithExecutables(executables: string[]) {
+		const dir = canonicalMkdtemp('resolver space 2303-');
+		dirs.push(dir);
+		const binDir = path.join(dir, 'node_modules', '.bin');
+		fs.mkdirSync(binDir, { recursive: true });
+		for (const executable of executables) {
+			fs.writeFileSync(path.join(binDir, executable), '');
+		}
+		return { dir };
 	}
 
 	test('rejects implicit-download wrappers', () => {
@@ -74,10 +86,154 @@ describe('local-only command resolution (#2303)', () => {
 		expect(result?.shellCommand).not.toContain(dir);
 	});
 
+	test('FB-001 prefers a local Windows PowerShell shim over a PATH binary when no .cmd shim exists', () => {
+		// Previous code only probed `<tool>.cmd`, so a repo-local `.ps1` shim was
+		// ignored and the resolver fell through to the global PATH binary.
+		const { dir } = fixtureWithExecutables(['tsc.ps1']);
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'node' || binary === 'tsc',
+			'win32',
+		);
+
+		expect(result).toEqual({
+			argv: [path.join(dir, 'node_modules', '.bin', 'tsc.ps1'), '--noEmit'],
+			shellCommand: 'node_modules\\.bin\\tsc.ps1 --noEmit',
+		});
+	});
+
+	test('FB-001 returns null instead of preferring a global PATH binary over a local Windows shim', () => {
+		// Previous code would skip the local shim when `.cmd` was absent and then
+		// accept a global PATH binary, bypassing the repository-local version.
+		const { dir } = fixtureWithExecutables(['tsc.ps1']);
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'tsc',
+			'win32',
+		);
+
+		expect(result).toBeNull();
+	});
+
+	test('FB-001 keeps scanning Windows local candidates when a .cmd shim needs node but a later .exe does not', () => {
+		// Previous code treated the first local hit as authoritative, so a
+		// non-runnable `.cmd` shim prevented a usable repo-local `.exe` from winning.
+		const { dir } = fixtureWithExecutables(['tsc.cmd', 'tsc.exe']);
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'tsc',
+			'win32',
+		);
+
+		expect(result).toEqual({
+			argv: [path.join(dir, 'node_modules', '.bin', 'tsc.exe'), '--noEmit'],
+			shellCommand: 'node_modules\\.bin\\tsc.exe --noEmit',
+		});
+	});
+
+	test('FB-001 resolves Windows local shims beyond .cmd for node tool execution', () => {
+		// Previous code hard-coded `<tool>.cmd`, so `.exe`, `.bat`, `.ps1`, and
+		// extensionless local shims were invisible to the test runner/backend path.
+		const { dir } = fixtureWithExecutables([
+			'vitest.exe',
+			'jest.bat',
+			'mocha.ps1',
+			'eslint',
+		]);
+
+		const isAvailable = (binary: string) =>
+			['node', 'vitest', 'jest', 'mocha', 'eslint'].includes(binary);
+
+		expect(
+			resolveLocalNodeTool('vitest', ['run'], dir, 'win32', isAvailable),
+		).toEqual([path.join(dir, 'node_modules', '.bin', 'vitest.exe'), 'run']);
+		expect(
+			resolveLocalNodeTool('jest', ['--json'], dir, 'win32', isAvailable),
+		).toEqual([path.join(dir, 'node_modules', '.bin', 'jest.bat'), '--json']);
+		expect(
+			resolveLocalNodeTool('mocha', [], dir, 'win32', isAvailable),
+		).toEqual([path.join(dir, 'node_modules', '.bin', 'mocha.ps1')]);
+		expect(
+			resolveLocalNodeTool('eslint', ['.'], dir, 'win32', isAvailable),
+		).toEqual([path.join(dir, 'node_modules', '.bin', 'eslint'), '.']);
+	});
+
+	test('FB-001 falls back to PATH for node tools only when the caller explicitly allows it', () => {
+		// Previous code had no PATH fallback at all for the node-tool helper, so
+		// default-backend/test-runner callers could not honor existing PATH tools.
+		const dir = canonicalMkdtemp('resolver-2303-');
+		dirs.push(dir);
+		const isAvailable = (binary: string) => binary === 'vitest';
+
+		expect(resolveLocalNodeTool('vitest', ['run'], dir, 'win32')).toBeNull();
+		expect(
+			resolveLocalNodeTool('vitest', ['run'], dir, 'win32', isAvailable),
+		).toEqual(['vitest', 'run']);
+	});
+
+	test('FB-001 still prefers a repository-local executable over an allowed PATH fallback', () => {
+		const { dir } = fixtureWithExecutables(['vitest.exe']);
+		const isAvailable = (binary: string) => binary === 'vitest';
+
+		expect(
+			resolveLocalNodeTool('vitest', ['run'], dir, 'win32', isAvailable),
+		).toEqual([path.join(dir, 'node_modules', '.bin', 'vitest.exe'), 'run']);
+	});
+
 	test('returns null when the local binary is absent', () => {
 		const dir = canonicalMkdtemp('resolver-2303-');
 		dirs.push(dir);
 		expect(resolveLocalNodeTool('vitest', ['run'], dir)).toBeNull();
+	});
+
+	test('FB-009 preserves quoted argument groups when rewriting a local shell command', () => {
+		// Previous code used whitespace splitting here, so `"path with spaces"`
+		// was broken into multiple argv entries when a local shim was selected.
+		const { dir } = fixture('linux');
+		const result = resolveLocalCommand(
+			'tsc --project "packages/app tsconfig.json" --pretty false',
+			dir,
+			(binary) => binary === 'node',
+			'linux',
+		);
+
+		expect(result).toEqual({
+			argv: [
+				path.join(dir, 'node_modules', '.bin', 'tsc'),
+				'--project',
+				'packages/app tsconfig.json',
+				'--pretty',
+				'false',
+			],
+			shellCommand:
+				'./node_modules/.bin/tsc --project "packages/app tsconfig.json" --pretty false',
+		});
+	});
+
+	test('FB-009 keeps shellCommand text unchanged while tokenizing quoted PATH commands safely', () => {
+		// Previous code also used whitespace splitting on the PATH fallback, so
+		// quoted groups were lost even though the original shell text was preserved.
+		const command = 'python -m pytest -k "fast | smoke suite"';
+		const result = resolveLocalCommand(
+			command,
+			'.',
+			(binary) => binary === 'python',
+			'linux',
+		);
+
+		expect(result).toEqual({
+			argv: ['python', '-m', 'pytest', '-k', 'fast | smoke suite'],
+			shellCommand: command,
+		});
+	});
+
+	test('FB-009 tokenizes quoted groups without interpreting shell metacharacters', () => {
+		expect(
+			tokenizeCommand(`vitest run --testNamePattern "fast | smoke"`),
+		).toEqual(['vitest', 'run', '--testNamePattern', 'fast | smoke']);
 	});
 
 	test('production-generated verification commands contain no implicit-download wrappers', () => {

--- a/tests/unit/build/command-resolution.test.ts
+++ b/tests/unit/build/command-resolution.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	resolveLocalCommand,
+	resolveLocalNodeTool,
+} from '../../../src/build/command-resolution';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const GENERATED_COMMAND_SOURCES = [
+	'src/lang/profiles.ts',
+	'src/lang/default-backend.ts',
+	'src/hooks/incremental-verify.ts',
+	'src/tools/test-runner.ts',
+];
+
+describe('local-only command resolution (#2303)', () => {
+	const dirs: string[] = [];
+	afterEach(() => {
+		for (const dir of dirs.splice(0))
+			fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	function fixture(platform: NodeJS.Platform, tool = 'tsc') {
+		const dir = canonicalMkdtemp('resolver space 2303-');
+		dirs.push(dir);
+		const binDir = path.join(dir, 'node_modules', '.bin');
+		fs.mkdirSync(binDir, { recursive: true });
+		const executable = platform === 'win32' ? `${tool}.cmd` : tool;
+		fs.writeFileSync(path.join(binDir, executable), '');
+		return { dir, executable };
+	}
+
+	test('rejects implicit-download wrappers', () => {
+		expect(resolveLocalCommand('npx tsc --noEmit', '.', () => true)).toBeNull();
+	});
+
+	test('emits a cwd-relative POSIX shell command and absolute argv', () => {
+		const { dir } = fixture('linux');
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'node',
+			'linux',
+		);
+		expect(result).toEqual({
+			argv: [path.join(dir, 'node_modules', '.bin', 'tsc'), '--noEmit'],
+			shellCommand: './node_modules/.bin/tsc --noEmit',
+		});
+	});
+
+	test('prefers the repository-local binary over a global installation', () => {
+		const { dir } = fixture('linux');
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'node' || binary === 'tsc',
+			'linux',
+		);
+
+		expect(result?.argv[0]).toBe(path.join(dir, 'node_modules', '.bin', 'tsc'));
+		expect(result?.shellCommand).toBe('./node_modules/.bin/tsc --noEmit');
+	});
+
+	test('emits the Windows cmd shim without embedding the absolute cwd', () => {
+		const { dir } = fixture('win32');
+		const result = resolveLocalCommand(
+			'tsc --noEmit',
+			dir,
+			(binary) => binary === 'node',
+			'win32',
+		);
+		expect(result?.shellCommand).toBe(
+			path.join('node_modules', '.bin', 'tsc.cmd') + ' --noEmit',
+		);
+		expect(result?.shellCommand).not.toContain(dir);
+	});
+
+	test('returns null when the local binary is absent', () => {
+		const dir = canonicalMkdtemp('resolver-2303-');
+		dirs.push(dir);
+		expect(resolveLocalNodeTool('vitest', ['run'], dir)).toBeNull();
+	});
+
+	test('production-generated verification commands contain no implicit-download wrappers', () => {
+		const root = path.resolve(import.meta.dir, '../../..');
+		const violations: string[] = [];
+		for (const relative of GENERATED_COMMAND_SOURCES) {
+			const source = fs.readFileSync(path.join(root, relative), 'utf8');
+			if (/cmd:\s*['"](?:npx|bunx|pnpx)\b/.test(source))
+				violations.push(relative);
+			if (/\[\s*['"](?:npx|bunx|pnpx)['"]\s*,/.test(source))
+				violations.push(relative);
+		}
+		expect(violations).toEqual([]);
+	});
+});

--- a/tests/unit/build/discovery-profiles-adversarial.test.ts
+++ b/tests/unit/build/discovery-profiles-adversarial.test.ts
@@ -481,8 +481,8 @@ describe('discoverBuildCommands - Attack: Scope with Empty changedFiles', () => 
 		// Note: When no profiles detected, fallback ecosystem detection runs and adds skipped entries
 		expect(result.commands).toEqual([]);
 		expect(Array.isArray(result.skipped)).toBe(true);
-		// Should have skipped entries from ecosystem fallback
-		expect(result.skipped.length).toBeGreaterThan(0);
+		// No build files exist, so unrelated ecosystems must not be reported unavailable.
+		expect(result.skipped).toEqual([]);
 	});
 });
 

--- a/tests/unit/build/discovery-profiles-adversarial.test.ts
+++ b/tests/unit/build/discovery-profiles-adversarial.test.ts
@@ -163,8 +163,9 @@ describe('discoverBuildCommandsFromProfiles - Attack: Empty Commands Array', () 
 		expect(result.commands).toEqual([]);
 		expect(result.skipped).toHaveLength(1);
 		expect(result.skipped[0].ecosystem).toBe('empty-lang');
-		expect(result.skipped[0].reason).toContain('No binary available');
-		expect(result.skipped[0].reason).toContain('tried'); // Should mention tried binaries
+		expect(result.skipped[0].reason).toBe(
+			'No matching build files for profile empty-lang',
+		);
 	});
 });
 

--- a/tests/unit/build/discovery-profiles-adversarial.test.ts
+++ b/tests/unit/build/discovery-profiles-adversarial.test.ts
@@ -130,7 +130,6 @@ describe('discoverBuildCommandsFromProfiles - Attack: Malformed workingDir', () 
 
 describe('discoverBuildCommandsFromProfiles - Attack: Empty Commands Array', () => {
 	it('should skip profile when build.commands is empty array', async () => {
-		// Arrange: Profile with no commands
 		const emptyCommandsProfile: MockLanguageProfile = {
 			id: 'empty-lang',
 			displayName: 'Empty Language',
@@ -159,7 +158,6 @@ describe('discoverBuildCommandsFromProfiles - Attack: Empty Commands Array', () 
 		// Act
 		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
 
-		// Assert: Should skip the profile (no commands, but no crash)
 		expect(result.commands).toEqual([]);
 		expect(result.skipped).toHaveLength(1);
 		expect(result.skipped[0].ecosystem).toBe('empty-lang');

--- a/tests/unit/build/discovery-profiles.test.ts
+++ b/tests/unit/build/discovery-profiles.test.ts
@@ -312,9 +312,10 @@ describe('discoverBuildCommands - Profile vs ECOSYSTEMS Priority', () => {
 		// Multiple ecosystems should have been processed (not just one)
 		expect(skippedEcosystems.length).toBeGreaterThan(0);
 
-		// At least some non-python ecosystems were processed (ECOSYSTEMS fallback)
+		// Ecosystem fallback now reports only ecosystems whose build files exist;
+		// an empty fixture must not claim unrelated runtime failures.
 		const nonPythonSkipped = skippedEcosystems.filter((e) => e !== 'python');
-		expect(nonPythonSkipped.length).toBeGreaterThan(0);
+		expect(nonPythonSkipped).toEqual([]);
 
 		// This demonstrates that:
 		// 1. Profile-driven detection ran (python was in the mix)
@@ -383,7 +384,7 @@ describe('discoverBuildCommands - Ecosystem Deduplication', () => {
 		// Verify PROFILE_TO_ECOSYSTEM_NAMES mapping by checking that
 		// Node ecosystem was in the ECOSYSTEMS list for processing
 		const nodeSkipped = result.skipped.find((s) => s.ecosystem === 'node');
-		expect(nodeSkipped).toBeDefined();
+		expect(nodeSkipped).toBeUndefined();
 
 		// The deduplication logic exists (we can verify this indirectly):
 		// - typescript maps to 'node' in PROFILE_TO_ECOSYSTEM_NAMES
@@ -464,7 +465,7 @@ describe('discoverBuildCommands - Ruby Profile Behavior', () => {
 
 		// At least one other ecosystem should have been processed
 		// (not skipped because ruby "covered" it)
-		expect(otherEcosystemsProcessed.length).toBeGreaterThan(0);
+		expect(otherEcosystemsProcessed).toEqual([]);
 
 		// Verify that the reason for skipping is NOT "covered by profile"
 		// (there's no such reason in the code, this is just to ensure we understand the behavior)

--- a/tests/unit/build/discovery-profiles.test.ts
+++ b/tests/unit/build/discovery-profiles.test.ts
@@ -1,477 +1,294 @@
-/**
- * Tests for profile-driven build discovery in src/build/discovery.ts
- *
- * Tests cover:
- * - discoverBuildCommandsFromProfiles behavior with empty/language detection
- * - Profile command discovery with/without available binaries
- * - detectFile filtering
- * - discoverBuildCommands primary/fallback ordering
- * - Ecosystem deduplication (typescript → node)
- * - Ruby profile (no ECOSYSTEMS entry) doesn't block others
- */
-
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as realDetector from '../../../src/lang/detector';
-import * as realProfiles from '../../../src/lang/profiles';
 import {
-	deriveMockedRegistry,
-	type MockLanguageProfile,
-} from './discovery-profiles-mocks';
+	_internals,
+	clearToolchainCache,
+	discoverBuildCommands,
+	discoverBuildCommandsFromProfiles,
+} from '../../../src/build/discovery';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+import type { MockLanguageProfile } from './discovery-profiles-mocks';
 
-// Test directory
-const TEST_DIR = path.join(process.cwd(), 'test-tmp-discovery-profiles');
+const originalDetectProjectLanguages = _internals.detectProjectLanguagesImpl;
+const originalGetLanguageProfile = _internals.getLanguageProfileImpl;
+const originalIsCommandAvailable = _internals.isCommandAvailable;
 
-// ============ Mock Pattern Setup ============
-// Always use local mock variables, not vi.mocked()
-// Both factories spread the real module per AGENTS.md invariant 7 — a partial
-// mock here leaks process-wide and breaks sibling files. See
-// ./discovery-profiles-mocks.ts for why the registry needs Object.create.
+function makeProfile(
+	overrides: Partial<MockLanguageProfile> & Pick<MockLanguageProfile, 'id'>,
+): MockLanguageProfile {
+	return {
+		id: overrides.id,
+		displayName: overrides.displayName ?? overrides.id,
+		tier: overrides.tier ?? 1,
+		extensions: overrides.extensions ?? ['.txt'],
+		treeSitter: overrides.treeSitter ?? {
+			grammarId: overrides.id,
+			wasmFile: `tree-sitter-${overrides.id}.wasm`,
+		},
+		build: overrides.build ?? { detectFiles: [], commands: [] },
+		test: overrides.test ?? { detectFiles: [], frameworks: [] },
+		lint: overrides.lint ?? { detectFiles: [], linters: [] },
+		audit: overrides.audit ?? {
+			detectFiles: [],
+			command: null,
+			outputFormat: 'json',
+		},
+		sast: overrides.sast ?? {
+			nativeRuleSet: null,
+			semgrepSupport: 'none',
+		},
+		prompts: overrides.prompts ?? {
+			coderConstraints: [],
+			reviewerChecklist: [],
+		},
+	};
+}
 
-const mockDetectProjectLanguages = mock();
-const mockLangRegistryGet = mock();
+describe('build discovery profile regressions (#2303)', () => {
+	const tempDirs: string[] = [];
 
-// Mock the detector module
-mock.module('../../../src/lang/detector', () => ({
-	...realDetector,
-	detectProjectLanguages: (...args: unknown[]) =>
-		mockDetectProjectLanguages(...args),
-}));
+	beforeEach(() => {
+		clearToolchainCache();
+		_internals.detectProjectLanguagesImpl = async () => [];
+		_internals.getLanguageProfileImpl = () => undefined;
+		_internals.isCommandAvailable = () => false;
+	});
 
-// Mock the profiles module
-mock.module('../../../src/lang/profiles', () => ({
-	...realProfiles,
-	LANGUAGE_REGISTRY: deriveMockedRegistry(
-		realProfiles.LANGUAGE_REGISTRY,
-		(...args) => mockLangRegistryGet(...args),
-	),
-}));
+	afterEach(() => {
+		_internals.detectProjectLanguagesImpl = originalDetectProjectLanguages;
+		_internals.getLanguageProfileImpl = originalGetLanguageProfile;
+		_internals.isCommandAvailable = originalIsCommandAvailable;
+		clearToolchainCache();
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
 
-// ============ Test Setup ============
-
-beforeEach(() => {
-	// Reset all mocks
-	mockDetectProjectLanguages.mockReset();
-	mockLangRegistryGet.mockReset();
-
-	// Create test directory if it doesn't exist
-	if (!fs.existsSync(TEST_DIR)) {
-		fs.mkdirSync(TEST_DIR, { recursive: true });
+	function makeDir(prefix: string): string {
+		const dir = canonicalMkdtemp(prefix);
+		tempDirs.push(dir);
+		return dir;
 	}
-});
 
-afterEach(() => {
-	// Clean up test directory
-	if (fs.existsSync(TEST_DIR)) {
-		fs.rmSync(TEST_DIR, { recursive: true, force: true });
-	}
-	mock.restore();
-});
+	test('returns no commands when no language profiles are detected', async () => {
+		const dir = makeDir('build-discovery-empty-');
 
-// ============ Test Suite 1: discoverBuildCommandsFromProfiles - Basic Behavior ============
+		const result = await discoverBuildCommandsFromProfiles(dir);
 
-describe('discoverBuildCommandsFromProfiles - Basic Behavior', () => {
-	it('should return { commands: [], skipped: [] } when detectProjectLanguages returns []', async () => {
-		// Arrange: No languages detected
-		mockDetectProjectLanguages.mockResolvedValue([]);
+		expect(result).toEqual({ commands: [], skipped: [] });
+	});
 
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
-
-		// Act
-		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
-
-		// Assert
-		expect(result).toEqual({
-			commands: [],
-			skipped: [],
+	test('FB-002 reports a structured environment skip when an applicable profile binary is unavailable', async () => {
+		const dir = makeDir('build-discovery-python-');
+		fs.writeFileSync(
+			path.join(dir, 'pyproject.toml'),
+			'[project]\nname="demo"\n',
+		);
+		const profile = makeProfile({
+			id: 'python',
+			build: {
+				detectFiles: ['pyproject.toml'],
+				commands: [
+					{
+						name: 'pip',
+						cmd: 'pip install -e .',
+						detectFile: 'setup.py',
+						priority: 20,
+					},
+					{
+						name: 'build',
+						cmd: 'python -m build',
+						detectFile: 'pyproject.toml',
+						priority: 10,
+					},
+				],
+			},
 		});
-		expect(mockDetectProjectLanguages).toHaveBeenCalledWith(TEST_DIR);
-		expect(mockLangRegistryGet).not.toHaveBeenCalled();
-	});
 
-	it('should skip profile with no available binary and include reason', async () => {
-		// Arrange: Python detected, but no binary available
-		const mockPythonProfile: MockLanguageProfile = {
-			id: 'python',
-			displayName: 'Python',
-			tier: 1,
-			extensions: ['.py'],
-			treeSitter: { grammarId: 'python', wasmFile: 'tree-sitter-python.wasm' },
-			build: {
-				detectFiles: ['pyproject.toml'],
-				commands: [
-					{
-						name: 'pip',
-						cmd: 'pip install -e .',
-						detectFile: 'setup.py',
-						priority: 10,
-					},
-					{
-						name: 'build',
-						cmd: 'python -m build',
-						detectFile: 'pyproject.toml',
-						priority: 9,
-					},
-				],
-			},
-			test: { detectFiles: ['pytest.ini'], frameworks: [] },
-			lint: { detectFiles: ['pyproject.toml'], linters: [] },
-			audit: {
-				detectFiles: ['pyproject.toml'],
-				command: null,
-				outputFormat: 'json',
-			},
-			sast: { nativeRuleSet: 'python', semgrepSupport: 'ga' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
+		_internals.detectProjectLanguagesImpl = async () =>
+			[{ id: 'python' }] as any;
+		_internals.getLanguageProfileImpl = () => profile as any;
 
-		mockDetectProjectLanguages.mockResolvedValue([mockPythonProfile]);
-		mockLangRegistryGet.mockReturnValue(mockPythonProfile);
+		const result = await discoverBuildCommandsFromProfiles(dir);
 
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
-
-		// Act
-		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
-
-		// Assert
 		expect(result.commands).toEqual([]);
-		expect(result.skipped).toHaveLength(1);
-		expect(result.skipped[0].ecosystem).toBe('python');
-		expect(result.skipped[0].reason).toContain('No binary available');
-		expect(result.skipped[0].reason).toContain('python');
-		expect(result.skipped[0].reason).toMatch(/pip|python/);
-		expect(mockLangRegistryGet).toHaveBeenCalledWith('python');
-	});
-});
-
-// ============ Test Suite 2: discoverBuildCommandsFromProfiles - detectFile Filtering ============
-
-describe('discoverBuildCommandsFromProfiles - detectFile Filtering', () => {
-	it('should skip command whose detectFile does not exist', async () => {
-		// Arrange: Python profile with commands that have detectFile requirements
-		const mockPythonProfile: MockLanguageProfile = {
-			id: 'python',
-			displayName: 'Python',
-			tier: 1,
-			extensions: ['.py'],
-			treeSitter: { grammarId: 'python', wasmFile: 'tree-sitter-python.wasm' },
-			build: {
-				detectFiles: ['pyproject.toml'],
-				commands: [
-					{
-						name: 'pip',
-						cmd: 'pip install -e .',
-						detectFile: 'setup.py',
-						priority: 10,
-					},
-					{
-						name: 'build',
-						cmd: 'python -m build',
-						detectFile: 'pyproject.toml',
-						priority: 9,
-					},
-				],
+		expect(result.skipped).toEqual([
+			{
+				ecosystem: 'python',
+				code: 'environment_unavailable',
+				required_commands: ['python'],
+				reason: 'No binary available for profile python: tried python',
 			},
-			test: { detectFiles: ['pytest.ini'], frameworks: [] },
-			lint: { detectFiles: ['pyproject.toml'], linters: [] },
-			audit: {
-				detectFiles: ['pyproject.toml'],
-				command: null,
-				outputFormat: 'json',
-			},
-			sast: { nativeRuleSet: 'python', semgrepSupport: 'ga' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
-
-		// Only create pyproject.toml, not setup.py
-		fs.writeFileSync(path.join(TEST_DIR, 'pyproject.toml'), '{}');
-
-		mockDetectProjectLanguages.mockResolvedValue([mockPythonProfile]);
-		mockLangRegistryGet.mockReturnValue(mockPythonProfile);
-
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
-
-		// Act
-		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
-
-		// Assert: Should use python -m build (detectFile: pyproject.toml exists)
-		// and skip pip install -e . (detectFile: setup.py does NOT exist)
-		expect(result.commands).toHaveLength(1);
-		expect(result.commands[0].command).toBe('python -m build');
-		expect(result.commands[0].ecosystem).toBe('python');
-		expect(result.skipped).toHaveLength(0);
+		]);
 	});
 
-	it('selects the highest numeric priority profile command when multiple are available', async () => {
-		const mockProfile: MockLanguageProfile = {
+	test('FB-004 ignores missing detectFile commands and still selects the highest-priority applicable command', async () => {
+		const dir = makeDir('build-discovery-custom-');
+		fs.writeFileSync(path.join(dir, 'project.custom'), '');
+		const profile = makeProfile({
 			id: 'custom',
-			displayName: 'Custom',
-			tier: 1,
-			extensions: ['.custom'],
-			treeSitter: { grammarId: 'custom', wasmFile: 'tree-sitter-custom.wasm' },
 			build: {
 				detectFiles: ['project.custom'],
 				commands: [
 					{
+						name: 'ignored',
+						cmd: 'node ignored.js',
+						detectFile: 'missing.custom',
+						priority: 30,
+					},
+					{
 						name: 'low',
 						cmd: 'node low.js',
 						detectFile: 'project.custom',
-						priority: 1,
+						priority: 10,
 					},
 					{
 						name: 'high',
 						cmd: 'node high.js',
 						detectFile: 'project.custom',
-						priority: 10,
+						priority: 20,
 					},
 				],
 			},
-			test: { detectFiles: [], frameworks: [] },
-			lint: { detectFiles: [], linters: [] },
-			audit: { detectFiles: [], command: null, outputFormat: 'json' },
-			sast: { nativeRuleSet: null, semgrepSupport: 'none' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
-		fs.writeFileSync(path.join(TEST_DIR, 'project.custom'), '');
-		mockDetectProjectLanguages.mockResolvedValue([mockProfile]);
-		mockLangRegistryGet.mockReturnValue(mockProfile);
+		});
 
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
+		_internals.detectProjectLanguagesImpl = async () =>
+			[{ id: 'custom' }] as any;
+		_internals.getLanguageProfileImpl = () => profile as any;
+		_internals.isCommandAvailable = (binary) => binary === 'node';
 
-		const result = await module.discoverBuildCommandsFromProfiles(TEST_DIR);
+		const result = await discoverBuildCommandsFromProfiles(dir);
 
-		expect(result.commands).toHaveLength(1);
-		expect(result.commands[0].command).toBe('node high.js');
+		expect(result.skipped).toEqual([]);
+		expect(result.commands).toEqual([
+			{
+				ecosystem: 'custom',
+				command: 'node high.js',
+				cwd: dir,
+				priority: 20,
+			},
+		]);
 	});
-});
 
-// ============ Test Suite 3: discoverBuildCommands - Profile vs ECOSYSTEMS Priority ============
-
-describe('discoverBuildCommands - Profile vs ECOSYSTEMS Priority', () => {
-	it('should place profile commands before ECOSYSTEMS commands in result', async () => {
-		// Arrange: Python profile detected
-		// This test verifies the order: profile-driven detection happens first, then ECOSYSTEMS fallback
-
-		const mockPythonProfile: MockLanguageProfile = {
-			id: 'python',
-			displayName: 'Python',
-			tier: 1,
-			extensions: ['.py'],
-			treeSitter: { grammarId: 'python', wasmFile: 'tree-sitter-python.wasm' },
-			build: {
-				detectFiles: ['pyproject.toml'],
-				commands: [
-					{
-						name: 'pip',
-						cmd: 'pip install -e .',
-						detectFile: 'setup.py',
-						priority: 10,
-					},
-					{
-						name: 'build',
-						cmd: 'python -m build',
-						detectFile: 'pyproject.toml',
-						priority: 9,
-					},
-				],
-			},
-			test: { detectFiles: ['pytest.ini'], frameworks: [] },
-			lint: { detectFiles: ['pyproject.toml'], linters: [] },
-			audit: {
-				detectFiles: ['pyproject.toml'],
-				command: null,
-				outputFormat: 'json',
-			},
-			sast: { nativeRuleSet: 'python', semgrepSupport: 'ga' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
-
-		mockDetectProjectLanguages.mockResolvedValue([mockPythonProfile]);
-		mockLangRegistryGet.mockReturnValue(mockPythonProfile);
-
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
-
-		// Act
-		const result = await module.discoverBuildCommands(TEST_DIR);
-
-		// Assert: Profile-driven discovery runs first
-		// verify that python profile was processed by LANGUAGE_REGISTRY.get being called
-		expect(mockLangRegistryGet).toHaveBeenCalledWith('python');
-
-		// The implementation should call discoverBuildCommandsFromProfiles first, then ECOSYSTEMS fallback
-		// We can verify this by checking that both sources contributed to skipped list
-		// (profile contributes 'python', ECOSYSTEMS contributes others like 'node', 'rust', etc.)
-		const skippedEcosystems = result.skipped.map((s) => s.ecosystem);
-
-		// Multiple ecosystems should have been processed (not just one)
-		expect(skippedEcosystems.length).toBeGreaterThan(0);
-
-		// Ecosystem fallback now reports only ecosystems whose build files exist;
-		// an empty fixture must not claim unrelated runtime failures.
-		const nonPythonSkipped = skippedEcosystems.filter((e) => e !== 'python');
-		expect(nonPythonSkipped).toEqual([]);
-
-		// This demonstrates that:
-		// 1. Profile-driven detection ran (python was in the mix)
-		// 2. ECOSYSTEMS fallback also ran (other ecosystems were checked)
-		// The order is: profiles first, then fallback
-	});
-});
-
-// ============ Test Suite 4: discoverBuildCommands - Ecosystem Deduplication ============
-
-describe('discoverBuildCommands - Ecosystem Deduplication', () => {
-	it('should deduplicate Node ecosystem when typescript profile is detected', async () => {
-		// Arrange: TypeScript profile detected, which covers 'node' ecosystem in PROFILE_TO_ECOSYSTEM_NAMES
-		// Note: Since we can't mock binary availability, the typescript profile will be skipped
-		// This means it won't contribute to coveredEcosystems, so Node from ECOSYSTEMS
-		// will still be processed (and skipped due to no npm)
-
-		// To properly test deduplication, we need to verify the logic exists:
-		// 1. PROFILE_TO_ECOSYSTEM_NAMES mapping includes 'typescript' -> ['node']
-		// 2. The coveredEcosystems Set is built from profile commands
-		// 3. ECOSYSTEMS loop checks coveredEcosystems before processing
-
-		const mockTypeScriptProfile: MockLanguageProfile = {
-			id: 'typescript',
-			displayName: 'TypeScript',
-			tier: 1,
-			extensions: ['.ts', '.tsx'],
-			treeSitter: {
-				grammarId: 'typescript',
-				wasmFile: 'tree-sitter-typescript.wasm',
-			},
-			build: {
-				detectFiles: ['package.json'],
-				commands: [
-					{
-						name: 'bun',
-						cmd: 'bun run build',
-						detectFile: 'package.json',
-						priority: 10,
-					},
-				],
-			},
-			test: { detectFiles: ['vitest.config.ts'], frameworks: [] },
-			lint: { detectFiles: ['biome.json'], linters: [] },
-			audit: {
-				detectFiles: ['package.json'],
-				command: null,
-				outputFormat: 'json',
-			},
-			sast: { nativeRuleSet: 'javascript', semgrepSupport: 'ga' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
-
-		mockDetectProjectLanguages.mockResolvedValue([mockTypeScriptProfile]);
-		mockLangRegistryGet.mockReturnValue(mockTypeScriptProfile);
-
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
-
-		// Act
-		const result = await module.discoverBuildCommands(TEST_DIR);
-
-		// Assert: typescript profile was processed
-		expect(mockLangRegistryGet).toHaveBeenCalledWith('typescript');
-
-		// Verify PROFILE_TO_ECOSYSTEM_NAMES mapping by checking that
-		// Node ecosystem was in the ECOSYSTEMS list for processing
-		const nodeSkipped = result.skipped.find((s) => s.ecosystem === 'node');
-		expect(nodeSkipped).toBeUndefined();
-
-		// The deduplication logic exists (we can verify this indirectly):
-		// - typescript maps to 'node' in PROFILE_TO_ECOSYSTEM_NAMES
-		// - If typescript HAD commands discovered, 'node' would be in coveredEcosystems
-		// - Then ECOSYSTEMS loop would skip 'node' with coveredEcosystems.has('node')
-		// - Since no binary available, typescript contributes no commands to coveredEcosystems
-		// - So 'node' is still processed by ECOSYSTEMS (and skipped for no npm)
-
-		// This verifies the structure: deduplication logic is in place
-		// (The actual behavior when binary IS available is covered by other tests)
-	});
-});
-
-// ============ Test Suite 5: discoverBuildCommands - Ruby Profile Behavior ============
-
-describe('discoverBuildCommands - Ruby Profile Behavior', () => {
-	it('should not block other ecosystems when ruby profile has no ECOSYSTEMS entry', async () => {
-		// Arrange: Ruby profile detected
-		// Ruby has no ECOSYSTEMS entry (PROFILE_TO_ECOSYSTEM_NAMES['ruby'] = [])
-		// This means ruby doesn't cover any ECOSYSTEM, so other ecosystems should still be processed
-
-		const mockRubyProfile: MockLanguageProfile = {
+	test('reports when a detected profile has no matching build files', async () => {
+		const dir = makeDir('build-discovery-ruby-');
+		const profile = makeProfile({
 			id: 'ruby',
-			displayName: 'Ruby',
-			tier: 3,
-			extensions: ['.rb'],
-			treeSitter: { grammarId: 'ruby', wasmFile: 'tree-sitter-ruby.wasm' },
 			build: {
 				detectFiles: ['Gemfile'],
 				commands: [
 					{
 						name: 'bundle',
-						cmd: 'bundle install',
+						cmd: 'bundle exec rake build',
 						detectFile: 'Gemfile',
 						priority: 10,
 					},
 				],
 			},
-			test: { detectFiles: ['.rspec'], frameworks: [] },
-			lint: { detectFiles: ['.rubocop.yml'], linters: [] },
-			audit: {
-				detectFiles: ['Gemfile.lock'],
-				command: null,
-				outputFormat: 'json',
+		});
+
+		_internals.detectProjectLanguagesImpl = async () => [{ id: 'ruby' }] as any;
+		_internals.getLanguageProfileImpl = () => profile as any;
+
+		const result = await discoverBuildCommandsFromProfiles(dir);
+
+		expect(result.commands).toEqual([]);
+		expect(result.skipped).toEqual([
+			{
+				ecosystem: 'ruby',
+				reason: 'No matching build files for profile ruby: expected Gemfile',
 			},
-			sast: { nativeRuleSet: null, semgrepSupport: 'experimental' },
-			prompts: { coderConstraints: [], reviewerChecklist: [] },
-		};
+		]);
+	});
 
-		mockDetectProjectLanguages.mockResolvedValue([mockRubyProfile]);
-		mockLangRegistryGet.mockReturnValue(mockRubyProfile);
+	test('FB-005 emits a covered-profile skip instead of adding a fallback node command', async () => {
+		const dir = makeDir('build-discovery-typescript-');
+		fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"demo"}');
+		const profile = makeProfile({
+			id: 'typescript',
+			build: {
+				detectFiles: ['package.json'],
+				commands: [
+					{
+						name: 'tsc',
+						cmd: 'tsc --noEmit',
+						detectFile: 'package.json',
+						priority: 15,
+					},
+				],
+			},
+		});
 
-		const module = await import('../../../src/build/discovery');
-		module.clearToolchainCache();
+		_internals.detectProjectLanguagesImpl = async () =>
+			[{ id: 'typescript' }] as any;
+		_internals.getLanguageProfileImpl = () => profile as any;
+		_internals.isCommandAvailable = (binary) => binary === 'tsc';
 
-		// Act
-		const result = await module.discoverBuildCommands(TEST_DIR);
+		const result = await discoverBuildCommands(dir);
 
-		// Verify that ruby profile was processed (skipped due to no binary)
-		const rubySkipped = result.skipped.find((s) => s.ecosystem === 'ruby');
-		expect(rubySkipped).toBeDefined();
-		expect(rubySkipped?.reason).toContain('No binary available');
+		expect(result.commands).toEqual([
+			{
+				ecosystem: 'typescript',
+				command: 'tsc --noEmit',
+				cwd: dir,
+				priority: 15,
+			},
+		]);
+		expect(
+			result.commands.some((entry) => entry.command === 'npm run build'),
+		).toBe(false);
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'node',
+			reason: 'Covered by profile detection',
+		});
+	});
 
-		// Critical assertion: Verify that ruby does NOT block other ecosystems
-		// The implementation should NOT skip an ecosystem because it's not in coveredEcosystems
-		// When PROFILE_TO_ECOSYSTEM_NAMES[profileId] is empty (ruby), no ecosystem is marked as covered
-
-		// Check that ecosystems like 'node', 'rust', 'go', etc. are still being processed
-		// (they may be skipped for other reasons like missing toolchain or build files,
-		// but they should NOT be skipped because ruby profile "covered" them)
-
-		// Verify that some other ecosystem was checked (appeared in either commands or skipped)
-		// This proves that ruby having empty PROFILE_TO_ECOSYSTEM_NAMES doesn't prevent
-		// the ECOSYSTEMS fallback from processing other ecosystems
-		const otherEcosystemsProcessed = result.skipped
-			.filter((s) => s.ecosystem !== 'ruby')
-			.map((s) => s.ecosystem);
-
-		// At least one other ecosystem should have been processed
-		// (not skipped because ruby "covered" it)
-		expect(otherEcosystemsProcessed).toEqual([]);
-
-		// Verify that the reason for skipping is NOT "covered by profile"
-		// (there's no such reason in the code, this is just to ensure we understand the behavior)
-		const blockedByProfileReasons = result.skipped.filter((s) =>
-			s.reason.includes('covered by profile'),
+	test('FB-004 lets profiles with no ecosystem mapping fall through to repository script discovery', async () => {
+		const dir = makeDir('build-discovery-mixed-');
+		fs.writeFileSync(
+			path.join(dir, 'Gemfile'),
+			'source "https://rubygems.org"\n',
 		);
-		expect(blockedByProfileReasons.length).toBe(0);
+		fs.writeFileSync(
+			path.join(dir, 'package.json'),
+			JSON.stringify({
+				name: 'mixed-project',
+				scripts: { build: 'echo build' },
+			}),
+		);
+		const profile = makeProfile({
+			id: 'ruby',
+			build: {
+				detectFiles: ['Gemfile'],
+				commands: [
+					{
+						name: 'bundle',
+						cmd: 'bundle exec rake build',
+						detectFile: 'Gemfile',
+						priority: 10,
+					},
+				],
+			},
+		});
+
+		_internals.detectProjectLanguagesImpl = async () => [{ id: 'ruby' }] as any;
+		_internals.getLanguageProfileImpl = () => profile as any;
+		_internals.isCommandAvailable = (binary) => binary === 'npm';
+
+		const result = await discoverBuildCommands(dir);
+
+		expect(result.commands).toContainEqual({
+			ecosystem: 'node',
+			command: 'npm run build',
+			cwd: dir,
+			priority: 100,
+		});
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'ruby',
+			code: 'environment_unavailable',
+			required_commands: ['bundle'],
+			reason: 'No binary available for profile ruby: tried bundle',
+		});
 	});
 });

--- a/tests/unit/build/discovery-repo-script-priority.test.ts
+++ b/tests/unit/build/discovery-repo-script-priority.test.ts
@@ -71,18 +71,24 @@ describe('repository build-script priority (#2303)', () => {
 	});
 
 	test('preserves Bun as the preferred runner when it is available', async () => {
-		_internals.spawnSyncImpl = ((argv: string[]) => ({
-			stdout: new Uint8Array(),
-			stderr: new Uint8Array(),
-			exitCode: argv.at(-1) === 'bun' ? 0 : 1,
-			success: argv.at(-1) === 'bun',
-		})) as typeof realSpawnSync;
+		const attempts: string[] = [];
+		_internals.spawnSyncImpl = ((argv: string[]) => {
+			const command = argv.at(-1) ?? '';
+			attempts.push(command);
+			return {
+				stdout: new Uint8Array(),
+				stderr: new Uint8Array(),
+				exitCode: command === 'bun' || command === 'npm' ? 0 : 1,
+				success: command === 'bun' || command === 'npm',
+			};
+		}) as typeof realSpawnSync;
 		clearToolchainCache();
 
 		const result = await discoverBuildCommands(tempDir);
 
 		expect(result.commands[0]?.command).toBe('bun run build');
 		expect(result.commands[0]?.priority).toBe(100);
+		expect(attempts).toEqual(['bun']);
 	});
 
 	for (const manager of ['npm', 'pnpm', 'yarn'] as const) {
@@ -157,6 +163,28 @@ describe('repository build-script priority (#2303)', () => {
 			required_commands: [],
 			reason: 'Unsupported packageManager: @1.0.0',
 		});
+	});
+
+	test('bounds unsupported packageManager evidence before surfacing it in skips', async () => {
+		const rawPackageManager = `unsupported-\u0000${'x'.repeat(180)}@1.0.0`;
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'build-discovery-fixture',
+				packageManager: rawPackageManager,
+				scripts: { build: 'tsc --emitDeclarationOnly' },
+			}),
+		);
+
+		const result = await discoverBuildCommands(tempDir);
+		const skip = result.skipped.find((entry) => entry.ecosystem === 'node');
+
+		expect(skip).toBeDefined();
+		expect(skip?.reason.length).toBeLessThan(rawPackageManager.length + 32);
+		expect(skip?.reason.includes('\u0000')).toBe(false);
+		expect(skip?.reason.endsWith('...')).toBe(true);
+		expect(skip?.required_commands?.[0]).toMatch(/^unsupported- x+\.\.\.$/);
+		expect(skip?.required_commands?.[0]?.length).toBeLessThanOrEqual(40);
 	});
 
 	test('reports a structured environment skip when no package manager exists', async () => {

--- a/tests/unit/build/discovery-repo-script-priority.test.ts
+++ b/tests/unit/build/discovery-repo-script-priority.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	_internals,
+	clearToolchainCache,
+	discoverBuildCommands,
+} from '../../../src/build/discovery';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('repository build-script priority (#2303)', () => {
+	const realProfileDiscovery = _internals.discoverBuildCommandsFromProfiles;
+	const realSpawnSync = _internals.spawnSyncImpl;
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = canonicalMkdtemp('build-discovery-2303-');
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'build-discovery-fixture',
+				scripts: { build: 'tsc --emitDeclarationOnly' },
+			}),
+		);
+
+		// Exercise the exact shadowing boundary without relying on the host PATH:
+		// profile discovery has already fallen back to npx, while the repository's
+		// package manager is available. Other profile-selection branches are covered
+		// by discovery-profiles.test.ts.
+		_internals.discoverBuildCommandsFromProfiles = async () => ({
+			commands: [
+				{
+					ecosystem: 'typescript',
+					command: 'npx tsc --noEmit',
+					cwd: tempDir,
+					priority: 9,
+				},
+			],
+			skipped: [],
+		});
+		_internals.spawnSyncImpl = ((argv: string[]) => ({
+			stdout: new Uint8Array(),
+			stderr: new Uint8Array(),
+			exitCode: argv.at(-1) === 'npm' ? 0 : 1,
+			success: argv.at(-1) === 'npm',
+		})) as typeof realSpawnSync;
+		clearToolchainCache();
+	});
+
+	afterEach(async () => {
+		_internals.discoverBuildCommandsFromProfiles = realProfileDiscovery;
+		_internals.spawnSyncImpl = realSpawnSync;
+		clearToolchainCache();
+		await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('does not let a profile fallback shadow the repository build script', async () => {
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands).toEqual([
+			{
+				ecosystem: 'node',
+				command: 'npm run build',
+				cwd: tempDir,
+				priority: 100,
+			},
+		]);
+		expect(
+			result.commands.some(({ command }) => command.startsWith('npx ')),
+		).toBe(false);
+	});
+
+	test('preserves Bun as the preferred runner when it is available', async () => {
+		_internals.spawnSyncImpl = ((argv: string[]) => ({
+			stdout: new Uint8Array(),
+			stderr: new Uint8Array(),
+			exitCode: argv.at(-1) === 'bun' ? 0 : 1,
+			success: argv.at(-1) === 'bun',
+		})) as typeof realSpawnSync;
+		clearToolchainCache();
+
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands[0]?.command).toBe('bun run build');
+		expect(result.commands[0]?.priority).toBe(100);
+	});
+
+	for (const manager of ['npm', 'pnpm', 'yarn'] as const) {
+		test(`honors an explicit ${manager} packageManager declaration`, async () => {
+			await fs.writeFile(
+				path.join(tempDir, 'package.json'),
+				JSON.stringify({
+					name: 'build-discovery-fixture',
+					packageManager: `${manager}@1.0.0`,
+					scripts: { build: 'tsc --emitDeclarationOnly' },
+				}),
+			);
+			_internals.spawnSyncImpl = ((argv: string[]) => ({
+				stdout: new Uint8Array(),
+				stderr: new Uint8Array(),
+				exitCode: argv.at(-1) === manager ? 0 : 1,
+				success: argv.at(-1) === manager,
+			})) as typeof realSpawnSync;
+			clearToolchainCache();
+
+			const result = await discoverBuildCommands(tempDir);
+
+			expect(result.commands[0]?.command).toBe(`${manager} run build`);
+		});
+	}
+
+	test('does not substitute a different runner for an unavailable explicit manager', async () => {
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'build-discovery-fixture',
+				packageManager: 'pnpm@10.0.0',
+				scripts: { build: 'tsc --emitDeclarationOnly' },
+			}),
+		);
+		// npm is available, but the repository explicitly requires pnpm.
+		_internals.spawnSyncImpl = ((argv: string[]) => ({
+			stdout: new Uint8Array(),
+			stderr: new Uint8Array(),
+			exitCode: argv.at(-1) === 'npm' ? 0 : 1,
+			success: argv.at(-1) === 'npm',
+		})) as typeof realSpawnSync;
+		clearToolchainCache();
+
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands).toEqual([]);
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'node',
+			code: 'environment_unavailable',
+			required_commands: ['pnpm'],
+			reason: 'Package manager not available: pnpm',
+		});
+	});
+
+	test('rejects a malformed packageManager declaration without fallback', async () => {
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'build-discovery-fixture',
+				packageManager: '@1.0.0',
+				scripts: { build: 'tsc --emitDeclarationOnly' },
+			}),
+		);
+
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands).toEqual([]);
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'node',
+			code: 'environment_unavailable',
+			required_commands: [],
+			reason: 'Unsupported packageManager: @1.0.0',
+		});
+	});
+
+	test('reports a structured environment skip when no package manager exists', async () => {
+		_internals.spawnSyncImpl = (() => ({
+			stdout: new Uint8Array(),
+			stderr: new Uint8Array(),
+			exitCode: 1,
+			success: false,
+		})) as typeof realSpawnSync;
+		clearToolchainCache();
+
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands).toEqual([]);
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'node',
+			code: 'environment_unavailable',
+			required_commands: ['bun', 'npm', 'pnpm', 'yarn'],
+			reason: 'Package manager not available: bun or npm or pnpm or yarn',
+		});
+	});
+
+	test('retains environment diagnostics when another ecosystem can run', async () => {
+		await fs.writeFile(
+			path.join(tempDir, 'Cargo.toml'),
+			'[package]\nname = "mixed"',
+		);
+
+		const result = await discoverBuildCommands(tempDir);
+
+		expect(result.commands[0]?.command).toBe('npm run build');
+		expect(result.skipped).toContainEqual({
+			ecosystem: 'rust',
+			code: 'environment_unavailable',
+			required_commands: ['cargo'],
+			reason: 'Toolchain not found: cargo not on PATH',
+		});
+	});
+});

--- a/tests/unit/build/discovery.test.ts
+++ b/tests/unit/build/discovery.test.ts
@@ -566,7 +566,7 @@ describe('build/discovery.ts - Discovery Function', () => {
 			// If there are multiple commands, they should be sorted
 			if (result.commands.length > 1) {
 				for (let i = 0; i < result.commands.length - 1; i++) {
-					expect(result.commands[i].priority).toBeLessThanOrEqual(
+					expect(result.commands[i].priority).toBeGreaterThanOrEqual(
 						result.commands[i + 1].priority,
 					);
 				}

--- a/tests/unit/config/build-evidence-environment.test.ts
+++ b/tests/unit/config/build-evidence-environment.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { BuildEvidenceSchema } from '../../../src/config/evidence-schema';
+
+describe('BuildEvidenceSchema environment diagnostics (#2303)', () => {
+	test('parses structured environment_unavailable details', () => {
+		const result = BuildEvidenceSchema.safeParse({
+			task_id: 'build',
+			type: 'build',
+			timestamp: '2026-08-30T00:00:00.000Z',
+			agent: 'build_check',
+			verdict: 'skip',
+			summary: 'runtime unavailable',
+			runs: [],
+			files_scanned: 0,
+			runs_count: 0,
+			failed_count: 0,
+			environment_unavailable: [
+				{
+					ecosystem: 'node',
+					code: 'environment_unavailable',
+					reason: 'Package manager not available',
+					required_commands: ['bun', 'npm'],
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+});

--- a/tests/unit/tools/build-check-environment.test.ts
+++ b/tests/unit/tools/build-check-environment.test.ts
@@ -38,4 +38,52 @@ describe('build_check environment diagnostics (#2303)', () => {
 			},
 		]);
 	});
+
+	test('reports a truthful skip reason when no supported build files are present', async () => {
+		tempDir = canonicalMkdtemp('build-check-empty-');
+
+		const result = await runBuildCheck(tempDir, {
+			scope: 'all',
+			mode: 'both',
+		});
+
+		expect(result.verdict).toBe('info');
+		expect(result.runs).toEqual([]);
+		expect(result.summary.skipped_reason).toBe(
+			'No build commands discovered (no supported build files found)',
+		);
+		expect(result.summary.environment_unavailable).toBeUndefined();
+	});
+
+	test('sanitizes and bounds packageManager text before exposing environment diagnostics', async () => {
+		tempDir = canonicalMkdtemp('build-check-sanitize-');
+		const noisySuffix = 'x'.repeat(200);
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'unsupported-runtime-fixture',
+				packageManager: `unsupported-pm@\n${noisySuffix}\twith-control`,
+				scripts: { build: 'echo build' },
+			}),
+		);
+
+		const result = await runBuildCheck(tempDir, {
+			scope: 'all',
+			mode: 'both',
+		});
+
+		const reason = result.summary.environment_unavailable?.[0]?.reason;
+		expect(
+			result.summary.environment_unavailable?.[0]?.required_commands,
+		).toEqual(['unsupported-pm']);
+		expect(reason).toBeDefined();
+		expect(reason).toStartWith('Unsupported packageManager: unsupported-pm@ ');
+		expect(reason).not.toContain('\n');
+		expect(reason).not.toContain('\t');
+		expect(reason?.endsWith('...')).toBe(true);
+		expect(reason!.length).toBeLessThanOrEqual(
+			'Unsupported packageManager: '.length + 120,
+		);
+		expect(result.summary.skipped_reason).toBe(`node: ${reason}`);
+	});
 });

--- a/tests/unit/tools/build-check-environment.test.ts
+++ b/tests/unit/tools/build-check-environment.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { runBuildCheck } from '../../../src/tools/build-check';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('build_check environment diagnostics (#2303)', () => {
+	let tempDir: string;
+
+	afterEach(async () => {
+		if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+	});
+
+	test('returns structured non-failing evidence for an unsupported runtime', async () => {
+		tempDir = canonicalMkdtemp('build-check-2303-');
+		await fs.writeFile(
+			path.join(tempDir, 'package.json'),
+			JSON.stringify({
+				name: 'unsupported-runtime-fixture',
+				packageManager: 'unsupported-pm@1.0.0',
+				scripts: { build: 'echo build' },
+			}),
+		);
+
+		const result = await runBuildCheck(tempDir, {
+			scope: 'all',
+			mode: 'both',
+		});
+
+		expect(result.verdict).toBe('skip');
+		expect(result.runs).toEqual([]);
+		expect(result.summary.environment_unavailable).toEqual([
+			{
+				ecosystem: 'node',
+				code: 'environment_unavailable',
+				required_commands: ['unsupported-pm'],
+				reason: 'Unsupported packageManager: unsupported-pm@1.0.0',
+			},
+		]);
+	});
+});

--- a/tests/unit/tools/build-check.test.ts
+++ b/tests/unit/tools/build-check.test.ts
@@ -204,7 +204,6 @@ describe('build-check.ts - runBuildCheck', () => {
 		expect(result.runs).toHaveLength(0);
 		expect(result.summary.skipped_reason).toBeDefined();
 	});
-
 	test('discovers npm build command when package.json exists', async () => {
 		// Create a package.json with a build script
 		await fs.promises.writeFile(

--- a/tests/unit/tools/test-runner-cwd.test.ts
+++ b/tests/unit/tools/test-runner-cwd.test.ts
@@ -1,11 +1,4 @@
-/**
- * Tests for cwd threading fix in test-runner.ts
- *
- * These tests verify that cwd is correctly threaded through:
- * 1. detectTestFramework(cwd) - uses cwd for all path joins
- * 2. runTests(..., cwd) - passes cwd to Bun.spawn
- * 3. execute() - extracts workingDir from ToolContext and passes it correctly
- */
+/** CWD threading regression coverage for test-runner.ts. */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/tests/unit/tools/test-runner-cwd.test.ts
+++ b/tests/unit/tools/test-runner-cwd.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for cwd threading fix in test-runner.ts
  *
- * These tests verify that the cwd (current working directory) parameter
- * is correctly threaded through:
+ * These tests verify that cwd is correctly threaded through:
  * 1. detectTestFramework(cwd) - uses cwd for all path joins
  * 2. runTests(..., cwd) - passes cwd to Bun.spawn
  * 3. execute() - extracts workingDir from ToolContext and passes it correctly
@@ -15,8 +14,9 @@ import * as path from 'node:path';
 // Import the module under test
 const testRunnerModule = await import('../../../src/tools/test-runner');
 
-// Extract the exports we need
-const { test_runner, detectTestFramework, runTests } = testRunnerModule;
+const { test_runner, detectTestFramework, runTests, _internals } =
+	testRunnerModule;
+const originalResolveLocalNodeTool = _internals.resolveLocalNodeTool;
 
 // Helper to create temp test directories
 function createTempDir(): string {
@@ -94,11 +94,16 @@ describe('test-runner.ts - CWD Threading', () => {
 		mockExitCode = 0;
 		mockStdout = '';
 		mockStderr = '';
+		_internals.resolveLocalNodeTool = (tool, args, baseDir) => [
+			path.join(baseDir, 'node_modules', '.bin', tool),
+			...args,
+		];
 	});
 
 	afterEach(() => {
 		process.chdir(originalCwd);
 		Bun.spawn = originalSpawn;
+		_internals.resolveLocalNodeTool = originalResolveLocalNodeTool;
 		// Cleanup temp dir
 		try {
 			fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tests/unit/tools/test-runner-dispatch-parity.test.ts
+++ b/tests/unit/tools/test-runner-dispatch-parity.test.ts
@@ -246,11 +246,15 @@ describe('SWARM_LANG_BACKEND env var routing', () => {
 describe('Phase 3b: buildTestCommandViaDispatch parity', () => {
 	beforeEach(() => clearDispatchCache());
 
-	test('vitest with coverage produces npx vitest run --coverage <files>', async () => {
+	test('vitest with coverage resolves the repository-local binary', async () => {
 		fs.writeFileSync(
 			path.join(tempDir, 'package.json'),
 			JSON.stringify({ scripts: { test: 'vitest run' } }),
 		);
+		const binDir = path.join(tempDir, 'node_modules', '.bin');
+		fs.mkdirSync(binDir, { recursive: true });
+		const vitestName = process.platform === 'win32' ? 'vitest.cmd' : 'vitest';
+		fs.writeFileSync(path.join(binDir, vitestName), '');
 		const cmd = await buildTestCommandViaDispatch(
 			'vitest',
 			'graph',
@@ -259,8 +263,7 @@ describe('Phase 3b: buildTestCommandViaDispatch parity', () => {
 			tempDir,
 		);
 		expect(cmd).toEqual([
-			'npx',
-			'vitest',
+			path.join(binDir, vitestName),
 			'run',
 			'--reporter=json',
 			'--outputFile',

--- a/tests/unit/tools/test-runner.test.ts
+++ b/tests/unit/tools/test-runner.test.ts
@@ -36,7 +36,14 @@ const {
 	runTests,
 } = testRunnerModule;
 
-/** Emit deterministic vitest-style JSON without spawning a subprocess. */
+/**
+ * Build a Bun.spawn stub that emits vitest-style JSON on stdout, so the
+ * test-runner's full execute -> buildTestCommand -> runTests -> parseTestOutput
+ * vitest path can be exercised deterministically without spawning a real
+ * `npx vitest` (which would require a network fetch when node_modules/vitest is
+ * absent — the source of intermittent coverage-gate timeouts). Mirrors the
+ * rspec Bun.spawn stub pattern used later in this file.
+ */
 function makeVitestSpawnStub(result: {
 	passed: number;
 	failed: number;
@@ -717,6 +724,10 @@ describe('test-runner.ts - Interactive Bulk-Execution Guards', () => {
 	});
 
 	test('allows Narrow scope requests to execute normally', async () => {
+		// The historical regression used `npx vitest` in a temp dir without
+		// dependencies, making the test depend on a network fetch and causing
+		// intermittent coverage-gate timeouts. Keep the full execution path
+		// deterministic with a local-tool fixture and a Bun.spawn JSON stub.
 		const tempDir = fs.realpathSync(
 			fs.mkdtempSync(path.join(os.tmpdir(), 'test-runner-narrow-')),
 		);
@@ -1084,7 +1095,8 @@ describe('test-runner.ts - scope:"all" gated access (env-only)', () => {
 				'import { describe, test, expect } from "vitest"; import { add } from "./utils"; describe("add", () => { test("adds incorrectly", () => { expect(add(1, 2)).toBe(999); }); });',
 			);
 
-			// Stub the spawn with a FAILING vitest result (1 failed test).
+			// Previously this path also depended on `npx vitest` network resolution;
+			// local fixtures plus a deterministic failing result keep it offline.
 			const originalSpawn = Bun.spawn;
 			Bun.spawn = makeVitestSpawnStub({ passed: 0, failed: 1, skipped: 0 });
 			try {

--- a/tests/unit/tools/test-runner.test.ts
+++ b/tests/unit/tools/test-runner.test.ts
@@ -36,14 +36,7 @@ const {
 	runTests,
 } = testRunnerModule;
 
-/**
- * Build a Bun.spawn stub that emits vitest-style JSON on stdout, so the
- * test-runner's full execute -> buildTestCommand -> runTests -> parseTestOutput
- * vitest path can be exercised deterministically without spawning a real
- * `npx vitest` (which would require a network fetch when node_modules/vitest is
- * absent — the source of intermittent coverage-gate timeouts). Mirrors the
- * rspec Bun.spawn stub pattern used later in this file.
- */
+/** Emit deterministic vitest-style JSON without spawning a subprocess. */
 function makeVitestSpawnStub(result: {
 	passed: number;
 	failed: number;
@@ -79,6 +72,15 @@ function makeVitestSpawnStub(result: {
 			exitCode: result.failed > 0 ? 1 : 0,
 			kill: () => {},
 		}) as ReturnType<typeof Bun.spawn>) as typeof Bun.spawn;
+}
+
+function installLocalNodeTool(baseDir: string, tool: string): void {
+	const binDir = path.join(baseDir, 'node_modules', '.bin');
+	fs.mkdirSync(binDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(binDir, process.platform === 'win32' ? `${tool}.cmd` : tool),
+		'',
+	);
 }
 
 describe('test-runner.ts - Constants and Types', () => {
@@ -714,13 +716,6 @@ describe('test-runner.ts - Interactive Bulk-Execution Guards', () => {
 		expect(parsed.message).toContain('scope "graph"');
 	});
 
-	// Previously spawned `npx vitest` in a temp dir without node_modules installed,
-	// which made the test depend on an npx network fetch and intermittently time
-	// out under the per-file coverage gate. The execution path is now exercised
-	// deterministically by stubbing Bun.spawn to emit vitest-style JSON (mirrors
-	// the rspec stub pattern below), so the test still validates the full
-	// execute -> buildTestCommand -> runTests -> parseTestOutput vitest path
-	// without any subprocess or network dependency.
 	test('allows Narrow scope requests to execute normally', async () => {
 		const tempDir = fs.realpathSync(
 			fs.mkdtempSync(path.join(os.tmpdir(), 'test-runner-narrow-')),
@@ -737,6 +732,7 @@ describe('test-runner.ts - Interactive Bulk-Execution Guards', () => {
 				devDependencies: { vitest: '^1.0.0' },
 			}),
 		);
+		installLocalNodeTool(tempDir, 'vitest');
 		fs.mkdirSync('src', { recursive: true });
 		fs.writeFileSync(
 			'src/utils.ts',
@@ -1062,9 +1058,6 @@ describe('test-runner.ts - scope:"all" gated access (env-only)', () => {
 			})();
 		}, 30000);
 
-		// Previously spawned `npx vitest` in a temp dir without node_modules
-		// installed (network fetch → intermittent coverage-gate timeout). Now
-		// stubbed to emit a failing vitest JSON result deterministically.
 		test('returns outcome "regression" when tests fail', async () => {
 			const tempDir = fs.realpathSync(
 				fs.mkdtempSync(path.join(os.tmpdir(), 'test-runner-fail-')),
@@ -1079,6 +1072,7 @@ describe('test-runner.ts - scope:"all" gated access (env-only)', () => {
 					devDependencies: { vitest: '^1.0.0' },
 				}),
 			);
+			installLocalNodeTool(tempDir, 'vitest');
 			fs.mkdirSync('src', { recursive: true });
 			fs.writeFileSync(
 				'src/utils.ts',

--- a/tests/unit/tools/test-runner.test.ts
+++ b/tests/unit/tools/test-runner.test.ts
@@ -36,14 +36,7 @@ const {
 	runTests,
 } = testRunnerModule;
 
-/**
- * Build a Bun.spawn stub that emits vitest-style JSON on stdout, so the
- * test-runner's full execute -> buildTestCommand -> runTests -> parseTestOutput
- * vitest path can be exercised deterministically without spawning a real
- * `npx vitest` (which would require a network fetch when node_modules/vitest is
- * absent — the source of intermittent coverage-gate timeouts). Mirrors the
- * rspec Bun.spawn stub pattern used later in this file.
- */
+/** Deterministic Bun.spawn stub exercises the full vitest path without network-dependent npx resolution (historical coverage-gate timeout source). */
 function makeVitestSpawnStub(result: {
 	passed: number;
 	failed: number;


### PR DESCRIPTION
Closes #2303

## Summary
- make repository-defined package scripts authoritative over language-profile fallbacks while preserving Bun-first behavior required by the issue
- resolve plugin-generated Node build, typecheck, and test commands locally before PATH and remove implicit-download `npx` fallbacks across modern and legacy consumers
- report unavailable package managers/toolchains as structured non-failing build evidence, with Windows/POSIX and mixed-ecosystem coverage

## Invariant audit
- 1 (plugin init): not touched - no initialization-path code changed; `node scripts/repro-704.mjs` passed all three startup deadlines
- 2 (runtime portability): touched - isolated `bun run build` and Node ESM import passed; Windows `.cmd` and POSIX local-bin resolution have focused tests
- 3 (subprocesses): touched - command selection changed without adding spawn sites; discovery subprocess invariant tests and `check:bare-spawn` passed
- 4 (.swarm containment): not touched - no runtime storage paths changed
- 5 (plan durability): not touched - no ledger, projection, or checkpoint code changed
- 6 (test_runner safety): touched - legacy framework command construction now resolves local binaries; the scoped CI unit gate passed and no broad `test_runner` scope was used
- 7 (test writing): touched - writing-tests and test-file-split protocols were followed; `check:mock-cleanup`, `check:test-file-cap`, `check:test-clock`, and `check:test-tmpdir` passed
- 8 (session state): not touched - no module-level session state changed
- 9 (guardrails/retry): not touched - no retry, circuit, scope, or guardrail logic changed
- 10 (chat/system msg): not touched - no chat transform code changed
- 11 (tool registration): not touched - no tools were added or remapped; `check-tool-registration.ts` passed
- 12 (release/cache): touched - added `docs/releases/pending/2303-build-discovery-runtime-safety.md`; no version/cache code changed

## Test plan
- [x] focused regression matrix for repo-script priority, Bun/npm/pnpm/Yarn selection, malformed/unavailable managers, mixed ecosystems, local-first resolution, Windows shims, and structured evidence
- [x] `bun run test:unit:ci` scoped to all 11 changed/new test files
- [x] integration, security, adversarial, and smoke tiers
- [x] build, Node ESM import, `repro-704`, package smoke, typecheck, Biome, invariant, drift, registration, portability, and repository quality gates

Pre-existing non-blocking output: one unrelated Biome unused-import warning, four mock-cleanup baseline warnings, and existing clock/cross-contamination advisories.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

