### PR TITLE
fix(timeout): harden abort timeout recurrence guard

### DIFF
--- a/docs/releases/pending/1964-abort-timeout-guardrail-hardening.md
+++ b/docs/releases/pending/1964-abort-timeout-guardrail-hardening.md
@@ -1,0 +1,5 @@
+# Abort timeout recurrence guardrail hardening
+
+The Windows-safe timeout migration now has an AST-based regression guard instead of an exact-text check. CI detects native `AbortSignal.timeout` access through whitespace, optional chaining, bracket notation, aliases, and destructuring, and verifies the shared cancellable helper is called at every affected runtime path.
+
+This closes a recurrence-detection gap discovered while validating issue #1964 after the runtime migration had already landed. No migration or configuration change is required.

--- a/src/learning/admission.ts
+++ b/src/learning/admission.ts
@@ -17,8 +17,8 @@
  *
  * - the `transactKnowledge` call is NEVER raced or timed out;
  * - only genuinely cancellable work (the optional LLM screening call) is
- *   bounded, via a manual `AbortController` + `setTimeout` (see
- *   `timeoutSignal` below) + `isAbortError`. This deliberately does NOT use
+ *   bounded by the shared `withTimeoutSignal` helper, which uses a manual
+ *   `AbortController` + `setTimeout` + `isAbortError`. This deliberately does NOT use
  *   the host's built-in timeout signal: Bun on Windows
  *   has a native bug where that signal's `abort` event never fires when
  *   awaited by a plain JS Promise (oven-sh/bun#29546) — exactly the shape

--- a/tests/unit/build/runtime-timeout-ast-helpers.ts
+++ b/tests/unit/build/runtime-timeout-ast-helpers.ts
@@ -1,0 +1,217 @@
+import ts from 'typescript';
+
+export function unwrapExpression(node: ts.Expression): ts.Expression {
+	let current = node;
+	while (
+		ts.isParenthesizedExpression(current) ||
+		ts.isAsExpression(current) ||
+		ts.isTypeAssertionExpression(current) ||
+		ts.isNonNullExpression(current) ||
+		ts.isSatisfiesExpression(current)
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+export function isNamedReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+): boolean {
+	const expression = unwrapExpression(node);
+	return ts.isIdentifier(expression) && aliases.has(expression.text);
+}
+
+export function collectBindingAliases(
+	pattern: ts.ObjectBindingPattern,
+	propertyText: string,
+	aliases: Set<string>,
+	markChanged: () => void,
+): void {
+	for (const element of pattern.elements) {
+		if (
+			propertyNameText(element.propertyName ?? element.name) === propertyText &&
+			ts.isIdentifier(element.name) &&
+			!aliases.has(element.name.text)
+		) {
+			aliases.add(element.name.text);
+			markChanged();
+		}
+		if (ts.isObjectBindingPattern(element.name)) {
+			collectBindingAliases(element.name, propertyText, aliases, markChanged);
+		}
+	}
+}
+
+export function isStringReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+	literalText: string,
+): boolean {
+	const expression = unwrapExpression(node);
+	return (
+		(ts.isIdentifier(expression) && aliases.has(expression.text)) ||
+		staticStringValue(expression) === literalText
+	);
+}
+
+export function isTimeoutKeyReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+): boolean {
+	return isStringReference(node, aliases, 'timeout');
+}
+
+export function isReflectGetReference(
+	node: ts.Expression,
+	reflectAliases: ReadonlySet<string> = new Set(['Reflect']),
+): boolean {
+	const expression = unwrapExpression(node);
+	return (
+		(ts.isPropertyAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			reflectAliases.has(expression.expression.text) &&
+			expression.name.text === 'get') ||
+		(ts.isElementAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			reflectAliases.has(expression.expression.text) &&
+			expression.argumentExpression !== undefined &&
+			ts.isStringLiteralLike(expression.argumentExpression) &&
+			expression.argumentExpression.text === 'get')
+	);
+}
+
+export function propertyNameText(
+	name: ts.PropertyName | undefined,
+): string | undefined {
+	if (!name) return undefined;
+	if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+	if (ts.isComputedPropertyName(name))
+		return staticStringValue(name.expression);
+	return undefined;
+}
+
+export function staticStringValue(
+	node: ts.Expression,
+	aliases: ReadonlyMap<string, string> = new Map(),
+): string | undefined {
+	const expression = unwrapExpression(node);
+	if (ts.isStringLiteralLike(expression)) return expression.text;
+	if (ts.isIdentifier(expression)) return aliases.get(expression.text);
+	if (
+		ts.isBinaryExpression(expression) &&
+		expression.operatorToken.kind === ts.SyntaxKind.PlusToken
+	) {
+		const left = staticStringValue(expression.left, aliases);
+		const right = staticStringValue(expression.right, aliases);
+		return left !== undefined && right !== undefined ? left + right : undefined;
+	}
+	return undefined;
+}
+
+export function countTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
+	return pattern.elements.reduce((count, element) => {
+		const current =
+			propertyNameText(element.propertyName ?? element.name) === 'timeout'
+				? 1
+				: 0;
+		return (
+			count +
+			current +
+			(ts.isObjectBindingPattern(element.name)
+				? countTimeoutBindings(element.name)
+				: 0)
+		);
+	}, 0);
+}
+
+export function countNestedTimeoutBindings(
+	pattern: ts.ObjectBindingPattern,
+): number {
+	return pattern.elements.reduce((count, element) => {
+		const property = propertyNameText(element.propertyName ?? element.name);
+		if (property !== 'AbortSignal') return count;
+		return (
+			count +
+			(ts.isObjectBindingPattern(element.name)
+				? countTimeoutBindings(element.name)
+				: 0)
+		);
+	}, 0);
+}
+
+export function countNestedTimeoutObjectProperties(
+	object: ts.ObjectLiteralExpression,
+): number {
+	return object.properties.reduce((count, property) => {
+		if (propertyNameText(property.name) !== 'AbortSignal') return count;
+		if (!ts.isPropertyAssignment(property)) return count;
+		if (ts.isObjectLiteralExpression(property.initializer)) {
+			return (
+				count +
+				property.initializer.properties.filter(
+					(nested) => propertyNameText(nested.name) === 'timeout',
+				).length
+			);
+		}
+		return 0;
+	}, 0);
+}
+
+export function hasShadowingBinding(
+	sourceFile: ts.SourceFile,
+	name: string,
+	node?: ts.Node,
+): boolean {
+	let shadowed = false;
+	const limit = node?.getStart(sourceFile) ?? Number.POSITIVE_INFINITY;
+	const visit = (current: ts.Node): void => {
+		if (shadowed || current.getStart(sourceFile) >= limit) return;
+		if (
+			!ts.isImportSpecifier(current) &&
+			(ts.isVariableDeclaration(current) || ts.isParameter(current)) &&
+			current.name !== undefined &&
+			bindingNameContains(current.name, name)
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			ts.isCatchClause(current) &&
+			current.variableDeclaration !== undefined &&
+			bindingNameContains(current.variableDeclaration.name, name)
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			(ts.isFunctionDeclaration(current) || ts.isClassDeclaration(current)) &&
+			current.name?.text === name
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			(ts.isFunctionExpression(current) || ts.isClassExpression(current)) &&
+			current.name?.text === name
+		) {
+			shadowed = true;
+			return;
+		}
+		ts.forEachChild(current, visit);
+	};
+	visit(sourceFile);
+	return shadowed;
+}
+
+export function bindingNameContains(
+	binding: ts.BindingName,
+	name: string,
+): boolean {
+	if (ts.isIdentifier(binding)) return binding.text === name;
+	return binding.elements.some(
+		(element) =>
+			!ts.isOmittedExpression(element) &&
+			bindingNameContains(element.name, name),
+	);
+}

