### PR TITLE
fix(pr-workflow): restore review and feedback execution

### DIFF
--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -679,6 +679,9 @@ mock.module('node:fs', () => ({
 | `src/background/pending-delegations.ts` | `_checkpointInternals` (`renameWithRetry`, `renameOnce`, `syncSleep`) | #2034 checkpoint crash-window + Windows rename-retry tests (inject EPERM at the atomic rename boundary) |
 | `src/background/delegation-health.ts` | `_healthInternals` (`renameOnce`) | #2034 health-artifact Windows rename-retry tests |
 | `src/hooks/init-orphan-recovery.ts` | `recordDelegationRecoveryObservation` | #2034/#1659 durable recovery-observation tests |
+| `src/hooks/delegation-gate.ts` | `_internals.beforePrFeedbackScopeConsume` | #2469 declaration-replacement interleave tests (pause between scope classification and locked consumption) |
+| `src/hooks/pr-workflow-gate.ts` | `_test_exports.beforePrReviewReentryReservation` | #2469 workflow-lock-held-through-reservation interleave tests |
+| `src/hooks/pr-workflow-response-gate.ts` | `_internals.scanDelegationsForRecovery` | #2469 lane-progress-token tests (inject receipt digests / throwing scans) |
 
 **Delegation-gate split pattern (FR-006 SC-006.1):**
 

--- a/docs/releases/pending/2469-restore-pr-review-pr-feedback.md
+++ b/docs/releases/pending/2469-restore-pr-review-pr-feedback.md
@@ -1,0 +1,17 @@
+# Restore PR_REVIEW re-entry and PR_FEEDBACK scope execution
+
+## What
+
+- Authenticated PR_FEEDBACK scope declarations now take precedence over generic plan membership, retry, critic, and stale Stage-A checks even when a plan exists. Declaration consumption is serialized and call-bound.
+- `authorize_pr_review_reentry` is admitted by the PR_REVIEW controller, and its exact reviewer/test-engineer `subagent_type` Task is reserved once under a workflow-state → authorization-store lock order. Competing calls, ambiguous role fields, stale bindings, and replay by another call fail closed. A Task carrying only the `agent` field is never admitted (the delegation gate cannot enforce on it), and a dispatch the delegation gate later rejects for an unrelated reason still burns the authorization.
+- PR workflow auto-resume now treats durable active-lane status and structured receipt transitions as progress. Repeated no-op collection still trips the brake; corrupt or unreadable delegation state never earns progress credit (a throwing recovery scan is treated as uncertainty, not a wake-killing error); the progress scan is no longer paid before the wake-cooldown early-return; running lanes remain running on wait-budget expiry.
+- The re-entry authorization store write is now hard-bounded to the persisted-record cap (a full store can no longer be written one record over the schema bound and become unreadable), and pruning prioritizes still-live unconsumed authorizations over consumed ones within the retention bound.
+- The optional PR-review resilience policy remains disabled by default.
+
+## Why
+
+The decomposed PR workflow had three integration gaps: plan-bearing feedback scopes fell into generic plan gates, the documented one-shot re-entry tool could not pass the real controller hook, and the wake brake observed only gate revision changes while lane collection writes its durable progress elsewhere.
+
+## Migration
+
+No configuration or persisted-state migration is required. Existing authorization, scope, workflow, and delegation records remain readable. Two single-consumption behaviors are intentional and now documented: a failed downstream re-entry dispatch burns its one-shot authorization (issue a fresh authorization before retrying), and a consumed PR-feedback scope declaration is not reclaimed — if a dispatch fails after consumption, prepare a fresh declaration for a new task id instead of retrying the consumed one.

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -125,7 +125,10 @@ import {
 	standardWorktreeByCallID,
 	standardWorktreeSerializationSessions,
 } from './delegation-gate/worktree-isolation';
-import { consumePrFeedbackScopeDeclaration } from './pr-workflow-gate.js';
+import {
+	consumePrFeedbackScopeDeclaration,
+	resolvePrFeedbackScopeDeclaration,
+} from './pr-workflow-gate.js';
 export { resetStandardWorktreeIsolationState };
 
 import { pushAdvisory } from '../utils/advisory-queue';
@@ -260,77 +263,98 @@ export function clearPendingCoderScope(): void {
 	pendingCoderScopeByTaskId.clear();
 }
 
-interface PreparedCoderScope {
-	plan: Plan | null;
-	taskId: string;
-	declaredFiles: string[] | null;
-	binding: ScopeBinding;
-}
+type PreparedCoderScope =
+	| {
+			kind: 'pr_feedback';
+			plan: null;
+			taskId: string;
+			declaredFiles: string[] | null;
+			binding: ScopeBinding;
+	  }
+	| {
+			kind: 'plan';
+			plan: Plan;
+			taskId: string;
+			declaredFiles: string[] | null;
+			binding: ScopeBinding;
+	  };
 
 async function prepareCoderScope(
 	directory: string,
 	input: { sessionID: string; callID: string },
 	args: Record<string, unknown>,
 ): Promise<PreparedCoderScope> {
-	// loadPlanJsonOnly swallows read/parse errors and returns null for missing,
-	// corrupt, or schema-invalid plan.json — it never throws (see plan/manager.ts).
-	const plan = await loadPlanJsonOnly(directory);
-	if (!plan) {
-		// PR #1915 PR-workflow gate: if there's no plan.json but the caller has
-		// declared a verified PR-feedback scope for an explicit plan-task-shaped
-		// task_id, bind that scope and return early (no plan needed).
-		const rawTaskId =
-			typeof args.task_id === 'string'
-				? args.task_id.trim()
-				: typeof args.taskId === 'string'
-					? args.taskId.trim()
-					: '';
-		if (isStrictTaskId(rawTaskId)) {
+	const rawTaskId =
+		typeof args.task_id === 'string'
+			? args.task_id.trim()
+			: typeof args.taskId === 'string'
+				? args.taskId.trim()
+				: '';
+	if (isStrictTaskId(rawTaskId)) {
+		// Issue #2469: authenticated PR_FEEDBACK scope is a controller-owned
+		// authority source, not a fallback for a missing generic plan. Resolve it
+		// first even when plan.json exists, validate all caller-supplied scope
+		// material before consuming it, then reserve it atomically to this call.
+		const resolvedFeedbackScope = await resolvePrFeedbackScopeDeclaration(
+			directory,
+			input.sessionID,
+			rawTaskId,
+		);
+		if (resolvedFeedbackScope) {
+			const directives = extractTaskFileDirectives(args);
+			if (directives.present && !directives.files) {
+				throw new Error(
+					'SCOPE_NOT_DECLARED: FILE: directives are present but empty or ambiguous; provide one complete relative path per FILE: line.',
+				);
+			}
+			const resolved = resolveCoderScopeSources({
+				explicitFiles: resolvedFeedbackScope.files,
+				planFiles: null,
+				fileDirectiveFiles: directives.files,
+			});
+			if (!resolved.ok) throw new Error(formatCoderScopeConflict(resolved));
+			await _internals.beforePrFeedbackScopeConsume?.();
 			const feedbackScope = await consumePrFeedbackScopeDeclaration(
 				directory,
 				input.sessionID,
 				rawTaskId,
 				input.callID,
+				resolvedFeedbackScope,
 			);
-			if (feedbackScope) {
-				const directives = extractTaskFileDirectives(args);
-				if (directives.present && !directives.files) {
-					throw new Error(
-						'SCOPE_NOT_DECLARED: FILE: directives are present but empty or ambiguous; provide one complete relative path per FILE: line.',
-					);
-				}
-				const resolved = resolveCoderScopeSources({
-					explicitFiles: feedbackScope.files,
-					planFiles: null,
-					fileDirectiveFiles: directives.files,
-				});
-				if (!resolved.ok) {
-					throw new Error(formatCoderScopeConflict(resolved));
-				}
-				const binding = createPrFeedbackScopeBinding({
-					directory,
-					taskId: rawTaskId,
-					files: resolved.files,
-					ownerSessionId: input.sessionID,
-					ownerMessageId: input.callID,
-					dispatchCallId: input.callID,
-					activation: 'pending_child',
-					workflowSessionId: input.sessionID,
-					workflowRevisionDigest: feedbackScope.revisionDigest,
-				});
-				if (!binding) {
-					throw new Error(
-						'SCOPE_NOT_DECLARED: PR-feedback scope could not be bound to this Task invocation.',
-					);
-				}
-				return {
-					plan: null,
-					taskId: rawTaskId,
-					declaredFiles: resolved.files,
-					binding,
-				};
+			if (!feedbackScope) {
+				throw new Error(
+					'SCOPE_NOT_DECLARED: PR-feedback scope could not be reserved by this Task invocation (the declaration was replaced, the workflow left PR_FEEDBACK, or its revision changed).',
+				);
 			}
+			const binding = createPrFeedbackScopeBinding({
+				directory,
+				taskId: rawTaskId,
+				files: resolved.files,
+				ownerSessionId: input.sessionID,
+				ownerMessageId: input.callID,
+				dispatchCallId: input.callID,
+				activation: 'pending_child',
+				workflowSessionId: input.sessionID,
+				workflowRevisionDigest: feedbackScope.revisionDigest,
+			});
+			if (!binding) {
+				throw new Error(
+					'SCOPE_NOT_DECLARED: PR-feedback scope could not be bound to this Task invocation.',
+				);
+			}
+			return {
+				kind: 'pr_feedback',
+				plan: null,
+				taskId: rawTaskId,
+				declaredFiles: resolved.files,
+				binding,
+			};
 		}
+	}
+	// loadPlanJsonOnly swallows read/parse errors and returns null for missing,
+	// corrupt, or schema-invalid plan.json — it never throws (see plan/manager.ts).
+	const plan = await loadPlanJsonOnly(directory);
+	if (!plan) {
 		// Issue #1914: no plan AND no PR-feedback declaration. One message
 		// covers missing / corrupt / schema-invalid (loadPlanJsonOnly already
 		// logged the validation warning).
@@ -413,7 +437,7 @@ async function prepareCoderScope(
 			'SCOPE_NOT_DECLARED: coder scope could not be bound to this Task invocation.',
 		);
 	}
-	return { plan, taskId, declaredFiles, binding };
+	return { kind: 'plan', plan, taskId, declaredFiles, binding };
 }
 
 /**
@@ -2958,6 +2982,7 @@ export const _internals = {
 	PLAN_CRITIC_TASK_SIGNALS,
 	extractPlanCriticVerdict,
 	forceRecordPlanCriticApproval,
+	beforePrFeedbackScopeConsume: undefined as (() => Promise<void>) | undefined,
 	get provisionWorktree() {
 		return _wtiInternals.provisionWorktree;
 	},
@@ -3881,10 +3906,10 @@ export function createDelegationGateHook(
 					// exemption: the council gate above, the background-task
 					// block, acceptance-criteria enforcement, and every other
 					// check in this hook remain fully authoritative.
-					const { consumePrReviewReentryAuthorization } = await import(
-						'../pr-review/authorization.js'
+					const { reserveActivePrReviewReentryAuthorization } = await import(
+						'./pr-workflow-gate.js'
 					);
-					const consumed = await consumePrReviewReentryAuthorization(
+					const consumed = await reserveActivePrReviewReentryAuthorization(
 						directory,
 						input.sessionID,
 						{
@@ -3934,12 +3959,28 @@ export function createDelegationGateHook(
 			readTaskEvidence,
 			transitionTaskWorkflowEvidence,
 		} = await import('../gate-evidence');
-		const resolvedPreflightTaskId = await resolveEvidenceTaskId(
-			args,
-			session,
-			directory,
-		);
-		const preflightPlan = await loadPlanJsonOnly(directory);
+		const requestedScopeTaskId =
+			typeof args.task_id === 'string'
+				? args.task_id.trim()
+				: typeof args.taskId === 'string'
+					? args.taskId.trim()
+					: '';
+		// Read-only classification comes before generic task-workflow gates. It
+		// intentionally creates no binding and consumes no declaration; the exact
+		// declaration is revalidated and atomically consumed in prepareCoderScope.
+		const classifiedFeedbackScope = isStrictTaskId(requestedScopeTaskId)
+			? await resolvePrFeedbackScopeDeclaration(
+					directory,
+					input.sessionID,
+					requestedScopeTaskId,
+				)
+			: null;
+		const resolvedPreflightTaskId = classifiedFeedbackScope
+			? null
+			: await resolveEvidenceTaskId(args, session, directory);
+		const preflightPlan = classifiedFeedbackScope
+			? null
+			: await loadPlanJsonOnly(directory);
 		const preflightTaskId =
 			resolvedPreflightTaskId &&
 			preflightPlan?.phases.some((phase) =>
@@ -4006,7 +4047,7 @@ export function createDelegationGateHook(
 			}
 			throw error;
 		}
-		const { plan, taskId: incomingCoderTaskId } = preparedScope;
+		const { taskId: incomingCoderTaskId } = preparedScope;
 		if (incomingCoderTaskId) {
 			// Structured dispatch-context attribution (Stage A wedge fix): the
 			// resolved task id comes from args.task_id / the plan-validated scope
@@ -4093,7 +4134,7 @@ export function createDelegationGateHook(
 			}
 			backgroundCoderReservationByCallID.set(input.callID, claim.reservation);
 		};
-		if (!plan) {
+		if (preparedScope.kind === 'pr_feedback') {
 			await reserveBackgroundCoderIfNeeded(1);
 			try {
 				if (
@@ -4127,7 +4168,8 @@ export function createDelegationGateHook(
 			}
 			return;
 		}
-		const profile = plan?.execution_profile;
+		const plan = preparedScope.plan;
+		const profile = plan.execution_profile;
 		const parallelEnabled = profile?.parallelization_enabled === true;
 		const maxConcurrent = profile?.max_concurrent_tasks ?? 10;
 		const effectiveMaxConcurrent =

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -98,7 +98,13 @@ import {
 	type PrWorkflowGitState,
 } from '../git/pr-workflow-state.js';
 import { redactSecrets } from '../memory/redaction.js';
-import { bindPrReviewReentryBindingReader } from '../pr-review/authorization.js';
+import {
+	bindPrReviewReentryBindingReader,
+	type PrReviewReentryAuthorizationRecord,
+	type PrReviewReentryBindingContext,
+	type PrReviewReentryRole,
+	reservePrReviewReentryAuthorizationAgainstBinding,
+} from '../pr-review/authorization.js';
 import {
 	adoptPrReviewCircuit,
 	CIRCUIT_TERMINAL_DELEGATION_STATUSES,
@@ -6507,11 +6513,11 @@ function prFeedbackCoveredItems(
 }
 
 /** Validate cumulative exact inventory ownership and settled verification artifacts. */
-export async function assertPrFeedbackVerificationSettled(
+async function assertPrFeedbackVerificationSettledState(
 	directory: string,
-	sessionID: string,
-): Promise<PrWorkflowGateState> {
-	const state = await requireBoundState(directory, sessionID, 'PR_FEEDBACK');
+	state: PrWorkflowGateState,
+): Promise<string> {
+	if (state.mode !== 'PR_FEEDBACK') throw wrongModeError(state, 'PR_FEEDBACK');
 	const currentDigest = await currentPrFeedbackRevisionDigest(directory, state);
 	const inventory = state.prFeedbackInventory;
 	const batches = state.prFeedbackVerifications ?? [];
@@ -6527,6 +6533,16 @@ export async function assertPrFeedbackVerificationSettled(
 			`BLOCKED: PR_FEEDBACK verification ownership is incomplete; missing inventory items: ${missing.join(', ') || '(none)'}`,
 		);
 	}
+	return currentDigest;
+}
+
+/** Validate cumulative exact inventory ownership and settled verification artifacts. */
+export async function assertPrFeedbackVerificationSettled(
+	directory: string,
+	sessionID: string,
+): Promise<PrWorkflowGateState> {
+	const state = await requireBoundState(directory, sessionID, 'PR_FEEDBACK');
+	await assertPrFeedbackVerificationSettledState(directory, state);
 	return state;
 }
 
@@ -10451,29 +10467,57 @@ export async function consumePrFeedbackScopeDeclaration(
 	sessionID: string,
 	taskId: string,
 	callID: string,
+	expected: Pick<
+		PrFeedbackScopeDeclarationRecord,
+		'declaredAt' | 'revisionDigest' | 'files'
+	>,
 ): Promise<PrFeedbackScopeDeclarationRecord | null> {
-	const declaration = await resolvePrFeedbackScopeDeclaration(
-		directory,
-		sessionID,
-		taskId,
-	);
-	if (!declaration) return null;
-	if (declaration.consumedByCallId && declaration.consumedByCallId !== callID) {
-		throw new Error(
-			`SCOPE_NOT_DECLARED: PR-feedback scope ${taskId} was already consumed by another Task call`,
+	const normalizedSessionID = normalizeSessionID(sessionID);
+	return withSessionStateMutation(directory, normalizedSessionID, async () => {
+		const state = await readPrWorkflowGateStateFromDisk(
+			directory,
+			normalizedSessionID,
 		);
-	}
-	if (declaration.consumedByCallId === callID) return declaration;
-	const state = await requireBoundState(directory, sessionID, 'PR_FEEDBACK');
-	const nextState: PrWorkflowGateState = {
-		...state,
-		updatedAt: isoNow(),
-		prFeedbackScopes: (state.prFeedbackScopes ?? []).map((entry) =>
-			entry.taskId === taskId ? { ...entry, consumedByCallId: callID } : entry,
-		),
-	};
-	await persistState(directory, nextState);
-	return { ...declaration, consumedByCallId: callID };
+		if (!state || state.mode !== 'PR_FEEDBACK') return null;
+		const declaration = (state.prFeedbackScopes ?? []).find(
+			(entry) => entry.taskId === taskId,
+		);
+		if (!declaration) return null;
+		// The declaration was classified before this lock was acquired so caller
+		// directives could be checked without holding the workflow-state lock. Pin
+		// the reservation to that exact snapshot: a controller replacement must
+		// never consume new authority while publishing files from the old record.
+		if (
+			declaration.declaredAt !== expected.declaredAt ||
+			declaration.revisionDigest !== expected.revisionDigest ||
+			JSON.stringify(declaration.files) !== JSON.stringify(expected.files)
+		) {
+			return null;
+		}
+		const currentDigest = await assertPrFeedbackVerificationSettledState(
+			directory,
+			state,
+		);
+		if (currentDigest !== declaration.revisionDigest) return null;
+		if (
+			declaration.consumedByCallId &&
+			declaration.consumedByCallId !== callID
+		) {
+			throw new Error(
+				`SCOPE_NOT_DECLARED: PR-feedback scope ${taskId} was already consumed by another Task call`,
+			);
+		}
+		if (declaration.consumedByCallId === callID) return declaration;
+		const consumed = { ...declaration, consumedByCallId: callID };
+		await writeStateWhileLocked(directory, {
+			...state,
+			updatedAt: isoNow(),
+			prFeedbackScopes: (state.prFeedbackScopes ?? []).map((entry) =>
+				entry.taskId === taskId ? consumed : entry,
+			),
+		});
+		return consumed;
+	});
 }
 
 export async function validatePrFeedbackScopeBinding(
@@ -10745,8 +10789,30 @@ export async function enforcePrWorkflowToolBefore(
 			? ` ${describeBlockedPrReviewShellCommand(command, shellPermissionEnvelope)}`
 			: '';
 	if (state.mode === 'PR_REVIEW') {
+		let hasAuthorizedDirectReentry = false;
+		if (
+			isDirectAgentTask &&
+			// Admission must key on `subagent_type` specifically: the delegation
+			// gate's enforcement (Stage-A, reviewer routing, acceptance) only
+			// runs for dispatches carrying `subagent_type`, so an `agent:`-only
+			// dispatch admitted here would skip every downstream gate.
+			requestedAgentFields.length === 1 &&
+			requestedAgentFields[0] === 'subagent_type' &&
+			requestedRoles.length === 1 &&
+			(requestedRoles[0] === 'reviewer' ||
+				requestedRoles[0] === 'test_engineer') &&
+			callID
+		) {
+			hasAuthorizedDirectReentry = Boolean(
+				await reserveActivePrReviewReentryAuthorization(directory, sessionID, {
+					role: requestedRoles[0],
+					callID,
+				}),
+			);
+		}
 		const isAllowedReviewTool =
 			isInternalWorkflowTool ||
+			hasAuthorizedDirectReentry ||
 			isNamedReadOnlyTool ||
 			(isReadOnlyShell && (!isShellCheckout || isCanonicalReviewCheckout));
 		if (
@@ -10928,18 +10994,19 @@ export async function enforcePrWorkflowToolBefore(
 export async function readPrReviewReentryBindingContext(
 	directory: string,
 	sessionID: string,
-): Promise<{
-	prHeadSha: string;
-	revisionDigest: string;
-	generation: number;
-	workflowInstanceId?: string;
-	runId?: string;
-} | null> {
+): Promise<PrReviewReentryBindingContext | null> {
 	const state = await readPrWorkflowGateStateFromDisk(
 		directory,
 		normalizeSessionID(sessionID),
 	);
-	if (!state || state.mode !== 'PR_REVIEW' || !state.prHeadSha) return null;
+	return state ? prReviewReentryBindingFromState(directory, state) : null;
+}
+
+async function prReviewReentryBindingFromState(
+	directory: string,
+	state: PrWorkflowGateState,
+): Promise<PrReviewReentryBindingContext | null> {
+	if (state.mode !== 'PR_REVIEW' || !state.prHeadSha) return null;
 	const ctx = await createPrReviewGateContext(directory, state);
 	return {
 		prHeadSha: state.prHeadSha,
@@ -10957,6 +11024,35 @@ export async function readPrReviewReentryBindingContext(
 				}
 			: {}),
 	};
+}
+
+/**
+ * Sole production reservation/verification path for direct PR-review re-entry.
+ * Lock order is fixed: workflow-session first, authorization store second. The
+ * active binding cannot change between its locked reread and reservation commit.
+ */
+export async function reserveActivePrReviewReentryAuthorization(
+	directory: string,
+	sessionID: string,
+	request: { role: PrReviewReentryRole; callID: string },
+): Promise<PrReviewReentryAuthorizationRecord | null> {
+	const normalizedSessionID = normalizeSessionID(sessionID);
+	return withSessionStateMutation(directory, normalizedSessionID, async () => {
+		const state = await readPrWorkflowGateStateFromDisk(
+			directory,
+			normalizedSessionID,
+		);
+		if (!state) return null;
+		const binding = await prReviewReentryBindingFromState(directory, state);
+		if (!binding) return null;
+		await _test_exports.beforePrReviewReentryReservation?.();
+		return reservePrReviewReentryAuthorizationAgainstBinding(
+			directory,
+			normalizedSessionID,
+			request,
+			binding,
+		);
+	});
 }
 
 // Issue #2385: the reentry authorization boundary (src/pr-review/
@@ -11469,6 +11565,7 @@ export const _test_exports = {
 		_test_exports.beforePrFeedbackTrackingSwitch = undefined;
 		_test_exports.afterPrFeedbackTrackingSwitch = undefined;
 		_test_exports.beforePrFeedbackTrackingPersist = undefined;
+		_test_exports.beforePrReviewReentryReservation = undefined;
 		_test_exports.beforeBoundedSwarmFileOpen = undefined;
 		_test_exports.beforeSessionStateLockWrite = undefined;
 		_test_exports.beforeCheckoutLockWrite = undefined;
@@ -11507,6 +11604,10 @@ export const _test_exports = {
 		| undefined,
 	afterPrFeedbackTrackingSwitch: undefined as (() => Promise<void>) | undefined,
 	beforePrFeedbackTrackingPersist: undefined as
+		| (() => Promise<void>)
+		| undefined,
+	/** Interleave point held inside the workflow-session lock before auth commit. */
+	beforePrReviewReentryReservation: undefined as
 		| (() => Promise<void>)
 		| undefined,
 	beforeBoundedSwarmFileOpen: undefined as (() => Promise<void>) | undefined,
@@ -11945,6 +12046,7 @@ const PR_WORKFLOW_SHARED_CONTROLLER_TOOLS = new Set([
 ]);
 
 const PR_REVIEW_CONTROLLER_TOOLS = new Set([
+	'authorize_pr_review_reentry',
 	'parse_lane_candidates',
 	'write_pr_review_artifact',
 	'write_pr_review_trigger_eval',

--- a/src/hooks/pr-workflow-response-gate.ts
+++ b/src/hooks/pr-workflow-response-gate.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+import { scanDelegationsForRecovery } from '../background/pending-delegations.js';
 import {
 	claimPrFeedbackMonitorEvents,
 	readPrFeedbackMonitorQueue,
@@ -29,28 +31,23 @@ export const _internals: {
 	claimPrFeedbackMonitorEvents: typeof claimPrFeedbackMonitorEvents;
 	readPrFeedbackMonitorQueue: typeof readPrFeedbackMonitorQueue;
 	observePrWorkflowAutoWakeEvent: typeof observePrWorkflowAutoWakeEvent;
+	scanDelegationsForRecovery: typeof scanDelegationsForRecovery;
 } = {
 	readPrWorkflowGateState,
 	claimPrFeedbackMonitorEvents,
 	readPrFeedbackMonitorQueue,
 	observePrWorkflowAutoWakeEvent,
+	scanDelegationsForRecovery,
 };
 
 /**
  * Maximum number of consecutive unproductive auto-resumes per gated session
  * before the response gate suspends further wakes. "Unproductive" means the
- * durable gate's `revision` did not advance between wakes — i.e. no
- * state-mutating controller tool (dispatch_lanes_async,
- * write_pr_review_trigger_eval, complete_pr_workflow, recordPrReview*,
- * bindPrReviewBase, …) made durable progress. A healthy review bumps
- * `revision` on every successful state-mutating controller call, so the
- * consecutive counter resets on progress and never exhausts the budget.
- * Read-only tools (collect_lane_results polling, grep, read) intentionally do
- * NOT bump `revision` — an architect that only polls without ever dispatching
- * new lanes or recording trigger evaluations IS making progress on the
- * runtime's bookkeeping but is not advancing the durable gate, so the budget
- * treats long polling-only stretches conservatively. Only a genuinely stuck
- * session holds `revision` constant across many idle cycles.
+ * fixed-size digest of the durable gate plus its exact active delegation lanes
+ * did not change. Controller revisions, lane status transitions, terminal
+ * events, and structured receipt digests count as progress; repeated
+ * collect_lane_results polls do not. Strict-ledger uncertainty is sticky and
+ * never earns progress credit, including the first recovered snapshot.
  */
 export const DEFAULT_MAX_CONSECUTIVE_UNPRODUCTIVE_WAKES = 5;
 
@@ -166,6 +163,8 @@ interface WakeBudget {
 	consecutiveUnproductive: number;
 	lastWakeAt: number;
 	lastSeenRevision?: number;
+	lastSeenProgressToken?: string;
+	progressUncertain: boolean;
 	suspended: boolean;
 	/** Total number of wake attempts recorded for this budget. NEVER reset by
 	 * revision progress — only the consecutive counter resets on progress; that
@@ -188,6 +187,125 @@ interface WakeBudget {
 	 * currently reports, was reached (same scope caveat as
 	 * {@link WakeBudget.totalWakes}). */
 	suspendedReason: 'consecutive' | 'total';
+}
+
+type WorkflowProgressSnapshot =
+	| { kind: 'valid'; token: string }
+	| { kind: 'uncertain' };
+
+function activeWorkflowLaneKeys(state: {
+	prReviewBaseDispatches?: Array<{
+		batchId: string;
+		lanes: Array<{ laneId: string }>;
+	}>;
+	prReviewValidationBatches?: Array<{
+		batchId: string;
+		lanes: Array<{ laneId: string }>;
+	}>;
+	prFeedbackVerifications?: Array<{
+		batchId: string;
+		ownership: Array<{ laneId: string }>;
+	}>;
+	prFeedbackGateBatches?: Array<{ batchId: string; laneId: string }>;
+}): Set<string> {
+	const keys = new Set<string>();
+	for (const batch of state.prReviewBaseDispatches ?? []) {
+		for (const lane of batch.lanes)
+			keys.add(`${batch.batchId}\0${lane.laneId}`);
+	}
+	for (const batch of state.prReviewValidationBatches ?? []) {
+		for (const lane of batch.lanes)
+			keys.add(`${batch.batchId}\0${lane.laneId}`);
+	}
+	for (const batch of state.prFeedbackVerifications ?? []) {
+		for (const lane of batch.ownership)
+			keys.add(`${batch.batchId}\0${lane.laneId}`);
+	}
+	for (const batch of state.prFeedbackGateBatches ?? []) {
+		keys.add(`${batch.batchId}\0${batch.laneId}`);
+	}
+	return keys;
+}
+
+function workflowProgressSnapshot(
+	directory: string,
+	sessionID: string,
+	state: NonNullable<Awaited<ReturnType<typeof readPrWorkflowGateState>>>,
+): WorkflowProgressSnapshot {
+	let scan: ReturnType<typeof scanDelegationsForRecovery>;
+	try {
+		scan = _internals.scanDelegationsForRecovery(directory);
+	} catch {
+		// A throwing scan (e.g. transient fs failure) is observation
+		// uncertainty, not a wake-killing error: surface it as an uncertain
+		// snapshot so the wake evaluation still runs and the brake treats the
+		// cycle conservatively.
+		return { kind: 'uncertain' };
+	}
+	if (scan.status !== 'ok') return { kind: 'uncertain' };
+	const activeKeys = activeWorkflowLaneKeys(state);
+	const activatedAt = Date.parse(state.activatedAt);
+	const modePrefix =
+		state.mode === 'PR_REVIEW' ? 'swarm-pr-review:' : 'swarm-pr-feedback:';
+	const tuples = scan.owners
+		.filter((record) => {
+			if (
+				record.parentSessionId !== sessionID ||
+				!record.mode?.startsWith(modePrefix) ||
+				!record.batchId ||
+				!record.laneId ||
+				!activeKeys.has(`${record.batchId}\0${record.laneId}`) ||
+				(Number.isFinite(activatedAt) && record.createdAt < activatedAt)
+			) {
+				return false;
+			}
+			return (
+				!state.prHeadSha || record.workspace?.prHeadSha === state.prHeadSha
+			);
+		})
+		.map((record) => {
+			const result = record.result ?? record.terminalResult?.result;
+			return [
+				record.correlationId,
+				record.batchId,
+				record.laneId,
+				record.status,
+				record.terminalResult?.eventId ?? '',
+				result?.digest ?? '',
+				result?.outputRef ?? '',
+				result?.prReviewResultReceipt?.semanticEnvelopeDigest ?? '',
+			].join('\0');
+		})
+		.sort((left, right) => left.localeCompare(right));
+	const workflowIdentity =
+		state.workflowInstanceId ?? `${state.mode}\0${state.activatedAt}`;
+	return {
+		kind: 'valid',
+		token: createHash('sha256')
+			.update(`${workflowIdentity}\0${state.revision}\0${tuples.join('\n')}`)
+			.digest('hex'),
+	};
+}
+
+function observeWorkflowProgress(
+	budget: WakeBudget,
+	snapshot: WorkflowProgressSnapshot,
+): boolean {
+	if (snapshot.kind === 'uncertain') {
+		budget.progressUncertain = true;
+		return false;
+	}
+	if (budget.progressUncertain) {
+		// Recovery establishes a trustworthy baseline; it is not productivity.
+		budget.progressUncertain = false;
+		budget.lastSeenProgressToken = snapshot.token;
+		return false;
+	}
+	const madeProgress =
+		budget.lastSeenProgressToken === undefined ||
+		budget.lastSeenProgressToken !== snapshot.token;
+	budget.lastSeenProgressToken = snapshot.token;
+	return madeProgress;
 }
 
 interface BoundaryActivityState {
@@ -372,7 +490,7 @@ function blockedText(
 		} else {
 			const max = options.maxConsecutive;
 			lines.push(
-				`Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries (the durable gate \`revision\` did not advance). The session will not be re-awoken automatically. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\` to publish normally.`,
+				`Auto-resume is suspended after ${max ?? 'the configured number of'} consecutive unproductive retries (no durable controller revision, lane status, or structured receipt transition was observed). The session will not be re-awoken automatically. Run \`/swarm abort-pr-workflow\` or call \`abort_pr_workflow\` to clear the gate, or complete the workflow with \`complete_pr_workflow\` to publish normally.`,
 			);
 		}
 	}
@@ -855,8 +973,8 @@ export function createPrWorkflowResponseGate(options: {
 	 *     handlers hold a live reference to their budget object: deleting the
 	 *     map entry detaches it, so their later `totalWakes += 1` / `suspended =
 	 *     true` writes land on an object nothing can read, and the next idle
-	 *     rebuilds a zeroed budget. A rebuilt budget has `lastSeenRevision ===
-	 *     undefined`, which makes `madeProgress` unconditionally true — so the
+	 *     rebuilds a zeroed budget. A rebuilt budget has no progress-token
+	 *     baseline, which makes the first valid observation productive — so the
 	 *     consecutive brake, the cooldown, and the total ceiling all become
 	 *     unreachable for that session.
 	 *  3. Among the survivors, evict the SMALLEST `lastWakeAt`.
@@ -1143,6 +1261,7 @@ export function createPrWorkflowResponseGate(options: {
 				budget = {
 					consecutiveUnproductive: 0,
 					lastWakeAt: 0,
+					progressUncertain: false,
 					suspended: false,
 					totalWakes: 0,
 					suspendedReason: 'consecutive',
@@ -1181,12 +1300,10 @@ export function createPrWorkflowResponseGate(options: {
 			if (!getLiveBoundaryActivity(sessionID, boundaryGeneration)) return;
 			state = postStatusState;
 
-			if (
-				budget.lastSeenRevision !== undefined &&
-				state.revision > budget.lastSeenRevision
-			) {
-				budget.consecutiveUnproductive = 0;
-			}
+			// The cooldown early-return comes BEFORE the progress observation:
+			// the observation pays a full delegation-ledger scan, and a wake the
+			// cooldown is about to discard must not pay it. Progress observed
+			// after the window only defers the counter reset to the next wake.
 			if (
 				budget.consecutiveUnproductive > 0 &&
 				budget.lastWakeAt > 0 &&
@@ -1194,11 +1311,13 @@ export function createPrWorkflowResponseGate(options: {
 			) {
 				return;
 			}
-
-			const madeProgress =
-				budget.lastSeenRevision === undefined
-					? true
-					: state.revision > budget.lastSeenRevision;
+			const madeProgress = observeWorkflowProgress(
+				budget,
+				workflowProgressSnapshot(options.directory, sessionID, state),
+			);
+			if (madeProgress) {
+				budget.consecutiveUnproductive = 0;
+			}
 
 			let feedbackTarget =
 				state.prFeedbackTargetUrl ?? state.prFeedbackReviewHandoff?.prUrl;
@@ -1331,12 +1450,17 @@ export function createPrWorkflowResponseGate(options: {
 				if (postWakeState === null) {
 					resetBudget(sessionID);
 				} else {
-					const currentRevision = postWakeState.revision;
 					const effectiveMadeProgress =
 						madeProgress ||
-						(budget.lastSeenRevision !== undefined &&
-							currentRevision > budget.lastSeenRevision);
-					budget.lastSeenRevision = currentRevision;
+						observeWorkflowProgress(
+							budget,
+							workflowProgressSnapshot(
+								options.directory,
+								sessionID,
+								postWakeState,
+							),
+						);
+					budget.lastSeenRevision = postWakeState.revision;
 					let suspensionTripped = false;
 					if (!effectiveMadeProgress) {
 						budget.consecutiveUnproductive += 1;

--- a/src/pr-review/authorization.ts
+++ b/src/pr-review/authorization.ts
@@ -7,10 +7,11 @@
  * `reviewer`/`test_engineer` may bypass the generic Stage-A task-workflow
  * requirement. The PR workflow controller issues an authorization bound to
  * the exact active session, workflow, run, base/head SHA, worktree revision
- * digest, role, and gate generation; the Task delegation gate consumes it
- * atomically, exactly once. Stale, cross-session, wrong-role, replayed,
- * expired, or revision-drifted requests fail closed to the normal gating
- * path.
+ * digest, role, and gate generation; the PR workflow controller boundary
+ * reserves it atomically for exactly one Task call and the Task delegation
+ * gate verifies that same call-bound reservation (idempotent for the same
+ * callID). Stale, cross-session, wrong-role, replayed, expired, or
+ * revision-drifted requests fail closed to the normal gating path.
  *
  * Binding verification: the CURRENT gate binding (head/revision/generation)
  * is supplied by the owning gate through a bound reader
@@ -224,20 +225,23 @@ async function writeAuthorizationFile(
 	}
 }
 
-/** Drop consumed/expired records past the retention bound; keep newest first. */
+/**
+ * Drop expired records past the retention bound; keep newest first. A burst
+ * of consumed records must never evict a still-live unconsumed authorization
+ * before its TTL, so unconsumed records take priority within the cap.
+ */
 function pruneAuthorizations(
 	records: readonly PrReviewReentryAuthorizationRecord[],
 	nowMs: number,
 ): PrReviewReentryAuthorizationRecord[] {
-	const kept: PrReviewReentryAuthorizationRecord[] = [];
-	for (const record of [...records]
-		.sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-		.slice(0, MAX_PERSISTED_AUTHORIZATIONS)) {
-		if (record.consumedAt) continue;
-		if (Date.parse(record.expiresAt) <= nowMs) continue;
-		kept.push(record);
-	}
-	return kept;
+	const unexpired = records
+		.filter((record) => Date.parse(record.expiresAt) > nowMs)
+		.sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+	const unconsumed = unexpired.filter((record) => !record.consumedAt);
+	const consumed = unexpired
+		.filter((record) => record.consumedAt)
+		.slice(0, Math.max(0, MAX_PERSISTED_AUTHORIZATIONS - unconsumed.length));
+	return [...unconsumed.slice(0, MAX_PERSISTED_AUTHORIZATIONS), ...consumed];
 }
 
 // proper-lockfile is a CommonJS module without published TypeScript types
@@ -322,7 +326,10 @@ export async function issuePrReviewReentryAuthorization(
 				`BLOCKED: an unconsumed re-entry authorization for role "${request.role}" at generation ${binding.generation} already exists; use it (one immediate Task dispatch) before issuing another`,
 			);
 		}
-		if (records.length >= MAX_ACTIVE_AUTHORIZATIONS) {
+		if (
+			records.filter((record) => !record.consumedAt).length >=
+			MAX_ACTIVE_AUTHORIZATIONS
+		) {
 			throw new Error(
 				`BLOCKED: re-entry authorization store is at its bound of ${MAX_ACTIVE_AUTHORIZATIONS} active authorizations`,
 			);
@@ -342,26 +349,46 @@ export async function issuePrReviewReentryAuthorization(
 			createdAt: now,
 			expiresAt: new Date(nowMs + AUTHORIZATION_TTL_MS).toISOString(),
 		};
+		// The schema caps the persisted array at MAX_PERSISTED_AUTHORIZATIONS;
+		// prune may legitimately retain up to that many records, so the append
+		// must re-slice or a full store would write one record over the cap and
+		// become unreadable (parse fails before any prune can run again).
 		await writeAuthorizationFile(filePath, {
 			schemaVersion: 1,
 			sessionId: trimmedSession,
-			authorizations: [record, ...records],
+			authorizations: [record, ...records].slice(
+				0,
+				MAX_PERSISTED_AUTHORIZATIONS,
+			),
 		});
 		return record;
 	});
 }
 
+function authorizationMatchesBinding(
+	record: PrReviewReentryAuthorizationRecord,
+	binding: PrReviewReentryBindingContext,
+): boolean {
+	return (
+		binding.prHeadSha === record.prHeadSha &&
+		binding.revisionDigest === record.revisionDigest &&
+		binding.generation === record.generation &&
+		binding.workflowInstanceId === record.workflowInstanceId &&
+		binding.runId === record.runId
+	);
+}
+
 /**
- * Atomically consume the one active authorization for this session+role.
- * Re-verifies the binding against the CURRENT PR_REVIEW gate state — any
- * drift (mode change, head change, revision digest change, generation bump)
- * fails closed to null, as does replay, expiry, cross-session use, or wrong
- * role. Returns the consumed record on success.
+ * Reserve or verify one authorization against a binding whose owning workflow
+ * lock is held by the caller. The authorization-file lock is always acquired
+ * second. A consumed record is retained until expiry so the exact same Task
+ * call can verify its reservation in a later hook (and after process restart).
  */
-export async function consumePrReviewReentryAuthorization(
+export async function reservePrReviewReentryAuthorizationAgainstBinding(
 	directory: string,
 	sessionID: string,
 	request: { role: PrReviewReentryRole; callID: string },
+	binding: PrReviewReentryBindingContext,
 ): Promise<PrReviewReentryAuthorizationRecord | null> {
 	const trimmedSession = sessionID.trim();
 	if (!trimmedSession) return null;
@@ -372,13 +399,23 @@ export async function consumePrReviewReentryAuthorization(
 			if (!existing) return null;
 			const nowMs = Date.now();
 			const records = pruneAuthorizations(existing.authorizations, nowMs);
-			const index = records.findIndex(
+			const sameCallIndex = records.findIndex(
 				(record) =>
-					!record.consumedAt &&
+					record.consumedCallId === request.callID &&
 					record.role === request.role &&
 					record.sessionId === trimmedSession &&
 					Date.parse(record.expiresAt) > nowMs,
 			);
+			const index =
+				sameCallIndex >= 0
+					? sameCallIndex
+					: records.findIndex(
+							(record) =>
+								!record.consumedAt &&
+								record.role === request.role &&
+								record.sessionId === trimmedSession &&
+								Date.parse(record.expiresAt) > nowMs,
+						);
 			if (index < 0) {
 				// Persist the prune even when nothing is consumable, so expired
 				// records do not accumulate.
@@ -390,23 +427,11 @@ export async function consumePrReviewReentryAuthorization(
 				}
 				return null;
 			}
-			// Re-verify against the CURRENT gate state BEFORE consuming: the
-			// authorization is generation- and revision-bound, so any workflow
-			// progress since issuance invalidates it.
-			const binding = await currentBinding(directory, trimmedSession);
 			const candidate = records[index]!;
-			if (
-				!binding ||
-				binding.prHeadSha !== candidate.prHeadSha ||
-				binding.revisionDigest !== candidate.revisionDigest ||
-				binding.generation !== candidate.generation ||
-				(candidate.workflowInstanceId !== undefined &&
-					binding.workflowInstanceId !== candidate.workflowInstanceId) ||
-				(candidate.workflowInstanceId === undefined &&
-					binding.workflowInstanceId !== undefined)
-			) {
+			if (!authorizationMatchesBinding(candidate, binding)) {
 				return null;
 			}
+			if (candidate.consumedCallId === request.callID) return candidate;
 			const consumed: PrReviewReentryAuthorizationRecord = {
 				...candidate,
 				consumedAt: new Date(nowMs).toISOString(),
@@ -432,6 +457,7 @@ export const _internals = {
 	MAX_ACTIVE_AUTHORIZATIONS,
 	reentryAuthorizationFilePath,
 	pruneAuthorizations,
+	authorizationMatchesBinding,
 	/** DI seam: the rename implementation (tests inject failure modes). */
 	renameImpl: (from: string, to: string): Promise<void> => fsp.rename(from, to),
 	/** DI seam: retry backoff schedule (tests shrink to avoid real sleeps). */

--- a/src/tools/authorize-pr-review-reentry.ts
+++ b/src/tools/authorize-pr-review-reentry.ts
@@ -21,14 +21,18 @@ const AuthorizePrReviewReentryArgsSchema = z
 
 /**
  * Issue a ONE-USE reviewer re-entry authorization (issue #2383) for the
- * CURRENT active PR_REVIEW workflow. The very next direct Task dispatch of
- * the declared role consumes it atomically and bypasses ONLY the generic
- * Stage-A task-workflow requirement; every other delegation gate stays
- * authoritative. Bindings are exact (session, workflow, run, head SHA,
- * worktree revision digest, role, gate generation): replay, cross-session
- * use, wrong role, expiry, or any workflow progress since issuance fails
- * closed. Issue immediately before the Task dispatch — authorizations are
- * not stockpilable.
+ * CURRENT active PR_REVIEW workflow. The very next direct subagent_type Task
+ * dispatch of the declared role reserves it atomically at the controller
+ * boundary — admitting that one dispatch past the PR_REVIEW read-only
+ * restriction — and the delegation gate verifies the same call-bound
+ * reservation while bypassing ONLY the generic Stage-A task-workflow
+ * requirement; every other delegation gate stays authoritative. Bindings are
+ * exact (session, workflow, run, head SHA, worktree revision digest, role,
+ * gate generation): replay, cross-session use, wrong role, expiry, or any
+ * workflow progress since issuance fails closed. A Task the delegation gate
+ * later rejects for an unrelated reason still burns the authorization —
+ * issue a fresh one before retrying. Issue immediately before the Task
+ * dispatch — authorizations are not stockpilable.
  */
 export async function executeAuthorizePrReviewReentry(
 	args: unknown,
@@ -70,7 +74,7 @@ export async function executeAuthorizePrReviewReentry(
 				generation: record.generation,
 				revision_digest: record.revisionDigest,
 				expires_at: record.expiresAt,
-				instructions: `Immediately dispatch exactly one Task call with subagent_type "${record.role}" for this PR-review re-entry; the delegation gate consumes this authorization once. Any other dispatch falls back to normal gating.`,
+				instructions: `Immediately dispatch exactly one Task call with subagent_type "${record.role}" for this PR-review re-entry; the PR workflow controller reserves this authorization once and the delegation gate verifies the same call-bound reservation. Any other dispatch falls back to normal gating.`,
 			},
 			null,
 			2,
@@ -86,7 +90,7 @@ export async function executeAuthorizePrReviewReentry(
 export const authorize_pr_review_reentry: ReturnType<typeof createSwarmTool> =
 	createSwarmTool({
 		description:
-			'Issue a one-use, identity-bound reviewer/test_engineer re-entry authorization for the active PR_REVIEW workflow (issue #2383). The authorization is consumed atomically by the very next direct Task dispatch of the declared role and bypasses ONLY the generic Stage-A task-workflow requirement — all other delegation gates remain authoritative. Bound to the exact session, workflow, run, PR head SHA, worktree revision digest, role, and gate generation; replay, cross-session use, wrong role, expiry (10 minutes), or any workflow progress since issuance fails closed. Requires an active head-bound PR_REVIEW gate. Issue immediately before the Task dispatch; unconsumed same-role authorizations at the same generation are refused.',
+			'Issue a one-use, identity-bound reviewer/test_engineer re-entry authorization for the active PR_REVIEW workflow (issue #2383). The authorization is reserved atomically by the PR workflow controller for the very next direct subagent_type Task dispatch of the declared role (admitting that one dispatch past the PR_REVIEW read-only restriction), then verified for that same call by the delegation gate, which bypasses ONLY the generic Stage-A task-workflow requirement; all other delegation gates remain authoritative. Bound to the exact session, workflow, run, PR head SHA, worktree revision digest, role, and gate generation; replay, cross-session use, wrong role, expiry (10 minutes), or workflow progress since issuance fails closed. A dispatch the delegation gate later rejects for another reason still burns the authorization. Requires an active head-bound PR_REVIEW gate. Issue immediately before the Task dispatch; unconsumed same-role authorizations at the same generation are refused.',
 		args: {
 			run_id: AuthorizePrReviewReentryArgsSchema.shape.run_id,
 			pr_head_sha: AuthorizePrReviewReentryArgsSchema.shape.pr_head_sha,

--- a/tests/integration/pr-workflow-hook-precedence-real-host.test.ts
+++ b/tests/integration/pr-workflow-hook-precedence-real-host.test.ts
@@ -7,12 +7,15 @@ import {
 	findByCorrelationId,
 	recordPendingDelegation,
 } from '../../src/background/pending-delegations.js';
+import { transitionTaskWorkflowEvidence } from '../../src/gate-evidence.js';
 import { getPendingCoderScope } from '../../src/hooks/delegation-gate.js';
 import {
 	_test_exports,
 	activatePrWorkflow,
 	declarePrFeedbackInventory,
 	enforcePrFeedbackVerificationOwnership,
+	enforcePrWorkflowToolBefore,
+	reserveActivePrReviewReentryAuthorization,
 } from '../../src/hooks/pr-workflow-gate.js';
 import { getScopeBindingForParentDispatch } from '../../src/scope/scope-binding.js';
 import { resetSwarmState, swarmState } from '../../src/state.js';
@@ -201,6 +204,144 @@ describe('PR workflow gate has authoritative real-host Task precedence', () => {
 				path.join(directory, '.swarm', 'background-delegations.jsonl'),
 			),
 		).toBeFalse();
+	});
+
+	test('registered re-entry authorization admits exactly one bound reviewer Task through the real hook chain', async () => {
+		await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		await transitionTaskWorkflowEvidence(directory, '1.1', {
+			type: 'accepted_mutation',
+			agentType: 'coder',
+			expectedGeneration: 0,
+			transitionId: 'seed-reentry-stage-a',
+		});
+		const before = plugin.hooks['tool.execute.before'];
+		await expect(
+			before(
+				{
+					tool: 'authorize_pr_review_reentry',
+					sessionID: SESSION_ID,
+					callID: 'authorize-reentry',
+				},
+				{ args: { pr_head_sha: HEAD_SHA, role: 'reviewer' } },
+			),
+		).resolves.toBeUndefined();
+		const issued = JSON.parse(
+			String(
+				await plugin.tool.authorize_pr_review_reentry.execute(
+					{ pr_head_sha: HEAD_SHA, role: 'reviewer' },
+					{ directory, sessionID: SESSION_ID },
+				),
+			),
+		) as { success: boolean; message?: string };
+		expect(issued).toMatchObject({ success: true });
+
+		await expect(
+			before(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'authorized-reviewer' },
+				{
+					args: {
+						subagent_type: 'reviewer',
+						task_id: '1.1',
+						prompt: 'TASK: 1.1\nACCEPTANCE: verify the bound PR-review task',
+					},
+				},
+			),
+		).resolves.toBeUndefined();
+
+		await expect(
+			before(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'replayed-reviewer' },
+				{
+					args: {
+						subagent_type: 'reviewer',
+						task_id: '1.1',
+						prompt: 'TASK: 1.1\nACCEPTANCE: replay must remain blocked',
+					},
+				},
+			),
+		).rejects.toThrow(/PR_REVIEW is read-only/i);
+	});
+
+	test('controller-only gating atomically reserves one exact role and rejects ambiguous fields', async () => {
+		await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		const issued = JSON.parse(
+			String(
+				await plugin.tool.authorize_pr_review_reentry.execute(
+					{ pr_head_sha: HEAD_SHA, role: 'reviewer' },
+					{ directory, sessionID: SESSION_ID },
+				),
+			),
+		) as { success: boolean };
+		expect(issued.success).toBe(true);
+		await expect(
+			enforcePrWorkflowToolBefore(
+				directory,
+				SESSION_ID,
+				'Task',
+				{ subagent_type: 'reviewer', agent: 'reviewer' },
+				[],
+				'ambiguous-call',
+			),
+		).rejects.toThrow(/PR_REVIEW is read-only/i);
+		await expect(
+			enforcePrWorkflowToolBefore(
+				directory,
+				SESSION_ID,
+				'Task',
+				{ subagent_type: 'reviewer' },
+				[],
+				'controller-only-call',
+			),
+		).resolves.toBeUndefined();
+		const verified = await reserveActivePrReviewReentryAuthorization(
+			directory,
+			SESSION_ID,
+			{ role: 'reviewer', callID: 'controller-only-call' },
+		);
+		expect(verified?.consumedCallId).toBe('controller-only-call');
+	});
+
+	test('an agent-field-only Task never spends a re-entry authorization', async () => {
+		await activatePrWorkflow(directory, SESSION_ID, 'PR_REVIEW', {
+			prHeadSha: HEAD_SHA,
+		});
+		const issued = JSON.parse(
+			String(
+				await plugin.tool.authorize_pr_review_reentry.execute(
+					{ pr_head_sha: HEAD_SHA, role: 'reviewer' },
+					{ directory, sessionID: SESSION_ID },
+				),
+			),
+		) as { success: boolean };
+		expect(issued.success).toBe(true);
+		// A dispatch carrying only `agent` (no subagent_type) is NOT admitted:
+		// the delegation gate's Stage-A/acceptance enforcement only runs for
+		// subagent_type dispatches, so admitting it would bypass every
+		// downstream gate while burning the one-shot authorization.
+		await expect(
+			enforcePrWorkflowToolBefore(
+				directory,
+				SESSION_ID,
+				'Task',
+				{ agent: 'reviewer' },
+				[],
+				'agent-field-only-call',
+			),
+		).rejects.toThrow(/PR_REVIEW is read-only/i);
+		// The authorization must still be unconsumed afterwards: a fresh
+		// callID can reserve it (it would fail closed had the rejected
+		// admission burned it).
+		const stillUnconsumed = await reserveActivePrReviewReentryAuthorization(
+			directory,
+			SESSION_ID,
+			{ role: 'reviewer', callID: 'verify-unburned-call' },
+		);
+		expect(stillUnconsumed).not.toBeNull();
+		expect(stillUnconsumed?.consumedCallId).toBe('verify-unburned-call');
 	});
 
 	test('inactive workflows preserve the reviewer acceptance contract', async () => {

--- a/tests/unit/hooks/pr-feedback-scope-controller.test.ts
+++ b/tests/unit/hooks/pr-feedback-scope-controller.test.ts
@@ -1,10 +1,20 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { createDelegationGateHook } from '../../../src/hooks/delegation-gate.js';
+import {
+	readTaskEvidence,
+	transitionTaskWorkflowEvidence,
+} from '../../../src/gate-evidence.js';
+import {
+	createDelegationGateHook,
+	_internals as delegationInternals,
+	getPendingCoderScope,
+} from '../../../src/hooks/delegation-gate.js';
 import {
 	_test_exports,
 	activatePrWorkflow,
 	declarePrFeedbackInventory,
+	declarePrFeedbackScope,
 	enforcePrFeedbackVerificationOwnership,
+	resolvePrFeedbackScopeDeclaration,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import { createScopeGuardHook } from '../../../src/hooks/scope-guard.js';
 import {
@@ -13,6 +23,7 @@ import {
 } from '../../../src/scope/scope-binding.js';
 import { ensureAgentSession, resetSwarmState } from '../../../src/state.js';
 import { executePreparePrFeedbackScope } from '../../../src/tools/prepare-pr-feedback-scope.js';
+import { writeApprovedPlan } from '../../helpers/approved-plan.js';
 import { makeConfig } from './_delegation-gate-helpers.js';
 import {
 	HEAD_SHA,
@@ -25,7 +36,10 @@ import {
 } from './pr-workflow-gate.test-fixtures.js';
 
 beforeEach(setupPrWorkflowGateFixtures);
-afterEach(teardownPrWorkflowGateFixtures);
+afterEach(async () => {
+	delegationInternals.beforePrFeedbackScopeConsume = undefined;
+	await teardownPrWorkflowGateFixtures();
+});
 
 async function settleFeedbackVerification(): Promise<void> {
 	await activatePrWorkflow(tempDir, SESSION_ID, 'PR_FEEDBACK');
@@ -185,6 +199,72 @@ describe('PR_FEEDBACK dedicated coder scope controller', () => {
 		).resolves.toBeUndefined();
 	});
 
+	test('gives an authenticated synthetic PR-feedback scope precedence over an unrelated plan', async () => {
+		await settleFeedbackVerification();
+		await writeApprovedPlan(tempDir, [
+			{ id: '1.1', files: ['src/unrelated-plan-task.ts'] },
+		]);
+		const prepared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '9.9', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean };
+		expect(prepared.success).toBe(true);
+
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		await expect(
+			delegation.toolBefore(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'feedback-with-plan' },
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '9.9',
+						prompt:
+							'TASK: 9.9\nFILE: src/index.ts\nACCEPTANCE: close the authenticated feedback item',
+					},
+				},
+			),
+		).resolves.toBeUndefined();
+	});
+
+	test('gives an authenticated PR-feedback scope precedence over stale plan Stage-A state', async () => {
+		await settleFeedbackVerification();
+		await writeApprovedPlan(tempDir, [
+			{ id: '1.1', files: ['src/unrelated-plan-task.ts'] },
+		]);
+		await transitionTaskWorkflowEvidence(tempDir, '1.1', {
+			type: 'accepted_mutation',
+			agentType: 'coder',
+			expectedGeneration: 0,
+			transitionId: 'seed-stale-plan-stage-a',
+		});
+		const prepared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '1.1', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean };
+		expect(prepared.success).toBe(true);
+
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		await expect(
+			delegation.toolBefore(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'feedback-stage-a' },
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt:
+							'TASK: 1.1\nFILE: src/index.ts\nACCEPTANCE: close the authenticated feedback item',
+					},
+				},
+			),
+		).resolves.toBeUndefined();
+	});
+
 	test('invalidates a prepared scope when the feedback revision changes', async () => {
 		await settleFeedbackVerification();
 		const result = JSON.parse(
@@ -210,5 +290,124 @@ describe('PR_FEEDBACK dedicated coder scope controller', () => {
 				},
 			),
 		).rejects.toThrow(/verification ownership is incomplete/i);
+	});
+
+	test('atomically reserves one PR-feedback declaration when Task calls race', async () => {
+		await settleFeedbackVerification();
+		const prepared = JSON.parse(
+			await executePreparePrFeedbackScope(
+				{ task_id: '8.8', files: ['src/index.ts'] },
+				tempDir,
+				{ sessionID: SESSION_ID },
+			),
+		) as { success: boolean };
+		expect(prepared.success).toBe(true);
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		const results = await Promise.allSettled(
+			['scope-race-a', 'scope-race-b'].map((callID) =>
+				delegation.toolBefore(
+					{ tool: 'Task', sessionID: SESSION_ID, callID },
+					{
+						args: {
+							subagent_type: 'coder',
+							task_id: '8.8',
+							prompt:
+								'TASK: 8.8\nFILE: src/index.ts\nACCEPTANCE: close the authenticated feedback item',
+						},
+					},
+				),
+			),
+		);
+		expect(
+			results.filter((result) => result.status === 'fulfilled'),
+		).toHaveLength(1);
+		const declaration = await resolvePrFeedbackScopeDeclaration(
+			tempDir,
+			SESSION_ID,
+			'8.8',
+		);
+		expect(['scope-race-a', 'scope-race-b']).toContain(
+			declaration?.consumedByCallId,
+		);
+	});
+
+	test('does not consume a replacement declaration after classifying its predecessor', async () => {
+		await settleFeedbackVerification();
+		await declarePrFeedbackScope(tempDir, SESSION_ID, '7.7', ['src/index.ts']);
+
+		let releaseClassification!: () => void;
+		const classificationReleased = new Promise<void>((resolve) => {
+			releaseClassification = resolve;
+		});
+		let signalClassified!: () => void;
+		const classified = new Promise<void>((resolve) => {
+			signalClassified = resolve;
+		});
+		delegationInternals.beforePrFeedbackScopeConsume = async () => {
+			signalClassified();
+			await classificationReleased;
+		};
+
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		const dispatch = delegation.toolBefore(
+			{ tool: 'Task', sessionID: SESSION_ID, callID: 'replaced-scope-call' },
+			{
+				args: {
+					subagent_type: 'coder',
+					task_id: '7.7',
+					prompt:
+						'TASK: 7.7\nFILE: src/index.ts\nACCEPTANCE: close the authenticated feedback item',
+				},
+			},
+		);
+		await classified;
+		await declarePrFeedbackScope(tempDir, SESSION_ID, '7.7', [
+			'src/replacement.ts',
+		]);
+		releaseClassification();
+
+		await expect(dispatch).rejects.toThrow(/could not be reserved/i);
+		const replacement = await resolvePrFeedbackScopeDeclaration(
+			tempDir,
+			SESSION_ID,
+			'7.7',
+		);
+		expect(replacement).toMatchObject({
+			files: ['src/replacement.ts'],
+		});
+		expect(replacement?.consumedByCallId).toBeUndefined();
+		expect(getPendingCoderScope(tempDir, '7.7')).toBeNull();
+	});
+
+	test('preserves normal-plan Stage-A rejection without scope or evidence leaks', async () => {
+		await writeApprovedPlan(tempDir, [
+			{ id: '1.1', files: ['src/normal-plan.ts'] },
+		]);
+		await transitionTaskWorkflowEvidence(tempDir, '1.1', {
+			type: 'accepted_mutation',
+			agentType: 'coder',
+			expectedGeneration: 0,
+			transitionId: 'normal-plan-accepted',
+		});
+		const beforeEvidence = await readTaskEvidence(tempDir, '1.1');
+		const delegation = createDelegationGateHook(makeConfig(), tempDir);
+		await expect(
+			delegation.toolBefore(
+				{ tool: 'Task', sessionID: SESSION_ID, callID: 'normal-plan-reject' },
+				{
+					args: {
+						subagent_type: 'coder',
+						task_id: '1.1',
+						prompt:
+							'TASK: 1.1\nFILE: src/normal-plan.ts\nACCEPTANCE: continue normal plan work',
+					},
+				},
+			),
+		).rejects.toThrow(/STAGE_A_REQUIRED/);
+		expect(getPendingCoderScope(tempDir, '1.1')).toBeNull();
+		expect(await readTaskEvidence(tempDir, '1.1')).toEqual(beforeEvidence);
+		expect(
+			await resolvePrFeedbackScopeDeclaration(tempDir, SESSION_ID, '1.1'),
+		).toBeNull();
 	});
 });

--- a/tests/unit/hooks/pr-review-reentry-authorization.test.ts
+++ b/tests/unit/hooks/pr-review-reentry-authorization.test.ts
@@ -4,9 +4,9 @@ import * as path from 'node:path';
 import {
 	_test_exports,
 	activatePrWorkflow,
+	reserveActivePrReviewReentryAuthorization,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import {
-	consumePrReviewReentryAuthorization,
 	issuePrReviewReentryAuthorization,
 	_internals as reentryInternals,
 } from '../../../src/pr-review/authorization.js';
@@ -81,7 +81,7 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 			role: 'reviewer',
 		});
 		expect(record.generation).toBeGreaterThanOrEqual(0);
-		const consumed = await consumePrReviewReentryAuthorization(
+		const consumed = await reserveActivePrReviewReentryAuthorization(
 			directory,
 			PR_ARTIFACT_SESSION_ID,
 			{ role: 'reviewer', callID: 'call-1' },
@@ -90,10 +90,14 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 		expect(consumed!.consumedCallId).toBe('call-1');
 		// REPLAY: a second consume finds nothing.
 		await expect(
-			consumePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
-				role: 'reviewer',
-				callID: 'call-2',
-			}),
+			reserveActivePrReviewReentryAuthorization(
+				directory,
+				PR_ARTIFACT_SESSION_ID,
+				{
+					role: 'reviewer',
+					callID: 'call-2',
+				},
+			),
 		).resolves.toBeNull();
 	});
 
@@ -104,13 +108,17 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 			role: 'reviewer',
 		});
 		await expect(
-			consumePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
-				role: 'test_engineer',
-				callID: 'call-1',
-			}),
+			reserveActivePrReviewReentryAuthorization(
+				directory,
+				PR_ARTIFACT_SESSION_ID,
+				{
+					role: 'test_engineer',
+					callID: 'call-1',
+				},
+			),
 		).resolves.toBeNull();
 		// The reviewer authorization is still unconsumed.
-		const consumed = await consumePrReviewReentryAuthorization(
+		const consumed = await reserveActivePrReviewReentryAuthorization(
 			directory,
 			PR_ARTIFACT_SESSION_ID,
 			{ role: 'reviewer', callID: 'call-2' },
@@ -125,7 +133,7 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 			role: 'reviewer',
 		});
 		await expect(
-			consumePrReviewReentryAuthorization(directory, 'session-foreign', {
+			reserveActivePrReviewReentryAuthorization(directory, 'session-foreign', {
 				role: 'reviewer',
 				callID: 'call-1',
 			}),
@@ -143,10 +151,14 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 		// The store still holds the record, but the CURRENT gate generation moved:
 		// consume must fail closed to null.
 		await expect(
-			consumePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
-				role: 'reviewer',
-				callID: 'call-1',
-			}),
+			reserveActivePrReviewReentryAuthorization(
+				directory,
+				PR_ARTIFACT_SESSION_ID,
+				{
+					role: 'reviewer',
+					callID: 'call-1',
+				},
+			),
 		).resolves.toBeNull();
 	});
 
@@ -180,10 +192,14 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 			'utf8',
 		);
 		await expect(
-			consumePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
-				role: 'reviewer',
-				callID: 'call-1',
-			}),
+			reserveActivePrReviewReentryAuthorization(
+				directory,
+				PR_ARTIFACT_SESSION_ID,
+				{
+					role: 'reviewer',
+					callID: 'call-1',
+				},
+			),
 		).resolves.toBeNull();
 	});
 
@@ -208,7 +224,7 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 		).resolves.toBeTruthy();
 	});
 
-	test('prune drops consumed and expired records', () => {
+	test('prune retains unexpired consumed records for same-call verification', () => {
 		withFrozenClock(() => {
 			const now = Date.now();
 			const live = {
@@ -226,6 +242,7 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 				...live,
 				authorizationId: 'used',
 				consumedAt: new Date(now).toISOString(),
+				consumedCallId: 'call-used',
 			};
 			const expired = {
 				...live,
@@ -236,7 +253,12 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 				[consumed, expired, live],
 				now,
 			);
-			expect(kept.map((record) => record.authorizationId)).toEqual(['live']);
+			// Both survive; on a recency tie the unconsumed record sorts first
+			// because prune prioritizes live authorizations within the cap.
+			expect(kept.map((record) => record.authorizationId)).toEqual([
+				'live',
+				'used',
+			]);
 		});
 	});
 
@@ -248,14 +270,133 @@ describe('pr-review reentry authorization (issue #2383)', () => {
 		});
 		const results = await Promise.all(
 			['call-a', 'call-b', 'call-c'].map((callID) =>
-				consumePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
-					role: 'reviewer',
-					callID,
-				}).catch(() => null),
+				reserveActivePrReviewReentryAuthorization(
+					directory,
+					PR_ARTIFACT_SESSION_ID,
+					{
+						role: 'reviewer',
+						callID,
+					},
+				).catch(() => null),
 			),
 		);
 		const winners = results.filter((result) => result !== null);
 		expect(winners).toHaveLength(1);
+	});
+
+	test('the winning call can verify its persisted reservation idempotently', async () => {
+		await establishActiveReview();
+		await issuePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
+			prHeadSha: PR_ARTIFACT_HEAD_SHA,
+			role: 'reviewer',
+		});
+		const request = { role: 'reviewer' as const, callID: 'same-call' };
+		const reserved = await reserveActivePrReviewReentryAuthorization(
+			directory,
+			PR_ARTIFACT_SESSION_ID,
+			request,
+		);
+		const verified = await reserveActivePrReviewReentryAuthorization(
+			directory,
+			PR_ARTIFACT_SESSION_ID,
+			request,
+		);
+		expect(verified?.authorizationId).toBe(reserved?.authorizationId);
+		expect(verified?.consumedCallId).toBe('same-call');
+	});
+
+	test('holds the workflow-session lock through authorization reservation commit', async () => {
+		await establishActiveReview();
+		await issuePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
+			prHeadSha: PR_ARTIFACT_HEAD_SHA,
+			role: 'reviewer',
+		});
+		const ALTERNATE_SHA = 'e'.repeat(40);
+		// Whether the head rebind resolves or rejects, settling requires the
+		// session's workflow-state lock — that is the property under test.
+		const competingBind = () =>
+			activatePrWorkflow(directory, PR_ARTIFACT_SESSION_ID, 'PR_REVIEW', {
+				prHeadSha: ALTERNATE_SHA,
+			}).then(
+				() => undefined,
+				() => undefined,
+			);
+		const settlesWithin = async (
+			promise: Promise<void>,
+			budgetMs: number,
+		): Promise<boolean> =>
+			Promise.race([
+				promise.then(() => true),
+				new Promise<boolean>((resolve) =>
+					setTimeout(() => resolve(false), budgetMs),
+				),
+			]);
+		// Negative control: an uncontended mutation of the exact same shape
+		// settles well inside the 2s budget, so the held-lock assertion below
+		// cannot pass merely because the call is slow. It runs on a separate
+		// session so it cannot disturb this session's gate state.
+		const controlSettled = await settlesWithin(
+			activatePrWorkflow(directory, 'lock-control-session', 'PR_REVIEW', {
+				prHeadSha: ALTERNATE_SHA,
+			}).then(
+				() => undefined,
+				() => undefined,
+			),
+			2_000,
+		);
+		expect(controlSettled).toBe(true);
+
+		let signalEntered!: () => void;
+		const entered = new Promise<void>((resolve) => {
+			signalEntered = resolve;
+		});
+		let releaseReservation!: () => void;
+		const hold = new Promise<void>((resolve) => {
+			releaseReservation = resolve;
+		});
+		_test_exports.beforePrReviewReentryReservation = async () => {
+			signalEntered();
+			await hold;
+		};
+		const reservation = reserveActivePrReviewReentryAuthorization(
+			directory,
+			PR_ARTIFACT_SESSION_ID,
+			{ role: 'reviewer', callID: 'locked-call' },
+		);
+		await entered;
+		const competingSettled = await settlesWithin(competingBind(), 2_000);
+		expect(competingSettled).toBe(false);
+		releaseReservation();
+		expect(await reservation).not.toBeNull();
+	});
+
+	test('workflow progress between reserve and same-call verify fails closed', async () => {
+		await establishActiveReview();
+		await issuePrReviewReentryAuthorization(directory, PR_ARTIFACT_SESSION_ID, {
+			prHeadSha: PR_ARTIFACT_HEAD_SHA,
+			role: 'reviewer',
+		});
+		const reserved = await reserveActivePrReviewReentryAuthorization(
+			directory,
+			PR_ARTIFACT_SESSION_ID,
+			{ role: 'reviewer', callID: 'burned-call' },
+		);
+		expect(reserved).not.toBeNull();
+		// Controller state advanced after the reservation was committed. The
+		// same call's later verification re-derives the CURRENT binding and
+		// must fail closed: the one-shot authorization is burned for the old
+		// generation and cannot be replayed against the new one.
+		await bumpGeneration();
+		await expect(
+			reserveActivePrReviewReentryAuthorization(
+				directory,
+				PR_ARTIFACT_SESSION_ID,
+				{
+					role: 'reviewer',
+					callID: 'burned-call',
+				},
+			),
+		).resolves.toBeNull();
 	});
 });
 

--- a/tests/unit/hooks/pr-workflow-response-gate-lane-progress.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate-lane-progress.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdirSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	appendDelegationTransition,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	activatePrWorkflow,
+	_test_exports as workflowInternals,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	createPrWorkflowResponseGate,
+	_internals as responseInternals,
+} from '../../../src/hooks/pr-workflow-response-gate.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+describe('PR workflow response-gate lane progress token (#2469)', () => {
+	let directory = '';
+	const sessionID = 'lane-progress-session';
+	const originalDelegationScan = responseInternals.scanDelegationsForRecovery;
+
+	async function registerActiveBatch(
+		batchId: string,
+		laneIds: readonly string[],
+	): Promise<void> {
+		const statePath = path.join(
+			directory,
+			'.swarm',
+			workflowInternals.workflowGateStateRelativePath(sessionID),
+		);
+		const state = JSON.parse(await fs.readFile(statePath, 'utf8'));
+		state.prReviewValidationBatches = [
+			{
+				batchId,
+				phase: 'council',
+				lanes: laneIds.map((laneId) => ({ laneId, workflowLane: laneId })),
+				// Fixed fixture timestamp (check:test-clock): fixture data, not a
+				// time-sensitive assertion.
+				validatedAt: '2026-01-01T00:00:00.000Z',
+			},
+		];
+		await fs.writeFile(statePath, JSON.stringify(state), 'utf8');
+		workflowInternals.resetTrackedStateCache();
+	}
+
+	beforeEach(() => {
+		directory = canonicalMkdtemp('pr-response-lane-progress-');
+		// The delegation ledger writes route through withEvidenceLock, whose
+		// assertProjectRoot fails closed for a bare temp directory whose
+		// ancestors carry `.swarm/` + a project indicator (e.g. a dev home).
+		// The shared pr-workflow-gate fixtures create the same marker.
+		mkdirSync(path.join(directory, '.git'), { recursive: true });
+		workflowInternals.resetTrackedStateCache();
+	});
+
+	afterEach(async () => {
+		responseInternals.scanDelegationsForRecovery = originalDelegationScan;
+		workflowInternals.resetTrackedStateCache();
+		await fs.rm(directory, { recursive: true, force: true });
+	});
+
+	test('five genuine lane transitions stay productive, then five unchanged wakes trip the brake', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch(
+			'lane-progress-batch',
+			Array.from({ length: 5 }, (_, index) => `lane-${index}`),
+		);
+		for (let index = 0; index < 5; index++) {
+			await recordPendingDelegation(directory, {
+				correlationId: `lane-progress-${index}`,
+				jobId: null,
+				subagentSessionId: `lane-progress-${index}`,
+				parentSessionId: sessionID,
+				callID: `lane-progress-call-${index}`,
+				normalizedAgent: 'explorer',
+				swarmPrefixedAgent: 'explorer',
+				planTaskId: null,
+				evidenceTaskId: null,
+				batchId: 'lane-progress-batch',
+				laneId: `lane-${index}`,
+				mode: 'swarm-pr-review:base',
+				workflowLane: `lane-${index}`,
+				workspace: {
+					directory,
+					gitHead: 'abc123',
+					dirtyHash: null,
+					prHeadSha: 'abc123',
+					scope: null,
+				},
+			});
+		}
+
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 5,
+			wakeCooldownMs: 0,
+		});
+		const idle = {
+			event: { type: 'session.idle', properties: { sessionID } },
+		};
+
+		await gate.event(idle);
+		for (let index = 0; index < 5; index++) {
+			await appendDelegationTransition(directory, `lane-progress-${index}`, {
+				status: 'running',
+			});
+			await gate.event(idle);
+		}
+		expect(gate._inspectWakeBudget(sessionID)?.suspended).toBe(false);
+		expect(gate._inspectWakeBudget(sessionID)?.consecutiveUnproductive).toBe(0);
+
+		for (let index = 0; index < 5; index++) {
+			await gate.event(idle);
+		}
+		expect(gate._inspectWakeBudget(sessionID)?.suspended).toBe(true);
+		expect(promptAsync).toHaveBeenCalledTimes(11);
+	});
+
+	test('valid to corrupt to recovered ledger never receives false progress credit', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch('corrupt-batch', ['lane-0']);
+		await recordPendingDelegation(directory, {
+			correlationId: 'corrupt-lane',
+			jobId: null,
+			subagentSessionId: 'corrupt-lane',
+			parentSessionId: sessionID,
+			callID: 'corrupt-call',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'corrupt-batch',
+			laneId: 'lane-0',
+			mode: 'swarm-pr-review:base',
+			workflowLane: 'lane-0',
+		});
+		const ledgerPath = path.join(
+			directory,
+			'.swarm',
+			'background-delegations.jsonl',
+		);
+		const validLedger = await fs.readFile(ledgerPath, 'utf8');
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			maxConsecutiveUnproductiveWakes: 3,
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		await gate.event(idle);
+		await fs.writeFile(ledgerPath, '{not-json}\n', 'utf8');
+		await gate.event(idle);
+		await gate.event(idle);
+		await fs.writeFile(ledgerPath, validLedger, 'utf8');
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget(sessionID)?.suspended).toBe(true);
+	});
+
+	test('duplicate active lane identities remain independently observable', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch('shared-batch', ['shared-lane']);
+		for (const correlationId of ['duplicate-a', 'duplicate-b']) {
+			await recordPendingDelegation(directory, {
+				correlationId,
+				jobId: null,
+				subagentSessionId: correlationId,
+				parentSessionId: sessionID,
+				callID: `${correlationId}-call`,
+				normalizedAgent: 'explorer',
+				swarmPrefixedAgent: 'explorer',
+				planTaskId: null,
+				evidenceTaskId: null,
+				batchId: 'shared-batch',
+				laneId: 'shared-lane',
+				mode: 'swarm-pr-review:base',
+				workflowLane: 'shared-lane',
+			});
+		}
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		await gate.event(idle);
+		await appendDelegationTransition(directory, 'duplicate-b', {
+			status: 'running',
+		});
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget(sessionID)?.consecutiveUnproductive).toBe(0);
+	});
+
+	test('excludes stale same-session records from a later workflow activation', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch('stale-batch', ['stale-lane']);
+		await recordPendingDelegation(directory, {
+			correlationId: 'stale-correlation',
+			jobId: null,
+			subagentSessionId: 'stale-correlation',
+			parentSessionId: sessionID,
+			callID: 'stale-call',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'stale-batch',
+			laneId: 'stale-lane',
+			mode: 'swarm-pr-review:base',
+			workflowLane: 'stale-lane',
+		});
+		const statePath = path.join(
+			directory,
+			'.swarm',
+			workflowInternals.workflowGateStateRelativePath(sessionID),
+		);
+		const state = JSON.parse(await fs.readFile(statePath, 'utf8'));
+		state.activatedAt = '2100-01-01T00:00:00.000Z';
+		await fs.writeFile(statePath, JSON.stringify(state), 'utf8');
+		workflowInternals.resetTrackedStateCache();
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		await gate.event(idle);
+		await appendDelegationTransition(directory, 'stale-correlation', {
+			status: 'running',
+		});
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget(sessionID)?.consecutiveUnproductive).toBe(1);
+	});
+
+	test('detects a genuine lane transition that lands during the wake', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch('mid-wake-batch', ['mid-wake-lane']);
+		await recordPendingDelegation(directory, {
+			correlationId: 'mid-wake-correlation',
+			jobId: null,
+			subagentSessionId: 'mid-wake-correlation',
+			parentSessionId: sessionID,
+			callID: 'mid-wake-call',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'mid-wake-batch',
+			laneId: 'mid-wake-lane',
+			mode: 'swarm-pr-review:base',
+			workflowLane: 'mid-wake-lane',
+		});
+		let mutateDuringPrompt = false;
+		const promptAsync = mock(async () => {
+			if (mutateDuringPrompt) {
+				mutateDuringPrompt = false;
+				await appendDelegationTransition(directory, 'mid-wake-correlation', {
+					status: 'running',
+				});
+			}
+			return {};
+		});
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		await gate.event(idle);
+		mutateDuringPrompt = true;
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget(sessionID)?.consecutiveUnproductive).toBe(0);
+	});
+
+	test('a structured receipt digest transition is productive without a gate revision bump', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		await registerActiveBatch('receipt-batch', ['receipt-lane']);
+		await recordPendingDelegation(directory, {
+			correlationId: 'receipt-correlation',
+			jobId: null,
+			subagentSessionId: 'receipt-correlation',
+			parentSessionId: sessionID,
+			callID: 'receipt-call',
+			normalizedAgent: 'reviewer',
+			swarmPrefixedAgent: 'reviewer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			batchId: 'receipt-batch',
+			laneId: 'receipt-lane',
+			mode: 'swarm-pr-review:reviewer',
+			workflowLane: 'receipt-lane',
+		});
+		let receiptDigest = 'receipt-a';
+		responseInternals.scanDelegationsForRecovery = (targetDirectory) => {
+			const scan = originalDelegationScan(targetDirectory);
+			if (scan.status !== 'ok') return scan;
+			return {
+				...scan,
+				owners: scan.owners.map((record) => ({
+					...record,
+					// Only semanticEnvelopeDigest is populated: it is the sole
+					// receipt field the progress token reads
+					// (pr-workflow-response-gate workflowProgressSnapshot).
+					result: {
+						chars: 0,
+						truncated: false,
+						digest: 'stable-result',
+						prReviewResultReceipt: {
+							semanticEnvelopeDigest: receiptDigest,
+						},
+					} as NonNullable<typeof record.result>,
+				})),
+			};
+		};
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		await gate.event(idle);
+		receiptDigest = 'receipt-b';
+		await gate.event(idle);
+		expect(gate._inspectWakeBudget(sessionID)?.consecutiveUnproductive).toBe(0);
+	});
+
+	test('a throwing recovery scan is treated as uncertain and never kills the wake', async () => {
+		await activatePrWorkflow(directory, sessionID, 'PR_REVIEW');
+		responseInternals.scanDelegationsForRecovery = () => {
+			throw new Error('scan blew up');
+		};
+		const promptAsync = mock(async () => ({}));
+		const gate = createPrWorkflowResponseGate({
+			directory,
+			client: { session: { prompt: promptAsync, promptAsync } },
+			wakeCooldownMs: 0,
+		});
+		const idle = { event: { type: 'session.idle', properties: { sessionID } } };
+		// workflowProgressSnapshot must convert the throw into an uncertain
+		// snapshot: the wake still fires (promptAsync called, budget updated)
+		// instead of the error discarding the whole evaluation.
+		await gate.event(idle);
+		expect(promptAsync).toHaveBeenCalledTimes(1);
+		const budget = gate._inspectWakeBudget(sessionID);
+		expect(budget?.totalWakes).toBe(1);
+		expect(budget?.consecutiveUnproductive).toBe(1);
+		expect(budget?.suspended).toBe(false);
+	});
+});

