### PR TITLE
feat(memory): add durable related memory links

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -423,7 +423,9 @@ If proposal text contains a likely secret, Swarm stores the proposal only with t
 
 Agents may also return an optional JSON `memoryProposals` array in Task output. The controller validates those proposals through `MemoryGateway.propose`; invalid proposals are logged and dropped without crashing the run. This path still creates pending proposals only.
 
-Curator agents may return an optional JSON `curatorMemoryDecisions` array in Task output. The controller accepts that key only from curator roles, schema-validates each decision, and applies it through `MemoryGateway.applyCuratorDecision`. Supported decisions are `add`, `update`, `supersede`, `reject`, and `noop`.
+Curator agents may return an optional JSON `curatorMemoryDecisions` array in Task output. The controller accepts that key only from curator roles, schema-validates each decision, and applies it through `MemoryGateway.applyCuratorDecision`. Supported decisions are `add`, `update`, `merge`, `supersede`, `reject`, and `noop`.
+
+A `merge` is non-destructive: it approves a proposal containing 2-8 distinct, active memory IDs from the same scope and records a durable `merged_with` relationship. The relationship is reconstructed from the applied proposal ledger after JSONL or SQLite reload; callers cannot forge it through memory create or patch inputs. Recall keeps ordinary relevance ordering, then may use otherwise-unused result slots for at most two active related memories per direct result. Related items carry their source memory ID and relation type in both structured output and the injected prompt, while missing, deleted, expired, superseded, out-of-scope, low-quality, and over-budget candidates remain excluded.
 
 In SQLite, decision application is transactional: Swarm loads the pending proposal, validates the decision and resulting memory record, applies the memory change, updates proposal status, and appends a `curator_decision` event in one transaction. Superseded memories are marked with `supersededBy` and stop appearing in recall.
 

--- a/docs/releases/pending/1603-related-memory-links.md
+++ b/docs/releases/pending/1603-related-memory-links.md
@@ -2,4 +2,16 @@
 type: Added
 ---
 
+## What changed
+
 - Add durable, bounded `merged_with` links between curator-approved memories, including JSONL and SQLite reload support and explicit recall provenance.
+- Centralize the participant and relation-degree limits and enforce the same bounds in proposal schemas, gateway validation, and SQLite projection.
+
+## Migration notes
+
+- Existing SQLite stores rebuild `memory_relations` from applied merge proposals when opened; invalid stored merges remain preserved as proposals but are skipped during materialization with bounded diagnostics.
+- Legacy JSONL imports reconstruct links from applied proposals. Existing rows that no longer satisfy the stricter relation schema are skipped and reported with sampled row diagnostics.
+
+## Known caveats
+
+- Relations are provider-derived and never written into canonical memory rows. Recall expansion is one hop from direct results and adds at most two related memories per source, subject to the overall recall limit.

--- a/docs/releases/pending/1603-related-memory-links.md
+++ b/docs/releases/pending/1603-related-memory-links.md
@@ -1,0 +1,5 @@
+---
+type: Added
+---
+
+- Add durable, bounded `merged_with` links between curator-approved memories, including JSONL and SQLite reload support and explicit recall provenance.

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -2294,7 +2294,7 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		pathGrammar: '.swarm/memory/{memories,proposals,audit,reward-events,outcome-events}.jsonl (+ cohort roots)',
 		canonicalRoot: 'project-swarm',
 		writerModules: ['src/memory/local-jsonl-provider.ts'],
-		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :290 appendOutcome / :540 applyCuratorDecision / :817 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1179) + atomic rewrites (:1166-1177)'],
+		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :300 appendOutcome / :567 applyCuratorDecision / :872 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1234) + atomic rewrites (:1221-1232)'],
 		readerCitations: ['initialize/refreshMemoriesUnlocked (:158-205) — full-file loads; listRecallUsage/listRewardEvents — full-file filtered'],
 		schemaVersion: 'legacy provider (migration source for SQLite)',
 		stateClass: 'derived-rebuildable',

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -2294,7 +2294,7 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		pathGrammar: '.swarm/memory/{memories,proposals,audit,reward-events,outcome-events}.jsonl (+ cohort roots)',
 		canonicalRoot: 'project-swarm',
 		writerModules: ['src/memory/local-jsonl-provider.ts'],
-		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :300 appendOutcome / :567 applyCuratorDecision / :872 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1234) + atomic rewrites (:1221-1232)'],
+		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :308 appendOutcome / :575 applyCuratorDecision / :904 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1234) + atomic rewrites (:1221-1232)'],
 		readerCitations: ['initialize/refreshMemoriesUnlocked (:158-205) — full-file loads; listRecallUsage/listRewardEvents — full-file filtered'],
 		schemaVersion: 'legacy provider (migration source for SQLite)',
 		stateClass: 'derived-rebuildable',

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -2294,7 +2294,7 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		pathGrammar: '.swarm/memory/{memories,proposals,audit,reward-events,outcome-events}.jsonl (+ cohort roots)',
 		canonicalRoot: 'project-swarm',
 		writerModules: ['src/memory/local-jsonl-provider.ts'],
-		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :308 appendOutcome / :575 applyCuratorDecision / :904 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1234) + atomic rewrites (:1221-1232)'],
+		writerCitations: ['src/memory/local-jsonl-provider.ts:207 upsert / :308 appendOutcome / :575 applyCuratorDecision / :910 rewriteMemoryFamilyUnlocked — dir lock + torn-tail repair (:1234) + atomic rewrites (:1221-1232)'],
 		readerCitations: ['initialize/refreshMemoriesUnlocked (:158-205) — full-file loads; listRecallUsage/listRewardEvents — full-file filtered'],
 		schemaVersion: 'legacy provider (migration source for SQLite)',
 		stateClass: 'derived-rebuildable',

--- a/src/db/sqlite-loader.test.ts
+++ b/src/db/sqlite-loader.test.ts
@@ -230,6 +230,21 @@ describe('createNodeDatabaseCtor — adapter translation', () => {
 		expect(calls.stmtIterate).toEqual([{ sql, params: ['c'] }]);
 	});
 
