### PR TITLE
fix: Auto-detected flaky tests (merge-group) — review for quarantine (#2368)

### DIFF
--- a/docs/releases/pending/issue-2368-quarantine-dispatch-lanes.md
+++ b/docs/releases/pending/issue-2368-quarantine-dispatch-lanes.md
@@ -1,0 +1,55 @@
+# Quarantine flaky dispatch-lanes test (issue #2368)
+
+## What changed
+
+- Appended `tests/unit/tools/dispatch-lanes.test.ts` to
+  `scripts/ci/quarantined-tests.txt` (the general/global quarantine ledger)
+  with a full evidence-trail comment block.
+- Added a regression describe-block (3 tests) to
+  `tests/unit/scripts/ci/ci-yml-integration.test.ts` pinning the ledger
+  contract: the path is an active general-ledger entry, is NOT duplicated in
+  the per-OS windows/macos ledgers, and resolves to a real on-disk file
+  discovered by the ci.yml find chain.
+
+## Why
+
+Flake-detection workflow (issue #1782) auto-filed issue #2368 from merge-group
+CI run 32984771338 (2026-08-26). Tracing the detection run's downloaded
+annotations to the originating job showed the flake occurred in the
+`coverage-shard (3)` cell on **ubuntu-latest** (attempt 1 failed,
+`Passed on retry 1` at 2026-08-26T15:31:27Z). Coverage shards run ubuntu-only
+and honor ONLY the general ledger `scripts/ci/quarantined-tests.txt`
+(`scripts/ci/run-coverage-gate.sh` never consults per-OS lists, to keep the
+partition aligned with the ubuntu unit cells) — so the general ledger is the
+correct target.
+
+The flake class is consistent with the open root-cause issue #2362
+(elapsed-timeout tests assert literal `timed out after 10ms`, which is
+load/measurement-sensitive under the `--isolate --coverage` environment). The
+root fix for #2362 has NOT landed (issue open, no PR), so quarantine is
+appropriate rather than suppressing an already-fixed file.
+
+Quarantining also stops duplicate auto-filed issues: sibling issue #2386
+(same file, filed 2026-08-27) is covered by this entry, and the detection
+script's rule A drops candidates already present in a ledger.
+
+## Migration steps
+
+None for runtime behavior — the `src/` tree is untouched. CI-only data-file
+change plus pinning tests. The file passes locally under clean TMPDIR, which
+is expected and is the quarantine rationale: the flake is
+environment-sensitive (merge-group coverage/isolate context), not a logic bug.
+
+## Known caveats
+
+- Requires CI quarter via merge-group shards to confirm no recurrence; the
+  entry retires under the #1782 test-stability sprint / once the #2362 root
+  fix lands and demonstrates a green streak.
+- Until the #2362 root fix lands, `tests/unit/tools/dispatch-lanes.test.ts`
+  is skipped repo-wide (ubuntu unit shards, coverage, macos/windows unit
+  shards) while quarantined — a broad scope, but required because the flake
+  surfaced in the ubuntu-only coverage job that only honors the general
+  ledger.
+- Sibling auto-fix branches may hold unmerged quarantine entries targeting
+  the same ledger; textual merge conflicts between sibling quarantine PRs are
+  the wrapper's concern, not a functional risk.

--- a/scripts/ci/quarantined-tests.txt
+++ b/scripts/ci/quarantined-tests.txt
@@ -4,3 +4,24 @@
 # starting with # are ignored.
 #
 # No active global test quarantines. Issue #1908 retired the tracked backlog.
+#
+# tests/unit/tools/dispatch-lanes.test.ts (issue #2368)
+# ---------------------------------------------------------------------------
+# Tests the dispatch-lanes tool's fan-out/settle lifecycle: lane creation,
+# batch record status polling (waitForBatchRecordStatus), async session
+# timeout/cleanup, and shared _internals mutation across concurrent lanes.
+#
+# Why flaky: the merge-group coverage job (coverage-shard 3, ubuntu-latest,
+# CI run 32984771338, attempt 1, 2026-08-26T15:31:27Z) failed attempt 1 and
+# passed on retry 1 under `bun test --isolate --coverage` — the elapsed-timeout
+# tests assert literal milliseconds in the timeout message (see issue #2362:
+# 'timed out after 10ms'), so measurement/load variance under the
+# coverage/isolate environment trips them. Pre-existing, unrelated to any
+# specific PR.
+#
+# Quarantined per issue #2368; tracked under #1737 (test quarantine debt)
+# pending a dedicated test-stability sprint (#1782).
+#
+# This entry also suppresses sibling auto-detected issue #2386 (same file).
+#
+tests/unit/tools/dispatch-lanes.test.ts

--- a/tests/unit/scripts/ci/ci-yml-integration.test.ts
+++ b/tests/unit/scripts/ci/ci-yml-integration.test.ts
@@ -358,3 +358,61 @@ describe('ci.yml integration — windows quarantine ledger entry for win32-wrapp
 		expect(declared).toBe(activeEntries(WINDOWS_LEDGER_PATH).length);
 	});
 });
