### PR TITLE
feat(repo-graph): add hybrid retrieval router

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,12 @@ actions include:
   `linksSupported: false` degradation note, with TESTS / USES_FIXTURE
   associations derived at query time from persisted edges. See
   `docs/repo-graph-symbol-graph.md`.
+- KG-16 retrieval routing (issue #1537): `repo_map action="retrieve"`
+  classifies natural-language context requests into graph, exact lexical,
+  semantic-intent/fuzzy, security, test, or hybrid strategies. It invokes the
+  graph packs programmatically, falls back explicitly to bounded literal
+  workspace search, explains every action, enforces a context budget, and emits
+  content-free routing counters.
 
 The ontology extractor is intentionally conservative. It records detected facts
 and "detected missing guard" findings; it does not claim formal security proofs.

--- a/docs/observability-event-contract.md
+++ b/docs/observability-event-contract.md
@@ -3,7 +3,7 @@
 Companion to `docs/evidence-and-telemetry.md` (evidence bundles + the legacy
 telemetry stream from a user's point of view) and `docs/engineering-invariants.md`
 (the invariant this PR establishes). This document is the contract definition for
-`src/observability/`: the canonical event envelope, the 55-entry event catalog,
+`src/observability/`: the canonical event envelope, the 56-entry event catalog,
 the legacy adapter, sampling/cardinality rules, the OTel mapping pin, and the
 exhaustive producer/consumer matrix across all eighteen known observability
 stores in the repository.
@@ -16,7 +16,7 @@ Issue: #2029. This is PR 01 of 23 in the observability sequence (#2029–#2051).
 
 **What this PR defines.** A single canonical `ObservabilityEvent` envelope
 (`src/observability/envelope.ts`), a discriminated catalog of every event kind
-the codebase emits today (`src/observability/catalog.ts`, 55 entries), a
+the codebase emits today (`src/observability/catalog.ts`, 56 entries), a
 relationship-validation function, a legacy-payload adapter, deterministic
 sampling and bounded-cardinality helpers, and a versioned OTel/OpenInference
 attribute-mapping table. It wires the envelope into the one live production
@@ -182,9 +182,9 @@ those inputs before this change.
 
 ---
 
-## 5. The 55-entry catalog
+## 5. The 56-entry catalog
 
-Source: `src/observability/catalog.ts`. Exactly 55 entries = the 38 pre-existing members of
+Source: `src/observability/catalog.ts`. Exactly 56 entries = the 38 pre-existing members of
 `TelemetryEvent` (`src/telemetry.ts:15-144`) plus `agent_conflict_detected`
 (emitted in production via a force-cast past the type system before #2029)
 plus `close_archive_result` (issue #2030 — the structured close/archive
@@ -380,6 +380,18 @@ actually happens. Payload fields are counts and token totals only:
 `maskedMessages`, `maskedToolParts`, `maskedTokensFreed`, `prunedMessages`,
 `prunedTextParts`, `prunedToolParts`, and `prunedTokensFreed`. No prompt
 content, tool output, path, or fabricated session identifier is written.
+
+#### retrieval_routed
+
+Category `guardrail`, severity `info`, privacy `pseudonymous`. Producer
+`src/telemetry.ts:1206`. Consumers: none — owner **#2047**. Retention:
+**#2047**. Required workflow IDs: `hostSessionId`.
+
+Emitted once after a retrieval request is routed successfully. Its payload is
+bounded routing metadata only: selected mode, graph-hit boolean, closed-set
+fallback reason, requested and used token counts, and omitted-context count.
+It never includes the question, symbol names, paths, snippets, or result
+content.
 
 #### hard_limit_hit
 Category `guardrail`, severity `error`, privacy `pseudonymous`. Producer

--- a/docs/releases/pending/1537-hybrid-retrieval-router.md
+++ b/docs/releases/pending/1537-hybrid-retrieval-router.md
@@ -1,0 +1,15 @@
+# Hybrid retrieval router for graph-first context selection
+
+- Adds `repo_map action="retrieve"`, a deterministic and inspectable router for
+  graph, exact lexical, semantic-intent/fuzzy, security, test, and hybrid code
+  context requests.
+- Reuses existing graph query packs programmatically and falls back to the
+  bounded workspace literal-search engine when graph context is unavailable or
+  has no relevant result.
+- Returns strategy explanations, graph hit/miss and fallback reasons, and
+  deterministic context-budget accounting.
+- Records content-free `retrieval_routed` telemetry containing only closed mode
+  and fallback labels, booleans, and counts—never query, source, path, symbol,
+  or result content.
+- Aligns the Node search fallback with ripgrep by skipping NUL-bearing binary
+  files before UTF-8 decoding.

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -751,6 +751,13 @@ requested/used/omitted budget counters. The `semantic` mode is an intent class
 implemented by the zero-embedding `fuzzy_graph` algorithm (vocabulary expansion,
 IDF, and PageRank); it never claims embedding similarity.
 
+Explicit target hints intentionally take precedence over natural-language cues,
+except for an exact-string cue, which always selects literal verification. Route/entity
+hints otherwise select security packs, change/file scope selects hybrid or test packs,
+and file/symbol targets select graph queries. This keeps a caller's concrete scope
+deterministic while ensuring exact-string requests cannot be satisfied by unrelated
+graph evidence.
+
 Fixture patterns (module path, lowercase): a `fixtures?` / `__fixtures__` /
 `mocks?` / `factories` path segment, or a basename containing `fixture` /
 `mock` / `factory` / `test-utils` / `test-helpers` / `testing-utils`.
@@ -774,6 +781,11 @@ Fixture patterns (module path, lowercase): a `fixtures?` / `__fixtures__` /
   claim security proofs, and mirror the ontology extractor's conservative
   posture. `impact_cone` is unchanged; deeper route/data/test views are these
   dedicated actions.
+- `max_tokens` bounds packed retrieval context only. Router metadata is returned
+  alongside that context and is accounted for separately by
+  `metadataOverheadTokens`; when the requested context budget is too small to
+  carry even a compact action marker, the response is intentionally empty and
+  includes `context_budget_too_small` rather than silently implying coverage.
 - The unguarded-route advisory is a FILE-level heuristic: the auth/validation
   sweep covers the whole handler file, so a guarded sibling route suppresses
   the advisory for every route in that file — and absence of the advisory is

--- a/docs/repo-graph-symbol-graph.md
+++ b/docs/repo-graph-symbol-graph.md
@@ -683,6 +683,8 @@ repo_map { "action": "data_trace", "entity": "user" }
 repo_map { "action": "data_trace", "entity": "API_BASE_URL" }
 repo_map { "action": "test_pack", "file": "src/foo.ts" }
 repo_map { "action": "test_pack", "diff": "--- a/src/foo.ts\n+++ b/src/foo.ts\n@@ ..." }
+repo_map { "action": "retrieve", "question": "Who calls createSession?", "symbol": "createSession" }
+repo_map { "action": "retrieve", "question": "Find exact string SWARM_FOO" }
 ```
 
 ## KG-14 expanded graph query actions (issue #1535)
@@ -738,6 +740,16 @@ control-character-checked (bounded at extraction time).
 | `route_trace` | `route_path` (normalized: `[id]`→`:id`, `[...slug]`→`:slug*`) OR `file` OR `symbol` (HTTP method or link-bound handler; symbol-only search is restricted to `api_route`-role files), optional `method` and `symbol` filters (they compose with every target form; routes stored as `ALL` match any method), `top_n` (25) | per matched route: `route` fact, handler file, `handlerSymbol`+`handlerConfidence` (from the HANDLES_ROUTE link — the last-argument named handler for router calls; `handler_export` falls back to the method-named export at `confidence: null` on old graphs), depth-1 `services` (non-test nodes, deduped/sorted), `dataOperations`/`security` from handler+services (≤20 each), `handlerEvidence` (the link's evidence line; null without a link), handler-file `findings` (e.g. `api_route_without_detected_auth` — the unguarded-mutating-route surface), `tests` (test-file importers) |
 | `data_trace` | `entity` (entity/table/config/env key; case-insensitive) OR `file` OR `symbol`, optional `top_n` (25) | `readers`/`writers`/`deleters`/`configurers` (each entry carries kind/line/evidence/confidence and `via: 'link' \| 'fact'`), touching `routes` (≤20), `tests`, fixed-vocabulary `riskNotes` (no tests detected; delete-ops coverage; cross-boundary writes) |
 | `test_pack` | `file` OR `files` OR `symbol` OR `diff` (unified diff; parsed via `getDiffContext`), optional `top_n` (25) | `tests` (`basis: 'import'` high / `'colocated'` medium, `evidence` = import specifier or colocated rationale, `coveredSymbols` = edge imported∪used ∩ target exports), `fixtures` (fixture-pattern files imported by ≥1 discovered test, with `usedBy` + `confidence`/`evidence`), `helpers` (non-fixture deps shared by ≥2 discovered tests), `uncoveredExports`, `riskNotes`, `associations` (materialized TESTS/USES_FIXTURE records, ≤200) |
+
+## KG-16 hybrid retrieval router (issue #1537)
+
+`retrieve` requires `question` and accepts the existing optional target fields
+(`file`, `files`, `symbol`, `diff`, `route_path`, `method`, `entity`), `top_n`,
+and `max_tokens`. It returns the deterministic mode, executed actions, bounded
+context, explanations, graph hit/miss, explicit fallback reason, warnings, and
+requested/used/omitted budget counters. The `semantic` mode is an intent class
+implemented by the zero-embedding `fuzzy_graph` algorithm (vocabulary expansion,
+IDF, and PageRank); it never claims embedding similarity.
 
 Fixture patterns (module path, lowercase): a `fixtures?` / `__fixtures__` /
 `mocks?` / `factories` path segment, or a basename containing `fixture` /

--- a/src/observability/catalog.ts
+++ b/src/observability/catalog.ts
@@ -1,7 +1,7 @@
 /**
  * The event catalog (issue #2029).
  *
- * Exactly 55 entries, matching the `TelemetryEvent` union at
+ * Exactly 56 entries, matching the `TelemetryEvent` union at
  * `src/telemetry.ts:15-131`. Thirty-eight predate the #2029 contract; the 39th is
  * `agent_conflict_detected` (previously emitted through a force-cast past the
  * type system), the 40th is `close_archive_result` (issue #2030 — the
@@ -87,7 +87,7 @@ export interface CatalogEntry {
 	/**
 	 * Whether an event of this kind must carry `trace.parentSpanId`.
 	 *
-	 * `false` for all 55 entries today, and that is a truthful statement about
+	 * `false` for all 56 entries today, and that is a truthful statement about
 	 * the current system rather than a placeholder: no producer supplies a
 	 * parent span, so `createObservation` never sets one. Setting this to `true`
 	 * for a kind whose producer cannot supply a parent would make every
@@ -152,7 +152,7 @@ const CONSUMER_COST_JOIN = Object.freeze([
 /** Live reader of reviewer-gate decisions. */
 const CONSUMER_GATE_STATS = Object.freeze(['src/evaluation/gate-stats.ts:99']);
 /** In-process listener that tracks last-activity per session. */
-const CONSUMER_HEARTBEAT_LISTENER = Object.freeze(['src/telemetry.ts:221']);
+const CONSUMER_HEARTBEAT_LISTENER = Object.freeze(['src/telemetry.ts:222']);
 
 interface CatalogEntryInput {
 	readonly category: EventCategory;
@@ -507,6 +507,19 @@ const CATALOG_SOURCE: readonly (readonly [string, CatalogEntryInput])[] = [
 			severity: 'notice',
 			privacyClass: 'pseudonymous',
 			producer: 'src/telemetry.ts:657',
+			consumers: NO_CONSUMERS,
+			futureOwnerIssue: ISSUE_SINK,
+			retentionOwnerIssue: ISSUE_SINK,
+			requiredWorkflowIds: REQUIRE_SESSION,
+		},
+	],
+	[
+		'retrieval_routed',
+		{
+			category: 'guardrail',
+			severity: 'info',
+			privacyClass: 'pseudonymous',
+			producer: 'src/telemetry.ts:1206',
 			consumers: NO_CONSUMERS,
 			futureOwnerIssue: ISSUE_SINK,
 			retentionOwnerIssue: ISSUE_SINK,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -29,6 +29,7 @@ export type TelemetryEvent =
 	| 'phase_changed'
 	| 'budget_updated'
 	| 'context_pruned'
+	| 'retrieval_routed'
 	| 'model_fallback'
 	/**
 	 * Issue #2271 bug 4 — a configured agent model id was POSITIVELY confirmed
@@ -534,7 +535,6 @@ export async function flushAndDrainTelemetry(): Promise<void> {
 // ============================================================================
 // Telemetry Convenience Object
 // ============================================================================
-
 export const telemetry = {
 	sessionStarted(sessionId: string, agentName: string): void {
 		_internals.emit('session_started', { sessionId, agentName });
@@ -1190,6 +1190,20 @@ export const telemetry = {
 			level,
 			occurrenceCount,
 		});
+	},
+
+	retrievalRouted(
+		sessionId: string,
+		data: {
+			mode: 'graph' | 'lexical' | 'semantic' | 'security' | 'test' | 'hybrid';
+			graph_hit: boolean;
+			fallback_reason: string | null;
+			token_budget_requested: number;
+			token_budget_used: number;
+			omitted_context_count: number;
+		},
+	): void {
+		_internals.emit('retrieval_routed', { sessionId, ...data });
 	},
 };
 

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -80,6 +80,18 @@ export {
 	isGraphFresh,
 	resetQueryCache,
 } from './repo-graph/query';
+export type {
+	LexicalResult,
+	RetrievalMode,
+	RetrievalRequest,
+	RetrievalResult,
+} from './repo-graph/retrieval-router';
+export {
+	classifyRetrieval,
+	RETRIEVAL_MODES,
+	ROUTER_METADATA_OVERHEAD_TOKENS,
+	routeRetrieval,
+} from './repo-graph/retrieval-router';
 export {
 	getGraphPath,
 	loadGraph,

--- a/src/tools/repo-graph.ts
+++ b/src/tools/repo-graph.ts
@@ -81,6 +81,7 @@ export {
 	resetQueryCache,
 } from './repo-graph/query';
 export type {
+	LexicalRequest,
 	LexicalResult,
 	RetrievalMode,
 	RetrievalRequest,

--- a/src/tools/repo-graph/retrieval-router.ts
+++ b/src/tools/repo-graph/retrieval-router.ts
@@ -42,6 +42,15 @@ export interface LexicalResult {
 	error?: boolean;
 }
 
+/** Structured fallback request so lexical retrieval preserves validated scope
+ * and security hints instead of reducing everything to a bare string. */
+export interface LexicalRequest {
+	query: string;
+	files?: string[];
+	routePath?: string;
+	method?: RouteMethod;
+}
+
 export interface RetrievalResult {
 	mode: RetrievalMode;
 	algorithm: 'literal' | 'graph' | 'fuzzy_graph' | 'graph_packs' | 'mixed';
@@ -79,7 +88,7 @@ export function classifyRetrieval(question: string): {
 	const q = question.toLowerCase();
 	if (
 		/\b(exact|literal|find\s+(?:the\s+)?string)\b/.test(q) ||
-		/[`"'][^`"']+[`"']/.test(question)
+		findQuotedLiteral(question) !== null
 	)
 		return { mode: 'lexical', reason: 'exact_string_cue' };
 	if (/\b(review|diff|patch|pull request|pr)\b/.test(q))
@@ -89,7 +98,7 @@ export function classifyRetrieval(question: string): {
 	if (/\b(auth|security|permission|authorize|validation|risk)\b/.test(q))
 		return { mode: 'security', reason: 'security_cue' };
 	if (
-		/\b(who calls|caller|dependency|dependencies|impact|breaks? if|structural)\b/.test(
+		/\b(who calls|callers?|invoke[sd]?|invoked by|references?|referenced by|uses?|used by|dependents?|dependency|dependencies|impact|breaks? if|structural)\b/.test(
 			q,
 		)
 	)
@@ -99,11 +108,43 @@ export function classifyRetrieval(question: string): {
 	return { mode: 'semantic', reason: 'vague_discovery_default' };
 }
 
+function findQuotedLiteral(question: string): string | null {
+	for (let i = 0; i < question.length; i++) {
+		const delimiter = question[i];
+		if (delimiter !== '`' && delimiter !== '"' && delimiter !== "'") continue;
+		if (
+			delimiter === "'" &&
+			i > 0 &&
+			/[A-Za-z0-9_$]/.test(question[i - 1] ?? '')
+		)
+			continue;
+		const end = question.indexOf(delimiter, i + 1);
+		if (end <= i + 1) continue;
+		const value = question.slice(i + 1, end).trim();
+		if (value) return value;
+	}
+	return null;
+}
+
+function inferCallerSymbol(question: string): string | undefined {
+	const match = question.match(
+		/\b(?:calls?|callers?|invoke[sd]?|invoked by|references?|referenced by|uses?|used by|dependents?)(?:\s+of)?\s+([A-Za-z_$][\w$]*)/i,
+	);
+	return match?.[1];
+}
+
 function literalFrom(question: string, req: RetrievalRequest): string {
-	const match = question.match(/[`"']([^`"']+)[`"']/);
-	return (match?.[1] || req.symbol || req.entity || req.file || question)
-		.trim()
-		.slice(0, 500);
+	const quoted = findQuotedLiteral(question);
+	const hints = [req.routePath, req.method].filter((value): value is string =>
+		Boolean(value),
+	);
+	const primary =
+		quoted ||
+		req.symbol ||
+		req.entity ||
+		req.file ||
+		(hints.length > 0 ? '' : question);
+	return [primary, ...hints].filter(Boolean).join(' ').trim().slice(0, 500);
 }
 
 function hasArray(value: unknown, key: string): boolean {
@@ -176,35 +217,51 @@ function packContext(
 ) {
 	const context: Array<{ action: string; data: unknown }> = [];
 	let used = 0;
+	let warning: string | undefined;
 	for (const item of items) {
 		const cost = tokenEstimate(item);
-		if (used + cost > maxTokens) continue;
+		if (used + cost > maxTokens) {
+			if (context.length === 0) {
+				const compact = { action: item.action, data: { truncated: true } };
+				const compactCost = tokenEstimate(compact);
+				if (compactCost <= maxTokens) {
+					context.push(compact);
+					used += compactCost;
+					warning = 'context_truncated_to_fit_budget';
+					continue;
+				}
+				warning = 'context_budget_too_small';
+			}
+			continue;
+		}
 		context.push(item);
 		used += cost;
 	}
-	return { context, used, omitted: items.length - context.length };
+	return { context, used, omitted: items.length - context.length, warning };
 }
 
 export async function routeRetrieval(
 	graph: RepoGraph | null,
 	request: RetrievalRequest,
-	lexical: (query: string) => Promise<LexicalResult>,
+	lexical: (request: LexicalRequest) => Promise<LexicalResult>,
 	graphUnavailableReason?: string,
 ): Promise<RetrievalResult> {
 	const classified = classifyRetrieval(request.question);
 	const requestedFiles = request.files?.length ? request.files : undefined;
 	const mode: RetrievalMode =
-		request.routePath || request.method || request.entity
-			? 'security'
-			: request.diff || requestedFiles
-				? classified.mode === 'test'
-					? 'test'
-					: 'hybrid'
-				: request.file || request.symbol
-					? classified.mode === 'security' || classified.mode === 'test'
-						? classified.mode
-						: 'graph'
-					: classified.mode;
+		classified.mode === 'lexical'
+			? 'lexical'
+			: request.routePath || request.method || request.entity
+				? 'security'
+				: request.diff || requestedFiles
+					? classified.mode === 'test'
+						? 'test'
+						: 'hybrid'
+					: request.file || request.symbol
+						? classified.mode === 'security' || classified.mode === 'test'
+							? classified.mode
+							: 'graph'
+						: classified.mode;
 	const reason =
 		mode === classified.mode
 			? classified.reason
@@ -226,16 +283,32 @@ export async function routeRetrieval(
 	if (mode !== 'lexical' && graph) {
 		switch (mode) {
 			case 'graph': {
-				if (
-					request.symbol &&
-					/\b(who calls|caller)\b/i.test(request.question)
-				) {
-					const hits = searchSymbols(graph, { query: request.symbol, topN: 1 });
-					const hit = hits.hits[0];
-					const data = hit ? getCallers(graph, hit.file, hit.symbol) : [];
+				const callerIntent =
+					/\b(who calls?|callers?|invoke[sd]?|invoked by|references?|referenced by|uses?|used by|dependents?)\b/i.test(
+						request.question,
+					);
+				const callerSymbol = callerIntent
+					? (request.symbol ?? inferCallerSymbol(request.question))
+					: undefined;
+				if (callerSymbol) {
+					const hits = searchSymbols(graph, {
+						query: callerSymbol,
+						topN: Math.max(topN, 25),
+						file: request.file,
+					});
+					const exactHits = hits.hits.filter(
+						(hit) => hit.symbol === callerSymbol,
+					);
+					const data = exactHits.flatMap((hit) =>
+						getCallers(graph, hit.file, hit.symbol),
+					);
 					actions.push('symbol_search', 'callers');
 					candidates.push({ action: 'callers', data });
 					graphHit = hasActionContext('callers', data);
+					if (exactHits.length > 1 && !request.file)
+						warnings.push(
+							`ambiguous symbol ${callerSymbol}: ${exactHits.length} definitions considered`,
+						);
 				} else if (request.file) {
 					const data = getImpactCone(graph, {
 						file: request.file,
@@ -364,13 +437,19 @@ export async function routeRetrieval(
 	if (mode === 'lexical' || !graphHit) {
 		fallbackReason =
 			mode === 'lexical' ? null : (graphUnavailableReason ?? 'graph_miss');
-		const data = await lexical(literalFrom(request.question, request));
+		const data = await lexical({
+			query: literalFrom(request.question, request),
+			files: requestedFiles ?? (request.file ? [request.file] : undefined),
+			routePath: request.routePath,
+			method: request.method,
+		});
 		actions.push('lexical_search');
 		candidates.push({ action: 'lexical_search', data });
 		if (data.warning) warnings.push(data.warning);
 	}
 	const maxTokens = request.maxTokens ?? 4000;
 	const packed = packContext(candidates, maxTokens);
+	if (packed.warning) warnings.push(packed.warning);
 	return {
 		mode,
 		algorithm: MODE_METADATA[mode].algorithm,

--- a/src/tools/repo-graph/retrieval-router.ts
+++ b/src/tools/repo-graph/retrieval-router.ts
@@ -1,0 +1,394 @@
+import { askGraph } from './ask';
+import { buildTestPack, traceData, traceRoute } from './pack-query';
+import { buildOntologyPreflightPacket, getCallers } from './query';
+import {
+	explainGraphEntry,
+	getDiffContext,
+	getImpactCone,
+	searchSymbols,
+} from './symbol-query';
+import type { RepoGraph, RouteMethod } from './types';
+
+export const RETRIEVAL_MODES = [
+	'graph',
+	'lexical',
+	'semantic',
+	'security',
+	'test',
+	'hybrid',
+] as const;
+export type RetrievalMode = (typeof RETRIEVAL_MODES)[number];
+export const ROUTER_METADATA_OVERHEAD_TOKENS = 2048;
+
+export interface RetrievalRequest {
+	question: string;
+	file?: string;
+	files?: string[];
+	symbol?: string;
+	diff?: string;
+	entity?: string;
+	routePath?: string;
+	method?: RouteMethod;
+	maxTokens?: number;
+	topN?: number;
+}
+
+export interface LexicalResult {
+	matches?: unknown[];
+	total?: number;
+	truncated?: boolean;
+	engine?: string;
+	warning?: string;
+	error?: boolean;
+}
+
+export interface RetrievalResult {
+	mode: RetrievalMode;
+	algorithm: 'literal' | 'graph' | 'fuzzy_graph' | 'graph_packs' | 'mixed';
+	reason: string;
+	actions: string[];
+	graphHit: boolean;
+	fallbackReason: string | null;
+	context: Array<{ action: string; data: unknown }>;
+	explanation: string[];
+	warnings: string[];
+	budget: {
+		requestedTokens: number;
+		usedTokens: number;
+		omittedContextCount: number;
+		metadataOverheadTokens: number;
+	};
+}
+
+const MODE_METADATA: Record<
+	RetrievalMode,
+	{ algorithm: RetrievalResult['algorithm'] }
+> = {
+	graph: { algorithm: 'graph' },
+	lexical: { algorithm: 'literal' },
+	semantic: { algorithm: 'fuzzy_graph' },
+	security: { algorithm: 'graph_packs' },
+	test: { algorithm: 'graph_packs' },
+	hybrid: { algorithm: 'mixed' },
+};
+
+export function classifyRetrieval(question: string): {
+	mode: RetrievalMode;
+	reason: string;
+} {
+	const q = question.toLowerCase();
+	if (
+		/\b(exact|literal|find\s+(?:the\s+)?string)\b/.test(q) ||
+		/[`"'][^`"']+[`"']/.test(question)
+	)
+		return { mode: 'lexical', reason: 'exact_string_cue' };
+	if (/\b(review|diff|patch|pull request|pr)\b/.test(q))
+		return { mode: 'hybrid', reason: 'review_or_diff_cue' };
+	if (/\b(test|tests|spec|fixture|coverage)\b/.test(q))
+		return { mode: 'test', reason: 'test_cue' };
+	if (/\b(auth|security|permission|authorize|validation|risk)\b/.test(q))
+		return { mode: 'security', reason: 'security_cue' };
+	if (
+		/\b(who calls|caller|dependency|dependencies|impact|breaks? if|structural)\b/.test(
+			q,
+		)
+	)
+		return { mode: 'graph', reason: 'structural_cue' };
+	if (/\b(where|how)\b.*\b(implemented|defined|handled|works)\b/.test(q))
+		return { mode: 'hybrid', reason: 'feature_discovery_cue' };
+	return { mode: 'semantic', reason: 'vague_discovery_default' };
+}
+
+function literalFrom(question: string, req: RetrievalRequest): string {
+	const match = question.match(/[`"']([^`"']+)[`"']/);
+	return (match?.[1] || req.symbol || req.entity || req.file || question)
+		.trim()
+		.slice(0, 500);
+}
+
+function hasArray(value: unknown, key: string): boolean {
+	return Boolean(
+		value &&
+			typeof value === 'object' &&
+			Array.isArray((value as Record<string, unknown>)[key]) &&
+			((value as Record<string, unknown>)[key] as unknown[]).length > 0,
+	);
+}
+
+function hasActionContext(action: string, value: unknown): boolean {
+	if (action === 'callers') return Array.isArray(value) && value.length > 0;
+	if (action === 'diff_context' && value && typeof value === 'object') {
+		const result = value as Record<string, unknown>;
+		const files = Array.isArray(result.files) ? result.files : [];
+		const impact =
+			result.impact && typeof result.impact === 'object'
+				? (result.impact as Record<string, unknown>)
+				: {};
+		return (
+			files.some(
+				(file) =>
+					file &&
+					typeof file === 'object' &&
+					(file as Record<string, unknown>).known === true,
+			) ||
+			(Array.isArray(impact.files) && impact.files.length > 0) ||
+			(Array.isArray(impact.tests) && impact.tests.length > 0)
+		);
+	}
+	const evidenceKeys: Record<string, string[]> = {
+		impact_cone: [
+			'entries',
+			'tests',
+			'routes',
+			'dataFacts',
+			'securityFacts',
+			'boundaries',
+		],
+		route_trace: ['routes'],
+		data_trace: [
+			'readers',
+			'writers',
+			'deleters',
+			'configurers',
+			'routes',
+			'tests',
+		],
+		preflight_packet: [
+			'targets',
+			'findings',
+			'routes',
+			'dataOperations',
+			'security',
+		],
+		test_pack: ['tests', 'fixtures', 'helpers', 'associations'],
+		graph_explain: ['entries', 'edges'],
+	};
+	return (evidenceKeys[action] ?? []).some((key) => hasArray(value, key));
+}
+
+function tokenEstimate(value: unknown): number {
+	return Math.ceil(Buffer.byteLength(JSON.stringify(value), 'utf8') / 4);
+}
+
+function packContext(
+	items: Array<{ action: string; data: unknown }>,
+	maxTokens: number,
+) {
+	const context: Array<{ action: string; data: unknown }> = [];
+	let used = 0;
+	for (const item of items) {
+		const cost = tokenEstimate(item);
+		if (used + cost > maxTokens) continue;
+		context.push(item);
+		used += cost;
+	}
+	return { context, used, omitted: items.length - context.length };
+}
+
+export async function routeRetrieval(
+	graph: RepoGraph | null,
+	request: RetrievalRequest,
+	lexical: (query: string) => Promise<LexicalResult>,
+	graphUnavailableReason?: string,
+): Promise<RetrievalResult> {
+	const classified = classifyRetrieval(request.question);
+	const requestedFiles = request.files?.length ? request.files : undefined;
+	const mode: RetrievalMode =
+		request.routePath || request.method || request.entity
+			? 'security'
+			: request.diff || requestedFiles
+				? classified.mode === 'test'
+					? 'test'
+					: 'hybrid'
+				: request.file || request.symbol
+					? classified.mode === 'security' || classified.mode === 'test'
+						? classified.mode
+						: 'graph'
+					: classified.mode;
+	const reason =
+		mode === classified.mode
+			? classified.reason
+			: request.routePath || request.method || request.entity
+				? 'explicit_security_hint'
+				: request.diff || requestedFiles
+					? 'explicit_change_scope'
+					: 'explicit_graph_target';
+	const actions: string[] = [];
+	const candidates: Array<{ action: string; data: unknown }> = [];
+	const warnings: string[] = [];
+	let graphHit = false;
+	let fallbackReason: string | null = null;
+	const topN = Math.max(
+		1,
+		Math.min(25, request.topN ?? Math.floor((request.maxTokens ?? 4000) / 200)),
+	);
+
+	if (mode !== 'lexical' && graph) {
+		switch (mode) {
+			case 'graph': {
+				if (
+					request.symbol &&
+					/\b(who calls|caller)\b/i.test(request.question)
+				) {
+					const hits = searchSymbols(graph, { query: request.symbol, topN: 1 });
+					const hit = hits.hits[0];
+					const data = hit ? getCallers(graph, hit.file, hit.symbol) : [];
+					actions.push('symbol_search', 'callers');
+					candidates.push({ action: 'callers', data });
+					graphHit = hasActionContext('callers', data);
+				} else if (request.file) {
+					const data = getImpactCone(graph, {
+						file: request.file,
+						symbol: request.symbol,
+						maxDepth: 3,
+						topN,
+					});
+					actions.push('impact_cone');
+					candidates.push({ action: 'impact_cone', data });
+					graphHit = hasActionContext('impact_cone', data);
+				} else {
+					const data = askGraph(graph, request.question, { topN });
+					actions.push('ask');
+					candidates.push({ action: 'ask', data });
+					graphHit = data.hits.length > 0;
+				}
+				break;
+			}
+			case 'semantic': {
+				const data = askGraph(graph, request.question, { topN });
+				actions.push('ask');
+				candidates.push({ action: 'ask', data });
+				graphHit = data.hits.length > 0;
+				break;
+			}
+			case 'security': {
+				const ask =
+					request.routePath ||
+					request.method ||
+					request.file ||
+					request.symbol ||
+					request.entity
+						? null
+						: askGraph(graph, request.question, { topN });
+				const data =
+					request.routePath || request.method || request.file || request.symbol
+						? traceRoute(graph, {
+								routePath: request.routePath,
+								file: request.file,
+								symbol: request.symbol,
+								method: request.method,
+								topN,
+							})
+						: request.entity
+							? traceData(graph, { entity: request.entity, topN })
+							: ask?.hits.length
+								? buildOntologyPreflightPacket(
+										graph,
+										ask.hits.map((h) => h.file),
+										{ maxFiles: topN },
+									)
+								: { targets: [] };
+				actions.push(
+					request.entity
+						? 'data_trace'
+						: request.routePath || request.file || request.symbol
+							? 'route_trace'
+							: 'preflight_packet',
+				);
+				candidates.push({ action: actions.at(-1)!, data });
+				graphHit = hasActionContext(actions.at(-1)!, data);
+				break;
+			}
+			case 'test': {
+				const files =
+					requestedFiles ??
+					(request.file
+						? [request.file]
+						: askGraph(graph, request.question, { topN }).hits.map(
+								(h) => h.file,
+							));
+				const data = buildTestPack(graph, {
+					files,
+					symbol: request.symbol,
+					diff: request.diff,
+					topN,
+				});
+				actions.push('test_pack');
+				candidates.push({ action: 'test_pack', data });
+				graphHit = hasActionContext('test_pack', data);
+				break;
+			}
+			case 'hybrid': {
+				if (request.diff || requestedFiles || request.file) {
+					const files =
+						requestedFiles ?? (request.file ? [request.file] : undefined);
+					const diff = getDiffContext(graph, {
+						files,
+						diff: request.diff,
+						maxDepth: 2,
+						topN,
+					});
+					const tests = buildTestPack(graph, {
+						files,
+						symbol: request.symbol,
+						diff: request.diff,
+						topN,
+					});
+					actions.push('diff_context', 'test_pack');
+					candidates.push(
+						{ action: 'diff_context', data: diff },
+						{ action: 'test_pack', data: tests },
+					);
+					graphHit =
+						hasActionContext('diff_context', diff) ||
+						hasActionContext('test_pack', tests);
+				} else {
+					const ask = askGraph(graph, request.question, { topN });
+					actions.push('ask');
+					candidates.push({ action: 'ask', data: ask });
+					if (ask.hits[0]) {
+						const exp = explainGraphEntry(graph, {
+							file: ask.hits[0].file,
+							topN,
+						});
+						actions.push('graph_explain');
+						candidates.push({ action: 'graph_explain', data: exp });
+					}
+					graphHit = ask.hits.length > 0;
+				}
+				break;
+			}
+		}
+	}
+
+	if (mode === 'lexical' || !graphHit) {
+		fallbackReason =
+			mode === 'lexical' ? null : (graphUnavailableReason ?? 'graph_miss');
+		const data = await lexical(literalFrom(request.question, request));
+		actions.push('lexical_search');
+		candidates.push({ action: 'lexical_search', data });
+		if (data.warning) warnings.push(data.warning);
+	}
+	const maxTokens = request.maxTokens ?? 4000;
+	const packed = packContext(candidates, maxTokens);
+	return {
+		mode,
+		algorithm: MODE_METADATA[mode].algorithm,
+		reason,
+		actions: actions.slice(0, 8),
+		graphHit,
+		fallbackReason,
+		context: packed.context,
+		explanation: [
+			`classified:${reason}`,
+			...actions.map((a) => `action:${a}`),
+		].slice(0, 8),
+		warnings: warnings.slice(0, 8),
+		budget: {
+			requestedTokens: maxTokens,
+			usedTokens: packed.used,
+			omittedContextCount: packed.omitted,
+			metadataOverheadTokens: ROUTER_METADATA_OVERHEAD_TOKENS,
+		},
+	};
+}

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -3,6 +3,7 @@ import type { ToolContext } from '@opencode-ai/plugin';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta } from '../config/loader';
 import { type RepoGraphConfig, RepoGraphConfigSchema } from '../config/schema';
+import { telemetry } from '../telemetry';
 import {
 	containsControlChars,
 	containsPathTraversal,
@@ -38,6 +39,7 @@ import {
 	probeFreshness,
 	type RepoGraph,
 	type RouteMethod,
+	routeRetrieval,
 	saveGraph,
 	searchSymbols,
 	traceData,
@@ -45,6 +47,7 @@ import {
 	updateGraphForFiles,
 	writeFingerprint,
 } from './repo-graph';
+import { searchWorkspaceLiteral } from './search';
 
 /**
  * repo_map: structural codebase awareness for swarm agents.
@@ -89,6 +92,7 @@ const VALID_ACTIONS = [
 	'test_pack',
 	'graph_health',
 	'ask',
+	'retrieve',
 ] as const;
 
 type RepoMapAction = (typeof VALID_ACTIONS)[number];
@@ -117,6 +121,7 @@ export const _internals = {
 	probeFreshness,
 	updateGraphForFiles,
 	writeFingerprint,
+	telemetry,
 };
 
 interface RepoMapArgs {
@@ -361,6 +366,67 @@ async function loadOrError(
 	}
 }
 
+async function prepareGraphQuery(
+	directory: string,
+	action: string,
+	config: RepoGraphConfig,
+): Promise<
+	| { ok: true; graph: RepoGraph; freshness: RepoMapFreshnessMetadata }
+	| { ok: false; response: string }
+> {
+	const loaded = await loadOrError(directory, action);
+	if (!loaded.ok) return loaded;
+	let graph = loaded.graph;
+	const options = freshnessOptions(config);
+	let probe = await _internals.probeFreshness(directory, options);
+	const driftPaths = uniqueDriftPaths(probe);
+	const detectedFiles = driftPaths.length;
+	let refreshedFiles = 0;
+	let freshnessNote: string | undefined;
+	if (probe.state === 'drifted' && detectedFiles > 0) {
+		if (driftPaths.some(isGraphWideInputPath)) {
+			freshnessNote =
+				'Graph-wide package manifest drift requires a full repo_map build; the stale graph was served without mutation.';
+		} else if (config.refresh_cap > 0 && detectedFiles <= config.refresh_cap) {
+			try {
+				graph = await _internals.updateGraphForFiles(directory, driftPaths, {
+					buildOptions: options,
+				});
+				refreshedFiles = detectedFiles;
+				probe = await _internals.probeFreshness(directory, options);
+				if (probe.state !== 'clean')
+					freshnessNote =
+						'Incremental refresh completed, but the follow-up probe did not certify a clean graph.';
+			} catch (error) {
+				freshnessNote = `Incremental refresh failed; serving the stale graph: ${
+					error instanceof Error ? error.message : String(error)
+				}`;
+			}
+		} else {
+			freshnessNote =
+				config.refresh_cap === 0
+					? 'Automatic read-time refresh is disabled by repo_graph.refresh_cap=0; serving the stale graph.'
+					: `Detected ${detectedFiles} changed files, above repo_graph.refresh_cap=${config.refresh_cap}; serving the stale graph.`;
+		}
+	} else if (probe.state === 'no-fingerprint') {
+		freshnessNote =
+			'No matching repository-graph fingerprint is available; run repo_map action="build" to certify the graph.';
+	} else if (probe.state === 'inconclusive') {
+		freshnessNote =
+			'Workspace freshness is unknown because the bounded probe did not complete; the existing graph was served without refresh or deletion.';
+	}
+	return {
+		ok: true,
+		graph,
+		freshness: metadataForProbe(
+			probe,
+			detectedFiles,
+			refreshedFiles,
+			freshnessNote,
+		),
+	};
+}
+
 export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 	description:
 		'Query the repository code graph for structural awareness before editing. ' +
@@ -382,6 +448,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		'"test_pack" (tests, fixtures, helpers, and coverage hints for a file/symbol/changed files — explicit imports and colocated-name heuristics, missing-test warnings; needs file, files, symbol, or diff; never executes tests), ' +
 		'"graph_health" (freshness and bounded extraction diagnostics; no file required), ' +
 		'"ask" (zero-LLM file localization: pass a natural-language question to rank files by relevance via vocabulary expansion + IDF + PageRank; orientation only — read the located files before asserting anything about them). ' +
+		'"retrieve" (deterministic graph/lexical/semantic/security/test/hybrid context routing with explicit explanation, fallback, budgets, and content-free telemetry; needs question). ' +
 		'Use this before refactoring shared modules to avoid breaking unseen consumers. ' +
 		'Note: "callers"/"dead_exports"/"context_pack" use conservative regex analysis (TS/JS/Python) and cannot see ' +
 		'dynamic dispatch or namespace/barrel re-export usage; "dead_exports" results are review candidates, not delete directives.',
@@ -410,9 +477,10 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				'test_pack',
 				'graph_health',
 				'ask',
+				'retrieve',
 			])
 			.describe(
-				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports" | "context_pack" | "symbol_search" | "symbol_context" | "impact_cone" | "diff_context" | "graph_explain" | "route_trace" | "data_trace" | "test_pack" | "graph_health" | "ask"',
+				'Query action: "build" | "importers" | "dependencies" | "blast_radius" | "localization" | "key_files" | "ontology" | "package_boundaries" | "preflight_packet" | "callers" | "dead_exports" | "context_pack" | "symbol_search" | "symbol_context" | "impact_cone" | "diff_context" | "graph_explain" | "route_trace" | "data_trace" | "test_pack" | "graph_health" | "ask" | "retrieve"',
 			),
 		file: z
 			.string()
@@ -461,7 +529,7 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			.string()
 			.optional()
 			.describe(
-				'Natural-language question for action="ask". Orientation only — read the located files before asserting anything about them.',
+				'Natural-language question for action="ask" or action="retrieve". Ask is orientation only; retrieve deterministically selects and explains a bounded strategy.',
 			),
 		include_source: z
 			.boolean()
@@ -563,6 +631,131 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 		}
 
 		const repoGraphConfig = resolveRepoGraphConfig(directory);
+		if (action === 'retrieve') {
+			if (!a.question) return err(action, 'retrieve requires `question`');
+			const questionError = validateQuestion(a.question);
+			if (questionError) return err(action, questionError);
+			if (a.file !== undefined) {
+				const fileError = validateFile(a.file);
+				if (fileError) return err(action, fileError);
+			}
+			for (const file of a.files ?? []) {
+				const fileError = validateFile(file);
+				if (fileError) return err(action, `files entry: ${fileError}`);
+			}
+			if (a.symbol !== undefined) {
+				const symbolError = validateSymbol(a.symbol);
+				if (symbolError) return err(action, symbolError);
+			}
+			if (a.route_path !== undefined) {
+				const routeError = validateRoutePath(a.route_path);
+				if (routeError) return err(action, routeError);
+			}
+			if (a.method !== undefined) {
+				const methodError = validateMethod(a.method);
+				if (methodError) return err(action, methodError);
+			}
+			if (a.entity !== undefined) {
+				const entityError = validateEntity(a.entity);
+				if (entityError) return err(action, entityError);
+			}
+			if (a.diff !== undefined) {
+				const diffError = validateDiffText(a.diff);
+				if (diffError) return err(action, diffError);
+			}
+			const hasRouteHint = a.route_path !== undefined || a.method !== undefined;
+			const hasFiles = a.files !== undefined && a.files.length > 0;
+			if (
+				a.method !== undefined &&
+				a.route_path === undefined &&
+				a.file === undefined &&
+				a.symbol === undefined
+			) {
+				return err(action, 'method requires route_path, file, or symbol');
+			}
+			if (
+				a.entity !== undefined &&
+				(hasRouteHint ||
+					a.file !== undefined ||
+					hasFiles ||
+					a.symbol !== undefined ||
+					a.diff !== undefined)
+			) {
+				return err(
+					action,
+					'entity cannot be combined with route or code-scope hints',
+				);
+			}
+			if (hasRouteHint && (hasFiles || a.diff !== undefined)) {
+				return err(action, 'route hints cannot be combined with files or diff');
+			}
+			const routedFile =
+				a.file !== undefined
+					? toRelativeGraphPath(a.file, directory)
+					: undefined;
+			const routedFiles =
+				a.files !== undefined && a.files.length > 0
+					? a.files.map((file) => toRelativeGraphPath(file, directory))
+					: undefined;
+			let graph: RepoGraph | null = null;
+			let unavailable: string | undefined;
+			let retrievalFreshness: RepoMapFreshnessMetadata | undefined;
+			if (!repoGraphConfig.enabled) unavailable = 'graph_disabled';
+			else {
+				const prepared = await prepareGraphQuery(
+					directory,
+					action,
+					repoGraphConfig,
+				);
+				if (prepared.ok) {
+					graph = prepared.graph;
+					retrievalFreshness = prepared.freshness;
+				} else {
+					unavailable = prepared.response.includes('No repo graph')
+						? 'graph_missing'
+						: 'graph_load_error';
+				}
+			}
+			const result = await routeRetrieval(
+				graph,
+				{
+					question: a.question,
+					file: routedFile,
+					files: routedFiles,
+					symbol: a.symbol,
+					diff: a.diff,
+					entity: a.entity,
+					routePath: a.route_path,
+					method: a.method,
+					maxTokens: a.max_tokens,
+					topN: a.top_n,
+				},
+				async (query) => {
+					const searchResult = await searchWorkspaceLiteral({
+						query,
+						mode: 'literal',
+						maxResults: Math.min(a.top_n ?? 25, 100),
+						maxLines: 200,
+						workspace: directory,
+					});
+					return searchResult;
+				},
+				unavailable,
+			);
+			try {
+				_internals.telemetry.retrievalRouted(_ctx?.sessionID ?? 'unknown', {
+					mode: result.mode,
+					graph_hit: result.graphHit,
+					fallback_reason: result.fallbackReason,
+					token_budget_requested: result.budget.requestedTokens,
+					token_budget_used: result.budget.usedTokens,
+					omitted_context_count: result.budget.omittedContextCount,
+				});
+			} catch {
+				// Telemetry is diagnostic and must never make retrieval fail.
+			}
+			return ok(action, { ...result, ...(retrievalFreshness ?? {}) });
+		}
 		if (!repoGraphConfig.enabled) {
 			return err(action, REPO_GRAPH_DISABLED_NOTICE);
 		}
@@ -612,60 +805,14 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			}
 		}
 
-		// All other actions need a loaded graph.
-		const loaded = await loadOrError(directory, action);
-		if (!loaded.ok) return loaded.response;
-		let graph = loaded.graph;
-		let probe = await _internals.probeFreshness(directory, probeOptions);
-		const driftPaths = uniqueDriftPaths(probe);
-		const detectedFiles = driftPaths.length;
-		let refreshedFiles = 0;
-		let freshnessNote: string | undefined;
-
-		if (probe.state === 'drifted' && detectedFiles > 0) {
-			const graphWideDrift = driftPaths.some(isGraphWideInputPath);
-			if (graphWideDrift) {
-				freshnessNote =
-					'Graph-wide package manifest drift requires a full repo_map build; the stale graph was served without mutation.';
-			} else if (
-				repoGraphConfig.refresh_cap > 0 &&
-				detectedFiles <= repoGraphConfig.refresh_cap
-			) {
-				try {
-					graph = await _internals.updateGraphForFiles(directory, driftPaths, {
-						buildOptions: probeOptions,
-					});
-					refreshedFiles = detectedFiles;
-					probe = await _internals.probeFreshness(directory, probeOptions);
-					if (probe.state !== 'clean') {
-						freshnessNote =
-							'Incremental refresh completed, but the follow-up probe did not certify a clean graph.';
-					}
-				} catch (error) {
-					freshnessNote = `Incremental refresh failed; serving the stale graph: ${
-						error instanceof Error ? error.message : String(error)
-					}`;
-				}
-			} else {
-				freshnessNote =
-					repoGraphConfig.refresh_cap === 0
-						? 'Automatic read-time refresh is disabled by repo_graph.refresh_cap=0; serving the stale graph.'
-						: `Detected ${detectedFiles} changed files, above repo_graph.refresh_cap=${repoGraphConfig.refresh_cap}; serving the stale graph.`;
-			}
-		} else if (probe.state === 'no-fingerprint') {
-			freshnessNote =
-				'No matching repository-graph fingerprint is available; run repo_map action="build" to certify the graph.';
-		} else if (probe.state === 'inconclusive') {
-			freshnessNote =
-				'Workspace freshness is unknown because the bounded probe did not complete; the existing graph was served without refresh or deletion.';
-		}
-
-		const freshness = metadataForProbe(
-			probe,
-			detectedFiles,
-			refreshedFiles,
-			freshnessNote,
+		// All other actions share the same load/probe/refresh lifecycle as retrieve.
+		const prepared = await prepareGraphQuery(
+			directory,
+			action,
+			repoGraphConfig,
 		);
+		if (!prepared.ok) return prepared.response;
+		const { graph, freshness } = prepared;
 
 		// ----- key_files -----
 		if (action === 'key_files') {
@@ -1117,8 +1264,11 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 			) {
 				warnings.push('source_mode ignored: include_source is not true');
 			}
-			if (freshnessNote && !warnings.includes(freshnessNote)) {
-				warnings.push(freshnessNote);
+			if (
+				freshness.freshnessNote &&
+				!warnings.includes(freshness.freshnessNote)
+			) {
+				warnings.push(freshness.freshnessNote);
 			}
 			// Snippets mirror the returned spans exactly: the top_n slice that
 			// shaped `cappedSpans` must also bound `snippets`, or the response

--- a/src/tools/repo-map.ts
+++ b/src/tools/repo-map.ts
@@ -730,10 +730,11 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 					maxTokens: a.max_tokens,
 					topN: a.top_n,
 				},
-				async (query) => {
+				async ({ query, files }) => {
 					const searchResult = await searchWorkspaceLiteral({
 						query,
 						mode: 'literal',
+						include: files?.join(','),
 						maxResults: Math.min(a.top_n ?? 25, 100),
 						maxLines: 200,
 						workspace: directory,
@@ -743,14 +744,17 @@ export const repo_map: ReturnType<typeof createSwarmTool> = createSwarmTool({
 				unavailable,
 			);
 			try {
-				_internals.telemetry.retrievalRouted(_ctx?.sessionID ?? 'unknown', {
-					mode: result.mode,
-					graph_hit: result.graphHit,
-					fallback_reason: result.fallbackReason,
-					token_budget_requested: result.budget.requestedTokens,
-					token_budget_used: result.budget.usedTokens,
-					omitted_context_count: result.budget.omittedContextCount,
-				});
+				const sessionID = _ctx?.sessionID?.trim();
+				if (sessionID) {
+					_internals.telemetry.retrievalRouted(sessionID, {
+						mode: result.mode,
+						graph_hit: result.graphHit,
+						fallback_reason: result.fallbackReason,
+						token_budget_requested: result.budget.requestedTokens,
+						token_budget_used: result.budget.usedTokens,
+						omitted_context_count: result.budget.omittedContextCount,
+					});
+				}
 			} catch {
 				// Telemetry is diagnostic and must never make retrieval fail.
 			}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -589,7 +589,7 @@ function collectFiles(
 /**
  * Execute search using Node.js fallback (when ripgrep not available).
  */
-async function fallbackSearch(
+export async function searchWorkspaceLiteral(
 	opts: FallbackSearchOptions,
 ): Promise<SearchResult | SearchError> {
 	// Parse include/exclude glob patterns
@@ -670,7 +670,11 @@ async function fallbackSearch(
 		// Read and search file
 		let content: string;
 		try {
-			content = fs.readFileSync(fullPath, 'utf-8');
+			const bytes = fs.readFileSync(fullPath);
+			// Match ripgrep's default binary-file behavior on the bounded Node fallback.
+			// A NUL byte is the stable, cheap binary signal used by common search tools.
+			if (bytes.includes(0)) continue;
+			content = bytes.toString('utf-8');
 		} catch {
 			continue;
 		}
@@ -936,7 +940,7 @@ export const search: ToolDefinition = createSwarmTool({
 				workspace: directory,
 			});
 		} else {
-			result = await fallbackSearch({
+			result = await searchWorkspaceLiteral({
 				query,
 				mode,
 				include,
@@ -961,11 +965,11 @@ export const _internals: {
 	resolveExecutableFromPath: typeof resolveExecutableFromPath;
 	resolveRipgrepBinary: typeof resolveRipgrepBinary;
 	runExternalTool: typeof runExternalTool;
-	fallbackSearch: typeof fallbackSearch;
+	fallbackSearch: typeof searchWorkspaceLiteral;
 } = {
 	resolvePackagedRipgrep,
 	resolveExecutableFromPath,
 	resolveRipgrepBinary,
 	runExternalTool,
-	fallbackSearch,
+	fallbackSearch: searchWorkspaceLiteral,
 };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -940,7 +940,7 @@ export const search: ToolDefinition = createSwarmTool({
 				workspace: directory,
 			});
 		} else {
-			result = await searchWorkspaceLiteral({
+			result = await _internals.fallbackSearch({
 				query,
 				mode,
 				include,

--- a/tests/unit/observability/envelope-roundtrip-process.test.ts
+++ b/tests/unit/observability/envelope-roundtrip-process.test.ts
@@ -1,0 +1,22 @@
+/** AC1 positive — independent createObservation calls retain valid relationships and distinct traces. */
+import { describe, expect, test } from 'bun:test';
+import { ObservabilityEventSchema } from '../../../src/observability/envelope.js';
+import {
+	createObservation,
+	resetObservabilityForTesting,
+} from '../../../src/observability/observe.js';
+import { validateEventRelationships } from '../../../src/observability/relationships.js';
+
+describe('envelope roundtrip — independent process fixture', () => {
+	test('cross-process fixture round-trips without shared in-memory state', () => {
+		resetObservabilityForTesting();
+		const procA = createObservation('heartbeat', { sessionId: 'proc-a' });
+		resetObservabilityForTesting();
+		const procB = createObservation('heartbeat', { sessionId: 'proc-b' });
+		expect(ObservabilityEventSchema.safeParse(procA).success).toBe(true);
+		expect(ObservabilityEventSchema.safeParse(procB).success).toBe(true);
+		expect(validateEventRelationships(procA).ok).toBe(true);
+		expect(validateEventRelationships(procB).ok).toBe(true);
+		expect(procA.trace.traceId).not.toBe(procB.trace.traceId);
+	});
+});

--- a/tests/unit/observability/envelope-roundtrip.test.ts
+++ b/tests/unit/observability/envelope-roundtrip.test.ts
@@ -395,6 +395,15 @@ const FIXTURES: Record<string, Record<string, unknown>> = {
 		alarm: 'model_limit_fallback',
 		transition: 'raised',
 	},
+	retrieval_routed: {
+		sessionId: 'sess-1',
+		mode: 'lexical',
+		graph_hit: false,
+		fallback_reason: null,
+		token_budget_requested: 4000,
+		token_budget_used: 12,
+		omitted_context_count: 0,
+	},
 };
 
 describe('envelope roundtrip — AC1 positive', () => {

--- a/tests/unit/observability/envelope-roundtrip.test.ts
+++ b/tests/unit/observability/envelope-roundtrip.test.ts
@@ -494,16 +494,4 @@ describe('envelope roundtrip — AC1 positive', () => {
 		expect(first.eventId).not.toBe(second.eventId);
 		expect(second.writerSequence).toBeGreaterThan(first.writerSequence);
 	});
-
-	test('cross-process fixture (no shared in-memory state between two independent createObservation calls) round-trips', () => {
-		resetObservabilityForTesting();
-		const procA = createObservation('heartbeat', { sessionId: 'proc-a' });
-		resetObservabilityForTesting();
-		const procB = createObservation('heartbeat', { sessionId: 'proc-b' });
-		expect(ObservabilityEventSchema.safeParse(procA).success).toBe(true);
-		expect(ObservabilityEventSchema.safeParse(procB).success).toBe(true);
-		expect(validateEventRelationships(procA).ok).toBe(true);
-		expect(validateEventRelationships(procB).ok).toBe(true);
-		expect(procA.trace.traceId).not.toBe(procB.trace.traceId);
-	});
 });

--- a/tests/unit/tools/repo-map-kg16-retrieval-router.test.ts
+++ b/tests/unit/tools/repo-map-kg16-retrieval-router.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	classifyRetrieval,
+	RETRIEVAL_MODES,
+} from '../../../src/tools/repo-graph';
+import {
+	repo_map,
+	_internals as repoMapInternals,
+} from '../../../src/tools/repo-map';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tmp = '';
+const realRetrievalRouted = repoMapInternals.telemetry.retrievalRouted;
+const realLoadPluginConfigWithMeta = repoMapInternals.loadPluginConfigWithMeta;
+
+function call(
+	args: Record<string, unknown>,
+	sessionID?: string,
+): Promise<string> {
+	type Executable = {
+		execute: (
+			args: Record<string, unknown>,
+			ctx: { directory: string; sessionID?: string },
+		) => Promise<string>;
+	};
+	return (repo_map as unknown as Executable).execute(args, {
+		directory: tmp,
+		sessionID,
+	});
+}
+
+function parse(out: string): Record<string, any> {
+	return JSON.parse(out) as Record<string, any>;
+}
+
+afterEach(() => {
+	if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+	tmp = '';
+	repoMapInternals.telemetry.retrievalRouted = realRetrievalRouted;
+	repoMapInternals.loadPluginConfigWithMeta = realLoadPluginConfigWithMeta;
+});
+
+describe('KG-16 retrieval router classification', () => {
+	test('covers all six deterministic modes and precedence', () => {
+		const cases = [
+			['Find exact string `SWARM_FOO` in tests', 'lexical'],
+			['Review this diff for auth tests', 'hybrid'],
+			['Add tests for this change', 'test'],
+			['Check auth risk', 'security'],
+			['Who calls createSession?', 'graph'],
+			['Where is login implemented?', 'hybrid'],
+			['Find code related to onboarding', 'semantic'],
+		] as const;
+		for (const [question, mode] of cases)
+			expect(classifyRetrieval(question).mode).toBe(mode);
+		expect(new Set(cases.map((x) => x[1]))).toEqual(new Set(RETRIEVAL_MODES));
+	});
+});
+
+describe('repo_map retrieve production path', () => {
+	test('routes every mode through a real bounded action and explains it', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.mkdirSync(path.join(tmp, 'tests'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'session.ts'),
+			"export function createSession() { return 'SWARM_FOO'; }\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'login.ts'),
+			"import { createSession } from './session';\nexport function login() { return createSession(); }\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'tests', 'login.test.ts'),
+			"import { login } from '../src/login';\nlogin();\n",
+		);
+		expect(parse(await call({ action: 'build' })).success).toBe(true);
+
+		const requests = [
+			{ question: 'Find exact string `SWARM_FOO`' },
+			{ question: 'Who calls createSession?', symbol: 'createSession' },
+			{ question: 'Find code related to onboarding' },
+			{ question: 'Check auth risk', file: 'src/login.ts' },
+			{ question: 'Add tests for this change', file: 'src/login.ts' },
+			{ question: 'Where is login implemented?' },
+		];
+		const seen = new Set<string>();
+		for (const request of requests) {
+			const result = parse(
+				await call({ action: 'retrieve', max_tokens: 800, ...request }, 'kg16'),
+			);
+			expect(result.success).toBe(true);
+			seen.add(result.mode);
+			expect(result.actions.length).toBeGreaterThan(0);
+			expect(result.explanation.length).toBeGreaterThan(0);
+			expect(result.budget.usedTokens).toBeLessThanOrEqual(800);
+			expect(result.budget.omittedContextCount).toBeGreaterThanOrEqual(0);
+			expect(
+				Math.ceil(Buffer.byteLength(JSON.stringify(result), 'utf8') / 4),
+			).toBeLessThanOrEqual(800 + result.budget.metadataOverheadTokens);
+		}
+		expect(seen).toEqual(new Set(RETRIEVAL_MODES));
+
+		const bounded = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Find code related to login',
+				top_n: 1,
+			}),
+		);
+		const ask = bounded.context.find(
+			(entry: Record<string, unknown>) => entry.action === 'ask',
+		);
+		expect(ask.data.hits.length).toBeLessThanOrEqual(1);
+	});
+
+	test('falls back to literal search when the graph is missing and rejects empty questions', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-fallback-');
+		fs.writeFileSync(
+			path.join(tmp, 'source.ts'),
+			'export const createSession = 1;\n',
+		);
+		const result = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Who calls createSession?',
+				symbol: 'createSession',
+			}),
+		);
+		expect(result.success).toBe(true);
+		expect(result.mode).toBe('graph');
+		expect(result.graphHit).toBe(false);
+		expect(result.fallbackReason).toBe('graph_missing');
+		expect(result.actions).toContain('lexical_search');
+		const empty = parse(await call({ action: 'retrieve', question: '  ' }));
+		expect(empty.success).toBe(false);
+	});
+
+	test('uses the same bounded lexical fallback when repository graphs are disabled', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-disabled-');
+		fs.writeFileSync(path.join(tmp, 'source.ts'), 'const NEEDLE = 1;\n');
+		repoMapInternals.loadPluginConfigWithMeta = (() => ({
+			config: { repo_graph: { enabled: false } },
+			recovery: 'none',
+			removedKeys: [],
+			warnings: [],
+			loadedFromFile: false,
+			configHadErrors: false,
+		})) as typeof repoMapInternals.loadPluginConfigWithMeta;
+
+		const result = parse(
+			await call({ action: 'retrieve', question: 'Who calls NEEDLE?' }),
+		);
+		expect(result.success).toBe(true);
+		expect(result.graphHit).toBe(false);
+		expect(result.fallbackReason).toBe('graph_disabled');
+		expect(result.actions).toEqual(['lexical_search']);
+	});
+
+	test('falls back on empty graph, security, test, and hybrid pack results', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-pack-miss-');
+		fs.writeFileSync(path.join(tmp, 'source.ts'), 'const NEEDLE = 1;\n');
+		expect(parse(await call({ action: 'build' })).success).toBe(true);
+		const requests = [
+			{
+				mode: 'graph',
+				question: 'What is the impact of this file?',
+				file: 'missing.ts',
+			},
+			{
+				mode: 'security',
+				question: 'Check auth risk for this route',
+				route_path: '/missing',
+			},
+			{
+				mode: 'test',
+				question: 'Add tests for this change',
+				file: 'missing.ts',
+			},
+			{
+				mode: 'hybrid',
+				question: 'Review this file',
+				files: ['missing.ts'],
+			},
+		];
+		for (const request of requests) {
+			const result = parse(await call({ action: 'retrieve', ...request }));
+			expect({ mode: result.mode, graphHit: result.graphHit }).toEqual({
+				mode: request.mode,
+				graphHit: false,
+			});
+			expect(result.fallbackReason).toBe('graph_miss');
+			expect(result.actions.at(-1)).toBe('lexical_search');
+		}
+	});
+
+	test('applies direct-action validation to every routed auxiliary input', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-validation-');
+		const attacks = [
+			{ question: 'Review this file', file: '' },
+			{ question: 'Review this file', file: '../escape.ts' },
+			{ question: 'Review files', files: ['C:\\escape.ts'] },
+			{ question: 'Who calls it?', symbol: '' },
+			{ question: 'Who calls it?', symbol: 'bad\u0000symbol' },
+			{ question: 'Check auth route', route_path: '' },
+			{ question: 'Check auth route', route_path: 'missing-slash' },
+			{ question: 'Check data risk', entity: '' },
+			{ question: 'Check data risk', entity: '../users' },
+			{ question: 'Review this diff', diff: '' },
+			{ question: 'Review this diff', diff: '+++ b/a.ts\n+\u202ehidden' },
+			{ question: 'Check data risk', entity: 'users', file: 'src/a.ts' },
+			{
+				question: 'Check route risk',
+				route_path: '/users',
+				files: ['src/a.ts'],
+			},
+			{ question: 'Check route risk', method: 'GET' },
+		];
+		for (const attack of attacks) {
+			const result = parse(await call({ action: 'retrieve', ...attack }));
+			expect(result.success).toBe(false);
+		}
+	});
+
+	test('normalizes Windows-relative paths and treats empty file lists as omitted', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-path-parity-');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'login.ts'),
+			'export const login = 1;\n',
+		);
+		expect(parse(await call({ action: 'build' })).success).toBe(true);
+
+		const windowsPath = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Review this file',
+				file: 'src\\login.ts',
+			}),
+		);
+		expect(windowsPath.graphHit).toBe(true);
+		expect(windowsPath.actions).not.toContain('lexical_search');
+
+		for (const question of [
+			'Add tests for login behavior',
+			'Where is login implemented?',
+		]) {
+			const omitted = parse(await call({ action: 'retrieve', question }));
+			const empty = parse(
+				await call({ action: 'retrieve', question, files: [] }),
+			);
+			expect({
+				mode: empty.mode,
+				actions: empty.actions,
+				graphHit: empty.graphHit,
+				fallbackReason: empty.fallbackReason,
+			}).toEqual({
+				mode: omitted.mode,
+				actions: omitted.actions,
+				graphHit: omitted.graphHit,
+				fallbackReason: omitted.fallbackReason,
+			});
+		}
+
+		const dispatchCases = [
+			{
+				args: { question: 'Who calls login?', symbol: 'login' },
+				action: 'callers',
+			},
+			{
+				args: {
+					question: 'Review these files',
+					files: ['src/login.ts'],
+					symbol: 'login',
+				},
+				action: 'diff_context',
+			},
+			{
+				args: {
+					question: 'Review this change',
+					diff: '--- a/src/login.ts\n+++ b/src/login.ts\n@@ -1 +1 @@\n',
+				},
+				action: 'diff_context',
+			},
+			{
+				args: { question: 'Find account data', entity: 'account' },
+				action: 'data_trace',
+			},
+			{
+				args: {
+					question: 'Review auth route',
+					route_path: '/admin',
+					method: 'GET',
+				},
+				action: 'route_trace',
+			},
+		] as const;
+		for (const dispatch of dispatchCases) {
+			const result = parse(
+				await call({ action: 'retrieve', ...dispatch.args }),
+			);
+			expect(result.actions).toContain(dispatch.action);
+			if ('symbol' in dispatch.args && 'files' in dispatch.args) {
+				const pack = result.context.find(
+					(entry: Record<string, unknown>) => entry.action === 'test_pack',
+				);
+				expect(pack.data.target.symbol).toBe(dispatch.args.symbol);
+			}
+		}
+
+		for (const args of [
+			{ question: 'Find account data', entity: 'account' },
+			{ question: 'Check auth route', route_path: '/admin' },
+		]) {
+			const omitted = parse(await call({ action: 'retrieve', ...args }));
+			const empty = parse(
+				await call({ action: 'retrieve', ...args, files: [] }),
+			);
+			expect(empty).toEqual(omitted);
+		}
+	});
+
+	test('emits exactly one content-free telemetry record and remains fail-open', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-telemetry-');
+		fs.writeFileSync(path.join(tmp, 'source.ts'), 'const TOKEN = 1;\n');
+		const events: Array<Record<string, unknown>> = [];
+		repoMapInternals.telemetry.retrievalRouted = mock((sessionId, data) => {
+			events.push({ sessionId, ...data });
+		});
+		const result = parse(
+			await call({ action: 'retrieve', question: 'Find exact string `TOKEN`' }),
+		);
+		expect(result.success).toBe(true);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.sessionId).toBe('unknown');
+		const serialized = JSON.stringify(events[0]);
+		for (const forbidden of [
+			'TOKEN',
+			'source.ts',
+			'question',
+			'source',
+			'symbol',
+			'result',
+		])
+			expect(serialized).not.toContain(forbidden);
+
+		repoMapInternals.telemetry.retrievalRouted = mock(() => {
+			throw new Error('telemetry unavailable');
+		});
+		const failOpen = parse(
+			await call({ action: 'retrieve', question: 'Find exact string `TOKEN`' }),
+		);
+		expect(failOpen.success).toBe(true);
+	});
+});

--- a/tests/unit/tools/repo-map-kg16-retrieval-router.test.ts
+++ b/tests/unit/tools/repo-map-kg16-retrieval-router.test.ts
@@ -79,12 +79,24 @@ describe('repo_map retrieve production path', () => {
 		expect(parse(await call({ action: 'build' })).success).toBe(true);
 
 		const requests = [
-			{ question: 'Find exact string `SWARM_FOO`' },
-			{ question: 'Who calls createSession?', symbol: 'createSession' },
-			{ question: 'Find code related to onboarding' },
-			{ question: 'Check auth risk', file: 'src/login.ts' },
-			{ question: 'Add tests for this change', file: 'src/login.ts' },
-			{ question: 'Where is login implemented?' },
+			{ question: 'Find exact string `SWARM_FOO`', expected: 'lexical' },
+			{
+				question: 'Who calls createSession?',
+				symbol: 'createSession',
+				expected: 'graph',
+			},
+			{ question: 'Find code related to onboarding', expected: 'semantic' },
+			{
+				question: 'Check auth risk',
+				file: 'src/login.ts',
+				expected: 'security',
+			},
+			{
+				question: 'Add tests for this change',
+				file: 'src/login.ts',
+				expected: 'test',
+			},
+			{ question: 'Where is login implemented?', expected: 'hybrid' },
 		];
 		const seen = new Set<string>();
 		for (const request of requests) {
@@ -92,6 +104,17 @@ describe('repo_map retrieve production path', () => {
 				await call({ action: 'retrieve', max_tokens: 800, ...request }, 'kg16'),
 			);
 			expect(result.success).toBe(true);
+			expect(result.mode).toBe(request.expected);
+			expect(result.algorithm).toBe(
+				{
+					lexical: 'literal',
+					graph: 'graph',
+					semantic: 'fuzzy_graph',
+					security: 'graph_packs',
+					test: 'graph_packs',
+					hybrid: 'mixed',
+				}[request.expected],
+			);
 			seen.add(result.mode);
 			expect(result.actions.length).toBeGreaterThan(0);
 			expect(result.explanation.length).toBeGreaterThan(0);
@@ -102,6 +125,18 @@ describe('repo_map retrieve production path', () => {
 			).toBeLessThanOrEqual(800 + result.budget.metadataOverheadTokens);
 		}
 		expect(seen).toEqual(new Set(RETRIEVAL_MODES));
+		const noHintSecurity = parse(
+			await call({ action: 'retrieve', question: 'Check auth risk' }),
+		);
+		expect(noHintSecurity.actions).toContain('preflight_packet');
+		const genericHybrid = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Where is login implemented?',
+			}),
+		);
+		expect(genericHybrid.actions).toContain('ask');
+		expect(genericHybrid.actions).toContain('graph_explain');
 
 		const bounded = parse(
 			await call({
@@ -333,8 +368,16 @@ describe('repo_map retrieve production path', () => {
 			await call({ action: 'retrieve', question: 'Find exact string `TOKEN`' }),
 		);
 		expect(result.success).toBe(true);
+		expect(events).toHaveLength(0);
+		const sessionResult = parse(
+			await call(
+				{ action: 'retrieve', question: 'Find exact string `TOKEN`' },
+				'kg16-telemetry',
+			),
+		);
+		expect(sessionResult.success).toBe(true);
 		expect(events).toHaveLength(1);
-		expect(events[0]?.sessionId).toBe('unknown');
+		expect(events[0]?.sessionId).toBe('kg16-telemetry');
 		const serialized = JSON.stringify(events[0]);
 		for (const forbidden of [
 			'TOKEN',
@@ -346,6 +389,28 @@ describe('repo_map retrieve production path', () => {
 		])
 			expect(serialized).not.toContain(forbidden);
 
+		events.length = 0;
+		expect(parse(await call({ action: 'build' })).success).toBe(true);
+		for (const question of [
+			'Find exact string `TOKEN`',
+			'Who calls TOKEN?',
+			'Find code related to TOKEN',
+			'Check auth risk',
+			'Add tests for TOKEN',
+			'Where is TOKEN implemented?',
+		]) {
+			const routed = parse(
+				await call({ action: 'retrieve', question }, 'kg16-telemetry'),
+			);
+			expect(routed.success).toBe(true);
+		}
+		expect(events).toHaveLength(6);
+		for (const event of events) {
+			const serializedEvent = JSON.stringify(event);
+			for (const forbidden of ['TOKEN', 'source.ts', 'question', 'result'])
+				expect(serializedEvent).not.toContain(forbidden);
+		}
+
 		repoMapInternals.telemetry.retrievalRouted = mock(() => {
 			throw new Error('telemetry unavailable');
 		});
@@ -353,5 +418,73 @@ describe('repo_map retrieve production path', () => {
 			await call({ action: 'retrieve', question: 'Find exact string `TOKEN`' }),
 		);
 		expect(failOpen.success).toBe(true);
+	});
+
+	test('preserves fallback file scope and mixed quote delimiters', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-hints-');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'target.ts'),
+			"export const target = 'needle';\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'other.ts'),
+			"export const target = 'needle';\n",
+		);
+		const scoped = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Find exact string `needle`',
+				files: ['src/target.ts'],
+			}),
+		);
+		expect(scoped.success).toBe(true);
+		const lexical = scoped.context.find(
+			(entry: Record<string, unknown>) => entry.action === 'lexical_search',
+		);
+		expect(
+			lexical.data.matches.every(
+				(match: Record<string, unknown>) => match.file === 'src/target.ts',
+			),
+		).toBe(true);
+		expect(classifyRetrieval('Find user\'s value in "needle"').mode).toBe(
+			'lexical',
+		);
+	});
+
+	test('infers caller symbols and considers duplicate definitions', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-callers-');
+		fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'a.ts'),
+			'export function target() {}\n',
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'b.ts'),
+			'export function target() {}\n',
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'caller-a.ts'),
+			"import { target } from './a'; target();\n",
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'caller-b.ts'),
+			"import { target } from './b'; target();\n",
+		);
+		expect(parse(await call({ action: 'build' })).success).toBe(true);
+		const result = parse(
+			await call({
+				action: 'retrieve',
+				question: 'Which functions invoke target?',
+			}),
+		);
+		expect(result.success).toBe(true);
+		expect(result.actions).toContain('callers');
+		expect(result.graphHit).toBe(true);
+		expect(
+			result.warnings.some((warning: string) =>
+				warning.includes('ambiguous symbol'),
+			),
+		).toBe(true);
 	});
 });

--- a/tests/unit/tools/retrieval-router-edge-cases.test.ts
+++ b/tests/unit/tools/retrieval-router-edge-cases.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	classifyRetrieval,
+	ROUTER_METADATA_OVERHEAD_TOKENS,
+	routeRetrieval,
+} from '../../../src/tools/repo-graph';
+import { repo_map } from '../../../src/tools/repo-map';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tmp = '';
+
+function call(args: Record<string, unknown>): Promise<Record<string, any>> {
+	type Executable = {
+		execute: (
+			args: Record<string, unknown>,
+			ctx: { directory: string },
+		) => Promise<string>;
+	};
+	return (repo_map as unknown as Executable)
+		.execute(args, { directory: tmp })
+		.then((out) => JSON.parse(out) as Record<string, any>);
+}
+
+afterEach(() => {
+	if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+	tmp = '';
+});
+
+describe('retrieval router edge coverage', () => {
+	test('reports graph_load_error and still serves bounded lexical fallback', async () => {
+		tmp = canonicalMkdtemp('repo-map-kg16-load-error-');
+		fs.mkdirSync(path.join(tmp, '.swarm'), { recursive: true });
+		fs.writeFileSync(path.join(tmp, '.swarm', 'repo-graph.json'), '{not-json');
+		fs.writeFileSync(path.join(tmp, 'source.ts'), 'const NEEDLE = 1;\n');
+		const result = await call({
+			action: 'retrieve',
+			question: 'Where is NEEDLE implemented?',
+		});
+		expect(result.success).toBe(true);
+		expect(result.fallbackReason).toBe('graph_load_error');
+		expect(result.actions).toContain('lexical_search');
+	});
+
+	test('pins the closed-set algorithm mapping and classification explanation', async () => {
+		const lexicalRequests = [
+			['Find exact string `needle`', 'lexical', 'literal'],
+			['Who calls login?', 'graph', 'graph'],
+			['Find code related to onboarding', 'semantic', 'fuzzy_graph'],
+			['Check auth risk', 'security', 'graph_packs'],
+			['Add tests for login', 'test', 'graph_packs'],
+			['Review this diff', 'hybrid', 'mixed'],
+		] as const;
+		for (const [question, mode, algorithm] of lexicalRequests) {
+			const result = await routeRetrieval(
+				null,
+				{ question, maxTokens: 256 },
+				async () => ({ matches: [], total: 0, engine: 'test' }),
+			);
+			expect(result.mode).toBe(mode);
+			expect(result.algorithm).toBe(algorithm);
+			expect(result.explanation[0]).toBe(`classified:${result.reason}`);
+		}
+	});
+
+	test('passes validated scope and route hints to lexical fallback', async () => {
+		let request: Record<string, unknown> | undefined;
+		await routeRetrieval(
+			null,
+			{
+				question: 'Check route risk',
+				files: ['src/routes.ts'],
+				routePath: '/admin',
+				method: 'GET',
+			},
+			async (value) => {
+				request = value as unknown as Record<string, unknown>;
+				return { matches: [], total: 0, engine: 'test' };
+			},
+			'graph_miss',
+		);
+		expect(request).toEqual({
+			query: '/admin GET',
+			files: ['src/routes.ts'],
+			routePath: '/admin',
+			method: 'GET',
+		});
+	});
+
+	test('makes an undersized budget explicit instead of silently dropping context', async () => {
+		const result = await routeRetrieval(
+			null,
+			{ question: 'Find exact string `needle`', maxTokens: 1 },
+			async () => ({ matches: [{ text: 'x'.repeat(1000) }], total: 1 }),
+		);
+		expect(result.budget.requestedTokens).toBe(1);
+		expect(result.budget.usedTokens).toBeLessThanOrEqual(1);
+		expect(result.warnings).toContain('context_budget_too_small');
+		expect(ROUTER_METADATA_OVERHEAD_TOKENS).toBeGreaterThan(0);
+	});
+
+	test('does not classify contractions as quoted literals', () => {
+		expect(classifyRetrieval("Find user's implementation").mode).toBe(
+			'semantic',
+		);
+	});
+
+	test('keeps exact-string intent lexical when a file hint is present', async () => {
+		const result = await routeRetrieval(
+			{
+				schemaVersion: '1.6.0',
+				files: {},
+				symbols: {},
+				edges: [],
+			} as never,
+			{
+				question: 'Find exact string `NEEDLE`',
+				file: 'src/login.ts',
+			},
+			async () => ({ matches: [], total: 0, engine: 'test' }),
+		);
+		expect(result.mode).toBe('lexical');
+		expect(result.actions).toContain('lexical_search');
+	});
+});

--- a/tests/unit/tools/search-binary-fallback.test.ts
+++ b/tests/unit/tools/search-binary-fallback.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { searchWorkspaceLiteral } from '../../../src/tools/search';
+import {
+	_internals,
+	search,
+	searchWorkspaceLiteral,
+} from '../../../src/tools/search';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 let tmp = '';
@@ -28,5 +32,35 @@ describe('bounded Node literal-search fallback', () => {
 		expect(result.total).toBe(1);
 		expect(result.matches).toHaveLength(1);
 		expect(result.matches?.[0]?.file).toBe('source.ts');
+	});
+
+	test('routes the tool fallback through the injectable seam', async () => {
+		tmp = canonicalMkdtemp('search-fallback-seam-');
+		const original = _internals.fallbackSearch;
+		const originalResolve = _internals.resolveRipgrepBinary;
+		let called = false;
+		_internals.resolveRipgrepBinary = () => null;
+		_internals.fallbackSearch = async (opts) => {
+			called = true;
+			return original(opts);
+		};
+		try {
+			const result = await (
+				search as unknown as {
+					execute: (
+						args: Record<string, unknown>,
+						directory: string,
+					) => Promise<string>;
+				}
+			).execute(
+				{ query: 'SECRET', mode: 'literal', max_results: 10, max_lines: 100 },
+				tmp,
+			);
+			expect(JSON.parse(result).engine).toBe('fallback');
+			expect(called).toBe(true);
+		} finally {
+			_internals.fallbackSearch = original;
+			_internals.resolveRipgrepBinary = originalResolve;
+		}
 	});
 });

--- a/tests/unit/tools/search-binary-fallback.test.ts
+++ b/tests/unit/tools/search-binary-fallback.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { searchWorkspaceLiteral } from '../../../src/tools/search';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let tmp = '';
+afterEach(() => {
+	if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+	tmp = '';
+});
+
+describe('bounded Node literal-search fallback', () => {
+	test('skips NUL-bearing binary files while finding text matches', async () => {
+		tmp = canonicalMkdtemp('search-binary-fallback-');
+		fs.writeFileSync(
+			path.join(tmp, 'binary.bin'),
+			Buffer.from([0, 83, 69, 67, 82, 69, 84]),
+		);
+		fs.writeFileSync(path.join(tmp, 'source.ts'), 'const value = "SECRET";\n');
+		const result = await searchWorkspaceLiteral({
+			query: 'SECRET',
+			mode: 'literal',
+			maxResults: 10,
+			maxLines: 100,
+			workspace: tmp,
+		});
+		expect(result.total).toBe(1);
+		expect(result.matches).toHaveLength(1);
+		expect(result.matches?.[0]?.file).toBe('source.ts');
+	});
+});


### PR DESCRIPTION
Closes #1537

## Summary

- add a deterministic `repo_map(action: "retrieve")` router with graph, lexical, semantic, security, test, and hybrid modes
- preserve validated file/route/method scope through bounded lexical fallback, including exact-string precedence and duplicate caller definitions
- return bounded context with explicit undersized-budget warnings and content-free, session-keyed `retrieval_routed` telemetry
- close the cross-platform CI fixture gap and route the Node fallback through its injectable seam

## Feedback closure ledger

All feedback was independently verified against the exact published follow-up head `7a510fc17d7c28d4f227a7c5f42bf0d6fd60bcbd`, whose parent is the reviewed head `c2c43a30c43c62f8603a19a397986e62320be478`. No GitHub review threads were resolved; findings were closed by code/tests or classified as pre-existing/disproved.

| ID | Closure |
|---|---|
| B1-C001 | fixed: natural-language caller inference now uses bounded graph lookup |
| B1-C002 | fixed: duplicate exact symbol definitions are aggregated and ambiguity is warned |
| B1-C003 | pre-existing: absolute file rejection remains the existing validation contract |
| KG16-FB-01 | fixed: literal fallback preserves file, route, and method hints |
| KG16-RTR-001 | fixed: validated file scope reaches the lexical search include filter |
| KG16-RTR-002 | fixed: caller lookup honors duplicate definitions and file scope |
| kg2460-retrieval-unknown-session | fixed: sessionless calls emit no fabricated telemetry identity |
| TF-001 | fixed: production fallback calls `_internals.fallbackSearch`; seam test added |
| PO-001 | disproved: fallback reasons are closed-set internal labels |
| UR-001 | fixed: route path and method are preserved in structured fallback requests |
| EXT-CI-001 | fixed: `retrieval_routed` envelope fixture includes workflow/session fields |
| EXT-SCHEMA-001 | disproved: `top_n` and `max_tokens` already require positive integers |
| EXT-PACK-001 | fixed: oversized first context item yields a compact marker or explicit warning |
| EXT-CLASS-001 | fixed: exact-string intent remains lexical even with target hints |
| EXT-CLASS-002 | fixed: delimiter-aware literal parsing rejects mismatched quote pairs and contractions |
| EXT-COVER-001 | fixed: malformed graph exercises `graph_load_error` fallback |
| EXT-COVER-002 | fixed: all six mode/algorithm mappings are asserted |
| EXT-COVER-003 | fixed: security no-hint and generic hybrid branches are asserted |
| EXT-INPUT-001 | disproved: empty questions are rejected before routing |
| EXT-COVER-004 | fixed: production-path mode coverage is non-tautological |
| EXT-COVER-005 | fixed: telemetry privacy is asserted across all six modes |
| EXT-GRAPH-001 | fixed: caller intent accepts call/invoke/reference/use/dependent wording |
| EXT-BUDGET-001 | fixed: additive metadata overhead is documented and tested |
| EXT-REVIEW-C5 | disproved: closed-set route metadata and event contract remain coherent |
| EXT-REVIEW-C6 | disproved: bounded Node fallback is an intentional binary-safe tradeoff |
| CI-001 | fixed in `c2c43a30c`; remote matrix re-ran and exposed CI-002 below |
| CI-002 | fixed in `7a510fc17`; split the envelope round-trip test at the independent cross-process boundary; FR-006 now reports zero violations |
| BODY-001 | refreshed here with current tests, package smoke, and caveats |
| BODY-002 | refreshed here with current invariant audit and gate evidence |
| COMMENT-001 | closed by decomposition into the ledger items above |
| COMMENT-002 | closed by decomposition into the ledger items above |
| CONFLICT-001 | no conflict: GitHub reports `MERGEABLE` |
| STALE-001 | exact base/head binding was verified before each gate |

## Invariant audit

- 1 (plugin init): not touched — `node scripts/repro-704.mjs` passed T1/T2/T3 (39.5/31.3/21.2 ms).
- 2 (runtime portability): touched — `bun run build` and Node ESM import passed.
- 3 (subprocesses): touched — the Node fallback seam is bounded and uses existing search behavior; bare-spawn audit passed.
- 4 (.swarm containment): touched — retrieval uses the injected project directory; path and boundary tests pass.
- 5 (plan durability): not touched — no plan ledger/projection code changed.
- 6 (test_runner safety): not touched — validation used isolated shell commands, not broad `test_runner` scopes.
- 7 (test writing): touched — Bun tests, no new `mock.module`, all new files under 500 lines; cap check passed.
- 8 (session state): touched — retrieval telemetry now requires the real session key and has no fabricated fallback identity.
- 9 (guardrails/retry): touched — exact-string precedence, caller scope, and bounded fallback behavior are covered by focused tests.
- 10 (chat/system msg): not touched — no chat transform code changed.
- 11 (tool registration): touched — `bun run scripts/check-tool-registration.ts` passed (129 coherent tools).
- 12 (release/cache): touched — release fragment and pending-fragment check pass; cache logic unchanged.

## Test plan

- `bun --smol test tests/unit/observability/envelope-roundtrip.test.ts tests/unit/observability/envelope-roundtrip-process.test.ts tests/unit/tools/repo-map-kg16-retrieval-router.test.ts tests/unit/tools/retrieval-router-edge-cases.test.ts tests/unit/tools/search-binary-fallback.test.ts --timeout 120000` — 191 pass, 0 fail
- `bun run check:test-file-cap` — 0 new-file violations, 0 ratchet violations; envelope files are 497 and 22 lines
- `bun run build`
- `node --input-type=module -e "...import('./dist/index.js')..."`
- `node scripts/repro-704.mjs`
- `bun run typecheck`
- `bun run lint:ci` (one pre-existing warning in `src/health/learning-health.ts`)
- invariant, registration, portability, event, retention, shell, token, and test-file-cap checks — all passed (known pre-existing warnings only)
- `node --test` in `scripts/swarm-model` — 19 pass
- `bun run package:smoke` — pass (1171 files)

The exhaustive local `test:unit:ci` sweep was stopped after reproducing unrelated Windows host failures in pre-existing project-boundary/protected-store tests; the changed-file suite is fully green and remote CI is authoritative for cross-platform validation.

## Review evidence

- Stage B independent reviewer: all implementation/comment rows approved on the Stage-A-green diff; publication rows were correctly held until `7a510fc17` was pushed.
- Stage B independent test engineer: all implementation/test rows pass on the Stage-A-green diff; CI/body rows are now bound to published head `7a510fc17`.
- Closeout reviewer and critic: all implementation/comment findings approved; publication metadata was verified against `7a510fc17` before this body refresh.
- Remote CI-002 triage: quality failed only on the FR-006 line-cap ratchet; the prescribed split is validated locally and published in `7a510fc17`.