--- a/tests/unit/build/runtime-timeout-consumer-callsites.test.ts
+++ b/tests/unit/build/runtime-timeout-consumer-callsites.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const ROOT = path.resolve(import.meta.dir, '../../..');
+
+const REQUIRED_CONSUMERS = [
+	'src/learning/admission.ts',
+	'src/hooks/micro-reflector.ts',
+	'src/hooks/knowledge-curator.ts',
+	'src/mutation/generator.ts',
+	'src/services/skill-generator.ts',
+	'src/tools/external-skill-discover.ts',
+] as const;
+
+const EXPECTED_CALL_SITES = new Map<string, readonly string[]>([
+	['src/learning/admission.ts', ['screenCandidate']],
+	['src/hooks/micro-reflector.ts', ['runMicroReflection']],
+	[
+		'src/hooks/knowledge-curator.ts',
+		['enrichLessonsToV3Batched', 'enrichLessonToV3'],
+	],
+	['src/mutation/generator.ts', ['dispatch']],
+	['src/services/skill-generator.ts', ['autoApplyProposals']],
+	['src/tools/external-skill-discover.ts', ['fetchContent']],
+]);
+
+describe('runtime timeout consumer callsites', () => {
+	test('keeps every reported consumer calling the shared cancellable helper', () => {
+		for (const relative of REQUIRED_CONSUMERS) {
+			const source = readFileSync(path.join(ROOT, relative), 'utf8');
+			expect(importedHelperCallSites(source)).toEqual(
+				EXPECTED_CALL_SITES.get(relative),
+			);
+		}
+	});
+
+	test('keeps property declarations visible to the helper callsite mapper', () => {
+		expect(
+			importedHelperCallSites(`
+				import { withTimeoutSignal } from '../../utils/timeout.js';
+				class Example {
+					withTimeoutSignal = () => {
+						withTimeoutSignal();
+					};
+				}
+			`),
+		).toEqual(['withTimeoutSignal']);
+	});
+
+	test('rejects helper calls shadowed away from the shared import', () => {
+		for (const declaration of [
+			'function screenCandidate(withTimeoutSignal: () => void) { withTimeoutSignal(); }',
+			'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
+			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }',
+			'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
+			'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
+		]) {
+			const source = `
+				import { withTimeoutSignal } from '../../utils/timeout.js';
+				${declaration}
+			`;
+			expect(importedHelperCallSites(source)).toEqual([]);
+		}
+	});
+});
+
+function importedHelperCallSites(source: string): string[] {
+	const sourceFile = ts.createSourceFile(
+		'consumer.ts',
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	let importedName: string | undefined;
+	for (const statement of sourceFile.statements) {
+		if (
+			ts.isImportDeclaration(statement) &&
+			statement.moduleSpecifier
+				.getText(sourceFile)
+				.includes('utils/timeout.js') &&
+			statement.importClause?.namedBindings !== undefined &&
+			ts.isNamedImports(statement.importClause.namedBindings)
+		) {
+			const specifier = statement.importClause.namedBindings.elements.find(
+				(element) =>
+					(element.propertyName ?? element.name).text === 'withTimeoutSignal',
+			);
+			if (specifier) importedName = specifier.name.text;
+		}
+	}
+	if (!importedName || hasShadowingBinding(sourceFile, importedName)) return [];
+	const callSites: string[] = [];
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			node.expression.text === importedName
+		) {
+			callSites.push(enclosingCallableName(node) ?? '<top-level>');
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return callSites;
+}
+
+function hasShadowingBinding(sourceFile: ts.SourceFile, name: string): boolean {
+	let shadowed = false;
+	const visit = (node: ts.Node): void => {
+		if (shadowed) return;
+		if (
+			!ts.isImportSpecifier(node) &&
+			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+			node.name !== undefined &&
+			bindingNameContains(node.name, name)
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			ts.isFunctionDeclaration(node) ||
+			ts.isClassDeclaration(node) ||
+			ts.isFunctionExpression(node) ||
+			ts.isClassExpression(node)
+		) {
+			if (node.name?.text === name) {
+				shadowed = true;
+				return;
+			}
+		}
+		if (ts.isCatchClause(node) && node.variableDeclaration !== undefined) {
+			if (bindingNameContains(node.variableDeclaration.name, name)) {
+				shadowed = true;
+				return;
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return shadowed;
+}
+
+function bindingNameContains(binding: ts.BindingName, name: string): boolean {
+	if (ts.isIdentifier(binding)) return binding.text === name;
+	return binding.elements.some(
+		(element) =>
+			!ts.isOmittedExpression(element) &&
+			bindingNameContains(element.name, name),
+	);
+}
+
+function enclosingCallableName(node: ts.Node): string | undefined {
+	for (let current = node.parent; current; current = current.parent) {
+		if (ts.isFunctionDeclaration(current) && current.name)
+			return current.name.text;
+		if (
+			(ts.isMethodDeclaration(current) || ts.isPropertyAssignment(current)) &&
+			(ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))
+		) {
+			return current.name.text;
+		}
+		if (
+			ts.isPropertyDeclaration(current) &&
+			(ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))
+		) {
+			return current.name.text;
+		}
+		if (
+			ts.isVariableDeclaration(current) &&
+			ts.isIdentifier(current.name) &&
+			current.initializer &&
+			(ts.isArrowFunction(current.initializer) ||
+				ts.isFunctionExpression(current.initializer))
+		) {
+			return current.name.text;
+		}
+	}
+	return undefined;
+}

--- a/tests/unit/build/runtime-timeout-consumer-callsites.test.ts
+++ b/tests/unit/build/runtime-timeout-consumer-callsites.test.ts
@@ -55,6 +55,7 @@ describe('runtime timeout consumer callsites', () => {
 			'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
 			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }',
 			'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
+			'function screenCandidate() { try {} catch (withTimeoutSignal) { withTimeoutSignal(); } }',
 			'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
 		]) {
 			const source = `

--- a/tests/unit/build/runtime-timeout-source-guard.test.ts
+++ b/tests/unit/build/runtime-timeout-source-guard.test.ts
@@ -5,441 +5,248 @@ import ts from 'typescript';
 
 const ROOT = path.resolve(import.meta.dir, '../../..');
 const SRC = path.join(ROOT, 'src');
-
 const REQUIRED_CONSUMERS = [
 	'src/learning/admission.ts',
 	'src/hooks/micro-reflector.ts',
 	'src/hooks/knowledge-curator.ts',
+	'src/mutation/generator.ts',
 	'src/services/skill-generator.ts',
 	'src/tools/external-skill-discover.ts',
 ] as const;
-
 const EXPECTED_CALL_SITES = new Map<string, readonly string[]>([
 	['src/learning/admission.ts', ['screenCandidate']],
 	['src/hooks/micro-reflector.ts', ['runMicroReflection']],
-	[
-		'src/hooks/knowledge-curator.ts',
-		['enrichLessonsToV3Batched', 'enrichLessonToV3'],
-	],
+	['src/hooks/knowledge-curator.ts', ['enrichLessonsToV3Batched', 'enrichLessonToV3']],
+	['src/mutation/generator.ts', ['dispatch']],
 	['src/services/skill-generator.ts', ['autoApplyProposals']],
 	['src/tools/external-skill-discover.ts', ['fetchContent']],
 ]);
 
 function findNativeAbortTimeoutAccesses(source: string): number {
-	const sourceFile = ts.createSourceFile(
-		'candidate.ts',
-		source,
-		ts.ScriptTarget.Latest,
-		true,
-		ts.ScriptKind.TS,
-	);
-	const signalAliases = new Set(['AbortSignal']);
-	const globalAliases = new Set(['globalThis']);
-	const reflectGetAliases = new Set<string>();
+	const file = ts.createSourceFile('candidate.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	const signals = new Set(['AbortSignal']);
+	const globals = new Set(['globalThis']);
+	const reflects = new Set(['Reflect']);
+	const reflectGets = new Set<string>();
+	const timeoutKeys = new Set(['timeout']);
 	let changed = true;
 	while (changed) {
 		changed = false;
-		const collectAliases = (node: ts.Node): void => {
-			if (
-				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-				ts.isIdentifier(node.name) &&
-				node.initializer &&
-				isNamedReference(node.initializer, globalAliases) &&
-				!globalAliases.has(node.name.text)
-			) {
-				globalAliases.add(node.name.text);
-				changed = true;
-			}
-			if (
-				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-				ts.isIdentifier(node.name) &&
-				node.initializer &&
-				isAbortSignalReference(
-					node.initializer,
-					signalAliases,
-					globalAliases,
-				) &&
-				!signalAliases.has(node.name.text)
-			) {
-				signalAliases.add(node.name.text);
-				changed = true;
-			}
-			if (
-				ts.isBinaryExpression(node) &&
-				node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-				ts.isIdentifier(node.left) &&
-				isAbortSignalReference(node.right, signalAliases, globalAliases) &&
-				!signalAliases.has(node.left.text)
-			) {
-				signalAliases.add(node.left.text);
-				changed = true;
-			}
-			if (
-				ts.isVariableDeclaration(node) &&
-				ts.isObjectBindingPattern(node.name) &&
-				node.initializer &&
-				isNamedReference(node.initializer, globalAliases)
-			) {
-				for (const element of node.name.elements) {
-					const property = element.propertyName ?? element.name;
-					if (
-						ts.isIdentifier(property) &&
-						property.text === 'AbortSignal' &&
-						ts.isIdentifier(element.name) &&
-						!signalAliases.has(element.name.text)
-					) {
-						signalAliases.add(element.name.text);
-						changed = true;
-					}
-				}
-			}
-			if (
-				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-				ts.isIdentifier(node.name) &&
-				node.initializer &&
-				isReflectGetReference(node.initializer) &&
-				!reflectGetAliases.has(node.name.text)
-			) {
-				reflectGetAliases.add(node.name.text);
-				changed = true;
-			}
-			if (
-				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-				ts.isObjectBindingPattern(node.name) &&
-				node.initializer &&
-				isNamedReference(node.initializer, new Set(['Reflect']))
-			) {
-				for (const element of node.name.elements) {
-					if (
-						propertyNameText(element.propertyName ?? element.name) === 'get' &&
-						ts.isIdentifier(element.name) &&
-						!reflectGetAliases.has(element.name.text)
-					) {
-						reflectGetAliases.add(element.name.text);
-						changed = true;
-					}
-				}
-			}
-			ts.forEachChild(node, collectAliases);
+		const mark = () => {
+			changed = true;
 		};
-		collectAliases(sourceFile);
+		const collect = (node: ts.Node): void => {
+			if (ts.isVariableDeclaration(node) || ts.isParameter(node)) {
+				const { name, initializer } = node;
+				if (ts.isIdentifier(name) && initializer) {
+					addAlias(globals, name.text, isNamedReference(initializer, globals), mark);
+					addAlias(signals, name.text, isAbortSignalReference(initializer, signals, globals, file), mark);
+					addAlias(reflects, name.text, isNamedReference(initializer, reflects), mark);
+					addAlias(reflectGets, name.text, isReflectGetReference(initializer, reflects), mark);
+					addAlias(timeoutKeys, name.text, isStringReference(initializer, timeoutKeys, 'timeout'), mark);
+				}
+				if (initializer && ts.isObjectBindingPattern(name)) {
+					if (isNamedReference(initializer, globals)) collectBindingAliases(name, 'AbortSignal', signals, mark);
+					if (isNamedReference(initializer, reflects)) collectBindingAliases(name, 'get', reflectGets, mark);
+				}
+			}
+			if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+				if (ts.isIdentifier(node.left)) {
+					addAlias(globals, node.left.text, isNamedReference(node.right, globals), mark);
+					addAlias(signals, node.left.text, isAbortSignalReference(node.right, signals, globals, file), mark);
+					addAlias(reflects, node.left.text, isNamedReference(node.right, reflects), mark);
+					addAlias(reflectGets, node.left.text, isReflectGetReference(node.right, reflects), mark);
+					addAlias(timeoutKeys, node.left.text, isStringReference(node.right, timeoutKeys, 'timeout'), mark);
+				}
+				if (ts.isObjectBindingPattern(node.left)) {
+					if (isNamedReference(node.right, globals)) collectBindingAliases(node.left, 'AbortSignal', signals, mark);
+					if (isNamedReference(node.right, reflects)) collectBindingAliases(node.left, 'get', reflectGets, mark);
+				}
+				if (ts.isObjectLiteralExpression(node.left)) {
+					if (isNamedReference(node.right, globals)) collectObjectAssignmentAliases(node.left, 'AbortSignal', signals, mark);
+					if (isNamedReference(node.right, reflects)) collectObjectAssignmentAliases(node.left, 'get', reflectGets, mark);
+				}
+			}
+			ts.forEachChild(node, collect);
+		};
+		collect(file);
 	}
 
 	let accesses = 0;
 	const visit = (node: ts.Node): void => {
-		if (
-			(ts.isPropertyAccessExpression(node) &&
-				node.name.text === 'timeout' &&
-				isAbortSignalReference(
-					node.expression,
-					signalAliases,
-					globalAliases,
-				)) ||
-			(ts.isElementAccessExpression(node) &&
-				node.argumentExpression !== undefined &&
-				ts.isStringLiteralLike(node.argumentExpression) &&
-				node.argumentExpression.text === 'timeout' &&
-				isAbortSignalReference(node.expression, signalAliases, globalAliases))
-		) {
-			accesses += 1;
+		if ((ts.isPropertyAccessExpression(node) && node.name.text === 'timeout' && isAbortSignalReference(node.expression, signals, globals, file)) || (ts.isElementAccessExpression(node) && node.argumentExpression && isTimeoutKeyReference(node.argumentExpression, timeoutKeys) && isAbortSignalReference(node.expression, signals, globals, file))) accesses++;
+		if (ts.isCallExpression(node) && (isReflectGetReference(node.expression, reflects) || (ts.isIdentifier(node.expression) && reflectGets.has(node.expression.text))) && node.arguments.length >= 2 && isAbortSignalReference(node.arguments[0], signals, globals, file) && isTimeoutKeyReference(node.arguments[1], timeoutKeys)) accesses++;
+		if ((ts.isVariableDeclaration(node) || ts.isParameter(node)) && ts.isObjectBindingPattern(node.name) && node.initializer) {
+			if (isAbortSignalReference(node.initializer, signals, globals, file)) accesses += countTimeoutBindings(node.name);
+			if (isNamedReference(node.initializer, globals)) accesses += countNestedTimeoutBindings(node.name);
 		}
-		if (
-			ts.isCallExpression(node) &&
-			(isReflectGetReference(node.expression) ||
-				(ts.isIdentifier(node.expression) &&
-					reflectGetAliases.has(node.expression.text))) &&
-			node.arguments.length >= 2 &&
-			isAbortSignalReference(node.arguments[0], signalAliases, globalAliases) &&
-			ts.isStringLiteralLike(node.arguments[1]) &&
-			node.arguments[1].text === 'timeout'
-		) {
-			accesses += 1;
-		}
-		if (
-			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-			ts.isObjectBindingPattern(node.name) &&
-			node.initializer &&
-			isAbortSignalReference(node.initializer, signalAliases, globalAliases)
-		) {
-			accesses += countTimeoutBindings(node.name);
-		}
-		if (
-			ts.isBinaryExpression(node) &&
-			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-			ts.isObjectLiteralExpression(node.left) &&
-			isAbortSignalReference(node.right, signalAliases, globalAliases)
-		) {
-			accesses += node.left.properties.filter(
-				(property) => propertyNameText(property.name) === 'timeout',
-			).length;
+		if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken && ts.isObjectLiteralExpression(node.left)) {
+			if (isAbortSignalReference(node.right, signals, globals, file)) accesses += countTimeoutProperties(node.left);
+			if (isNamedReference(node.right, globals)) accesses += countNestedTimeoutObjectProperties(node.left);
 		}
 		ts.forEachChild(node, visit);
 	};
-	visit(sourceFile);
+	visit(file);
 	return accesses;
 }
 
-function isAbortSignalReference(
-	node: ts.Expression,
-	aliases: ReadonlySet<string>,
-	globalAliases: ReadonlySet<string>,
-): boolean {
-	const expression = unwrapExpression(node);
-	return (
-		(ts.isIdentifier(expression) && aliases.has(expression.text)) ||
-		(ts.isPropertyAccessExpression(expression) &&
-			isNamedReference(expression.expression, globalAliases) &&
-			expression.name.text === 'AbortSignal') ||
-		(ts.isElementAccessExpression(expression) &&
-			isNamedReference(expression.expression, globalAliases) &&
-			expression.argumentExpression !== undefined &&
-			ts.isStringLiteralLike(expression.argumentExpression) &&
-			expression.argumentExpression.text === 'AbortSignal')
-	);
-}
-
-function unwrapExpression(node: ts.Expression): ts.Expression {
-	let current = node;
-	while (
-		ts.isParenthesizedExpression(current) ||
-		ts.isAsExpression(current) ||
-		ts.isTypeAssertionExpression(current) ||
-		ts.isNonNullExpression(current) ||
-		ts.isSatisfiesExpression(current)
-	) {
-		current = current.expression;
+function addAlias(set: Set<string>, name: string, shouldAdd: boolean, mark: () => void): void {
+	if (shouldAdd && !set.has(name)) {
+		set.add(name);
+		mark();
 	}
+}
+function unwrap(node: ts.Expression): ts.Expression {
+	let current = node;
+	while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current) || ts.isNonNullExpression(current) || ts.isSatisfiesExpression(current)) current = current.expression;
 	return current;
 }
-
-function isNamedReference(
-	node: ts.Expression,
-	aliases: ReadonlySet<string>,
-): boolean {
-	const expression = unwrapExpression(node);
-	return ts.isIdentifier(expression) && aliases.has(expression.text);
-}
-
-function isReflectGetReference(node: ts.Expression): boolean {
-	const expression = unwrapExpression(node);
-	return (
-		(ts.isPropertyAccessExpression(expression) &&
-			ts.isIdentifier(expression.expression) &&
-			expression.expression.text === 'Reflect' &&
-			expression.name.text === 'get') ||
-		(ts.isElementAccessExpression(expression) &&
-			ts.isIdentifier(expression.expression) &&
-			expression.expression.text === 'Reflect' &&
-			expression.argumentExpression !== undefined &&
-			ts.isStringLiteralLike(expression.argumentExpression) &&
-			expression.argumentExpression.text === 'get')
-	);
-}
-
-function propertyNameText(
-	name: ts.PropertyName | undefined,
-): string | undefined {
-	if (!name) return undefined;
-	if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
-	if (
-		ts.isComputedPropertyName(name) &&
-		ts.isStringLiteralLike(name.expression)
-	) {
-		return name.expression.text;
+function staticStringValue(node: ts.Expression, aliases: ReadonlyMap<string, string> = new Map()): string | undefined {
+	const expression = unwrap(node);
+	if (ts.isStringLiteralLike(expression)) return expression.text;
+	if (ts.isIdentifier(expression)) return aliases.get(expression.text);
+	if (ts.isBinaryExpression(expression) && expression.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+		const left = staticStringValue(expression.left, aliases);
+		const right = staticStringValue(expression.right, aliases);
+		return left !== undefined && right !== undefined ? left + right : undefined;
 	}
 	return undefined;
 }
-
+function isNamedReference(node: ts.Expression, aliases: ReadonlySet<string>): boolean {
+	const expression = unwrap(node);
+	return ts.isIdentifier(expression) && aliases.has(expression.text);
+}
+function isAbortSignalReference(node: ts.Expression, aliases: ReadonlySet<string>, globals: ReadonlySet<string>, file: ts.SourceFile): boolean {
+	const expression = unwrap(node);
+	return (ts.isIdentifier(expression) && aliases.has(expression.text) && !(expression.text === 'AbortSignal' && hasShadowingBinding(file, 'AbortSignal', expression))) || (ts.isPropertyAccessExpression(expression) && isNamedReference(expression.expression, globals) && expression.name.text === 'AbortSignal') || (ts.isElementAccessExpression(expression) && isNamedReference(expression.expression, globals) && expression.argumentExpression !== undefined && staticStringValue(expression.argumentExpression) === 'AbortSignal');
+}
+function isStringReference(node: ts.Expression, aliases: ReadonlySet<string>, value: string, _mark?: () => void): boolean {
+	const expression = unwrap(node);
+	return (ts.isIdentifier(expression) && aliases.has(expression.text)) || staticStringValue(expression) === value;
+}
+function isTimeoutKeyReference(node: ts.Expression, aliases: ReadonlySet<string>): boolean {
+	return isStringReference(node, aliases, 'timeout');
+}
+function isReflectGetReference(node: ts.Expression, reflects: ReadonlySet<string>): boolean {
+	const expression = unwrap(node);
+	return (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.expression) && reflects.has(expression.expression.text) && expression.name.text === 'get') || (ts.isElementAccessExpression(expression) && ts.isIdentifier(expression.expression) && reflects.has(expression.expression.text) && expression.argumentExpression !== undefined && staticStringValue(expression.argumentExpression) === 'get');
+}
+function propertyNameText(name: ts.PropertyName | undefined): string | undefined {
+	if (!name) return undefined;
+	if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+	return ts.isComputedPropertyName(name) ? staticStringValue(name.expression) : undefined;
+}
+function collectBindingAliases(pattern: ts.ObjectBindingPattern, property: string, aliases: Set<string>, mark: () => void): void {
+	for (const element of pattern.elements) {
+		if (propertyNameText(element.propertyName ?? element.name) === property && ts.isIdentifier(element.name)) addAlias(aliases, element.name.text, true, mark);
+		if (ts.isObjectBindingPattern(element.name)) collectBindingAliases(element.name, property, aliases, mark);
+	}
+}
+function collectObjectAssignmentAliases(object: ts.ObjectLiteralExpression, property: string, aliases: Set<string>, mark: () => void): void {
+	for (const entry of object.properties) {
+		if (propertyNameText(entry.name) !== property) continue;
+		const target = ts.isPropertyAssignment(entry) ? entry.initializer : ts.isShorthandPropertyAssignment(entry) ? entry.name : undefined;
+		if (target && ts.isIdentifier(target)) addAlias(aliases, target.text, true, mark);
+	}
+}
 function countTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
-	return pattern.elements.filter(
-		(element) =>
-			propertyNameText(element.propertyName ?? element.name) === 'timeout',
-	).length;
+	return pattern.elements.reduce((count, element) => count + (propertyNameText(element.propertyName ?? element.name) === 'timeout' ? 1 : 0) + (ts.isObjectBindingPattern(element.name) ? countTimeoutBindings(element.name) : 0), 0);
+}
+function countNestedTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
+	return pattern.elements.reduce((count, element) => count + (propertyNameText(element.propertyName ?? element.name) === 'AbortSignal' && ts.isObjectBindingPattern(element.name) ? countTimeoutBindings(element.name) : 0), 0);
+}
+function countTimeoutProperties(object: ts.ObjectLiteralExpression): number {
+	return object.properties.filter((property) => propertyNameText(property.name) === 'timeout').length;
+}
+function countNestedTimeoutObjectProperties(object: ts.ObjectLiteralExpression): number {
+	return object.properties.reduce((count, property) => count + (propertyNameText(property.name) === 'AbortSignal' && ts.isPropertyAssignment(property) && ts.isObjectLiteralExpression(property.initializer) ? countTimeoutProperties(property.initializer) : 0), 0);
 }
 
 function importedHelperCallSites(source: string): string[] {
-	const sourceFile = ts.createSourceFile(
-		'consumer.ts',
-		source,
-		ts.ScriptTarget.Latest,
-		true,
-		ts.ScriptKind.TS,
-	);
+	const file = ts.createSourceFile('consumer.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	let importedName: string | undefined;
-	for (const statement of sourceFile.statements) {
-		if (
-			ts.isImportDeclaration(statement) &&
-			statement.moduleSpecifier
-				.getText(sourceFile)
-				.includes('utils/timeout.js') &&
-			statement.importClause?.namedBindings !== undefined &&
-			ts.isNamedImports(statement.importClause.namedBindings)
-		) {
-			const specifier = statement.importClause.namedBindings.elements.find(
-				(element) =>
-					(element.propertyName ?? element.name).text === 'withTimeoutSignal',
-			);
+	for (const statement of file.statements) {
+		if (ts.isImportDeclaration(statement) && statement.moduleSpecifier.getText(file).includes('utils/timeout.js') && statement.importClause?.namedBindings && ts.isNamedImports(statement.importClause.namedBindings)) {
+			const specifier = statement.importClause.namedBindings.elements.find((element) => (element.propertyName ?? element.name).text === 'withTimeoutSignal');
 			if (specifier) importedName = specifier.name.text;
 		}
 	}
-	if (!importedName || hasShadowingBinding(sourceFile, importedName)) return [];
-	const callSites: string[] = [];
+	if (!importedName || hasShadowingBinding(file, importedName)) return [];
+	const calls: string[] = [];
 	const visit = (node: ts.Node): void => {
-		if (
-			ts.isCallExpression(node) &&
-			ts.isIdentifier(node.expression) &&
-			node.expression.text === importedName
-		) {
-			callSites.push(enclosingCallableName(node) ?? '<top-level>');
-		}
+		if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === importedName) calls.push(enclosingCallableName(node) ?? '<top-level>');
 		ts.forEachChild(node, visit);
 	};
-	visit(sourceFile);
-	return callSites;
+	visit(file);
+	return calls;
 }
-
-function hasShadowingBinding(sourceFile: ts.SourceFile, name: string): boolean {
-	let shadowed = false;
+function hasShadowingBinding(file: ts.SourceFile, name: string, target?: ts.Node): boolean {
+	let found = false;
+	const limit = target?.getStart(file) ?? Number.POSITIVE_INFINITY;
 	const visit = (node: ts.Node): void => {
-		if (shadowed) return;
-		if (
-			!ts.isImportSpecifier(node) &&
-			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
-			node.name !== undefined &&
-			bindingNameContains(node.name, name)
-		) {
-			shadowed = true;
+		if (found || node.getStart(file) >= limit) return;
+		if (!ts.isImportSpecifier(node) && ((ts.isVariableDeclaration(node) || ts.isParameter(node)) && bindingNameContains(node.name, name) || (ts.isCatchClause(node) && node.variableDeclaration && bindingNameContains(node.variableDeclaration.name, name)))) {
+			found = true;
 			return;
 		}
-		if (
-			(ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
-			node.name?.text === name
-		) {
-			shadowed = true;
-			return;
-		}
-		if (
-			(ts.isFunctionExpression(node) || ts.isClassExpression(node)) &&
-			node.name?.text === name
-		) {
-			shadowed = true;
+		if ((ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isFunctionExpression(node) || ts.isClassExpression(node)) && node.name?.text === name) {
+			found = true;
 			return;
 		}
 		ts.forEachChild(node, visit);
 	};
-	visit(sourceFile);
-	return shadowed;
+	visit(file);
+	return found;
 }
-
 function bindingNameContains(binding: ts.BindingName, name: string): boolean {
-	if (ts.isIdentifier(binding)) return binding.text === name;
-	return binding.elements.some(
-		(element) =>
-			!ts.isOmittedExpression(element) &&
-			bindingNameContains(element.name, name),
-	);
+	return ts.isIdentifier(binding) ? binding.text === name : binding.elements.some((element) => !ts.isOmittedExpression(element) && bindingNameContains(element.name, name));
 }
-
 function enclosingCallableName(node: ts.Node): string | undefined {
 	for (let current = node.parent; current; current = current.parent) {
-		if (ts.isFunctionDeclaration(current) && current.name) {
-			return current.name.text;
-		}
-		if (
-			(ts.isMethodDeclaration(current) || ts.isPropertyAssignment(current)) &&
-			(ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))
-		) {
-			return current.name.text;
-		}
-		if (
-			ts.isVariableDeclaration(current) &&
-			ts.isIdentifier(current.name) &&
-			current.initializer &&
-			(ts.isArrowFunction(current.initializer) ||
-				ts.isFunctionExpression(current.initializer))
-		) {
-			return current.name.text;
-		}
+		if (ts.isFunctionDeclaration(current) && current.name) return current.name.text;
+		if ((ts.isMethodDeclaration(current) || ts.isPropertyAssignment(current) || ts.isPropertyDeclaration(current)) && (ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))) return current.name.text;
+		if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name) && current.initializer && (ts.isArrowFunction(current.initializer) || ts.isFunctionExpression(current.initializer))) return current.name.text;
 	}
 	return undefined;
 }
-
 function runtimeSourceFiles(): string[] {
-	return (readdirSync(SRC, { recursive: true }) as string[])
-		.filter((entry) => entry.endsWith('.ts'))
-		.filter((entry) => !entry.endsWith('.test.ts'))
-		.filter((entry) => !entry.includes(`${path.sep}__tests__${path.sep}`))
-		.map((entry) => path.join(SRC, entry));
+	return (readdirSync(SRC, { recursive: true }) as string[]).filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts') && !entry.includes(`${path.sep}__tests__${path.sep}`)).map((entry) => path.join(SRC, entry));
 }
 
 describe('runtime timeout source guard (#1964/#2103)', () => {
 	test('forbids runtime AbortSignal timeout construction', () => {
-		const offenders = runtimeSourceFiles()
-			.filter((file) =>
-				findNativeAbortTimeoutAccesses(readFileSync(file, 'utf8')),
-			)
-			.map((file) => path.relative(ROOT, file));
+		const offenders = runtimeSourceFiles().filter((file) => findNativeAbortTimeoutAccesses(readFileSync(file, 'utf8'))).map((file) => path.relative(ROOT, file));
 		expect(offenders).toEqual([]);
 	});
-
-	test('rejects equivalent native timeout access syntax (review F1)', () => {
-		// Previous guard used one exact substring, so harmless formatting and
-		// property-access variants silently bypassed the recurrence machinery.
+	test('rejects equivalent native timeout access syntax (F-001, FB-006)', () => {
+		// Before F-001/FB-006, alias, nested, assignment, reflection, and computed-key forms bypassed the recurrence guard.
 		for (const source of [
-			'AbortSignal.timeout (100)',
-			'AbortSignal?.timeout(100)',
-			'AbortSignal["timeout"](100)',
-			'const timeout = AbortSignal.timeout; timeout(100)',
-			'const { timeout } = AbortSignal; timeout(100)',
-			'const { timeout: deadline } = AbortSignal; deadline(100)',
-			'const Signal = AbortSignal; Signal.timeout(100)',
-			'globalThis.AbortSignal.timeout(100)',
-			'((AbortSignal)).timeout(100)',
-			'(AbortSignal as typeof AbortSignal).timeout(100)',
-			'AbortSignal!.timeout(100)',
-			'globalThis["AbortSignal"].timeout(100)',
-			'const { AbortSignal: Signal } = globalThis; Signal.timeout(100)',
-			'let Signal: typeof AbortSignal; Signal = AbortSignal; Signal.timeout(100)',
-			'function f(Signal = AbortSignal) { Signal.timeout(100); }',
-			'Reflect.get(AbortSignal, "timeout")(100)',
-			'({ timeout } = AbortSignal)',
-			'function f({ timeout } = AbortSignal) {}',
-			'const { ["timeout"]: deadline } = AbortSignal',
-			'const root = globalThis; root.AbortSignal.timeout(100)',
-			'const get = Reflect.get; get(AbortSignal, "timeout")(100)',
-			'const { get } = Reflect; get(AbortSignal, "timeout")(100)',
-		]) {
-			expect(findNativeAbortTimeoutAccesses(source)).toBeGreaterThan(0);
-		}
-		expect(
-			findNativeAbortTimeoutAccesses(
-				'withTimeoutSignal(async () => "ok", 100, new Error("late"))',
-			),
-		).toBe(0);
+			'AbortSignal.timeout (100)', 'AbortSignal?.timeout(100)', 'AbortSignal["timeout"](100)', 'const k = "time" + "out"; AbortSignal[k](100)',
+			'const timeout = AbortSignal.timeout; timeout(100)', 'const { timeout: deadline } = AbortSignal; deadline(100)', 'const Signal = AbortSignal; Signal.timeout(100)',
+			'globalThis.AbortSignal.timeout(100)', 'globalThis["AbortSignal"].timeout(100)', 'const { AbortSignal: Signal } = globalThis; Signal.timeout(100)',
+			'({ AbortSignal: Signal } = globalThis); Signal.timeout(100)', 'const { AbortSignal: { timeout: deadline } } = globalThis; deadline(100)',
+			'let Signal: typeof AbortSignal; Signal = AbortSignal; Signal.timeout(100)', 'Reflect.get(AbortSignal, "timeout")(100)', 'const R = Reflect; R.get(AbortSignal, "timeout")(100)',
+			'const get = Reflect.get; get(AbortSignal, "timeout")(100)', 'const { get } = Reflect; get(AbortSignal, "timeout")(100)', '({ timeout } = AbortSignal)',
+			'function f({ timeout } = AbortSignal) {}', 'const { ["timeout"]: deadline } = AbortSignal',
+		]) expect(findNativeAbortTimeoutAccesses(source), source).toBeGreaterThan(0);
+		expect(findNativeAbortTimeoutAccesses('withTimeoutSignal(async () => "ok", 100, new Error("late"))')).toBe(0);
 	});
-
-	test('rejects helper calls shadowed away from the shared import', () => {
+	test('rejects helper calls shadowed away from the shared import (F-003)', () => {
 		for (const declaration of [
-			'function screenCandidate(withTimeoutSignal: () => void) { withTimeoutSignal(); }',
-			'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
-			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }',
-			'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
-			'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
+			'function screenCandidate(withTimeoutSignal: () => void) { withTimeoutSignal(); }', 'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
+			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }', 'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
+			'function screenCandidate() { try {} catch (withTimeoutSignal) { withTimeoutSignal(); } }', 'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
 		]) {
-			const source = `
-				import { withTimeoutSignal } from '../../utils/timeout.js';
-				${declaration}
-			`;
-			expect(importedHelperCallSites(source)).toEqual([]);
+			expect(importedHelperCallSites(`import { withTimeoutSignal } from '../../utils/timeout.js'; ${declaration}`)).toEqual([]);
 		}
 	});
-
+	test('keeps shadowed native names and class-field callables safe (F-002, FB-005)', () => {
+		// Before F-002, a local AbortSignal binding was mistaken for the global object.
+		expect(findNativeAbortTimeoutAccesses('function f(AbortSignal: { timeout: (ms: number) => void }) { AbortSignal.timeout(100); }')).toBe(0);
+		// Before FB-005, class-field arrows were reported as <top-level>.
+		expect(importedHelperCallSites('import { withTimeoutSignal } from "../../utils/timeout.js"; class C { run = () => withTimeoutSignal(); }')).toEqual(['run']);
+	});
 	test('keeps every reported consumer calling the shared cancellable helper', () => {
-		for (const relative of REQUIRED_CONSUMERS) {
-			const source = readFileSync(path.join(ROOT, relative), 'utf8');
-			expect(importedHelperCallSites(source)).toEqual(
-				EXPECTED_CALL_SITES.get(relative),
-			);
-		}
+		for (const relative of REQUIRED_CONSUMERS) expect(importedHelperCallSites(readFileSync(path.join(ROOT, relative), 'utf8'))).toEqual(EXPECTED_CALL_SITES.get(relative));
 	});
 });

--- a/tests/unit/build/runtime-timeout-source-guard.test.ts
+++ b/tests/unit/build/runtime-timeout-source-guard.test.ts
@@ -2,28 +2,18 @@ import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
+import { hasShadowingBinding } from './runtime-timeout-ast-helpers.ts';
 
 const ROOT = path.resolve(import.meta.dir, '../../..');
 const SRC = path.join(ROOT, 'src');
-const REQUIRED_CONSUMERS = [
-	'src/learning/admission.ts',
-	'src/hooks/micro-reflector.ts',
-	'src/hooks/knowledge-curator.ts',
-	'src/mutation/generator.ts',
-	'src/services/skill-generator.ts',
-	'src/tools/external-skill-discover.ts',
-] as const;
-const EXPECTED_CALL_SITES = new Map<string, readonly string[]>([
-	['src/learning/admission.ts', ['screenCandidate']],
-	['src/hooks/micro-reflector.ts', ['runMicroReflection']],
-	['src/hooks/knowledge-curator.ts', ['enrichLessonsToV3Batched', 'enrichLessonToV3']],
-	['src/mutation/generator.ts', ['dispatch']],
-	['src/services/skill-generator.ts', ['autoApplyProposals']],
-	['src/tools/external-skill-discover.ts', ['fetchContent']],
-]);
-
 function findNativeAbortTimeoutAccesses(source: string): number {
-	const file = ts.createSourceFile('candidate.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+	const file = ts.createSourceFile(
+		'candidate.ts',
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
 	const signals = new Set(['AbortSignal']);
 	const globals = new Set(['globalThis']);
 	const reflects = new Set(['Reflect']);
@@ -39,32 +29,96 @@ function findNativeAbortTimeoutAccesses(source: string): number {
 			if (ts.isVariableDeclaration(node) || ts.isParameter(node)) {
 				const { name, initializer } = node;
 				if (ts.isIdentifier(name) && initializer) {
-					addAlias(globals, name.text, isNamedReference(initializer, globals), mark);
-					addAlias(signals, name.text, isAbortSignalReference(initializer, signals, globals, file), mark);
-					addAlias(reflects, name.text, isNamedReference(initializer, reflects), mark);
-					addAlias(reflectGets, name.text, isReflectGetReference(initializer, reflects), mark);
-					addAlias(timeoutKeys, name.text, isStringReference(initializer, timeoutKeys, 'timeout'), mark);
+					addAlias(
+						globals,
+						name.text,
+						isNamedReference(initializer, globals),
+						mark,
+					);
+					addAlias(
+						signals,
+						name.text,
+						isAbortSignalReference(initializer, signals, globals, file),
+						mark,
+					);
+					addAlias(
+						reflects,
+						name.text,
+						isNamedReference(initializer, reflects),
+						mark,
+					);
+					addAlias(
+						reflectGets,
+						name.text,
+						isReflectGetReference(initializer, reflects),
+						mark,
+					);
+					addAlias(
+						timeoutKeys,
+						name.text,
+						isStringReference(initializer, timeoutKeys, 'timeout'),
+						mark,
+					);
 				}
 				if (initializer && ts.isObjectBindingPattern(name)) {
-					if (isNamedReference(initializer, globals)) collectBindingAliases(name, 'AbortSignal', signals, mark);
-					if (isNamedReference(initializer, reflects)) collectBindingAliases(name, 'get', reflectGets, mark);
+					if (isNamedReference(initializer, globals))
+						collectBindingAliases(name, 'AbortSignal', signals, mark);
+					if (isNamedReference(initializer, reflects))
+						collectBindingAliases(name, 'get', reflectGets, mark);
 				}
 			}
-			if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+			if (
+				ts.isBinaryExpression(node) &&
+				node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+			) {
 				if (ts.isIdentifier(node.left)) {
-					addAlias(globals, node.left.text, isNamedReference(node.right, globals), mark);
-					addAlias(signals, node.left.text, isAbortSignalReference(node.right, signals, globals, file), mark);
-					addAlias(reflects, node.left.text, isNamedReference(node.right, reflects), mark);
-					addAlias(reflectGets, node.left.text, isReflectGetReference(node.right, reflects), mark);
-					addAlias(timeoutKeys, node.left.text, isStringReference(node.right, timeoutKeys, 'timeout'), mark);
+					addAlias(
+						globals,
+						node.left.text,
+						isNamedReference(node.right, globals),
+						mark,
+					);
+					addAlias(
+						signals,
+						node.left.text,
+						isAbortSignalReference(node.right, signals, globals, file),
+						mark,
+					);
+					addAlias(
+						reflects,
+						node.left.text,
+						isNamedReference(node.right, reflects),
+						mark,
+					);
+					addAlias(
+						reflectGets,
+						node.left.text,
+						isReflectGetReference(node.right, reflects),
+						mark,
+					);
+					addAlias(
+						timeoutKeys,
+						node.left.text,
+						isStringReference(node.right, timeoutKeys, 'timeout'),
+						mark,
+					);
 				}
 				if (ts.isObjectBindingPattern(node.left)) {
-					if (isNamedReference(node.right, globals)) collectBindingAliases(node.left, 'AbortSignal', signals, mark);
-					if (isNamedReference(node.right, reflects)) collectBindingAliases(node.left, 'get', reflectGets, mark);
+					if (isNamedReference(node.right, globals))
+						collectBindingAliases(node.left, 'AbortSignal', signals, mark);
+					if (isNamedReference(node.right, reflects))
+						collectBindingAliases(node.left, 'get', reflectGets, mark);
 				}
 				if (ts.isObjectLiteralExpression(node.left)) {
-					if (isNamedReference(node.right, globals)) collectObjectAssignmentAliases(node.left, 'AbortSignal', signals, mark);
-					if (isNamedReference(node.right, reflects)) collectObjectAssignmentAliases(node.left, 'get', reflectGets, mark);
+					if (isNamedReference(node.right, globals))
+						collectObjectAssignmentAliases(
+							node.left,
+							'AbortSignal',
+							signals,
+							mark,
+						);
+					if (isNamedReference(node.right, reflects))
+						collectObjectAssignmentAliases(node.left, 'get', reflectGets, mark);
 				}
 			}
 			ts.forEachChild(node, collect);
@@ -74,15 +128,45 @@ function findNativeAbortTimeoutAccesses(source: string): number {
 
 	let accesses = 0;
 	const visit = (node: ts.Node): void => {
-		if ((ts.isPropertyAccessExpression(node) && node.name.text === 'timeout' && isAbortSignalReference(node.expression, signals, globals, file)) || (ts.isElementAccessExpression(node) && node.argumentExpression && isTimeoutKeyReference(node.argumentExpression, timeoutKeys) && isAbortSignalReference(node.expression, signals, globals, file))) accesses++;
-		if (ts.isCallExpression(node) && (isReflectGetReference(node.expression, reflects) || (ts.isIdentifier(node.expression) && reflectGets.has(node.expression.text))) && node.arguments.length >= 2 && isAbortSignalReference(node.arguments[0], signals, globals, file) && isTimeoutKeyReference(node.arguments[1], timeoutKeys)) accesses++;
-		if ((ts.isVariableDeclaration(node) || ts.isParameter(node)) && ts.isObjectBindingPattern(node.name) && node.initializer) {
-			if (isAbortSignalReference(node.initializer, signals, globals, file)) accesses += countTimeoutBindings(node.name);
-			if (isNamedReference(node.initializer, globals)) accesses += countNestedTimeoutBindings(node.name);
+		if (
+			(ts.isPropertyAccessExpression(node) &&
+				node.name.text === 'timeout' &&
+				isAbortSignalReference(node.expression, signals, globals, file)) ||
+			(ts.isElementAccessExpression(node) &&
+				node.argumentExpression &&
+				isTimeoutKeyReference(node.argumentExpression, timeoutKeys) &&
+				isAbortSignalReference(node.expression, signals, globals, file))
+		)
+			accesses++;
+		if (
+			ts.isCallExpression(node) &&
+			(isReflectGetReference(node.expression, reflects) ||
+				(ts.isIdentifier(node.expression) &&
+					reflectGets.has(node.expression.text))) &&
+			node.arguments.length >= 2 &&
+			isAbortSignalReference(node.arguments[0], signals, globals, file) &&
+			isTimeoutKeyReference(node.arguments[1], timeoutKeys)
+		)
+			accesses++;
+		if (
+			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+			ts.isObjectBindingPattern(node.name) &&
+			node.initializer
+		) {
+			if (isAbortSignalReference(node.initializer, signals, globals, file))
+				accesses += countTimeoutBindings(node.name);
+			if (isNamedReference(node.initializer, globals))
+				accesses += countNestedTimeoutBindings(node.name);
 		}
-		if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken && ts.isObjectLiteralExpression(node.left)) {
-			if (isAbortSignalReference(node.right, signals, globals, file)) accesses += countTimeoutProperties(node.left);
-			if (isNamedReference(node.right, globals)) accesses += countNestedTimeoutObjectProperties(node.left);
+		if (
+			ts.isBinaryExpression(node) &&
+			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			ts.isObjectLiteralExpression(node.left)
+		) {
+			if (isAbortSignalReference(node.right, signals, globals, file))
+				accesses += countTimeoutProperties(node.left);
+			if (isNamedReference(node.right, globals))
+				accesses += countNestedTimeoutObjectProperties(node.left);
 		}
 		ts.forEachChild(node, visit);
 	};
@@ -90,7 +174,12 @@ function findNativeAbortTimeoutAccesses(source: string): number {
 	return accesses;
 }
 
-function addAlias(set: Set<string>, name: string, shouldAdd: boolean, mark: () => void): void {
+function addAlias(
+	set: Set<string>,
+	name: string,
+	shouldAdd: boolean,
+	mark: () => void,
+): void {
 	if (shouldAdd && !set.has(name)) {
 		set.add(name);
 		mark();
@@ -98,155 +187,241 @@ function addAlias(set: Set<string>, name: string, shouldAdd: boolean, mark: () =
 }
 function unwrap(node: ts.Expression): ts.Expression {
 	let current = node;
-	while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current) || ts.isNonNullExpression(current) || ts.isSatisfiesExpression(current)) current = current.expression;
+	while (
+		ts.isParenthesizedExpression(current) ||
+		ts.isAsExpression(current) ||
+		ts.isTypeAssertionExpression(current) ||
+		ts.isNonNullExpression(current) ||
+		ts.isSatisfiesExpression(current)
+	)
+		current = current.expression;
 	return current;
 }
-function staticStringValue(node: ts.Expression, aliases: ReadonlyMap<string, string> = new Map()): string | undefined {
+function staticStringValue(
+	node: ts.Expression,
+	aliases: ReadonlyMap<string, string> = new Map(),
+): string | undefined {
 	const expression = unwrap(node);
 	if (ts.isStringLiteralLike(expression)) return expression.text;
 	if (ts.isIdentifier(expression)) return aliases.get(expression.text);
-	if (ts.isBinaryExpression(expression) && expression.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+	if (
+		ts.isBinaryExpression(expression) &&
+		expression.operatorToken.kind === ts.SyntaxKind.PlusToken
+	) {
 		const left = staticStringValue(expression.left, aliases);
 		const right = staticStringValue(expression.right, aliases);
 		return left !== undefined && right !== undefined ? left + right : undefined;
 	}
 	return undefined;
 }
-function isNamedReference(node: ts.Expression, aliases: ReadonlySet<string>): boolean {
+function isNamedReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+): boolean {
 	const expression = unwrap(node);
 	return ts.isIdentifier(expression) && aliases.has(expression.text);
 }
-function isAbortSignalReference(node: ts.Expression, aliases: ReadonlySet<string>, globals: ReadonlySet<string>, file: ts.SourceFile): boolean {
+function isAbortSignalReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+	globals: ReadonlySet<string>,
+	file: ts.SourceFile,
+): boolean {
 	const expression = unwrap(node);
-	return (ts.isIdentifier(expression) && aliases.has(expression.text) && !(expression.text === 'AbortSignal' && hasShadowingBinding(file, 'AbortSignal', expression))) || (ts.isPropertyAccessExpression(expression) && isNamedReference(expression.expression, globals) && expression.name.text === 'AbortSignal') || (ts.isElementAccessExpression(expression) && isNamedReference(expression.expression, globals) && expression.argumentExpression !== undefined && staticStringValue(expression.argumentExpression) === 'AbortSignal');
+	return (
+		(ts.isIdentifier(expression) &&
+			aliases.has(expression.text) &&
+			!(
+				expression.text === 'AbortSignal' &&
+				hasShadowingBinding(file, 'AbortSignal', expression)
+			)) ||
+		(ts.isPropertyAccessExpression(expression) &&
+			isNamedReference(expression.expression, globals) &&
+			expression.name.text === 'AbortSignal') ||
+		(ts.isElementAccessExpression(expression) &&
+			isNamedReference(expression.expression, globals) &&
+			expression.argumentExpression !== undefined &&
+			staticStringValue(expression.argumentExpression) === 'AbortSignal')
+	);
 }
-function isStringReference(node: ts.Expression, aliases: ReadonlySet<string>, value: string, _mark?: () => void): boolean {
+function isStringReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+	value: string,
+	_mark?: () => void,
+): boolean {
 	const expression = unwrap(node);
-	return (ts.isIdentifier(expression) && aliases.has(expression.text)) || staticStringValue(expression) === value;
+	return (
+		(ts.isIdentifier(expression) && aliases.has(expression.text)) ||
+		staticStringValue(expression) === value
+	);
 }
-function isTimeoutKeyReference(node: ts.Expression, aliases: ReadonlySet<string>): boolean {
+function isTimeoutKeyReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+): boolean {
 	return isStringReference(node, aliases, 'timeout');
 }
-function isReflectGetReference(node: ts.Expression, reflects: ReadonlySet<string>): boolean {
+function isReflectGetReference(
+	node: ts.Expression,
+	reflects: ReadonlySet<string>,
+): boolean {
 	const expression = unwrap(node);
-	return (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.expression) && reflects.has(expression.expression.text) && expression.name.text === 'get') || (ts.isElementAccessExpression(expression) && ts.isIdentifier(expression.expression) && reflects.has(expression.expression.text) && expression.argumentExpression !== undefined && staticStringValue(expression.argumentExpression) === 'get');
+	return (
+		(ts.isPropertyAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			reflects.has(expression.expression.text) &&
+			expression.name.text === 'get') ||
+		(ts.isElementAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			reflects.has(expression.expression.text) &&
+			expression.argumentExpression !== undefined &&
+			staticStringValue(expression.argumentExpression) === 'get')
+	);
 }
-function propertyNameText(name: ts.PropertyName | undefined): string | undefined {
+function propertyNameText(
+	name: ts.PropertyName | undefined,
+): string | undefined {
 	if (!name) return undefined;
 	if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
-	return ts.isComputedPropertyName(name) ? staticStringValue(name.expression) : undefined;
+	return ts.isComputedPropertyName(name)
+		? staticStringValue(name.expression)
+		: undefined;
 }
-function collectBindingAliases(pattern: ts.ObjectBindingPattern, property: string, aliases: Set<string>, mark: () => void): void {
+function collectBindingAliases(
+	pattern: ts.ObjectBindingPattern,
+	property: string,
+	aliases: Set<string>,
+	mark: () => void,
+): void {
 	for (const element of pattern.elements) {
-		if (propertyNameText(element.propertyName ?? element.name) === property && ts.isIdentifier(element.name)) addAlias(aliases, element.name.text, true, mark);
-		if (ts.isObjectBindingPattern(element.name)) collectBindingAliases(element.name, property, aliases, mark);
+		if (
+			propertyNameText(element.propertyName ?? element.name) === property &&
+			ts.isIdentifier(element.name)
+		)
+			addAlias(aliases, element.name.text, true, mark);
+		if (ts.isObjectBindingPattern(element.name))
+			collectBindingAliases(element.name, property, aliases, mark);
 	}
 }
-function collectObjectAssignmentAliases(object: ts.ObjectLiteralExpression, property: string, aliases: Set<string>, mark: () => void): void {
+function collectObjectAssignmentAliases(
+	object: ts.ObjectLiteralExpression,
+	property: string,
+	aliases: Set<string>,
+	mark: () => void,
+): void {
 	for (const entry of object.properties) {
 		if (propertyNameText(entry.name) !== property) continue;
-		const target = ts.isPropertyAssignment(entry) ? entry.initializer : ts.isShorthandPropertyAssignment(entry) ? entry.name : undefined;
-		if (target && ts.isIdentifier(target)) addAlias(aliases, target.text, true, mark);
+		const target = ts.isPropertyAssignment(entry)
+			? entry.initializer
+			: ts.isShorthandPropertyAssignment(entry)
+				? entry.name
+				: undefined;
+		if (target && ts.isIdentifier(target))
+			addAlias(aliases, target.text, true, mark);
 	}
 }
 function countTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
-	return pattern.elements.reduce((count, element) => count + (propertyNameText(element.propertyName ?? element.name) === 'timeout' ? 1 : 0) + (ts.isObjectBindingPattern(element.name) ? countTimeoutBindings(element.name) : 0), 0);
+	return pattern.elements.reduce(
+		(count, element) =>
+			count +
+			(propertyNameText(element.propertyName ?? element.name) === 'timeout'
+				? 1
+				: 0) +
+			(ts.isObjectBindingPattern(element.name)
+				? countTimeoutBindings(element.name)
+				: 0),
+		0,
+	);
 }
 function countNestedTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
-	return pattern.elements.reduce((count, element) => count + (propertyNameText(element.propertyName ?? element.name) === 'AbortSignal' && ts.isObjectBindingPattern(element.name) ? countTimeoutBindings(element.name) : 0), 0);
+	return pattern.elements.reduce(
+		(count, element) =>
+			count +
+			(propertyNameText(element.propertyName ?? element.name) ===
+				'AbortSignal' && ts.isObjectBindingPattern(element.name)
+				? countTimeoutBindings(element.name)
+				: 0),
+		0,
+	);
 }
 function countTimeoutProperties(object: ts.ObjectLiteralExpression): number {
-	return object.properties.filter((property) => propertyNameText(property.name) === 'timeout').length;
+	return object.properties.filter(
+		(property) => propertyNameText(property.name) === 'timeout',
+	).length;
 }
-function countNestedTimeoutObjectProperties(object: ts.ObjectLiteralExpression): number {
-	return object.properties.reduce((count, property) => count + (propertyNameText(property.name) === 'AbortSignal' && ts.isPropertyAssignment(property) && ts.isObjectLiteralExpression(property.initializer) ? countTimeoutProperties(property.initializer) : 0), 0);
+function countNestedTimeoutObjectProperties(
+	object: ts.ObjectLiteralExpression,
+): number {
+	return object.properties.reduce(
+		(count, property) =>
+			count +
+			(propertyNameText(property.name) === 'AbortSignal' &&
+			ts.isPropertyAssignment(property) &&
+			ts.isObjectLiteralExpression(property.initializer)
+				? countTimeoutProperties(property.initializer)
+				: 0),
+		0,
+	);
 }
 
-function importedHelperCallSites(source: string): string[] {
-	const file = ts.createSourceFile('consumer.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-	let importedName: string | undefined;
-	for (const statement of file.statements) {
-		if (ts.isImportDeclaration(statement) && statement.moduleSpecifier.getText(file).includes('utils/timeout.js') && statement.importClause?.namedBindings && ts.isNamedImports(statement.importClause.namedBindings)) {
-			const specifier = statement.importClause.namedBindings.elements.find((element) => (element.propertyName ?? element.name).text === 'withTimeoutSignal');
-			if (specifier) importedName = specifier.name.text;
-		}
-	}
-	if (!importedName || hasShadowingBinding(file, importedName)) return [];
-	const calls: string[] = [];
-	const visit = (node: ts.Node): void => {
-		if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === importedName) calls.push(enclosingCallableName(node) ?? '<top-level>');
-		ts.forEachChild(node, visit);
-	};
-	visit(file);
-	return calls;
-}
-function hasShadowingBinding(file: ts.SourceFile, name: string, target?: ts.Node): boolean {
-	let found = false;
-	const limit = target?.getStart(file) ?? Number.POSITIVE_INFINITY;
-	const visit = (node: ts.Node): void => {
-		if (found || node.getStart(file) >= limit) return;
-		if (!ts.isImportSpecifier(node) && ((ts.isVariableDeclaration(node) || ts.isParameter(node)) && bindingNameContains(node.name, name) || (ts.isCatchClause(node) && node.variableDeclaration && bindingNameContains(node.variableDeclaration.name, name)))) {
-			found = true;
-			return;
-		}
-		if ((ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isFunctionExpression(node) || ts.isClassExpression(node)) && node.name?.text === name) {
-			found = true;
-			return;
-		}
-		ts.forEachChild(node, visit);
-	};
-	visit(file);
-	return found;
-}
-function bindingNameContains(binding: ts.BindingName, name: string): boolean {
-	return ts.isIdentifier(binding) ? binding.text === name : binding.elements.some((element) => !ts.isOmittedExpression(element) && bindingNameContains(element.name, name));
-}
-function enclosingCallableName(node: ts.Node): string | undefined {
-	for (let current = node.parent; current; current = current.parent) {
-		if (ts.isFunctionDeclaration(current) && current.name) return current.name.text;
-		if ((ts.isMethodDeclaration(current) || ts.isPropertyAssignment(current) || ts.isPropertyDeclaration(current)) && (ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))) return current.name.text;
-		if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name) && current.initializer && (ts.isArrowFunction(current.initializer) || ts.isFunctionExpression(current.initializer))) return current.name.text;
-	}
-	return undefined;
-}
 function runtimeSourceFiles(): string[] {
-	return (readdirSync(SRC, { recursive: true }) as string[]).filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts') && !entry.includes(`${path.sep}__tests__${path.sep}`)).map((entry) => path.join(SRC, entry));
+	return (readdirSync(SRC, { recursive: true }) as string[])
+		.filter(
+			(entry) =>
+				entry.endsWith('.ts') &&
+				!entry.endsWith('.test.ts') &&
+				!entry.includes(`${path.sep}__tests__${path.sep}`),
+		)
+		.map((entry) => path.join(SRC, entry));
 }
 
 describe('runtime timeout source guard (#1964/#2103)', () => {
 	test('forbids runtime AbortSignal timeout construction', () => {
-		const offenders = runtimeSourceFiles().filter((file) => findNativeAbortTimeoutAccesses(readFileSync(file, 'utf8'))).map((file) => path.relative(ROOT, file));
+		const offenders = runtimeSourceFiles()
+			.filter((file) =>
+				findNativeAbortTimeoutAccesses(readFileSync(file, 'utf8')),
+			)
+			.map((file) => path.relative(ROOT, file));
 		expect(offenders).toEqual([]);
 	});
 	test('rejects equivalent native timeout access syntax (F-001, FB-006)', () => {
 		// Before F-001/FB-006, alias, nested, assignment, reflection, and computed-key forms bypassed the recurrence guard.
 		for (const source of [
-			'AbortSignal.timeout (100)', 'AbortSignal?.timeout(100)', 'AbortSignal["timeout"](100)', 'const k = "time" + "out"; AbortSignal[k](100)',
-			'const timeout = AbortSignal.timeout; timeout(100)', 'const { timeout: deadline } = AbortSignal; deadline(100)', 'const Signal = AbortSignal; Signal.timeout(100)',
-			'globalThis.AbortSignal.timeout(100)', 'globalThis["AbortSignal"].timeout(100)', 'const { AbortSignal: Signal } = globalThis; Signal.timeout(100)',
-			'({ AbortSignal: Signal } = globalThis); Signal.timeout(100)', 'const { AbortSignal: { timeout: deadline } } = globalThis; deadline(100)',
-			'let Signal: typeof AbortSignal; Signal = AbortSignal; Signal.timeout(100)', 'Reflect.get(AbortSignal, "timeout")(100)', 'const R = Reflect; R.get(AbortSignal, "timeout")(100)',
-			'const get = Reflect.get; get(AbortSignal, "timeout")(100)', 'const { get } = Reflect; get(AbortSignal, "timeout")(100)', '({ timeout } = AbortSignal)',
-			'function f({ timeout } = AbortSignal) {}', 'const { ["timeout"]: deadline } = AbortSignal',
-		]) expect(findNativeAbortTimeoutAccesses(source), source).toBeGreaterThan(0);
-		expect(findNativeAbortTimeoutAccesses('withTimeoutSignal(async () => "ok", 100, new Error("late"))')).toBe(0);
+			'AbortSignal.timeout (100)',
+			'AbortSignal?.timeout(100)',
+			'AbortSignal["timeout"](100)',
+			'const k = "time" + "out"; AbortSignal[k](100)',
+			'const timeout = AbortSignal.timeout; timeout(100)',
+			'const { timeout: deadline } = AbortSignal; deadline(100)',
+			'const Signal = AbortSignal; Signal.timeout(100)',
+			'globalThis.AbortSignal.timeout(100)',
+			'globalThis["AbortSignal"].timeout(100)',
+			'const { AbortSignal: Signal } = globalThis; Signal.timeout(100)',
+			'({ AbortSignal: Signal } = globalThis); Signal.timeout(100)',
+			'const { AbortSignal: { timeout: deadline } } = globalThis; deadline(100)',
+			'let Signal: typeof AbortSignal; Signal = AbortSignal; Signal.timeout(100)',
+			'Reflect.get(AbortSignal, "timeout")(100)',
+			'const R = Reflect; R.get(AbortSignal, "timeout")(100)',
+			'const get = Reflect.get; get(AbortSignal, "timeout")(100)',
+			'const { get } = Reflect; get(AbortSignal, "timeout")(100)',
+			'({ timeout } = AbortSignal)',
+			'function f({ timeout } = AbortSignal) {}',
+			'const { ["timeout"]: deadline } = AbortSignal',
+		])
+			expect(findNativeAbortTimeoutAccesses(source), source).toBeGreaterThan(0);
+		expect(
+			findNativeAbortTimeoutAccesses(
+				'withTimeoutSignal(async () => "ok", 100, new Error("late"))',
+			),
+		).toBe(0);
 	});
-	test('rejects helper calls shadowed away from the shared import (F-003)', () => {
-		for (const declaration of [
-			'function screenCandidate(withTimeoutSignal: () => void) { withTimeoutSignal(); }', 'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
-			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }', 'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
-			'function screenCandidate() { try {} catch (withTimeoutSignal) { withTimeoutSignal(); } }', 'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
-		]) {
-			expect(importedHelperCallSites(`import { withTimeoutSignal } from '../../utils/timeout.js'; ${declaration}`)).toEqual([]);
-		}
-	});
-	test('keeps shadowed native names and class-field callables safe (F-002, FB-005)', () => {
+	test('keeps shadowed native names safe (F-002)', () => {
 		// Before F-002, a local AbortSignal binding was mistaken for the global object.
-		expect(findNativeAbortTimeoutAccesses('function f(AbortSignal: { timeout: (ms: number) => void }) { AbortSignal.timeout(100); }')).toBe(0);
-		// Before FB-005, class-field arrows were reported as <top-level>.
-		expect(importedHelperCallSites('import { withTimeoutSignal } from "../../utils/timeout.js"; class C { run = () => withTimeoutSignal(); }')).toEqual(['run']);
-	});
-	test('keeps every reported consumer calling the shared cancellable helper', () => {
-		for (const relative of REQUIRED_CONSUMERS) expect(importedHelperCallSites(readFileSync(path.join(ROOT, relative), 'utf8'))).toEqual(EXPECTED_CALL_SITES.get(relative));
+		expect(
+			findNativeAbortTimeoutAccesses(
+				'function f(AbortSignal: { timeout: (ms: number) => void }) { AbortSignal.timeout(100); }',
+			),
+		).toBe(0);
 	});
 });

--- a/tests/unit/build/runtime-timeout-source-guard.test.ts
+++ b/tests/unit/build/runtime-timeout-source-guard.test.ts
@@ -1,16 +1,368 @@
 import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import ts from 'typescript';
 
 const ROOT = path.resolve(import.meta.dir, '../../..');
 const SRC = path.join(ROOT, 'src');
 
 const REQUIRED_CONSUMERS = [
+	'src/learning/admission.ts',
 	'src/hooks/micro-reflector.ts',
 	'src/hooks/knowledge-curator.ts',
 	'src/services/skill-generator.ts',
 	'src/tools/external-skill-discover.ts',
 ] as const;
+
+const EXPECTED_CALL_SITES = new Map<string, readonly string[]>([
+	['src/learning/admission.ts', ['screenCandidate']],
+	['src/hooks/micro-reflector.ts', ['runMicroReflection']],
+	[
+		'src/hooks/knowledge-curator.ts',
+		['enrichLessonsToV3Batched', 'enrichLessonToV3'],
+	],
+	['src/services/skill-generator.ts', ['autoApplyProposals']],
+	['src/tools/external-skill-discover.ts', ['fetchContent']],
+]);
+
+function findNativeAbortTimeoutAccesses(source: string): number {
+	const sourceFile = ts.createSourceFile(
+		'candidate.ts',
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	const signalAliases = new Set(['AbortSignal']);
+	const globalAliases = new Set(['globalThis']);
+	const reflectGetAliases = new Set<string>();
+	let changed = true;
+	while (changed) {
+		changed = false;
+		const collectAliases = (node: ts.Node): void => {
+			if (
+				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+				ts.isIdentifier(node.name) &&
+				node.initializer &&
+				isNamedReference(node.initializer, globalAliases) &&
+				!globalAliases.has(node.name.text)
+			) {
+				globalAliases.add(node.name.text);
+				changed = true;
+			}
+			if (
+				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+				ts.isIdentifier(node.name) &&
+				node.initializer &&
+				isAbortSignalReference(
+					node.initializer,
+					signalAliases,
+					globalAliases,
+				) &&
+				!signalAliases.has(node.name.text)
+			) {
+				signalAliases.add(node.name.text);
+				changed = true;
+			}
+			if (
+				ts.isBinaryExpression(node) &&
+				node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+				ts.isIdentifier(node.left) &&
+				isAbortSignalReference(node.right, signalAliases, globalAliases) &&
+				!signalAliases.has(node.left.text)
+			) {
+				signalAliases.add(node.left.text);
+				changed = true;
+			}
+			if (
+				ts.isVariableDeclaration(node) &&
+				ts.isObjectBindingPattern(node.name) &&
+				node.initializer &&
+				isNamedReference(node.initializer, globalAliases)
+			) {
+				for (const element of node.name.elements) {
+					const property = element.propertyName ?? element.name;
+					if (
+						ts.isIdentifier(property) &&
+						property.text === 'AbortSignal' &&
+						ts.isIdentifier(element.name) &&
+						!signalAliases.has(element.name.text)
+					) {
+						signalAliases.add(element.name.text);
+						changed = true;
+					}
+				}
+			}
+			if (
+				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+				ts.isIdentifier(node.name) &&
+				node.initializer &&
+				isReflectGetReference(node.initializer) &&
+				!reflectGetAliases.has(node.name.text)
+			) {
+				reflectGetAliases.add(node.name.text);
+				changed = true;
+			}
+			if (
+				(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+				ts.isObjectBindingPattern(node.name) &&
+				node.initializer &&
+				isNamedReference(node.initializer, new Set(['Reflect']))
+			) {
+				for (const element of node.name.elements) {
+					if (
+						propertyNameText(element.propertyName ?? element.name) === 'get' &&
+						ts.isIdentifier(element.name) &&
+						!reflectGetAliases.has(element.name.text)
+					) {
+						reflectGetAliases.add(element.name.text);
+						changed = true;
+					}
+				}
+			}
+			ts.forEachChild(node, collectAliases);
+		};
+		collectAliases(sourceFile);
+	}
+
+	let accesses = 0;
+	const visit = (node: ts.Node): void => {
+		if (
+			(ts.isPropertyAccessExpression(node) &&
+				node.name.text === 'timeout' &&
+				isAbortSignalReference(
+					node.expression,
+					signalAliases,
+					globalAliases,
+				)) ||
+			(ts.isElementAccessExpression(node) &&
+				node.argumentExpression !== undefined &&
+				ts.isStringLiteralLike(node.argumentExpression) &&
+				node.argumentExpression.text === 'timeout' &&
+				isAbortSignalReference(node.expression, signalAliases, globalAliases))
+		) {
+			accesses += 1;
+		}
+		if (
+			ts.isCallExpression(node) &&
+			(isReflectGetReference(node.expression) ||
+				(ts.isIdentifier(node.expression) &&
+					reflectGetAliases.has(node.expression.text))) &&
+			node.arguments.length >= 2 &&
+			isAbortSignalReference(node.arguments[0], signalAliases, globalAliases) &&
+			ts.isStringLiteralLike(node.arguments[1]) &&
+			node.arguments[1].text === 'timeout'
+		) {
+			accesses += 1;
+		}
+		if (
+			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+			ts.isObjectBindingPattern(node.name) &&
+			node.initializer &&
+			isAbortSignalReference(node.initializer, signalAliases, globalAliases)
+		) {
+			accesses += countTimeoutBindings(node.name);
+		}
+		if (
+			ts.isBinaryExpression(node) &&
+			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			ts.isObjectLiteralExpression(node.left) &&
+			isAbortSignalReference(node.right, signalAliases, globalAliases)
+		) {
+			accesses += node.left.properties.filter(
+				(property) => propertyNameText(property.name) === 'timeout',
+			).length;
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return accesses;
+}
+
+function isAbortSignalReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+	globalAliases: ReadonlySet<string>,
+): boolean {
+	const expression = unwrapExpression(node);
+	return (
+		(ts.isIdentifier(expression) && aliases.has(expression.text)) ||
+		(ts.isPropertyAccessExpression(expression) &&
+			isNamedReference(expression.expression, globalAliases) &&
+			expression.name.text === 'AbortSignal') ||
+		(ts.isElementAccessExpression(expression) &&
+			isNamedReference(expression.expression, globalAliases) &&
+			expression.argumentExpression !== undefined &&
+			ts.isStringLiteralLike(expression.argumentExpression) &&
+			expression.argumentExpression.text === 'AbortSignal')
+	);
+}
+
+function unwrapExpression(node: ts.Expression): ts.Expression {
+	let current = node;
+	while (
+		ts.isParenthesizedExpression(current) ||
+		ts.isAsExpression(current) ||
+		ts.isTypeAssertionExpression(current) ||
+		ts.isNonNullExpression(current) ||
+		ts.isSatisfiesExpression(current)
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function isNamedReference(
+	node: ts.Expression,
+	aliases: ReadonlySet<string>,
+): boolean {
+	const expression = unwrapExpression(node);
+	return ts.isIdentifier(expression) && aliases.has(expression.text);
+}
+
+function isReflectGetReference(node: ts.Expression): boolean {
+	const expression = unwrapExpression(node);
+	return (
+		(ts.isPropertyAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			expression.expression.text === 'Reflect' &&
+			expression.name.text === 'get') ||
+		(ts.isElementAccessExpression(expression) &&
+			ts.isIdentifier(expression.expression) &&
+			expression.expression.text === 'Reflect' &&
+			expression.argumentExpression !== undefined &&
+			ts.isStringLiteralLike(expression.argumentExpression) &&
+			expression.argumentExpression.text === 'get')
+	);
+}
+
+function propertyNameText(
+	name: ts.PropertyName | undefined,
+): string | undefined {
+	if (!name) return undefined;
+	if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+	if (
+		ts.isComputedPropertyName(name) &&
+		ts.isStringLiteralLike(name.expression)
+	) {
+		return name.expression.text;
+	}
+	return undefined;
+}
+
+function countTimeoutBindings(pattern: ts.ObjectBindingPattern): number {
+	return pattern.elements.filter(
+		(element) =>
+			propertyNameText(element.propertyName ?? element.name) === 'timeout',
+	).length;
+}
+
+function importedHelperCallSites(source: string): string[] {
+	const sourceFile = ts.createSourceFile(
+		'consumer.ts',
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	let importedName: string | undefined;
+	for (const statement of sourceFile.statements) {
+		if (
+			ts.isImportDeclaration(statement) &&
+			statement.moduleSpecifier
+				.getText(sourceFile)
+				.includes('utils/timeout.js') &&
+			statement.importClause?.namedBindings !== undefined &&
+			ts.isNamedImports(statement.importClause.namedBindings)
+		) {
+			const specifier = statement.importClause.namedBindings.elements.find(
+				(element) =>
+					(element.propertyName ?? element.name).text === 'withTimeoutSignal',
+			);
+			if (specifier) importedName = specifier.name.text;
+		}
+	}
+	if (!importedName || hasShadowingBinding(sourceFile, importedName)) return [];
+	const callSites: string[] = [];
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			node.expression.text === importedName
+		) {
+			callSites.push(enclosingCallableName(node) ?? '<top-level>');
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return callSites;
+}
+
+function hasShadowingBinding(sourceFile: ts.SourceFile, name: string): boolean {
+	let shadowed = false;
+	const visit = (node: ts.Node): void => {
+		if (shadowed) return;
+		if (
+			!ts.isImportSpecifier(node) &&
+			(ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+			node.name !== undefined &&
+			bindingNameContains(node.name, name)
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			(ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+			node.name?.text === name
+		) {
+			shadowed = true;
+			return;
+		}
+		if (
+			(ts.isFunctionExpression(node) || ts.isClassExpression(node)) &&
+			node.name?.text === name
+		) {
+			shadowed = true;
+			return;
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return shadowed;
+}
+
+function bindingNameContains(binding: ts.BindingName, name: string): boolean {
+	if (ts.isIdentifier(binding)) return binding.text === name;
+	return binding.elements.some(
+		(element) =>
+			!ts.isOmittedExpression(element) &&
+			bindingNameContains(element.name, name),
+	);
+}
+
+function enclosingCallableName(node: ts.Node): string | undefined {
+	for (let current = node.parent; current; current = current.parent) {
+		if (ts.isFunctionDeclaration(current) && current.name) {
+			return current.name.text;
+		}
+		if (
+			(ts.isMethodDeclaration(current) || ts.isPropertyAssignment(current)) &&
+			(ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))
+		) {
+			return current.name.text;
+		}
+		if (
+			ts.isVariableDeclaration(current) &&
+			ts.isIdentifier(current.name) &&
+			current.initializer &&
+			(ts.isArrowFunction(current.initializer) ||
+				ts.isFunctionExpression(current.initializer))
+		) {
+			return current.name.text;
+		}
+	}
+	return undefined;
+}
 
 function runtimeSourceFiles(): string[] {
 	return (readdirSync(SRC, { recursive: true }) as string[])
@@ -24,16 +376,70 @@ describe('runtime timeout source guard (#1964/#2103)', () => {
 	test('forbids runtime AbortSignal timeout construction', () => {
 		const offenders = runtimeSourceFiles()
 			.filter((file) =>
-				readFileSync(file, 'utf8').includes('AbortSignal.timeout('),
+				findNativeAbortTimeoutAccesses(readFileSync(file, 'utf8')),
 			)
 			.map((file) => path.relative(ROOT, file));
 		expect(offenders).toEqual([]);
 	});
 
-	test('keeps every reported consumer on the shared cancellable helper', () => {
+	test('rejects equivalent native timeout access syntax (review F1)', () => {
+		// Previous guard used one exact substring, so harmless formatting and
+		// property-access variants silently bypassed the recurrence machinery.
+		for (const source of [
+			'AbortSignal.timeout (100)',
+			'AbortSignal?.timeout(100)',
+			'AbortSignal["timeout"](100)',
+			'const timeout = AbortSignal.timeout; timeout(100)',
+			'const { timeout } = AbortSignal; timeout(100)',
+			'const { timeout: deadline } = AbortSignal; deadline(100)',
+			'const Signal = AbortSignal; Signal.timeout(100)',
+			'globalThis.AbortSignal.timeout(100)',
+			'((AbortSignal)).timeout(100)',
+			'(AbortSignal as typeof AbortSignal).timeout(100)',
+			'AbortSignal!.timeout(100)',
+			'globalThis["AbortSignal"].timeout(100)',
+			'const { AbortSignal: Signal } = globalThis; Signal.timeout(100)',
+			'let Signal: typeof AbortSignal; Signal = AbortSignal; Signal.timeout(100)',
+			'function f(Signal = AbortSignal) { Signal.timeout(100); }',
+			'Reflect.get(AbortSignal, "timeout")(100)',
+			'({ timeout } = AbortSignal)',
+			'function f({ timeout } = AbortSignal) {}',
+			'const { ["timeout"]: deadline } = AbortSignal',
+			'const root = globalThis; root.AbortSignal.timeout(100)',
+			'const get = Reflect.get; get(AbortSignal, "timeout")(100)',
+			'const { get } = Reflect; get(AbortSignal, "timeout")(100)',
+		]) {
+			expect(findNativeAbortTimeoutAccesses(source)).toBeGreaterThan(0);
+		}
+		expect(
+			findNativeAbortTimeoutAccesses(
+				'withTimeoutSignal(async () => "ok", 100, new Error("late"))',
+			),
+		).toBe(0);
+	});
+
+	test('rejects helper calls shadowed away from the shared import', () => {
+		for (const declaration of [
+			'function screenCandidate(withTimeoutSignal: () => void) { withTimeoutSignal(); }',
+			'function screenCandidate({ withTimeoutSignal }) { withTimeoutSignal(); }',
+			'function screenCandidate(...[withTimeoutSignal]) { withTimeoutSignal(); }',
+			'function screenCandidate() { const { withTimeoutSignal } = deps; withTimeoutSignal(); }',
+			'const screenCandidate = function withTimeoutSignal() { withTimeoutSignal(); }',
+		]) {
+			const source = `
+				import { withTimeoutSignal } from '../../utils/timeout.js';
+				${declaration}
+			`;
+			expect(importedHelperCallSites(source)).toEqual([]);
+		}
+	});
+
+	test('keeps every reported consumer calling the shared cancellable helper', () => {
 		for (const relative of REQUIRED_CONSUMERS) {
 			const source = readFileSync(path.join(ROOT, relative), 'utf8');
-			expect(source).toContain('withTimeoutSignal');
+			expect(importedHelperCallSites(source)).toEqual(
+				EXPECTED_CALL_SITES.get(relative),
+			);
 		}
 	});
 });


### PR DESCRIPTION
Closes #1964

## Summary

- validate the reported regression against the current tree and confirm the production `AbortSignal.timeout()` migration was already fixed by PR #2335; scope this PR to the reopened recurrence-guard gap only
- replace the exact-text guard with a TypeScript AST guard that blocks native timeout construction through aliases, bracket access, reflection, nested destructuring, assignment patterns, and static computed string keys
- prove every required runtime consumer calls the shared `withTimeoutSignal` import from the correct enclosing callable, reject local shadowing including catch bindings, and add the previously omitted `src/mutation/generator.ts` consumer coverage
- update the learning-admission source comment to describe the shared helper accurately, split the guard suite into focused sub-500-line test files, and keep the required pending release fragment

## Invariant audit

- 1 (plugin init): not touched — no initialization-path runtime code changed
- 2 (runtime portability): not touched — runtime implementation is unchanged; `bun run build` and `node --input-type=module -e "await import('./dist/index.js')"` passed on `3c57030ebc79f2d3974fc798dfd00aa120b6fb3e`
- 3 (subprocesses): not touched — no subprocess code changed
- 4 (.swarm containment): not touched — no runtime-state path changed
- 5 (plan durability): not touched — no plan schema, ledger, or projection code changed
- 6 (test_runner safety): not touched — validation used focused shell commands, not broad `test_runner` scope
- 7 (test writing): touched — loaded the writing-tests skill; new suites stay under the FR-006 cap; `bun --smol test tests/unit/build/runtime-timeout-source-guard.test.ts tests/unit/build/runtime-timeout-consumer-callsites.test.ts --timeout 60000` passed 6/6 with 36 `expect()` calls, and `bun run check:test-file-cap` passed
- 8 (session state): not touched — no module/session state changed
- 9 (guardrails/retry): not touched — runtime timeout semantics are unchanged; `bun test src/utils/__tests__/timeout.test.ts` passed 8/8 with 18 `expect()` calls
- 10 (chat/system msg): not touched — no chat hook code changed
- 11 (tool registration): not touched — no tools, maps, commands, or help surfaces changed
- 12 (release/cache): touched — `docs/releases/pending/1964-abort-timeout-guardrail-hardening.md` is present and `bun run check:pending-fragment` passed

## Test plan

- `bun --smol test tests/unit/build/runtime-timeout-source-guard.test.ts tests/unit/build/runtime-timeout-consumer-callsites.test.ts --timeout 60000` — pass (6 tests, 36 `expect()` calls)
- `bun test src/utils/__tests__/timeout.test.ts` — pass (8 tests, 18 `expect()` calls)
- `bun run typecheck` — pass
- `bunx biome ci .` — pass; one pre-existing unused-function warning remains in `src/health/learning-health.ts`
- `bun run check:test-file-cap` — pass
- `bun run check:pending-fragment` — pass
- `bun run build` — pass
- `node --input-type=module -e "await import('./dist/index.js')"` — pass
- `git diff --check origin/main...HEAD` — pass

## Acceptance Criteria → Evidence

- every reopened issue consumer stays wired to the shared cancellable helper — `tests/unit/build/runtime-timeout-consumer-callsites.test.ts` verifies `screenCandidate`, `runMicroReflection`, both curator enrichment callsites, `autoApplyProposals`, `fetchContent`, and `dispatch`
- native timeout recurrence is blocked across realistic static TypeScript forms — `tests/unit/build/runtime-timeout-source-guard.test.ts` covers aliases, object/assignment destructuring, nested rebinding, `Reflect.get`, bracket access, and folded constant keys
- helper-call attribution cannot be faked through local shadowing — the consumer matrix rejects local `withTimeoutSignal` shadowing and catch-binding rebinding, while the source guard rejects local `AbortSignal` shadowing
- timeout semantics remain bounded and cancellable — `src/utils/__tests__/timeout.test.ts` proves timeout rejection, abort propagation, invalid-bound rejection, and timer cleanup
- user-visible documentation and release hygiene stay accurate — the `src/learning/admission.ts` comment now references the shared helper, and the pending release fragment is present

## Waivers

None.

## Review evidence

- base branch tip validated before merge work: `53cb39ce8e6426d8ee6eac42d7037bb6029465b1`
- reviewed commit: `3c57030ebc79f2d3974fc798dfd00aa120b6fb3e`
- reproducible diff hash: `5c2c3c9348c3bb9c644f2cdd579bbed0caa4a26d`
- live GitHub review state at update time: no inline review comments, no review objects, and only CI remained blocking
- local closeout validation on current head: focused guard suites, timeout helper suite, typecheck, Biome CI, build, Node ESM import, pending fragment, file-cap, and diff-check all passed