+
+describe('ci.yml integration — general quarantine ledger entry for dispatch-lanes (issue #2368)', () => {
+	// Repo root is four levels up from tests/unit/scripts/ci/.
+	const REPO_ROOT = join(import.meta.dir, '../../../..');
+	const GENERAL_LEDGER_PATH = join(
+		REPO_ROOT,
+		'scripts/ci/quarantined-tests.txt',
+	);
+	const WINDOWS_LEDGER_PATH = join(
+		REPO_ROOT,
+		'scripts/ci/quarantined-tests-windows.txt',
+	);
+	const MACOS_LEDGER_PATH = join(
+		REPO_ROOT,
+		'scripts/ci/quarantined-tests-macos.txt',
+	);
+	const QUARANTINED_PATH = 'tests/unit/tools/dispatch-lanes.test.ts';
+
+	// Mirror ci.yml's active-entry extraction exactly:
+	//   grep -vE '^\s*#|^\s*$' scripts/ci/quarantined-tests-<os>.txt
+	// (CRLF is normalized first so the assertion holds on any checkout config.)
+	function activeEntries(ledgerPath: string): string[] {
+		const raw = readFileSync(ledgerPath, 'utf8').replace(/\r\n/g, '\n');
+		return raw
+			.split('\n')
+			.filter((line: string) => !/^\s*#/.test(line) && !/^\s*$/.test(line))
+			.map((line: string) => line.trim());
+	}
+
+	test('dispatch-lanes.test.ts is an active entry in the general ledger', () => {
+		// Regression guard for issue #2368: the merge-group coverage job
+		// (coverage-shard 3, ubuntu-latest) flagged a retry-flake for this file.
+		// Coverage shards run ubuntu-only and honor ONLY the general ledger
+		// (run-coverage-gate.sh never consults per-OS lists), so the entry must
+		// live in the general ledger. Without it, the flake-detection workflow
+		// keeps re-filing duplicates (rule A only drops already-quarantined
+		// candidates).
+		expect(existsSync(GENERAL_LEDGER_PATH)).toBe(true);
+		expect(activeEntries(GENERAL_LEDGER_PATH)).toContain(QUARANTINED_PATH);
+	});
+
+	test('the general-ledger entry is not duplicated in the per-OS ledgers', () => {
+		// Cross-OS duplicates would be harmless but confusing: the general
+		// ledger already applies on every RUNNER_OS, so re-listing the file in
+		// the windows/macos ledgers would imply OS-specific evidence.
+		expect(activeEntries(WINDOWS_LEDGER_PATH)).not.toContain(QUARANTINED_PATH);
+		expect(activeEntries(MACOS_LEDGER_PATH)).not.toContain(QUARANTINED_PATH);
+	});
+
+	test('the quarantined path exists and is discovered by the ci.yml find chain', () => {
+		// A typo'd ledger path would be a silent no-op: CI's comm -23 gated set
+		// would never exclude it (the path never appears in all-tests.txt) and
+		// the flake would keep re-filing. The discovery chain globs
+		// tests/unit/**/*.test.ts, so the on-disk file must exist at exactly
+		// the ledger path relative to the repo root.
+		expect(existsSync(join(REPO_ROOT, QUARANTINED_PATH))).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #2368

## Summary
**Scope:** Appends `tests/unit/tools/dispatch-lanes.test.ts` to the general quarantine ledger `scripts/ci/quarantined-tests.txt` (issue #2368, merge-group coverage-shard flake), with pinning tests in `ci-yml-integration.test.ts` and the mandated release fragment.
**Verdict:** APPROVE
|
|### Findings
|
|#### LOW — Stale header contradicts the new active entry
|- **Location:** `scripts/ci/quarantined-tests.txt:6`
|- **Evidence:** Header line `# No active global test quarantines. Issue #1908 retired the tracked backlog.` remains immediately above the new active entry at line 27.
|- **Why it matters:** Purely cosmetic triage confusion; no code or test pins this string (grep across `tests/`, `scripts/`, `.github/` finds zero references), so no functional effect.
|- **Suggested fix:** In a follow-up (or this PR), reword to e.g. "Issue #1908 retired the tracked backlog; see entries below for post-#1908 quarantines."
|
|### What I Checked
|- Target file present in diff: yes (`scripts/ci/quarantined-tests.txt` — the exact file the issue instructs appending to)
|- Ledger choice verified against real consumption: `run-coverage-gate.sh:85,111` consults ONLY the general ledger (its own comment at :98-104 states coverage is ubuntu-only and must never branch per-OS); ci.yml's unit job (`ci.yml:412`) applies the general ledger on every RUNNER_OS. The flagged flake was `coverage-shard (3)` on ubuntu, so the general ledger is the only correct target.
|- New/updated test exercises the changed code path: yes — `tests/unit/scripts/ci/ci-yml-integration.test.ts:399` reads the real ledger from disk and asserts the active entry; `:413-415` pins no cross-OS duplication; `:421` pins the quarantined path exists on disk (typo guard, since CI's `comm -23` would silently never match a bad path)
|- Suppression mechanism verified: `detect-and-quarantine-flakes.sh:46-56` rule A builds its quarantine set from all four ledger files and matches with `grep -qxF` (exact full-line) — the verbatim appended path matches, so sibling issue #2386 stops re-filing
|- No cross-pinning breakage: the pre-existing `not.toContain(GENERAL_LEDGER)` assertions (`ci-yml-integration.test.ts:328`) are scoped to the #2185 win32-wrapper path; the STATUS count-ratchet exists only on the windows ledger (untouched); no test asserts the general ledger is empty
|- Evidence trail verified on GitHub: #2362 is OPEN with root cause (literal elapsed-ms assertions at `:572`/`:1903` of exactly this file) matching the ledger's flake-class claim; #2386 is a real same-file sibling; run 32984771338 is a merge_group run at 2026-08-26T15:20Z containing `coverage-shard (3)`, final success consistent with the retry-flake narrative
|- Coverage-gate risk checked: aggregator threshold (65% over merged union) cannot collapse — `src/tools/dispatch-lanes.ts` stays covered by 8+ sibling dispatch-lanes test files that are not quarantined
|- Doc tooling risk checked: `check-pending-fragment.ts` is satisfied by this PR adding a fragment; `drift-check-docs-claims.ts` pending-scan patterns (lane-cap, MiB, hours claims) absent from the fragment; `release-notes-fragments.mjs` imposes no naming schema
|- Scope creep beyond the issue: no — ledger + pinning tests + mandated fragment only; `src/` untouched
|- Anti-patterns scanned: silent-except, mock-without-call, off-by-one, signature-break, scope-creep, stale-docs (one LOW stale-header nit above)
|
|### Confidence
|high — I attempted to refute via wrong-ledger targeting, silent no-op (typo'd path / find-chain mismatch), rule-A non-match, broken cross-pinning tests, doc-linter trips, and coverage-threshold collapse; all failed. The verdict would change only if the flake originated in a test-execution path that ignores the general ledger — I checked every `bun test` invocation in ci.yml and the coverage gate script; all consult it.

## Invariant audit
- No engineering invariants were identified as touched by this diff; the change is confined to docs/releases/pending/issue-2368-quarantine-dispatch-lanes.md, scripts/ci/quarantined-tests.txt, tests/unit/scripts/ci/ci-yml-integration.test.ts

## Test plan
See the linked issue and the change summary.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