+	test('prepare(sql) creates an uncached short-lived statement', () => {
+		const { FakeDatabaseSync, calls } = makeFake();
+		const db = new (createNodeDatabaseCtor(FakeDatabaseSync))(
+			':x:',
+		) as unknown as AdapterDb;
+		const sql = 'SELECT * FROM t WHERE id = ?';
+		const first = db.prepare(sql);
+		expect(first.all('a')).toEqual([{ sql, op: 'all' }]);
+		first.finalize();
+		const second = db.prepare(sql);
+		expect(second.get('b')).toEqual({ sql, op: 'get' });
+		second.finalize();
+		expect(calls.prepared.filter((s) => s === sql)).toHaveLength(2);
+	});
+
 	test('transaction(fn) wraps BEGIN/COMMIT and returns the callback value', () => {
 		const { FakeDatabaseSync, calls } = makeFake();
 		const db = new (createNodeDatabaseCtor(FakeDatabaseSync))(

--- a/src/db/sqlite-loader.ts
+++ b/src/db/sqlite-loader.ts
@@ -21,6 +21,7 @@
  *      behind `--experimental-sqlite` in 22.5; shipped by Electron 42+) in a small
  *      adapter that presents the exact `Database` subset the
  *      codebase uses — `run(sql, params?)`, `query(sql).{get,all,iterate}`,
+ *      `prepare(sql).{get,all,iterate,finalize}`,
  *      `transaction(fn)`, `inTransaction`, `loadExtension(path)`, `close()`. A bare
  *      constructor swap is NOT enough: `DatabaseSync` has none of
  *      `run/query/transaction/inTransaction`.
@@ -133,6 +134,25 @@ export function createNodeDatabaseCtor(
 				get: (...params: unknown[]) => stmt.get(...params),
 				all: (...params: unknown[]) => stmt.all(...params),
 				iterate: (...params: unknown[]) => stmt.iterate(...params),
+			};
+		}
+
+		prepare(sql: string): {
+			get(...params: unknown[]): unknown;
+			all(...params: unknown[]): unknown[];
+			iterate(...params: unknown[]): IterableIterator<unknown>;
+			finalize(): void;
+		} {
+			// Unlike query(), prepare() is intentionally uncached. Callers use it for
+			// short-lived statements whose native resources must be released explicitly
+			// under Bun. node:sqlite owns statements at the DatabaseSync level and releases
+			// them on close(), so finalize is a portable no-op on this adapter.
+			const stmt = this.raw.prepare(sql);
+			return {
+				get: (...params: unknown[]) => stmt.get(...params),
+				all: (...params: unknown[]) => stmt.all(...params),
+				iterate: (...params: unknown[]) => stmt.iterate(...params),
+				finalize: () => {},
 			};
 		}
 

--- a/src/memory/curator-decision-helpers.ts
+++ b/src/memory/curator-decision-helpers.ts
@@ -1,5 +1,6 @@
 import { DURABLE_MEMORY_KINDS } from './config';
 import { MemoryValidationError } from './errors';
+import { canonicalMemoryIds } from './relations';
 import {
 	computeMemoryContentHash,
 	createMemoryId,
@@ -23,7 +24,8 @@ export function validateDecisionMatchesProposal(
 	if (
 		(decision.action === 'add' && proposal.operation !== 'add') ||
 		(decision.action === 'update' && proposal.operation !== 'update') ||
-		(decision.action === 'supersede' && proposal.operation !== 'supersede')
+		(decision.action === 'supersede' && proposal.operation !== 'supersede') ||
+		(decision.action === 'merge' && proposal.operation !== 'merge')
 	) {
 		throw new MemoryValidationError(
 			`curator ${decision.action} decision does not match ${proposal.operation} proposal`,
@@ -45,6 +47,15 @@ export function validateDecisionMatchesProposal(
 	) {
 		throw new MemoryValidationError(
 			'curator supersede decision target does not match proposal target',
+		);
+	}
+	if (
+		decision.action === 'merge' &&
+		canonicalMemoryIds(proposal.relatedMemoryIds ?? []).join('\0') !==
+			canonicalMemoryIds(decision.relatedMemoryIds).join('\0')
+	) {
+		throw new MemoryValidationError(
+			'curator merge decision related memories do not match proposal',
 		);
 	}
 }
@@ -110,6 +121,7 @@ export function markProposalReviewed(
 		targetMemoryId?: string;
 		oldMemoryId?: string;
 		replacementMemoryId?: string;
+		relatedMemoryIds?: string[];
 	},
 ): MemoryProposal {
 	const reason = curatorDecisionReason(decision);
@@ -139,6 +151,7 @@ export function curatorDecisionReason(
 			return undefined;
 		case 'update':
 		case 'supersede':
+		case 'merge':
 		case 'reject':
 		case 'noop':
 			return decision.reason;

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -27,6 +27,7 @@ import type {
 } from './provider';
 import { getOrCreateProviderForRoot } from './provider-pool';
 import { computeRedactionPolicyVersion, redactSecrets } from './redaction';
+import { MAX_MERGE_PARTICIPANTS } from './relation-constants';
 import { canonicalMemoryIds } from './relations';
 import {
 	computeMemoryContentHash,
@@ -378,10 +379,10 @@ export class MemoryGateway {
 		if (
 			input.operation === 'merge' &&
 			((relatedMemoryIds ?? []).length < 2 ||
-				(relatedMemoryIds ?? []).length > 8)
+				(relatedMemoryIds ?? []).length > MAX_MERGE_PARTICIPANTS)
 		) {
 			throw new MemoryValidationError(
-				'merge proposals require 2-8 distinct relatedMemoryIds',
+				`merge proposals require 2-${MAX_MERGE_PARTICIPANTS} distinct relatedMemoryIds`,
 			);
 		}
 

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -27,6 +27,7 @@ import type {
 } from './provider';
 import { getOrCreateProviderForRoot } from './provider-pool';
 import { computeRedactionPolicyVersion, redactSecrets } from './redaction';
+import { canonicalMemoryIds } from './relations';
 import {
 	computeMemoryContentHash,
 	createBundleId,
@@ -308,10 +309,17 @@ export class MemoryGateway {
 						'targetMemoryId',
 						normalizeMemoryText(input.targetMemoryId),
 					);
-		const relatedMemoryIds = input.relatedMemoryIds?.map((id) =>
-			redactProposalField('relatedMemoryIds', normalizeMemoryText(id)),
-		);
+		const relatedMemoryIds = input.relatedMemoryIds
+			? canonicalMemoryIds(
+					input.relatedMemoryIds.map((id) =>
+						redactProposalField('relatedMemoryIds', normalizeMemoryText(id)),
+					),
+				)
+			: undefined;
 		let proposalText = `${input.operation}:${targetMemoryId ?? ''}`;
+		if (input.operation === 'merge') {
+			proposalText = `merge:${(relatedMemoryIds ?? []).join(',')}`;
+		}
 		// #1466: detect-only PII summary attached to proposal metadata (never
 		// matched text) when memory.redaction.detectPii is enabled.
 		let piiSummary:
@@ -367,9 +375,13 @@ export class MemoryGateway {
 				`${input.operation} proposals require targetMemoryId`,
 			);
 		}
-		if (input.operation === 'merge' && (relatedMemoryIds ?? []).length < 2) {
+		if (
+			input.operation === 'merge' &&
+			((relatedMemoryIds ?? []).length < 2 ||
+				(relatedMemoryIds ?? []).length > 8)
+		) {
 			throw new MemoryValidationError(
-				'merge proposals require relatedMemoryIds',
+				'merge proposals require 2-8 distinct relatedMemoryIds',
 			);
 		}
 
@@ -821,6 +833,13 @@ export class MemoryGateway {
 					proposalId: decision.proposalId,
 					oldMemoryId: decision.oldMemoryId,
 					replacement: this.createRecordFromNew(decision.replacement),
+					reason: normalizeMemoryText(decision.reason),
+				};
+			case 'merge':
+				return {
+					action: 'merge' as const,
+					proposalId: decision.proposalId,
+					relatedMemoryIds: canonicalMemoryIds(decision.relatedMemoryIds),
 					reason: normalizeMemoryText(decision.reason),
 				};
 			case 'update': {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -157,6 +157,7 @@ export type {
 	MemoryPatch,
 	MemoryProposal,
 	MemoryRecord,
+	MemoryRelation,
 	MemoryScopeRef,
 	MemoryScopeType,
 	NewMemoryRecord,

--- a/src/memory/jsonl-migration.ts
+++ b/src/memory/jsonl-migration.ts
@@ -7,7 +7,11 @@ import {
 	type MemoryOutcomeEvent,
 	validateOutcomeEvent,
 } from './outcome-events';
-import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
+import {
+	parseLoadedProposal,
+	proposalLoadIssueFromValue,
+} from './proposal-load';
+import { validateMemoryRecordRules } from './schema';
 import type { MemoryProposal, MemoryRecord } from './types';
 
 export const LEGACY_JSONL_MIGRATION_VERSION = 2;
@@ -394,18 +398,17 @@ async function readProposalJsonl(
 	const invalidRows: JsonlInvalidRow[] = [];
 	for (const row of rows.rows) {
 		try {
-			const proposal = validateMemoryProposal(row.value as MemoryProposal);
-			if (proposal.proposedRecord) {
-				validateMemoryRecordRules(proposal.proposedRecord, {
-					rejectDurableSecrets: config.redaction.rejectDurableSecrets,
-				});
-			}
+			const proposal = parseLoadedProposal(
+				row.value,
+				config.redaction.rejectDurableSecrets,
+			);
 			records.push(proposal);
 		} catch (err) {
+			const issue = proposalLoadIssueFromValue(row.value, err);
 			invalidRows.push({
 				file: 'proposals.jsonl',
 				line: row.line,
-				error: err instanceof Error ? err.message : String(err),
+				error: issue.reason,
 			});
 		}
 	}

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -48,6 +48,12 @@ import {
 	classifyStoredFingerprintAlgorithmVersion,
 	computeMemoryCohortFingerprint,
 } from './redaction';
+import {
+	expandRelatedRecallItems,
+	projectMemoryRelations,
+	stripDerivedRelations,
+	validateMergeParticipants,
+} from './relations';
 import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
 import type { RecallScoringDiagnostics } from './scoring';
 import {
@@ -216,7 +222,7 @@ export class LocalJsonlMemoryProvider
 			}
 			let parsed = validateMemoryRecordRules(
 				{
-					...record,
+					...stripDerivedRelations(record),
 					createdAt: existing?.createdAt ?? record.createdAt,
 					metadata: {
 						...record.metadata,
@@ -283,7 +289,11 @@ export class LocalJsonlMemoryProvider
 		await this.initialize();
 		return this.withOutcomeStoreLock(async () => {
 			await this.refreshMemoriesUnlocked();
-			return this.memories.get(id) ?? null;
+			await this.refreshProposalsUnlocked();
+			const record = this.memories.get(id);
+			return record
+				? projectMemoryRelations([record], this.proposals.values())[0]
+				: null;
 		});
 	}
 
@@ -416,15 +426,23 @@ export class LocalJsonlMemoryProvider
 			result.items,
 			request.maxItems,
 		);
+		const expanded = expandRelatedRecallItems(
+			sliced,
+			projectMemoryRelations(
+				Array.from(this.memories.values()),
+				this.proposals.values(),
+			),
+			request,
+		);
 		return {
-			items: sliced,
+			items: expanded,
 			diagnostics: {
 				...result.diagnostics,
 				// Fix 3: derive exploredCount from what actually survived
 				// slicing, not the pre-slice diagnostics, so the count always
 				// matches an item present in the returned bundle.
-				exploredCount: sliced.some((item) => item.explored) ? 1 : 0,
-				returnedCount: sliced.length,
+				exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
+				returnedCount: expanded.length,
 			},
 		};
 	}
@@ -483,8 +501,12 @@ export class LocalJsonlMemoryProvider
 		await this.initialize();
 		await this.withOutcomeStoreLock(async () => {
 			await this.refreshMemoriesUnlocked();
+			await this.refreshProposalsUnlocked();
 		});
-		let records = Array.from(this.memories.values());
+		let records = projectMemoryRelations(
+			Array.from(this.memories.values()),
+			this.proposals.values(),
+		);
 		if (filter.scopes && filter.scopes.length > 0) {
 			records = records.filter((record) =>
 				scopeAllowed(record.scope, filter.scopes ?? []),
@@ -516,8 +538,13 @@ export class LocalJsonlMemoryProvider
 	async createProposal(proposal: MemoryProposal): Promise<MemoryProposal> {
 		await this.initialize();
 		const next = validateMemoryProposal(proposal);
-		this.proposals.set(next.id, next);
-		await appendJsonl(this.pathFor('proposals'), next);
+		await this.withOutcomeStoreLock(async () => {
+			await this.refreshProposalsUnlocked();
+			const filePath = this.pathFor('proposals');
+			await repairIncompleteJsonlTail(filePath);
+			await appendJsonl(filePath, next);
+			this.proposals.set(next.id, next);
+		});
 		await this.audit('proposal', next.id);
 		this.bumpCohortGeneration();
 		return next;
@@ -629,6 +656,16 @@ export class LocalJsonlMemoryProvider
 			oldMemoryId = oldMemory.id;
 			replacementMemoryId = replacement.id;
 			memoryId = replacement.id;
+		} else if (decision.action === 'merge') {
+			decision = {
+				...decision,
+				relatedMemoryIds: validateMergeParticipants(
+					decision.relatedMemoryIds,
+					this.memories.values(),
+					this.proposals.values(),
+					new Date(appliedAt),
+				),
+			};
 		}
 
 		const proposalStatus =
@@ -638,10 +675,19 @@ export class LocalJsonlMemoryProvider
 			decision,
 			proposalStatus,
 			appliedAt,
-			{ memoryId, targetMemoryId, oldMemoryId, replacementMemoryId },
+			{
+				memoryId,
+				targetMemoryId,
+				oldMemoryId,
+				replacementMemoryId,
+				relatedMemoryIds:
+					decision.action === 'merge' ? decision.relatedMemoryIds : undefined,
+			},
 		);
+		const proposalsPath = this.pathFor('proposals');
+		await repairIncompleteJsonlTail(proposalsPath);
+		await appendJsonl(proposalsPath, reviewedProposal);
 		this.proposals.set(reviewedProposal.id, reviewedProposal);
-		await appendJsonl(this.pathFor('proposals'), reviewedProposal);
 		const change: AppliedMemoryChange = {
 			action: decision.action,
 			proposalId: decision.proposalId,
@@ -651,14 +697,22 @@ export class LocalJsonlMemoryProvider
 			targetMemoryId,
 			oldMemoryId,
 			replacementMemoryId,
+			relatedMemoryIds:
+				decision.action === 'merge' ? decision.relatedMemoryIds : undefined,
 			reason: curatorDecisionReason(decision),
 		};
-		await this.audit(
-			'curator_decision',
-			decision.proposalId,
-			change.reason,
-			buildCuratorDecisionEvent(change, proposal),
-		);
+		try {
+			await this.audit(
+				'curator_decision',
+				decision.proposalId,
+				change.reason,
+				buildCuratorDecisionEvent(change, proposal),
+			);
+		} catch (error) {
+			warn('[memory] failed to persist curator decision audit event', {
+				reason: error instanceof Error ? error.message : String(error),
+			});
+		}
 		return change;
 	}
 
@@ -769,6 +823,7 @@ export class LocalJsonlMemoryProvider
 	}
 
 	private async refreshProposalsUnlocked(): Promise<void> {
+		await repairIncompleteJsonlTail(this.pathFor('proposals'));
 		const loaded = validateLoadedProposals(
 			await readJsonl(this.pathFor('proposals')),
 			this.config,

--- a/src/memory/local-jsonl-provider.ts
+++ b/src/memory/local-jsonl-provider.ts
@@ -33,6 +33,12 @@ import {
 	validateOutcomeEvent,
 	validateOutcomeEventForMemory,
 } from './outcome-events';
+import {
+	buildProposalLoadDiagnostics,
+	type ProposalLoadIssue,
+	parseLoadedProposal,
+	proposalLoadIssueFromValue,
+} from './proposal-load';
 import type {
 	MemoryCompactOptions,
 	MemoryCompactResult,
@@ -117,6 +123,7 @@ export class LocalJsonlMemoryProvider
 	private initialized = false;
 	private memories = new Map<string, MemoryRecord>();
 	private proposals = new Map<string, MemoryProposal>();
+	private lastInvalidProposalLoadSignature: string | null = null;
 
 	constructor(
 		rootDirectory: string,
@@ -175,10 +182,13 @@ export class LocalJsonlMemoryProvider
 			await readJsonl(memoryPath),
 			this.config,
 		);
+		const rawProposalLoad = await readProposalJsonl(proposalPath);
 		const proposalLoad = validateLoadedProposals(
-			await readJsonl(proposalPath),
+			rawProposalLoad.values,
 			this.config,
 		);
+		proposalLoad.invalidCount += rawProposalLoad.invalidRows.length;
+		proposalLoad.invalidRows.unshift(...rawProposalLoad.invalidRows);
 		const outcomeEvents = this.readOutcomeEventsSync();
 		const materializedLoad = validateMaterializedMemories(
 			memoryLoad.records,
@@ -202,11 +212,9 @@ export class LocalJsonlMemoryProvider
 			);
 		}
 		if (proposalLoad.invalidCount > 0) {
-			await this.audit(
-				'invalid_load',
-				'proposals',
-				`${proposalLoad.invalidCount} invalid proposal JSONL row(s) skipped`,
-			);
+			await this.reportInvalidProposalLoad(proposalLoad.invalidRows);
+		} else {
+			this.lastInvalidProposalLoadSignature = null;
 		}
 	}
 
@@ -701,6 +709,9 @@ export class LocalJsonlMemoryProvider
 				decision.action === 'merge' ? decision.relatedMemoryIds : undefined,
 			reason: curatorDecisionReason(decision),
 		};
+		// The canonical proposal append is complete before this auxiliary audit
+		// event. Best effort keeps an applied curator decision from being reported
+		// as rejected when forensic audit storage is unavailable.
 		try {
 			await this.audit(
 				'curator_decision',
@@ -823,14 +834,41 @@ export class LocalJsonlMemoryProvider
 	}
 
 	private async refreshProposalsUnlocked(): Promise<void> {
-		await repairIncompleteJsonlTail(this.pathFor('proposals'));
-		const loaded = validateLoadedProposals(
-			await readJsonl(this.pathFor('proposals')),
-			this.config,
-		);
+		const proposalPath = this.pathFor('proposals');
+		await repairIncompleteJsonlTail(proposalPath);
+		const rawProposalLoad = await readProposalJsonl(proposalPath);
+		const loaded = validateLoadedProposals(rawProposalLoad.values, this.config);
+		loaded.invalidCount += rawProposalLoad.invalidRows.length;
+		loaded.invalidRows.unshift(...rawProposalLoad.invalidRows);
 		this.proposals = new Map(
 			loaded.records.map((proposal) => [proposal.id, proposal]),
 		);
+		if (loaded.invalidCount > 0) {
+			await this.reportInvalidProposalLoad(loaded.invalidRows);
+		} else {
+			this.lastInvalidProposalLoadSignature = null;
+		}
+	}
+
+	private async reportInvalidProposalLoad(
+		issues: readonly ProposalLoadIssue[],
+	): Promise<void> {
+		const eventJson = buildProposalLoadDiagnostics(issues);
+		const signature = JSON.stringify(eventJson);
+		if (signature === this.lastInvalidProposalLoadSignature) return;
+		this.lastInvalidProposalLoadSignature = signature;
+		try {
+			await this.audit(
+				'invalid_load',
+				'proposals',
+				`${issues.length} invalid proposal JSONL row(s) skipped`,
+				eventJson,
+			);
+		} catch (error) {
+			warn('[memory] failed to persist invalid proposal load audit event', {
+				reason: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	private readOutcomeEventsSync(): MemoryOutcomeEvent[] {
@@ -1080,23 +1118,24 @@ function validateLoadedProposals(
 ): {
 	records: MemoryProposal[];
 	invalidCount: number;
+	invalidRows: ProposalLoadIssue[];
 } {
 	const records: MemoryProposal[] = [];
+	const invalidRows: ProposalLoadIssue[] = [];
 	let invalidCount = 0;
 	for (const value of values) {
 		try {
-			const proposal = validateMemoryProposal(value as MemoryProposal);
-			if (proposal.proposedRecord) {
-				validateMemoryRecordRules(proposal.proposedRecord, {
-					rejectDurableSecrets: config.redaction.rejectDurableSecrets,
-				});
-			}
+			const proposal = parseLoadedProposal(
+				value,
+				config.redaction.rejectDurableSecrets,
+			);
 			records.push(proposal);
-		} catch {
+		} catch (error) {
 			invalidCount++;
+			invalidRows.push(proposalLoadIssueFromValue(value, error));
 		}
 	}
-	return { records, invalidCount };
+	return { records, invalidCount, invalidRows };
 }
 
 async function readJsonl(filePath: string): Promise<unknown[]> {
@@ -1113,6 +1152,29 @@ async function readJsonl(filePath: string): Promise<unknown[]> {
 		}
 	}
 	return records;
+}
+
+async function readProposalJsonl(filePath: string): Promise<{
+	values: unknown[];
+	invalidRows: ProposalLoadIssue[];
+}> {
+	if (!existsSync(filePath)) return { values: [], invalidRows: [] };
+	const content = await readFile(filePath, 'utf-8');
+	const values: unknown[] = [];
+	const invalidRows: ProposalLoadIssue[] = [];
+	for (const [index, line] of content.split('\n').entries()) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			values.push(JSON.parse(trimmed));
+		} catch {
+			invalidRows.push({
+				proposalId: '<unknown>',
+				reason: `invalid JSONL at line ${index + 1}`,
+			});
+		}
+	}
+	return { values, invalidRows };
 }
 
 async function readAuditEvents(filePath: string): Promise<AuditEvent[]> {

--- a/src/memory/prompt-block.ts
+++ b/src/memory/prompt-block.ts
@@ -19,6 +19,11 @@ function formatItem(item: RecallResultItem, generatedAt: string): string {
 		`- [${record.id}] kind=${record.kind} scope=${record.scope.type} confidence=${record.confidence.toFixed(2)} age=${age} score=${item.score.toFixed(2)}`,
 		`  ${redactSecrets(record.text)}`,
 		`  Source: ${sourceText(item)}`,
+		...(item.relation
+			? [
+					`  Related via ${item.relation.type} from ${item.relation.sourceMemoryId}`,
+				]
+			: []),
 	].join('\n');
 }
 

--- a/src/memory/proposal-load.ts
+++ b/src/memory/proposal-load.ts
@@ -1,0 +1,84 @@
+import { MemoryValidationError } from './errors';
+import { validateMemoryProposal, validateMemoryRecordRules } from './schema';
+import type { MemoryProposal } from './types';
+
+export interface ProposalLoadIssue {
+	proposalId: string;
+	reason: string;
+}
+
+export const INVALID_PROPOSAL_LOAD_SAMPLE_LIMIT = 5;
+
+const UNKNOWN_PROPOSAL_ID = '<unknown>';
+const MAX_PROPOSAL_LOAD_REASON_LENGTH = 200;
+
+export function parseLoadedProposal(
+	value: unknown,
+	rejectDurableSecrets: boolean,
+): MemoryProposal {
+	const proposal = validateMemoryProposal(value as MemoryProposal);
+	if (proposal.proposedRecord) {
+		validateMemoryRecordRules(proposal.proposedRecord, {
+			rejectDurableSecrets,
+		});
+	}
+	return proposal;
+}
+
+export function proposalLoadIssueFromValue(
+	value: unknown,
+	error: unknown,
+): ProposalLoadIssue {
+	return {
+		proposalId: extractProposalId(value) ?? UNKNOWN_PROPOSAL_ID,
+		reason: normalizeProposalLoadReason(error),
+	};
+}
+
+export function proposalLoadIssueFromId(
+	proposalId: string,
+	error: unknown,
+): ProposalLoadIssue {
+	return {
+		proposalId: proposalId || UNKNOWN_PROPOSAL_ID,
+		reason: normalizeProposalLoadReason(error),
+	};
+}
+
+export function buildProposalLoadDiagnostics(
+	issues: readonly ProposalLoadIssue[],
+): {
+	invalidCount: number;
+	samples: ProposalLoadIssue[];
+} {
+	return {
+		invalidCount: issues.length,
+		samples: issues.slice(0, INVALID_PROPOSAL_LOAD_SAMPLE_LIMIT),
+	};
+}
+
+export function asStoredProposalValidationError(
+	proposalId: string,
+	error: unknown,
+): MemoryValidationError {
+	if (error instanceof MemoryValidationError) return error;
+	return new MemoryValidationError(
+		`stored memory proposal is malformed: ${proposalId} (${normalizeProposalLoadReason(error)})`,
+		'stored_memory_proposal_invalid',
+	);
+}
+
+function extractProposalId(value: unknown): string | undefined {
+	if (!value || typeof value !== 'object') return undefined;
+	const candidate = (value as { id?: unknown }).id;
+	return typeof candidate === 'string' && candidate.length > 0
+		? candidate
+		: undefined;
+}
+
+function normalizeProposalLoadReason(error: unknown): string {
+	const raw = error instanceof Error ? error.message : String(error);
+	const trimmed = raw.replace(/\s+/g, ' ').trim();
+	if (trimmed.length <= MAX_PROPOSAL_LOAD_REASON_LENGTH) return trimmed;
+	return `${trimmed.slice(0, MAX_PROPOSAL_LOAD_REASON_LENGTH - 1)}…`;
+}

--- a/src/memory/relation-constants.ts
+++ b/src/memory/relation-constants.ts
@@ -1,0 +1,3 @@
+export const MAX_MERGE_PARTICIPANTS = 8;
+export const MAX_RELATIONS_PER_MEMORY = 32;
+export const RELATED_RECALL_FANOUT = 2;

--- a/src/memory/relations.ts
+++ b/src/memory/relations.ts
@@ -1,0 +1,155 @@
+import { MemoryValidationError } from './errors';
+import { isExpired, stableScopeKey } from './schema';
+import { scoreMemoryRecord } from './scoring';
+import type {
+	MemoryProposal,
+	MemoryRecord,
+	MemoryRelation,
+	RecallRequest,
+	RecallResultItem,
+} from './types';
+
+export const MAX_MERGE_PARTICIPANTS = 8;
+export const MAX_RELATIONS_PER_MEMORY = 32;
+export const RELATED_RECALL_FANOUT = 2;
+
+export function canonicalMemoryIds(ids: readonly string[]): string[] {
+	return Array.from(new Set(ids)).sort();
+}
+
+export function buildMemoryRelationIndex(
+	proposals: Iterable<MemoryProposal>,
+): Map<string, MemoryRelation[]> {
+	const index = new Map<string, Map<string, MemoryRelation>>();
+	for (const proposal of proposals) {
+		if (proposal.operation !== 'merge' || proposal.status !== 'applied')
+			continue;
+		const ids = canonicalMemoryIds(proposal.relatedMemoryIds ?? []);
+		for (const sourceId of ids) {
+			let related = index.get(sourceId);
+			if (!related) {
+				related = new Map();
+				index.set(sourceId, related);
+			}
+			for (const targetId of ids) {
+				if (targetId !== sourceId) {
+					related.set(targetId, { memoryId: targetId, type: 'merged_with' });
+				}
+			}
+		}
+	}
+	return new Map(
+		Array.from(index, ([id, relations]) => [
+			id,
+			Array.from(relations.values()).sort((a, b) =>
+				a.memoryId.localeCompare(b.memoryId),
+			),
+		]),
+	);
+}
+
+export function projectMemoryRelations(
+	records: readonly MemoryRecord[],
+	proposals: Iterable<MemoryProposal>,
+): MemoryRecord[] {
+	const index = buildMemoryRelationIndex(proposals);
+	return records.map(({ relations: _derived, ...record }) => {
+		const relations = index.get(record.id);
+		return relations?.length ? { ...record, relations } : record;
+	});
+}
+
+export function stripDerivedRelations(record: MemoryRecord): MemoryRecord {
+	const { relations: _derived, ...stored } = record;
+	return stored;
+}
+
+export function validateMergeParticipants(
+	ids: readonly string[],
+	records: Iterable<MemoryRecord>,
+	proposals: Iterable<MemoryProposal>,
+	now = new Date(),
+): string[] {
+	const canonical = canonicalMemoryIds(ids);
+	if (canonical.length < 2 || canonical.length > MAX_MERGE_PARTICIPANTS) {
+		throw new MemoryValidationError(
+			`merge decisions require 2-${MAX_MERGE_PARTICIPANTS} distinct relatedMemoryIds`,
+		);
+	}
+	const byId = new Map(Array.from(records, (record) => [record.id, record]));
+	const participants = canonical.map((id) => {
+		const record = byId.get(id);
+		if (
+			!record ||
+			record.metadata.deleted === true ||
+			record.supersededBy ||
+			isExpired(record, now)
+		) {
+			throw new MemoryValidationError(`merge participant is not active: ${id}`);
+		}
+		return record;
+	});
+	const scopeKey = stableScopeKey(participants[0].scope);
+	if (
+		participants.some((record) => stableScopeKey(record.scope) !== scopeKey)
+	) {
+		throw new MemoryValidationError(
+			'merge participants must share one memory scope',
+		);
+	}
+	const index = buildMemoryRelationIndex(proposals);
+	for (const id of canonical) {
+		const degree = new Set([
+			...(index.get(id)?.map((relation) => relation.memoryId) ?? []),
+			...canonical.filter((candidate) => candidate !== id),
+		]).size;
+		if (degree > MAX_RELATIONS_PER_MEMORY) {
+			throw new MemoryValidationError(
+				`merge would exceed ${MAX_RELATIONS_PER_MEMORY} relations for ${id}`,
+			);
+		}
+	}
+	return canonical;
+}
+
+export function expandRelatedRecallItems(
+	items: readonly RecallResultItem[],
+	allRecords: readonly MemoryRecord[],
+	request: RecallRequest,
+): RecallResultItem[] {
+	const normal = items
+		.filter((item) => !item.explored)
+		.slice(0, request.maxItems);
+	const explored = items.filter((item) => item.explored);
+	if (normal.length >= request.maxItems) return [...normal, ...explored];
+	const byId = new Map(allRecords.map((record) => [record.id, record]));
+	const selected = new Set(normal.map((item) => item.record.id));
+	for (const source of normal) {
+		const sourceRecord = byId.get(source.record.id) ?? source.record;
+		let addedForSource = 0;
+		for (const relation of sourceRecord.relations ?? []) {
+			if (
+				normal.length >= request.maxItems ||
+				addedForSource >= RELATED_RECALL_FANOUT
+			) {
+				break;
+			}
+			if (selected.has(relation.memoryId)) continue;
+			const record = byId.get(relation.memoryId);
+			if (!record) continue;
+			const scored = scoreMemoryRecord(record, {
+				...request,
+				requireQuerySignal: false,
+			});
+			if (!scored) continue;
+			normal.push({
+				...scored,
+				reason: `${scored.reason}, relation=${relation.type}, related_from=${source.record.id}`,
+				relation: { type: relation.type, sourceMemoryId: source.record.id },
+			});
+			selected.add(record.id);
+			addedForSource++;
+		}
+	}
+	return [...normal, ...explored];
+}

--- a/src/memory/relations.ts
+++ b/src/memory/relations.ts
@@ -1,4 +1,16 @@
 import { MemoryValidationError } from './errors';
+
+export {
+	MAX_MERGE_PARTICIPANTS,
+	MAX_RELATIONS_PER_MEMORY,
+	RELATED_RECALL_FANOUT,
+} from './relation-constants';
+
+import {
+	MAX_MERGE_PARTICIPANTS,
+	MAX_RELATIONS_PER_MEMORY,
+	RELATED_RECALL_FANOUT,
+} from './relation-constants';
 import { isExpired, stableScopeKey } from './schema';
 import { scoreMemoryRecord } from './scoring';
 import type {
@@ -8,10 +20,6 @@ import type {
 	RecallRequest,
 	RecallResultItem,
 } from './types';
-
-export const MAX_MERGE_PARTICIPANTS = 8;
-export const MAX_RELATIONS_PER_MEMORY = 32;
-export const RELATED_RECALL_FANOUT = 2;
 
 export function canonicalMemoryIds(ids: readonly string[]): string[] {
 	return Array.from(new Set(ids)).sort();
@@ -121,35 +129,47 @@ export function expandRelatedRecallItems(
 		.filter((item) => !item.explored)
 		.slice(0, request.maxItems);
 	const explored = items.filter((item) => item.explored);
-	if (normal.length >= request.maxItems) return [...normal, ...explored];
-	const byId = new Map(allRecords.map((record) => [record.id, record]));
-	const selected = new Set(normal.map((item) => item.record.id));
-	for (const source of normal) {
-		const sourceRecord = byId.get(source.record.id) ?? source.record;
-		let addedForSource = 0;
-		for (const relation of sourceRecord.relations ?? []) {
-			if (
-				normal.length >= request.maxItems ||
-				addedForSource >= RELATED_RECALL_FANOUT
-			) {
-				break;
+	if (normal.length < request.maxItems) {
+		const byId = new Map(allRecords.map((record) => [record.id, record]));
+		// Expansion is intentionally one hop from the direct recall set. Keep the
+		// source list immutable so relation hits cannot recursively become sources,
+		// and reserve explored IDs so exploration never produces duplicate results.
+		const selected = new Set(
+			[...normal, ...explored].map((item) => item.record.id),
+		);
+		const directSources = [...normal];
+		for (const source of directSources) {
+			const sourceRecord = byId.get(source.record.id) ?? source.record;
+			let addedForSource = 0;
+			for (const relation of sourceRecord.relations ?? []) {
+				if (
+					normal.length >= request.maxItems ||
+					addedForSource >= RELATED_RECALL_FANOUT
+				) {
+					break;
+				}
+				if (selected.has(relation.memoryId)) continue;
+				const record = byId.get(relation.memoryId);
+				if (!record) continue;
+				const scored = scoreMemoryRecord(record, {
+					...request,
+					requireQuerySignal: false,
+				});
+				if (!scored) continue;
+				normal.push({
+					...scored,
+					reason: `${scored.reason}, relation=${relation.type}, related_from=${source.record.id}`,
+					relation: { type: relation.type, sourceMemoryId: source.record.id },
+				});
+				selected.add(record.id);
+				addedForSource++;
 			}
-			if (selected.has(relation.memoryId)) continue;
-			const record = byId.get(relation.memoryId);
-			if (!record) continue;
-			const scored = scoreMemoryRecord(record, {
-				...request,
-				requireQuerySignal: false,
-			});
-			if (!scored) continue;
-			normal.push({
-				...scored,
-				reason: `${scored.reason}, relation=${relation.type}, related_from=${source.record.id}`,
-				relation: { type: relation.type, sourceMemoryId: source.record.id },
-			});
-			selected.add(record.id);
-			addedForSource++;
 		}
 	}
-	return [...normal, ...explored];
+	const seen = new Set<string>();
+	return [...normal, ...explored].filter((item) => {
+		if (seen.has(item.record.id)) return false;
+		seen.add(item.record.id);
+		return true;
+	});
 }

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -4,6 +4,7 @@ import { DURABLE_MEMORY_KINDS, EVIDENCE_REQUIRED_KINDS } from './config';
 import { MemoryValidationError } from './errors';
 import { computePiiScore, type PiiFinding, summarizePiiFindings } from './pii';
 import { containsSecret } from './redaction';
+import { MAX_MERGE_PARTICIPANTS } from './relation-constants';
 import { MEMORY_RECALL_SENTINEL } from './sentinel';
 import type {
 	CuratorMemoryDecision,
@@ -237,7 +238,7 @@ export const MemoryProposalSchema = z
 		targetMemoryId: z.string().optional(),
 		relatedMemoryIds: z
 			.array(z.string().regex(/^mem_[a-f0-9]{16}$/))
-			.max(8)
+			.max(MAX_MERGE_PARTICIPANTS)
 			.optional(),
 		proposedBy: z
 			.object({
@@ -271,7 +272,7 @@ export const MemoryProposalSchema = z
 			context.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ['relatedMemoryIds'],
-				message: 'merge proposals require 2-8 distinct relatedMemoryIds',
+				message: `merge proposals require 2-${MAX_MERGE_PARTICIPANTS} distinct relatedMemoryIds`,
 			});
 		}
 	});
@@ -349,7 +350,7 @@ export const CuratorMemoryDecisionSchema: z.ZodType<CuratorMemoryDecision> =
 				relatedMemoryIds: z
 					.array(MemoryIdSchema)
 					.min(2)
-					.max(8)
+					.max(MAX_MERGE_PARTICIPANTS)
 					.refine((ids) => new Set(ids).size === ids.length, {
 						message: 'merge decisions require distinct relatedMemoryIds',
 					}),

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -187,6 +187,17 @@ export const MemoryRecordSchema = z
 		updatedAt: z.string().datetime(),
 		lastAccessedAt: z.string().datetime().optional(),
 		expiresAt: z.string().datetime().optional(),
+		relations: z
+			.array(
+				z
+					.object({
+						memoryId: z.string().regex(/^mem_[a-f0-9]{16}$/),
+						type: z.literal('merged_with'),
+					})
+					.strict(),
+			)
+			.max(32)
+			.optional(),
 		qValue: z.number().min(0).max(1).optional(),
 		supersedes: z.array(z.string()).optional(),
 		supersededBy: z.string().optional(),
@@ -224,7 +235,10 @@ export const MemoryProposalSchema = z
 		]),
 		proposedRecord: MemoryRecordSchema.optional(),
 		targetMemoryId: z.string().optional(),
-		relatedMemoryIds: z.array(z.string()).optional(),
+		relatedMemoryIds: z
+			.array(z.string().regex(/^mem_[a-f0-9]{16}$/))
+			.max(8)
+			.optional(),
 		proposedBy: z
 			.object({
 				agentRole: z.string().optional(),
@@ -249,7 +263,18 @@ export const MemoryProposalSchema = z
 		createdAt: z.string().datetime(),
 		metadata: z.record(z.string(), z.unknown()),
 	})
-	.strict();
+	.strict()
+	.superRefine((proposal, context) => {
+		if (proposal.operation !== 'merge') return;
+		const ids = proposal.relatedMemoryIds ?? [];
+		if (ids.length < 2 || new Set(ids).size !== ids.length) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['relatedMemoryIds'],
+				message: 'merge proposals require 2-8 distinct relatedMemoryIds',
+			});
+		}
+	});
 
 export const NewMemoryRecordSchema: z.ZodType<NewMemoryRecord> = z
 	.object({
@@ -314,6 +339,20 @@ export const CuratorMemoryDecisionSchema: z.ZodType<CuratorMemoryDecision> =
 				proposalId: ProposalIdSchema,
 				oldMemoryId: MemoryIdSchema,
 				replacement: NewMemoryRecordSchema,
+				reason: CuratorDecisionReasonSchema,
+			})
+			.strict(),
+		z
+			.object({
+				action: z.literal('merge'),
+				proposalId: ProposalIdSchema,
+				relatedMemoryIds: z
+					.array(MemoryIdSchema)
+					.min(2)
+					.max(8)
+					.refine((ids) => new Set(ids).size === ids.length, {
+						message: 'merge decisions require distinct relatedMemoryIds',
+					}),
 				reason: CuratorDecisionReasonSchema,
 			})
 			.strict(),

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -79,6 +79,12 @@ import {
 	computeMemoryCohortFingerprint,
 } from './redaction';
 import {
+	canonicalMemoryIds,
+	expandRelatedRecallItems,
+	stripDerivedRelations,
+	validateMergeParticipants,
+} from './relations';
+import {
 	normalizeMemoryText,
 	stableScopeKey,
 	validateMemoryProposal,
@@ -510,6 +516,24 @@ export const MIGRATIONS: Migration[] = [
 			ALTER TABLE memory_events ADD COLUMN prev_hash TEXT;
 		`,
 	},
+	{
+		version: 14,
+		name: 'create_memory_relations',
+		sql: `
+			CREATE TABLE IF NOT EXISTS memory_relations (
+				source_id TEXT NOT NULL,
+				target_id TEXT NOT NULL,
+				proposal_id TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				PRIMARY KEY (source_id, target_id),
+				FOREIGN KEY (source_id) REFERENCES memory_items(id) ON DELETE CASCADE,
+				FOREIGN KEY (target_id) REFERENCES memory_items(id) ON DELETE CASCADE,
+				FOREIGN KEY (proposal_id) REFERENCES memory_proposals(id)
+			);
+			CREATE INDEX IF NOT EXISTS idx_memory_relations_source
+				ON memory_relations(source_id, target_id);
+		`,
+	},
 ];
 
 /** #1466: name of the migration that introduces memory_events.prev_hash. */
@@ -816,6 +840,11 @@ export class SQLiteMemoryProvider
 			await this.migrateLegacyJsonlIfNeeded();
 			const memoryLoad = this.loadMemories();
 			const proposalLoad = this.loadProposals();
+			for (const proposal of proposalLoad.records) {
+				if (proposal.operation === 'merge' && proposal.status === 'applied') {
+					this.writeProposal(proposal);
+				}
+			}
 			this.memories = new Map(
 				memoryLoad.records.map((record) => [record.id, record]),
 			);
@@ -879,9 +908,10 @@ export class SQLiteMemoryProvider
 			// source_task_id/agent_role to the ALTER TABLE defaults.
 			// mergeProvenanceColumns only fills fields the record LACKS, so a
 			// caller-provided (gateway-stamped) value still wins.
+			const storedRecord = stripDerivedRelations(record);
 			const merged = existingRow
-				? mergeProvenanceColumns(record, existingRow)
-				: record;
+				? mergeProvenanceColumns(storedRecord, existingRow)
+				: storedRecord;
 			next = validateMemoryRecordRules(
 				{
 					...merged,
@@ -947,7 +977,7 @@ export class SQLiteMemoryProvider
 		await this.initialize();
 		const record = this.readMemoryById(id);
 		if (record) this.memories.set(id, record);
-		return record;
+		return record ? this.projectRelationsFromStorage([record])[0] : null;
 	}
 
 	async appendOutcome(
@@ -1129,17 +1159,16 @@ export class SQLiteMemoryProvider
 				reranked,
 				request.maxItems,
 			);
+			const expanded = this.expandRelated(disabledPathSliced, request);
 			return {
-				items: disabledPathSliced,
+				items: expanded,
 				diagnostics: {
 					...result.diagnostics,
 					// Fix 3: derive exploredCount from what actually survived
 					// slicing so the count always matches an item present in the
 					// returned bundle.
-					exploredCount: disabledPathSliced.some((item) => item.explored)
-						? 1
-						: 0,
-					returnedCount: disabledPathSliced.length,
+					exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
+					returnedCount: expanded.length,
 				},
 			};
 		}
@@ -1209,16 +1238,15 @@ export class SQLiteMemoryProvider
 				lexicalReranked,
 				request.maxItems,
 			);
+			const expanded = this.expandRelated(denseFailedSliced, request);
 			return {
-				items: denseFailedSliced,
+				items: expanded,
 				diagnostics: {
 					...lexicalResult.diagnostics,
 					// Fix 3: derive exploredCount from what actually survived
 					// slicing.
-					exploredCount: denseFailedSliced.some((item) => item.explored)
-						? 1
-						: 0,
-					returnedCount: denseFailedSliced.length,
+					exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
+					returnedCount: expanded.length,
 				},
 			};
 		}
@@ -1344,8 +1372,9 @@ export class SQLiteMemoryProvider
 			rerankedItems,
 			request.maxItems,
 		);
+		const expanded = this.expandRelated(fusionSliced, request);
 		return {
-			items: fusionSliced,
+			items: expanded,
 			diagnostics: {
 				...lexicalResult.diagnostics,
 				// Fix 3: derive exploredCount from what actually survived fusion
@@ -1354,11 +1383,36 @@ export class SQLiteMemoryProvider
 				// explored item on its own normalised-score scale, so
 				// `lexicalResult.diagnostics.exploredCount` alone is not a
 				// reliable signal of what is actually present here.
-				exploredCount: fusionSliced.some((item) => item.explored) ? 1 : 0,
-				returnedCount: fusionSliced.length,
+				exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
+				returnedCount: expanded.length,
 				fusionActive: true,
 			},
 		};
+	}
+
+	private expandRelated(
+		items: readonly RecallResultItem[],
+		request: RecallRequest,
+	): RecallResultItem[] {
+		const sources = this.projectRelationsFromStorage(
+			items.map((item) => item.record),
+		);
+		const sourceById = new Map(sources.map((record) => [record.id, record]));
+		const relatedRecords: MemoryRecord[] = [];
+		for (const source of sources) {
+			for (const relation of source.relations ?? []) {
+				const record = this.readMemoryById(relation.memoryId);
+				if (record) relatedRecords.push(record);
+			}
+		}
+		return expandRelatedRecallItems(
+			items.map((item) => ({
+				...item,
+				record: sourceById.get(item.record.id) ?? item.record,
+			})),
+			[...sources, ...relatedRecords],
+			request,
+		);
 	}
 
 	async recordRecallUsage(event: MemoryRecallUsageEvent): Promise<void> {
@@ -1627,7 +1681,7 @@ export class SQLiteMemoryProvider
 			});
 		}
 
-		return records;
+		return this.projectRelationsFromStorage(records);
 	}
 
 	async createProposal(proposal: MemoryProposal): Promise<MemoryProposal> {
@@ -1648,7 +1702,7 @@ export class SQLiteMemoryProvider
 		filter: { status?: MemoryProposal['status']; limit?: number } = {},
 	): Promise<MemoryProposal[]> {
 		await this.initialize();
-		let proposals = Array.from(this.proposals.values());
+		let proposals = this.refreshProposalsFromStorage();
 		if (filter.status) {
 			proposals = proposals.filter(
 				(proposal) => proposal.status === filter.status,
@@ -1893,7 +1947,8 @@ export class SQLiteMemoryProvider
 		);
 		const enriched = memories.map((memory) => {
 			const row = provenanceById.get(memory.id);
-			return row ? mergeProvenanceColumns(memory, row) : memory;
+			const stored = stripDerivedRelations(memory);
+			return row ? mergeProvenanceColumns(stored, row) : stored;
 		});
 		const proposals = await this.listProposals();
 		const outcomeEvents = this.readOutcomeEvents();
@@ -2627,6 +2682,31 @@ export class SQLiteMemoryProvider
 		return { records, invalidCount };
 	}
 
+	private refreshProposalsFromStorage(): MemoryProposal[] {
+		const records = this.loadProposals().records;
+		this.proposals.clear();
+		for (const proposal of records) this.proposals.set(proposal.id, proposal);
+		return records;
+	}
+
+	private projectRelationsFromStorage(
+		records: readonly MemoryRecord[],
+	): MemoryRecord[] {
+		const query = this.requireDb().query<
+			{ target_id: string },
+			[string, number]
+		>(
+			' SELECT target_id FROM memory_relations WHERE source_id = ? ORDER BY target_id ASC LIMIT ?',
+		);
+		return records.map(({ relations: _derived, ...record }) => {
+			const relations = query.all(record.id, 32).map((row) => ({
+				memoryId: row.target_id,
+				type: 'merged_with' as const,
+			}));
+			return relations.length ? { ...record, relations } : record;
+		});
+	}
+
 	private writeMemory(record: MemoryRecord): void {
 		const stored = stripMaterializedOutcomes(record);
 		this.requireDb().run(
@@ -2999,6 +3079,40 @@ export class SQLiteMemoryProvider
 				JSON.stringify(proposal),
 			],
 		);
+		if (proposal.operation === 'merge' && proposal.status === 'applied') {
+			const ids = canonicalMemoryIds(proposal.relatedMemoryIds ?? []);
+			const existingIds = new Set(
+				ids.filter((id) =>
+					Boolean(
+						this.requireDb()
+							.query<{ id: string }, [string]>(
+								'SELECT id FROM memory_items WHERE id = ? LIMIT 1',
+							)
+							.get(id),
+					),
+				),
+			);
+			for (const sourceId of ids) {
+				for (const targetId of ids) {
+					if (
+						sourceId === targetId ||
+						!existingIds.has(sourceId) ||
+						!existingIds.has(targetId)
+					) {
+						continue;
+					}
+					this.requireDb().run(
+						'INSERT OR IGNORE INTO memory_relations (source_id, target_id, proposal_id, created_at) VALUES (?, ?, ?, ?)',
+						[
+							sourceId,
+							targetId,
+							proposal.id,
+							proposal.reviewedAt ?? proposal.createdAt,
+						],
+					);
+				}
+			}
+		}
 	}
 
 	private applyDecisionToStorage(
@@ -3079,6 +3193,18 @@ export class SQLiteMemoryProvider
 			oldMemoryId = oldMemory.id;
 			replacementMemoryId = replacement.id;
 			memoryId = replacement.id;
+		} else if (decision.action === 'merge') {
+			const currentMemories = this.loadMemories().records;
+			const currentProposals = this.loadProposals().records;
+			decision = {
+				...decision,
+				relatedMemoryIds: validateMergeParticipants(
+					decision.relatedMemoryIds,
+					currentMemories,
+					currentProposals,
+					new Date(appliedAt),
+				),
+			};
 		}
 
 		const proposalStatus =
@@ -3093,6 +3219,8 @@ export class SQLiteMemoryProvider
 				targetMemoryId,
 				oldMemoryId,
 				replacementMemoryId,
+				relatedMemoryIds:
+					decision.action === 'merge' ? decision.relatedMemoryIds : undefined,
 			},
 		);
 		const change: Omit<AppliedMemoryChange, 'eventId'> = {
@@ -3104,6 +3232,8 @@ export class SQLiteMemoryProvider
 			targetMemoryId,
 			oldMemoryId,
 			replacementMemoryId,
+			relatedMemoryIds:
+				decision.action === 'merge' ? decision.relatedMemoryIds : undefined,
 			reason: curatorDecisionReason(decision),
 		};
 		return {
@@ -3225,7 +3355,9 @@ export class SQLiteMemoryProvider
 				(rawRecord.outcomes?.length ?? 0) > 0
 					? ensureOutcomeGeneration(rawRecord)
 					: rawRecord;
-			this.writeMemory(stripMaterializedOutcomes(record));
+			this.writeMemory(
+				stripDerivedRelations(stripMaterializedOutcomes(record)),
+			);
 			if (typeof record.metadata.outcomeGeneration === 'string') {
 				try {
 					materializedRows.push({

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -62,6 +62,13 @@ import {
 	validateOutcomeEvent,
 	validateOutcomeEventForMemory,
 } from './outcome-events';
+import {
+	asStoredProposalValidationError,
+	buildProposalLoadDiagnostics,
+	type ProposalLoadIssue,
+	parseLoadedProposal,
+	proposalLoadIssueFromId,
+} from './proposal-load';
 import type {
 	MemoryCompactOptions,
 	MemoryCompactResult,
@@ -79,7 +86,10 @@ import {
 	computeMemoryCohortFingerprint,
 } from './redaction';
 import {
-	canonicalMemoryIds,
+	MAX_RELATIONS_PER_MEMORY,
+	RELATED_RECALL_FANOUT,
+} from './relation-constants';
+import {
 	expandRelatedRecallItems,
 	stripDerivedRelations,
 	validateMergeParticipants,
@@ -840,9 +850,16 @@ export class SQLiteMemoryProvider
 			await this.migrateLegacyJsonlIfNeeded();
 			const memoryLoad = this.loadMemories();
 			const proposalLoad = this.loadProposals();
+			// Replay is intentionally idempotent self-healing: rebuild
+			// `memory_relations` from the canonical proposal rows on every fresh open.
+			// `writeProposal` revalidates merge participants and skips invalid stored
+			// merges, so replay/import fail closed without deleting proposal rows.
 			for (const proposal of proposalLoad.records) {
 				if (proposal.operation === 'merge' && proposal.status === 'applied') {
-					this.writeProposal(proposal);
+					this.writeProposal(proposal, {
+						records: memoryLoad.records,
+						proposals: proposalLoad.records,
+					});
 				}
 			}
 			this.memories = new Map(
@@ -860,11 +877,20 @@ export class SQLiteMemoryProvider
 				);
 			}
 			if (proposalLoad.invalidCount > 0) {
-				await this.event(
-					'invalid_load',
-					'memory_proposals',
-					`${proposalLoad.invalidCount} invalid SQLite proposal row(s) skipped`,
-				);
+				try {
+					this.insertEvent(
+						'invalid_load',
+						'memory_proposals',
+						`${proposalLoad.invalidCount} invalid SQLite proposal row(s) skipped`,
+						JSON.stringify(
+							buildProposalLoadDiagnostics(proposalLoad.invalidRows),
+						),
+					);
+				} catch (error) {
+					warn('[memory] failed to persist invalid SQLite proposal load event', {
+						reason: error instanceof Error ? error.message : String(error),
+					});
+				}
 			}
 		} catch (err) {
 			try {
@@ -1400,7 +1426,10 @@ export class SQLiteMemoryProvider
 		const sourceById = new Map(sources.map((record) => [record.id, record]));
 		const relatedRecords: MemoryRecord[] = [];
 		for (const source of sources) {
-			for (const relation of source.relations ?? []) {
+			for (const relation of (source.relations ?? []).slice(
+				0,
+				RELATED_RECALL_FANOUT,
+			)) {
 				const record = this.readMemoryById(relation.memoryId);
 				if (record) relatedRecords.push(record);
 			}
@@ -2658,6 +2687,7 @@ export class SQLiteMemoryProvider
 	private loadProposals(): {
 		records: MemoryProposal[];
 		invalidCount: number;
+		invalidRows: ProposalLoadIssue[];
 	} {
 		const rows = this.requireDb()
 			.query<ProposalRow, []>(
@@ -2665,21 +2695,21 @@ export class SQLiteMemoryProvider
 			)
 			.all();
 		const records: MemoryProposal[] = [];
+		const invalidRows: ProposalLoadIssue[] = [];
 		let invalidCount = 0;
 		for (const row of rows) {
 			try {
-				const proposal = validateMemoryProposal(JSON.parse(row.proposal_json));
-				if (proposal.proposedRecord) {
-					validateMemoryRecordRules(proposal.proposedRecord, {
-						rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
-					});
-				}
+				const proposal = parseLoadedProposal(
+					JSON.parse(row.proposal_json),
+					this.config.redaction.rejectDurableSecrets,
+				);
 				records.push(proposal);
-			} catch {
+			} catch (error) {
 				invalidCount++;
+				invalidRows.push(proposalLoadIssueFromId(row.id, error));
 			}
 		}
-		return { records, invalidCount };
+		return { records, invalidCount, invalidRows };
 	}
 
 	private refreshProposalsFromStorage(): MemoryProposal[] {
@@ -2705,10 +2735,12 @@ export class SQLiteMemoryProvider
 		);
 		try {
 			return records.map(({ relations: _derived, ...record }) => {
-				const relations = query.all(record.id, 32).map((row) => ({
-					memoryId: row.target_id,
-					type: 'merged_with' as const,
-				}));
+				const relations = query
+					.all(record.id, MAX_RELATIONS_PER_MEMORY)
+					.map((row) => ({
+						memoryId: row.target_id,
+						type: 'merged_with' as const,
+					}));
 				return relations.length ? { ...record, relations } : record;
 			});
 		} finally {
@@ -3073,7 +3105,13 @@ export class SQLiteMemoryProvider
 		}
 	}
 
-	private writeProposal(proposal: MemoryProposal): void {
+	private writeProposal(
+		proposal: MemoryProposal,
+		validationContext?: {
+			records: readonly MemoryRecord[];
+			proposals: readonly MemoryProposal[];
+		},
+	): void {
 		this.requireDb().run(
 			`INSERT OR REPLACE INTO memory_proposals (
 				id,
@@ -3089,7 +3127,25 @@ export class SQLiteMemoryProvider
 			],
 		);
 		if (proposal.operation === 'merge' && proposal.status === 'applied') {
-			const ids = canonicalMemoryIds(proposal.relatedMemoryIds ?? []);
+			this.requireDb().run(
+				'DELETE FROM memory_relations WHERE proposal_id = ?',
+				[proposal.id],
+			);
+			let ids: string[];
+			try {
+				ids = validateMergeParticipants(
+					proposal.relatedMemoryIds ?? [],
+					validationContext?.records ?? this.loadMemories().records,
+					validationContext?.proposals ?? this.loadProposals().records,
+					proposal.reviewedAt ? new Date(proposal.reviewedAt) : new Date(),
+				);
+			} catch (error) {
+				warn('Skipping invalid applied merge during relation materialization', {
+					proposalId: proposal.id,
+					reason: error instanceof Error ? error.message : String(error),
+				});
+				return;
+			}
 			const existingIds = new Set(
 				ids.filter((id) =>
 					Boolean(
@@ -3262,14 +3318,17 @@ export class SQLiteMemoryProvider
 		if (!row) {
 			throw new MemoryValidationError('memory proposal was not found');
 		}
-		const proposal = validateMemoryProposal(JSON.parse(row.proposal_json));
+		let proposal: MemoryProposal;
+		try {
+			proposal = parseLoadedProposal(
+				JSON.parse(row.proposal_json),
+				this.config.redaction.rejectDurableSecrets,
+			);
+		} catch (error) {
+			throw asStoredProposalValidationError(row.id, error);
+		}
 		if (proposal.status !== 'pending') {
 			throw new MemoryValidationError('memory proposal is not pending');
-		}
-		if (proposal.proposedRecord) {
-			validateMemoryRecordRules(proposal.proposedRecord, {
-				rejectDurableSecrets: this.config.redaction.rejectDurableSecrets,
-			});
 		}
 		return proposal;
 	}

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -2692,19 +2692,28 @@ export class SQLiteMemoryProvider
 	private projectRelationsFromStorage(
 		records: readonly MemoryRecord[],
 	): MemoryRecord[] {
-		const query = this.requireDb().query<
+		if (records.length === 0) return [];
+		// Do not add this read to bun:sqlite's small per-Database query cache. Once
+		// that cache evicts a compiled statement, Bun can retain its Windows file
+		// handle until GC even after db.close() (see backfillProvenanceColumns).
+		// prepare()+finalize() gives this bounded projection an explicit lifetime.
+		const query = this.requireDb().prepare<
 			{ target_id: string },
 			[string, number]
 		>(
 			' SELECT target_id FROM memory_relations WHERE source_id = ? ORDER BY target_id ASC LIMIT ?',
 		);
-		return records.map(({ relations: _derived, ...record }) => {
-			const relations = query.all(record.id, 32).map((row) => ({
-				memoryId: row.target_id,
-				type: 'merged_with' as const,
-			}));
-			return relations.length ? { ...record, relations } : record;
-		});
+		try {
+			return records.map(({ relations: _derived, ...record }) => {
+				const relations = query.all(record.id, 32).map((row) => ({
+					memoryId: row.target_id,
+					type: 'merged_with' as const,
+				}));
+				return relations.length ? { ...record, relations } : record;
+			});
+		} finally {
+			query.finalize();
+		}
 	}
 
 	private writeMemory(record: MemoryRecord): void {

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -887,9 +887,12 @@ export class SQLiteMemoryProvider
 						),
 					);
 				} catch (error) {
-					warn('[memory] failed to persist invalid SQLite proposal load event', {
-						reason: error instanceof Error ? error.message : String(error),
-					});
+					warn(
+						'[memory] failed to persist invalid SQLite proposal load event',
+						{
+							reason: error instanceof Error ? error.message : String(error),
+						},
+					);
 				}
 			}
 		} catch (err) {

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -73,6 +73,11 @@ export interface MemoryOutcome {
 	correction?: string;
 }
 
+export interface MemoryRelation {
+	memoryId: string;
+	type: 'merged_with';
+}
+
 export interface MemoryRecord {
 	id: string;
 	scope: MemoryScopeRef;
@@ -86,6 +91,8 @@ export interface MemoryRecord {
 	updatedAt: string;
 	lastAccessedAt?: string;
 	expiresAt?: string;
+	/** Provider-derived from applied curator proposals; never user-writable. */
+	relations?: MemoryRelation[];
 	supersedes?: string[];
 	supersededBy?: string;
 	contentHash: string;
@@ -196,6 +203,12 @@ export type CuratorMemoryDecision =
 			replacement: NewMemoryRecord;
 			reason: string;
 	  }
+	| {
+			action: 'merge';
+			proposalId: string;
+			relatedMemoryIds: string[];
+			reason: string;
+	  }
 	| { action: 'reject'; proposalId: string; reason: string }
 	| { action: 'noop'; proposalId: string; reason: string };
 
@@ -215,6 +228,12 @@ export type ResolvedCuratorMemoryDecision =
 			replacement: MemoryRecord;
 			reason: string;
 	  }
+	| {
+			action: 'merge';
+			proposalId: string;
+			relatedMemoryIds: string[];
+			reason: string;
+	  }
 	| { action: 'reject'; proposalId: string; reason: string }
 	| { action: 'noop'; proposalId: string; reason: string };
 
@@ -228,6 +247,7 @@ export interface AppliedMemoryChange {
 	targetMemoryId?: string;
 	oldMemoryId?: string;
 	replacementMemoryId?: string;
+	relatedMemoryIds?: string[];
 	reason?: string;
 }
 
@@ -263,6 +283,7 @@ export interface RecallResultItem {
 	record: MemoryRecord;
 	score: number;
 	reason: string;
+	relation?: { type: MemoryRelation['type']; sourceMemoryId: string };
 	signals: {
 		textOverlap: number;
 		tagOverlap: number;

--- a/src/tools/swarm-memory-propose.ts
+++ b/src/tools/swarm-memory-propose.ts
@@ -60,7 +60,9 @@ export const swarm_memory_propose: ReturnType<typeof createSwarmTool> =
 			relatedMemoryIds: z
 				.array(z.string())
 				.optional()
-				.describe('Related memory IDs for merge/supersede proposals'),
+				.describe(
+					'For merge, 2-8 distinct memory IDs in one scope; also accepted as provenance for supersede proposals',
+				),
 			rationale: z
 				.string()
 				.min(1)

--- a/src/tools/swarm-memory-recall.ts
+++ b/src/tools/swarm-memory-recall.ts
@@ -89,6 +89,7 @@ export const swarm_memory_recall: ReturnType<typeof createSwarmTool> =
 						token_estimate: bundle.tokenEstimate,
 						signals: bundle.items.map((item) => ({
 							memory_id: item.record.id,
+							relation: item.relation,
 							...item.signals,
 						})),
 						prompt_block: bundle.promptBlock,

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -94,7 +94,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 		producers: [
 			'src/commands/handoff.ts:48 (pre-#2035)',
 			'src/commands/handoff.ts:79 (pre-#2035)',
-			'src/memory/local-jsonl-provider.ts:1226',
+			'src/memory/local-jsonl-provider.ts:1288',
 			'src/config/bundled-skills.ts:250',
 		],
 	},
@@ -154,7 +154,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/turbo/epic/state.ts:177',
 			'src/turbo/epic/calibration.ts:197',
 			'src/commands/archive-sqlite.ts:318',
-			'src/memory/jsonl-migration.ts:157',
+			'src/memory/jsonl-migration.ts:161',
 		],
 		note: 'fsync-discipline / lock-scoped fd writers whose temp naming is pinned by their own durability test suites (plan-durability invariant 5, #2034 crash matrix); grammars registered here so their residue stays discoverable',
 	},

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -94,7 +94,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 		producers: [
 			'src/commands/handoff.ts:48 (pre-#2035)',
 			'src/commands/handoff.ts:79 (pre-#2035)',
-			'src/memory/local-jsonl-provider.ts:1171',
+			'src/memory/local-jsonl-provider.ts:1226',
 			'src/config/bundled-skills.ts:250',
 		],
 	},

--- a/tests/unit/memory/gateway.test.ts
+++ b/tests/unit/memory/gateway.test.ts
@@ -711,7 +711,7 @@ describe('MemoryGateway', () => {
 				relatedMemoryIds: ['mem_1111111111111111'],
 				rationale: 'A merge needs at least two records.',
 			}),
-		).rejects.toThrow('merge proposals require relatedMemoryIds');
+		).rejects.toThrow('merge proposals require 2-8 distinct relatedMemoryIds');
 	});
 
 	test('repository-scoped local memories survive checkout directory renames', async () => {

--- a/tests/unit/memory/migration-renumber.test.ts
+++ b/tests/unit/memory/migration-renumber.test.ts
@@ -69,11 +69,11 @@ function dbPathFor(root: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Test A — all migrations through v11 apply correctly;
+// Test A — all migrations through v14 apply correctly;
 // v2 is skipped (LEGACY_JSONL_MIGRATION_VERSION — see jsonl-migration.ts)
 // ---------------------------------------------------------------------------
 describe('FB-001 — migration renumber coverage', () => {
-	test('migrations v1-v13 are sequential with no version skipping except v2', async () => {
+	test('migrations v1-v14 are sequential with no version skipping except v2', async () => {
 		const root = await providerRoot('v1-v10-sequential');
 		const provider = track(
 			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
@@ -88,7 +88,7 @@ describe('FB-001 — migration renumber coverage', () => {
 				'SELECT MAX(version) as max_version FROM schema_migrations',
 			)
 			.get();
-		expect(row?.max_version).toBe(13);
+		expect(row?.max_version).toBe(14);
 
 		// Verify each expected version is recorded.
 		// v2 is inserted by LEGACY_JSONL_MIGRATION_VERSION (jsonl-migration.ts:9)
@@ -99,7 +99,7 @@ describe('FB-001 — migration renumber coverage', () => {
 			)
 			.all();
 		expect(applied.map((r) => r.version)).toEqual([
-			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
 		]);
 	});
 
@@ -268,12 +268,12 @@ describe('FB-001 — migration renumber coverage', () => {
 			expect(row.cnt).toBe(1);
 		}
 
-		// Max version is still 11
+		// Max version remains at the current schema version.
 		const maxRow = db
 			.query<{ max_version: number | null }, []>(
 				'SELECT MAX(version) as max_version FROM schema_migrations',
 			)
 			.get();
-		expect(maxRow?.max_version).toBe(13);
+		expect(maxRow?.max_version).toBe(14);
 	});
 });

--- a/tests/unit/memory/prompt-block.test.ts
+++ b/tests/unit/memory/prompt-block.test.ts
@@ -61,4 +61,20 @@ describe('memory prompt block', () => {
 		expect(block.promptBlock).toContain('Use bun for tests.');
 		expect(block.promptBlock).not.toContain('Large note.');
 	});
+
+	test('renders relation provenance for expanded recall items', () => {
+		const source = makeItem('Use bun for tests.');
+		const related = {
+			...makeItem('Use the Windows command shim.'),
+			relation: {
+				type: 'merged_with' as const,
+				sourceMemoryId: source.record.id,
+			},
+		};
+		const block = buildRecallPromptBlock([source, related], 1000);
+
+		expect(block.promptBlock).toContain(
+			`Related via merged_with from ${source.record.id}`,
+		);
+	});
 });

--- a/tests/unit/memory/related-memory-boundaries.test.ts
+++ b/tests/unit/memory/related-memory-boundaries.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	expandRelatedRecallItems,
+	MAX_MERGE_PARTICIPANTS,
+	MAX_RELATIONS_PER_MEMORY,
+	validateMergeParticipants,
+} from '../../../src/memory/relations';
+import { MemoryProposalSchema } from '../../../src/memory/schema';
+import type {
+	MemoryProposal,
+	MemoryRecord,
+	RecallResultItem,
+} from '../../../src/memory/types';
+
+const scope = {
+	type: 'repository' as const,
+	repoId: 'boundary-repo',
+	repoRoot: 'boundary-root',
+};
+
+function record(id: string): MemoryRecord {
+	return {
+		id,
+		scope,
+		kind: 'repo_convention',
+		text: `memory ${id}`,
+		tags: [],
+		confidence: 0.9,
+		stability: 'durable',
+		source: { type: 'manual' },
+		createdAt: '2026-09-01T00:00:00.000Z',
+		updatedAt: '2026-09-01T00:00:00.000Z',
+		contentHash: `hash-${id}`,
+		metadata: {},
+	};
+}
+
+function proposal(ids: string[], suffix: string): MemoryProposal {
+	return {
+		id: `prop_${suffix}`,
+		operation: 'merge',
+		relatedMemoryIds: ids,
+		proposedBy: { agentRole: 'curator' },
+		rationale: 'boundary fixture',
+		evidenceRefs: [],
+		status: 'applied',
+		createdAt: '2026-09-01T00:00:00.000Z',
+		metadata: {},
+	};
+}
+
+function item(recordValue: MemoryRecord, explored = false): RecallResultItem {
+	return {
+		record: recordValue,
+		score: 1,
+		reason: 'fixture',
+		signals: {
+			textOverlap: 1,
+			tagOverlap: 0,
+			kindMatch: true,
+			scopeMatch: true,
+		},
+		explored,
+	};
+}
+
+describe('related-memory bounds and expansion', () => {
+	test('accepts exactly 2 and 8 participants but rejects 9', () => {
+		const ids = Array.from(
+			{ length: 9 },
+			(_, index) => `mem_${String(index + 1).padStart(16, '0')}`,
+		);
+		const base = {
+			operation: 'merge' as const,
+			proposedBy: { agentRole: 'curator' },
+			rationale: 'boundary fixture',
+			evidenceRefs: [],
+			status: 'pending' as const,
+			createdAt: '2026-09-01T00:00:00.000Z',
+			metadata: {},
+		};
+		const parse = (relatedMemoryIds: string[]) =>
+			MemoryProposalSchema.safeParse({
+				...base,
+				id: 'prop_0000000000000001',
+				relatedMemoryIds,
+			});
+		expect(parse(ids.slice(0, 2)).success).toBe(true);
+		expect(parse(ids.slice(0, MAX_MERGE_PARTICIPANTS)).success).toBe(true);
+		expect(parse(ids).success).toBe(false);
+	});
+
+	test('accepts degree 32 and rejects degree 33', () => {
+		const anchor = record('anchor');
+		const neighbors = Array.from(
+			{ length: MAX_RELATIONS_PER_MEMORY + 1 },
+			(_, index) => record(`neighbor-${index}`),
+		);
+		const records = [anchor, ...neighbors];
+		const existing = neighbors
+			.slice(0, MAX_RELATIONS_PER_MEMORY - 1)
+			.map((neighbor, index) =>
+				proposal(
+					[anchor.id, neighbor.id],
+					String(index + 1).padStart(16, '0'),
+				),
+			);
+		const next = proposal(
+			[anchor.id, neighbors[MAX_RELATIONS_PER_MEMORY - 1].id],
+			'00000000000000aa',
+		);
+		expect(
+			validateMergeParticipants(next.relatedMemoryIds ?? [], records, existing),
+		).toEqual([anchor.id, neighbors[MAX_RELATIONS_PER_MEMORY - 1].id].sort());
+		const overLimit = proposal(
+			[anchor.id, neighbors[MAX_RELATIONS_PER_MEMORY].id],
+			'00000000000000ab',
+		);
+		expect(() =>
+			validateMergeParticipants(overLimit.relatedMemoryIds ?? [], records, [
+				...existing,
+				next,
+			]),
+		).toThrow(`merge would exceed ${MAX_RELATIONS_PER_MEMORY} relations`);
+	});
+
+	test('expands only direct sources and deduplicates explored overlap', () => {
+		const source = record('source');
+		const direct = {
+			...record('direct'),
+			relations: [{ memoryId: 'transitive', type: 'merged_with' as const }],
+		};
+		const transitive = record('transitive');
+		source.relations = [{ memoryId: direct.id, type: 'merged_with' }];
+		const request = {
+			query: 'memory',
+			scopes: [scope],
+			maxItems: 4,
+			tokenBudget: 1000,
+			requireQuerySignal: false,
+		};
+		const expanded = expandRelatedRecallItems(
+			[item(source)],
+			[source, direct, transitive],
+			request,
+		);
+		expect(expanded.map(({ record: value }) => value.id)).toEqual([
+			source.id,
+			direct.id,
+		]);
+		const overlap = expandRelatedRecallItems(
+			[item(source), item(direct, true)],
+			[source, direct, transitive],
+			request,
+		);
+		expect(new Set(overlap.map(({ record: value }) => value.id)).size).toBe(
+			overlap.length,
+		);
+	});
+});

--- a/tests/unit/memory/related-memory-boundaries.test.ts
+++ b/tests/unit/memory/related-memory-boundaries.test.ts
@@ -100,10 +100,7 @@ describe('related-memory bounds and expansion', () => {
 		const existing = neighbors
 			.slice(0, MAX_RELATIONS_PER_MEMORY - 1)
 			.map((neighbor, index) =>
-				proposal(
-					[anchor.id, neighbor.id],
-					String(index + 1).padStart(16, '0'),
-				),
+				proposal([anchor.id, neighbor.id], String(index + 1).padStart(16, '0')),
 			);
 		const next = proposal(
 			[anchor.id, neighbors[MAX_RELATIONS_PER_MEMORY - 1].id],

--- a/tests/unit/memory/related-memory-gateway.test.ts
+++ b/tests/unit/memory/related-memory-gateway.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { MemoryGateway } from '../../../src/memory';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = canonicalMkdtemp('swarm-related-gateway-');
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('merge proposal identity', () => {
+	test('canonicalizes participants and avoids same-clock set collisions', async () => {
+		const gateway = new MemoryGateway(
+			{ directory: tmpDir, agentRole: 'curator' },
+			{
+				config: { enabled: true, provider: 'local-jsonl' },
+				now: () => new Date('2026-09-01T00:00:00.000Z'),
+			},
+		);
+		const a = 'mem_1111111111111111';
+		const b = 'mem_2222222222222222';
+		const c = 'mem_3333333333333333';
+		const first = await gateway.propose({
+			operation: 'merge',
+			relatedMemoryIds: [b, a],
+			rationale: 'First set.',
+		});
+		const reordered = await gateway.propose({
+			operation: 'merge',
+			relatedMemoryIds: [a, b],
+			rationale: 'Equivalent set.',
+		});
+		const different = await gateway.propose({
+			operation: 'merge',
+			relatedMemoryIds: [a, c],
+			rationale: 'Different set.',
+		});
+
+		expect(first.relatedMemoryIds).toEqual([a, b]);
+		expect(reordered.id).toBe(first.id);
+		expect(different.id).not.toBe(first.id);
+		await gateway.dispose();
+	});
+
+	test('rejects duplicate-only participants', async () => {
+		const gateway = new MemoryGateway(
+			{ directory: tmpDir, agentRole: 'curator' },
+			{ config: { enabled: true, provider: 'local-jsonl' } },
+		);
+		await expect(
+			gateway.propose({
+				operation: 'merge',
+				relatedMemoryIds: ['mem_1111111111111111', 'mem_1111111111111111'],
+				rationale: 'Invalid duplicate set.',
+			}),
+		).rejects.toThrow('2-8 distinct relatedMemoryIds');
+		await gateway.dispose();
+	});
+});

--- a/tests/unit/memory/related-memory.test.ts
+++ b/tests/unit/memory/related-memory.test.ts
@@ -1,0 +1,456 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	computeMemoryContentHash,
+	createMemoryId,
+	createProposalId,
+	LocalJsonlMemoryProvider,
+	type MemoryProposal,
+	type MemoryProposalStore,
+	type MemoryProvider,
+	type MemoryRecord,
+	MemoryValidationError,
+	SQLiteMemoryProvider,
+} from '../../../src/memory';
+import {
+	expandRelatedRecallItems,
+	projectMemoryRelations,
+} from '../../../src/memory/relations';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+type Provider = MemoryProvider & MemoryProposalStore & { close?: () => void };
+
+const cases = [
+	{
+		name: 'local-jsonl',
+		create: (root: string): Provider =>
+			new LocalJsonlMemoryProvider(root, { enabled: true }),
+	},
+	{
+		name: 'sqlite',
+		create: (root: string): Provider =>
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+	},
+] as const;
+
+let tmpDir: string;
+const providers: Provider[] = [];
+
+beforeEach(async () => {
+	tmpDir = canonicalMkdtemp('swarm-related-memory-');
+});
+
+afterEach(async () => {
+	for (const provider of providers.splice(0)) provider.close?.();
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function track(provider: Provider): Provider {
+	providers.push(provider);
+	return provider;
+}
+
+function memory(
+	text: string,
+	repoId = 'repo-a',
+	filePath = 'package.json',
+): MemoryRecord {
+	const base = {
+		scope: {
+			type: 'repository' as const,
+			repoId,
+			repoRoot: path.join(tmpDir, repoId),
+		},
+		kind: 'repo_convention' as const,
+		text,
+	};
+	return {
+		id: createMemoryId(base),
+		...base,
+		tags: [],
+		confidence: 0.9,
+		stability: 'durable',
+		source: { type: 'file', filePath },
+		createdAt: '2026-09-01T00:00:00.000Z',
+		updatedAt: '2026-09-01T00:00:00.000Z',
+		contentHash: computeMemoryContentHash(base),
+		metadata: {},
+	};
+}
+
+function mergeProposal(ids: string[]): MemoryProposal {
+	const createdAt = '2026-09-01T00:00:00.000Z';
+	const canonical = [...ids].sort();
+	return {
+		id: createProposalId({
+			createdAt,
+			proposer: 'curator',
+			text: `merge:${canonical.join(',')}`,
+		}),
+		operation: 'merge',
+		relatedMemoryIds: canonical,
+		proposedBy: { agentRole: 'curator' },
+		rationale: 'These facts are useful together.',
+		evidenceRefs: [],
+		status: 'pending',
+		createdAt,
+		metadata: {},
+	};
+}
+
+describe('durable related-memory semantics', () => {
+	test('expands a dense-only source whose result record lacks projected links', () => {
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		const proposal = {
+			...mergeProposal([left.id, right.id]),
+			status: 'applied' as const,
+		};
+		const projected = projectMemoryRelations([left, right], [proposal]);
+		const expanded = expandRelatedRecallItems(
+			[
+				{
+					record: left,
+					score: 1,
+					reason: 'dense-only',
+					signals: {
+						textOverlap: 0,
+						tagOverlap: 0,
+						fileOverlap: 0,
+						symbolOverlap: 0,
+						kindMatch: false,
+						scopeMatch: true,
+					},
+				},
+			],
+			projected,
+			{
+				query: 'unrelated dense query',
+				mode: 'injection',
+				requireQuerySignal: true,
+				scopes: [left.scope],
+				maxItems: 2,
+				tokenBudget: 1000,
+				minScore: 0,
+			},
+		);
+		expect(expanded.map((item) => item.record.id)).toEqual([left.id, right.id]);
+		expect(expanded[1].relation?.sourceMemoryId).toBe(left.id);
+	});
+
+	for (const providerCase of cases) {
+		describe(providerCase.name, () => {
+			test('applies, reloads, and recalls a bounded related memory', async () => {
+				const root = path.join(tmpDir, providerCase.name);
+				await fs.mkdir(root, { recursive: true });
+				const provider = track(providerCase.create(root));
+				const direct = memory('Use bun for package scripts.');
+				const related = memory(
+					'On Microsoft hosts invoke the command shim.',
+					'repo-a',
+					'docs/windows.md',
+				);
+				await provider.upsert(direct);
+				await provider.upsert(related);
+				const proposal = await provider.createProposal(
+					mergeProposal([related.id, direct.id]),
+				);
+
+				const change = await provider.applyCuratorDecision?.({
+					action: 'merge',
+					proposalId: proposal.id,
+					relatedMemoryIds: [direct.id, related.id],
+					reason: 'Both facts describe the package runner.',
+				});
+				expect(change?.relatedMemoryIds).toEqual(
+					[direct.id, related.id].sort(),
+				);
+				expect((await provider.get(direct.id))?.relations).toEqual([
+					{ memoryId: related.id, type: 'merged_with' },
+				]);
+
+				provider.close?.();
+				const reloaded = track(providerCase.create(root));
+				const results = await reloaded.recall({
+					query: 'package scripts bun',
+					mode: 'injection',
+					requireQuerySignal: true,
+					scopes: [direct.scope],
+					maxItems: 2,
+					tokenBudget: 1000,
+					minScore: 0,
+				});
+				expect(results.map((item) => item.record.id)).toEqual([
+					direct.id,
+					related.id,
+				]);
+				expect(results[1].relation).toEqual({
+					type: 'merged_with',
+					sourceMemoryId: direct.id,
+				});
+			});
+
+			test('rejects cross-scope merges without reviewing the proposal', async () => {
+				const root = path.join(tmpDir, `${providerCase.name}-scope`);
+				await fs.mkdir(root, { recursive: true });
+				const provider = track(providerCase.create(root));
+				const left = memory('Left fact.', 'repo-a');
+				const right = memory('Right fact.', 'repo-b');
+				await provider.upsert(left);
+				await provider.upsert(right);
+				const proposal = await provider.createProposal(
+					mergeProposal([left.id, right.id]),
+				);
+
+				await expect(
+					provider.applyCuratorDecision?.({
+						action: 'merge',
+						proposalId: proposal.id,
+						relatedMemoryIds: [left.id, right.id],
+						reason: 'Invalid cross-scope relation.',
+					}),
+				).rejects.toBeInstanceOf(MemoryValidationError);
+				expect(
+					(await provider.listProposals({ status: 'pending' }))[0]?.id,
+				).toBe(proposal.id);
+			});
+
+			test('does not persist caller-forged links and suppresses deleted targets', async () => {
+				const root = path.join(tmpDir, `${providerCase.name}-stale`);
+				await fs.mkdir(root, { recursive: true });
+				const provider = track(providerCase.create(root));
+				const direct = memory('Use bun for package scripts.');
+				const related = memory(
+					'The Windows shim is required.',
+					'repo-a',
+					'docs/windows.md',
+				);
+				await provider.upsert({
+					...direct,
+					relations: [{ memoryId: related.id, type: 'merged_with' }],
+				});
+				expect((await provider.get(direct.id))?.relations).toBeUndefined();
+
+				await provider.upsert(related);
+				const proposal = await provider.createProposal(
+					mergeProposal([direct.id, related.id]),
+				);
+				await provider.applyCuratorDecision?.({
+					action: 'merge',
+					proposalId: proposal.id,
+					relatedMemoryIds: [direct.id, related.id],
+					reason: 'Related package runner facts.',
+				});
+				await provider.delete(related.id, 'obsolete');
+				const results = await provider.recall({
+					query: 'package scripts bun',
+					mode: 'injection',
+					requireQuerySignal: true,
+					scopes: [direct.scope],
+					maxItems: 2,
+					tokenBudget: 1000,
+					minScore: 0,
+				});
+				expect(results.map((item) => item.record.id)).toEqual([direct.id]);
+				if (providerCase.name === 'sqlite') {
+					await expect(
+						provider.compactMaintenance?.({ dryRun: false }),
+					).resolves.toMatchObject({ removedDeleted: 1 });
+					expect((await provider.get(direct.id))?.relations).toBeUndefined();
+				}
+			});
+		});
+	}
+
+	test('repairs a partial proposal tail before applying a merge', async () => {
+		const root = path.join(tmpDir, 'partial-tail');
+		await fs.mkdir(root, { recursive: true });
+		const provider = track(
+			new LocalJsonlMemoryProvider(root, { enabled: true }),
+		);
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		await provider.upsert(left);
+		await provider.upsert(right);
+		const proposal = await provider.createProposal(
+			mergeProposal([left.id, right.id]),
+		);
+		await fs.appendFile(
+			path.join(root, '.swarm', 'memory', 'proposals.jsonl'),
+			'{"incomplete":',
+		);
+
+		await expect(
+			provider.applyCuratorDecision?.({
+				action: 'merge',
+				proposalId: proposal.id,
+				relatedMemoryIds: [left.id, right.id],
+				reason: 'The proposal ledger remains recoverable.',
+			}),
+		).resolves.toMatchObject({ action: 'merge' });
+		expect((await provider.get(left.id))?.relations?.[0]?.memoryId).toBe(
+			right.id,
+		);
+	});
+
+	test('keeps an applied JSONL merge when the auxiliary audit append fails', async () => {
+		const root = path.join(tmpDir, 'audit-failure');
+		await fs.mkdir(root, { recursive: true });
+		const provider = track(
+			new LocalJsonlMemoryProvider(root, { enabled: true }),
+		);
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		await provider.upsert(left);
+		await provider.upsert(right);
+		const proposal = await provider.createProposal(
+			mergeProposal([left.id, right.id]),
+		);
+		const auditPath = path.join(root, '.swarm', 'memory', 'audit.jsonl');
+		await fs.rm(auditPath);
+		await fs.mkdir(auditPath);
+
+		await expect(
+			provider.applyCuratorDecision?.({
+				action: 'merge',
+				proposalId: proposal.id,
+				relatedMemoryIds: [left.id, right.id],
+				reason: 'Audit failure must not roll back the canonical ledger.',
+			}),
+		).resolves.toMatchObject({ action: 'merge' });
+		expect((await provider.get(left.id))?.relations?.[0]?.memoryId).toBe(
+			right.id,
+		);
+	});
+
+	test('SQLite revalidates participants against concurrent provider changes', async () => {
+		const root = path.join(tmpDir, 'sqlite-concurrent');
+		await fs.mkdir(root, { recursive: true });
+		const first = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const second = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		await first.upsert(left);
+		await first.upsert(right);
+		const proposal = await first.createProposal(
+			mergeProposal([left.id, right.id]),
+		);
+		await second.list();
+		await second.delete(right.id, 'removed concurrently');
+
+		await expect(
+			first.applyCuratorDecision?.({
+				action: 'merge',
+				proposalId: proposal.id,
+				relatedMemoryIds: [left.id, right.id],
+				reason: 'Must see the transaction snapshot.',
+			}),
+		).rejects.toThrow(`merge participant is not active: ${right.id}`);
+	});
+
+	test('SQLite exports canonical records without materialized relations', async () => {
+		const root = path.join(tmpDir, 'sqlite-export');
+		await fs.mkdir(root, { recursive: true });
+		const provider = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		await provider.upsert(left);
+		await provider.upsert(right);
+		const proposal = await provider.createProposal(
+			mergeProposal([left.id, right.id]),
+		);
+		await provider.applyCuratorDecision?.({
+			action: 'merge',
+			proposalId: proposal.id,
+			relatedMemoryIds: [left.id, right.id],
+			reason: 'Export only canonical state.',
+		});
+		const exported = await provider.exportJsonl();
+		const rows = (await fs.readFile(exported.memoriesPath, 'utf8'))
+			.trim()
+			.split('\n')
+			.map((line) => JSON.parse(line) as MemoryRecord);
+		expect(rows.every((record) => record.relations === undefined)).toBe(true);
+
+		const importedRoot = path.join(tmpDir, 'sqlite-import');
+		const importedMemoryDir = path.join(importedRoot, '.swarm', 'memory');
+		await fs.mkdir(importedMemoryDir, { recursive: true });
+		await fs.copyFile(
+			exported.memoriesPath,
+			path.join(importedMemoryDir, 'memories.jsonl'),
+		);
+		await fs.copyFile(
+			exported.proposalsPath,
+			path.join(importedMemoryDir, 'proposals.jsonl'),
+		);
+		const imported = track(
+			new SQLiteMemoryProvider(importedRoot, {
+				enabled: true,
+				provider: 'sqlite',
+			}),
+		);
+		expect((await imported.get(left.id))?.relations).toEqual([
+			{ memoryId: right.id, type: 'merged_with' },
+		]);
+	});
+
+	test('SQLite readers observe merges applied by another live provider', async () => {
+		const root = path.join(tmpDir, 'sqlite-live-read');
+		await fs.mkdir(root, { recursive: true });
+		const reader = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const writer = track(
+			new SQLiteMemoryProvider(root, { enabled: true, provider: 'sqlite' }),
+		);
+		const left = memory('Use bun for package scripts.');
+		const right = memory(
+			'Invoke the Windows command shim.',
+			'repo-a',
+			'docs/windows.md',
+		);
+		await writer.upsert(left);
+		await writer.upsert(right);
+		await reader.list();
+		const proposal = await writer.createProposal(
+			mergeProposal([left.id, right.id]),
+		);
+		await writer.applyCuratorDecision?.({
+			action: 'merge',
+			proposalId: proposal.id,
+			relatedMemoryIds: [left.id, right.id],
+			reason: 'Live readers must refresh applied proposal state.',
+		});
+
+		expect((await reader.get(left.id))?.relations).toEqual([
+			{ memoryId: right.id, type: 'merged_with' },
+		]);
+	});
+});

--- a/tests/unit/memory/sqlite-provider-recall-exploration.test.ts
+++ b/tests/unit/memory/sqlite-provider-recall-exploration.test.ts
@@ -99,7 +99,12 @@ function patchDbForKnn(
 					return originalQuery(sql, ...args);
 				};
 			}
-			return (target as Record<string, unknown>)[prop as string];
+			const value = Reflect.get(target, prop, target) as unknown;
+			// bun:sqlite methods use private native receiver state. Returning a method
+			// through the Proxy without rebinding it makes calls such as prepare()
+			// throw "Cannot access invalid private field" even though production uses
+			// a real Database. Preserve the receiver for every non-intercepted method.
+			return typeof value === 'function' ? value.bind(target) : value;
 		},
 	});
 	priv.db = patchedDb as Database;


### PR DESCRIPTION
Closes #1603

## Summary

- Harden durable related-memory links across JSONL and SQLite providers.
- Keep recall expansion one-hop, bounded, and duplicate-free; centralize participant, relation-degree, and fanout limits.
- Add strict proposal-load diagnostics, fail-closed SQLite replay/import revalidation, and explicit migration/caveat documentation.
- Add exact boundary and recall-overlap regression tests.

## Feedback closure

- F-001/F-005: relation expansion is one-hop, capped per source and request, and SQLite target reads are bounded.
- F-002/F-004: malformed proposals produce sampled diagnostics; applied SQLite merges are revalidated for schema, scope, lifecycle, degree, and participant existence before relations are materialized.
- F-003/F-006: best-effort audit degradation and idempotent proposal replay are documented at the code path.
- F-007/F-008/F-009: limits are centralized, 2/8/9 and 32/33 boundaries are tested, and the release fragment includes migration and known-caveat notes.
- CS-001/IA-001/CM-001: recall output now deduplicates explored and related records.
- RP-001/RP-002: JSONL consistency refresh and SQLite relation projection remain bounded/intentional; focused tests and static review found no correctness issue.
- TF-001/CM-002/ASM-001/DX-001/UIB-001/STALE-001/CI-001: verified pre-existing or disproved; no additional fix required.

## Invariant audit

- 1 (plugin init): not touched — memory/provider paths only; `node scripts/repro-704.mjs` passed.
- 2 (runtime portability): not touched — `bun run build` and Node ESM import passed; `node scripts/repro-1873.mjs` passed.
- 3 (subprocesses): not touched — no subprocess code changed.
- 4 (.swarm containment): not touched — provider roots remain existing `.swarm/memory` paths.
- 5 (plan durability): not touched — no plan ledger/projection code changed.
- 6 (test_runner safety): not touched — bounded shell tests used; no broad test_runner invocation.
- 7 (test writing): touched — new `bun:test` file is under 500 lines, uses no `mock.module`; test-file-cap and tempdir gates passed.
- 8 (session state): not touched — no session/global state behavior changed.
- 9 (guardrails/retry): not touched — no guardrail/retry/circuit behavior changed.
- 10 (chat/system messages): not touched — no chat transform changed.
- 11 (tool registration): not touched — no tool/map additions; registration and invariant checks passed.
- 12 (release/cache): touched — pending release fragment added; pending-fragment and registry-citation checks passed.

## Test plan

- `bun run typecheck` — PASS
- `bunx biome ci .` — PASS (one pre-existing warning)
- Focused memory/SQLite tests — PASS (34 tests, 80 expects)
- `bun run build`, Node ESM import, repro-704, repro-1873 — PASS
- `bun run check:invariants`, `check:registry-citations`, `check:memory-recall`, package smoke, and diff-scoped quality gates — PASS
- Full `bun run test:unit:ci` was environment-blocked by the known Windows shared-temp `.swarm` containment collision; unrelated focused tests and CI-equivalent checks pass.