--- a/tests/unit/hooks/pr-workflow-response-gate.test.ts
+++ b/tests/unit/hooks/pr-workflow-response-gate.test.ts
@@ -301,7 +301,7 @@ describe('PR workflow response-gate wake budget', () => {
 		await gate.event(idle('healthy-session'));
 		// Now the controller makes progress â€” revision bumps to 5.
 		await writeStateWithRevision('healthy-session', 5);
-		// Wake 3 sees revision 5 > lastSeenRevision 0 â†’ progress â†’ counter resets.
+		// Wake 3's progress token changes (revision is hashed into it), so the counter resets.
 		await gate.event(idle('healthy-session'));
 		// Wake 4 (revision unchanged at 5 â†’ unproductive again, counterâ†’1).
 		await gate.event(idle('healthy-session'));


### PR DESCRIPTION
Refs #2469 (partial: the three integration gaps are fixed; the issue's exit gate — real tier-M runs on Windows/macOS/Linux — stays open because `submit_pr_review_result` remains unusable by child lanes until batch/lane identifiers are transmitted or resolved tool-side; tracked as the PRREVIEW-1 follow-up)

## Summary
- Restored authenticated PR_FEEDBACK scope precedence over generic plan/Stage-A state with exact under-lock declaration correlation and one-call consumption.
- Wired authorize_pr_review_reentry through the live PR_REVIEW controller/delegation chain with exact binding checks, fixed lock ordering, replay protection, and same-call idempotence. Admission requires a `subagent_type` dispatch (an `agent:`-only Task is never admitted and never burns the authorization); a dispatch the delegation gate later rejects for an unrelated reason intentionally burns the one-shot authorization — issue a fresh one before retrying. The authorization store write is hard-bounded to the persisted cap and pruning prioritizes still-live unconsumed authorizations.
- Made response-gate auto-resume depend on the composite progress token (active-lane status + structured receipt digests + gate revision). A throwing recovery scan is treated as uncertainty rather than killing the wake; the progress scan is no longer paid before the wake-cooldown early-return; strict stale/corrupt/duplicate/mid-wake handling with wait expiry remaining non-terminal.
- Preserved existing CR/LF/CRLF/U+2028/U+2029 sanitizer coverage and resilience default-off; no migration is required.
- Review-feedback round: fixed both CI quality ratchets the new lane-progress suite tripped (check:test-clock, check:test-tmpdir) and the host-dependent fixture failure (missing `.git` project marker), deleted the dead compat consume wrapper in favor of the production reservation path, made the workflow-lock test discriminating (uncontended negative control + real mutation), and documented the two single-consumption burn semantics.

## Invariant audit
- 1 (plugin init): not touched - no initialization-path changes; `node scripts/repro-704.mjs` passed.
- 2 (runtime portability): touched - no portability regressions; build, typecheck, Node ESM import (`await import('./dist/index.js')` OK), and package smoke passed.
- 3 (subprocesses): not touched - no subprocess call sites changed; bare-spawn/invariant checks passed.
- 4 (.swarm containment): touched - scope/workflow writes remain in existing project-root stores; declaration replacement interleave passed; test fixtures create explicit `.git` project markers instead of relying on ambient temp ancestors.
- 5 (plan durability): touched - generic plan and Stage-A behavior remain intact; normal-plan no-leak regression passed.
- 6 (test_runner safety): not touched - repository validation used shell-based isolated tests; no broad test_runner was used.
- 7 (test writing): touched - Bun tests only, DI seams (beforePrFeedbackScopeConsume, beforePrReviewReentryReservation, scanDelegationsForRecovery) registered in docs/engineering-invariants.md and restored in afterEach, no new mock.module target, changed tests under 500 lines. An earlier revision of this body claimed the test ratchets had passed; that was wrong — the new lane-progress suite tripped check:test-clock and check:test-tmpdir and failed on hosts whose temp root sits under `.swarm`-bearing ancestors. All ratchets now pass on this head (0 new violations) and the suite is green locally with mutation-checked regression tests.
- 8 (session state): touched - workflow/auth state is session-keyed, bounded, exact-call idempotent; concurrency tests passed.
- 9 (guardrails/retry): touched - exact scope/re-entry authority and fail-closed race behavior covered by real-chain/interleaving tests; same-call re-verification after workflow progress fails closed (pinned by test).
- 10 (chat/system msg): not touched - no chat transform changes.
- 11 (tool registration): touched - registered authorization capability is admitted only on the PR_REVIEW controller path and only for `subagent_type` dispatches; tool registration and capability tests passed.
- 12 (release/cache): touched - pending release fragment updated (store bounds, burn semantics), version files/cache logic untouched; package smoke packed 1182 files.

## Test plan
- `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` — OK
- `bun run typecheck`, `bun run lint:ci` — clean
- `bun run check:test-clock` — 0 new violations (was 1)
- `bun run check:test-tmpdir` — 0 new violations (was 1)
- `bun run check:test-file-cap`, `check:mock-cleanup`, `check:pending-fragment`, `scripts/check-tool-registration.ts`, `drift:check` — pass
- Targeted suites (clean temp root): lane-progress 7/7 (was 1/6 pre-fix on this host), reentry-authorization 16/16, feedback-scope-controller 8/8, hook-precedence integration 7/7, response-gate siblings 55/55
- Mutation checks: reverting the scan try/catch or the subagent_type admission each makes its new test fail, then passes on restore
- Reviewer gate (Kimi K2.7) and critic gate (Kimi K3) on the fix diff: both APPROVE
- `bun run test:unit:ci` previously completed with exit 1 only on unrelated pre-existing/environment-sensitive tests (learning admission, real-platform knowledge-store tripwires, phase-complete timeout, architecture-supervisor evidence); the failing files are unchanged relative to `origin/main`.
