### PR TITLE
test: root-fix async, timeout, and quota-batch flakes (#2478)

### DIFF
--- a/docs/releases/pending/root-fix-async-timeout-quota-flake-family.md
+++ b/docs/releases/pending/root-fix-async-timeout-quota-flake-family.md
@@ -1,0 +1,30 @@
+# Root-fix the async, timeout, and quota-batch flake family (issue #2478)
+
+## What changed
+
+Four CI/test-stability flake families are root-fixed instead of quarantine-hidden. The change is tests-and-ledger only — no production code was touched.
+
+### dispatch-lanes timeout assertions (issues #2362 / #2368 / #2386)
+
+The two hung-lane timeout tests pinned the literal elapsed milliseconds embedded in the timeout error message. The `session.prompt` and `session.promptAsync` messages embed the **deadline-derived remaining budget** (`deadlineAtMs - now()`, computed by `dispatchWithModelFallback` before the timeout fires), so under multi-file single-process load — or coverage instrumentation — the digits read `9` instead of the configured `10` and the assertion failed; those two pins now assert the message prefix (`expect.stringContaining('… timed out after')`), pinning the timeout path rather than the elapsed value. The two `session.create` timeout messages embed the configured `timeout_ms` (deterministic), so their exact-string assertions are retained unchanged. The `waitForBatchRecordStatus` helper's fixed 50×1ms polling loop (~50ms wall budget, routinely exceeded under load) was replaced with the repo's attempt-counting convention (10ms × 200 attempts ≥ 2s). The file's existing per-test `afterEach` restore remains the `_internals` seam-hygiene mechanism for multi-file single-process runs (an additionally planned `afterAll` belt-and-braces duplicate was dropped to keep the grandfathered 2430-line file inside the FR-006 growth ratchet — the afterEach restore is complete: production `_internals` exports every key the tests mutate).
+
+### evaluation-runner and gate-utils timeout/temp races (issues #2330 / #2416 / #2449)
+
+- `runner-failures.test.ts`: the per-task-deadline test's `performance.now() < 500ms` pin (deadline under test: 20ms) flipped on shared-runner stalls; it now uses a 5s semantic bound that still fails well before the run-level fallback if the deadline mechanism breaks. The real-subprocess scorer cases keep asserting output classification but with generous subprocess budgets (8s scorer / 10s task) so a cold child boot under load cannot masquerade as a timeout. All temp-dir cleanups use `safeRmRecursive` (EBUSY/EPERM-retrying, tmpdir-containment-guarded).
+- `gate-utils.test.ts`: the non-Windows probe timeout (200ms) raced child cold-start — the exact class Windows already carried a 2s budget for; the probe now uses 2s on every platform, and the elapsed bound is derived from the actual contract (`timeout + 1s kill grace + 2s stall slack`) instead of platform-specific magic numbers. Cleanup uses `safeRmRecursive`.
+
+### skill_improver "merge-group batch suppression" (issue #2396) — real root cause found
+
+The #2396 theory (quota state polluted by batch order) is **disproven**: quota state was already per-directory and file-backed. The actual failure was a merge-combination regression — PR #2377's approval-gate enforcement met the integration test's stale `require_user_approval: true` config (no session-bound approval provided), so `runSkillImprover` fast-exited with `ran: false` in both failing queue runs on 2026-08-27. It was reproduced deterministically at the exact failing queue merge commit and had already been repaired on main by `75d47bd3c` (minutes after the failures); the interim quarantine kept hiding the green test from every merge-group run since. This change:
+
+- removes the quarantine entry, restoring merge-group validation of the file. The un-quarantine is validated by the merge-group run that consumes it: the file is deterministically green on main (the historical failure was a since-fixed regression), so if it regressed the queue blocks the merge rather than hiding the failure;
+- injects a per-call `now` (one fixed UTC day, 2026-09-02, with distinct second offsets per call) on every `runSkillImprover` invocation so the sequential quota calls can never straddle a UTC-midnight rollover — the one genuine live-clock hazard left in the file. (A global `freezeClock` spy was tried first and rejected: freezing `toISOString` collapses every run's proposal filename onto one timestamp, making consecutive successful runs overwrite each other's proposals; per-call injection protects the quota day while keeping proposal slugs distinct.); and
+- adds a **batch-order independence test**: exhausting project root A's daily quota never suppresses a run in independent root B, pinning the per-directory quota-isolation invariant through the registered `runSkillImprover` path.
+
+### Supersedes PR #2455
+
+PR #2455 proposed quarantining `dispatch-lanes.test.ts`; it was closed unmerged and the general ledger stayed empty. This root fix supersedes that approach — no quarantine is needed.
+
+## Known limitation (documented)
+
+The integration job runs only on `merge_group` events, so ordinary PR CI never executes integration tests against merge combinations — the blind spot that let the #2377 regression reach the queue undetected. Redesigning the trigger is a CI-cost decision outside this issue; recorded here for the test-stability workstream.

--- a/scripts/ci/quarantined-integration-tests.txt
+++ b/scripts/ci/quarantined-integration-tests.txt
@@ -13,11 +13,13 @@
 #
 # Issue #1908 requires merge-group proof for any entry here.
 
-# Refs #2396: skill_improver quota tests refuse to run inside the merge_group
-# integration batch (r.ran false); pass standalone. Merge-group proof: PR #2377
-# run 33109018048 and PR #2387 run 33110714121 failed identically on
-# 2026-08-27 while the standalone file passed on both branches.
-# OWNER: @zaxbysauce — issue #2396
-# EXPIRY: 2026-09-30 — root-fix the merge-group integration-batch refusal
-# (r.ran false) or renew with updated diagnosis under #2396/#2477
-tests/integration/issue-629-skill-improver.test.ts
+# No active integration-test quarantines. The issue #2396 entry
+# (tests/integration/issue-629-skill-improver.test.ts) was retired by the
+# issue #2478 root fix: the merge-group "refusal to run" was root-caused to
+# a merge-combination regression (PR #2377's approval-gate enforcement
+# meeting the test's stale `require_user_approval: true` config), already
+# repaired on main by 75d47bd3c; the file passes standalone. Removal and
+# validation are atomic in the queue run: if the file regresses there, the
+# queue blocks the merge rather than hiding the failure, and re-quarantine
+# remains available. Same-PR ordering explicitly accepted by maintainer
+# review on PR #2542, 2026-09-03.

--- a/tests/integration/issue-629-skill-improver.test.ts
+++ b/tests/integration/issue-629-skill-improver.test.ts
@@ -17,6 +17,7 @@ import type { SwarmKnowledgeEntry } from '../../src/hooks/knowledge-types';
 import { runSkillImprover } from '../../src/services/skill-improver';
 import { resolveQuotaPath } from '../../src/services/skill-improver-quota';
 import { createIsolatedTestEnv } from '../helpers/isolated-test-env';
+import { createSafeTestDir } from '../helpers/safe-test-dir';
 
 let tmp: string;
 let cleanupEnv: () => void;
@@ -31,8 +32,25 @@ afterEach(() => {
 	cleanupEnv();
 });
 
-async function seedMatureKnowledge(): Promise<void> {
-	await mkdir(path.join(tmp, '.swarm'), { recursive: true });
+/**
+ * Injected clock (issue #2478): every runSkillImprover call below pins its
+ * `now` to this fixed UTC day via distinct per-call offsets.
+ *
+ * Why per-call injection instead of a freezeClock spy: a live clock lets a
+ * UTC-midnight rollover between the sequential quota calls reset
+ * `calls_used` (getQuotaState's date-mismatch rollover) and flip the
+ * quota-exhaustion assertions — the one genuine live-clock hazard in this
+ * file. A global toISOString spy, however, makes every proposal share one
+ * `timestampSlug(now)` filename, so consecutive successful runs overwrite
+ * each other's proposals. Per-call `now` values on a single UTC day close
+ * the rollover window while keeping proposal slugs distinct.
+ */
+const FIXED_DAY_MS = Date.parse('2026-09-02T00:00:00.000Z');
+const fixedNow = (secondsOffset: number): Date =>
+	new Date(FIXED_DAY_MS + secondsOffset * 1_000);
+
+async function seedMatureKnowledge(directory: string = tmp): Promise<void> {
+	await mkdir(path.join(directory, '.swarm'), { recursive: true });
 	const e: SwarmKnowledgeEntry = {
 		id: '11111111-1111-4111-9111-111111111111',
 		tier: 'swarm',
@@ -70,7 +88,7 @@ async function seedMatureKnowledge(): Promise<void> {
 		directive_priority: 'critical',
 	};
 	await writeFile(
-		resolveSwarmKnowledgePath(tmp),
+		resolveSwarmKnowledgePath(directory),
 		JSON.stringify(e) + '\n',
 		'utf-8',
 	);
@@ -98,6 +116,7 @@ describe('issue #629 — low-frequency expensive skill_improver', () => {
 		const r = await runSkillImprover({
 			directory: tmp,
 			config,
+			now: fixedNow(0),
 		});
 		expect(r.ran).toBe(true);
 		expect(r.proposalPath).toContain(
@@ -130,9 +149,21 @@ describe('issue #629 — low-frequency expensive skill_improver', () => {
 			quota_window: 'utc' as const,
 			allow_deterministic_fallback: true,
 		};
-		const r1 = await runSkillImprover({ directory: tmp, config });
-		const r2 = await runSkillImprover({ directory: tmp, config });
-		const r3 = await runSkillImprover({ directory: tmp, config });
+		const r1 = await runSkillImprover({
+			directory: tmp,
+			config,
+			now: fixedNow(0),
+		});
+		const r2 = await runSkillImprover({
+			directory: tmp,
+			config,
+			now: fixedNow(1),
+		});
+		const r3 = await runSkillImprover({
+			directory: tmp,
+			config,
+			now: fixedNow(2),
+		});
 		expect(r1.ran).toBe(true);
 		expect(r2.ran).toBe(true);
 		expect(r3.ran).toBe(false);
@@ -165,6 +196,7 @@ describe('issue #629 — low-frequency expensive skill_improver', () => {
 			directory: tmp,
 			config,
 			mode: 'draft_skills',
+			now: fixedNow(0),
 		});
 		expect(r.ran).toBe(true);
 		expect(r.draftSkillsWritten?.length ?? 0).toBeGreaterThan(0);
@@ -194,8 +226,70 @@ describe('issue #629 — low-frequency expensive skill_improver', () => {
 			quota_window: 'utc' as const,
 			allow_deterministic_fallback: true,
 		};
-		await runSkillImprover({ directory: tmp, config });
+		await runSkillImprover({ directory: tmp, config, now: fixedNow(0) });
 		const after = readFileSync(resolveSwarmKnowledgePath(tmp), 'utf-8');
 		expect(after).toBe(before);
+	});
+
+	it('quota state is per-directory: exhausting one root never suppresses another (issue #2478 batch-order independence)', async () => {
+		// Two independent project roots (realpath-canonical via
+		// createSafeTestDir). Root A burns its entire daily quota; root B
+		// must still run through the same registered runSkillImprover path.
+		// This pins the per-directory quota-file isolation invariant: a
+		// merge_group integration batch-mate — or any other project sharing
+		// the process/filesystem — cannot suppress this suite's execution by
+		// consuming quota elsewhere (the failure class issue #2396 was
+		// filed under, later root-caused to a merge-combination test
+		// regression; this test guards the quota-isolation property the
+		// original theory assumed was broken).
+		const rootA = createSafeTestDir('issue-629-projA-');
+		const rootB = createSafeTestDir('issue-629-projB-');
+		try {
+			await seedMatureKnowledge(rootA.dir);
+			await seedMatureKnowledge(rootB.dir);
+			const config = {
+				enabled: true,
+				model: 'openrouter/expensive-model',
+				fallback_models: [] as string[],
+				max_calls_per_day: 1,
+				trigger: 'manual' as const,
+				targets: ['skills'] as Array<
+					'skills' | 'spec' | 'architect_prompt' | 'knowledge'
+				>,
+				write_mode: 'proposal' as const,
+				require_user_approval: false,
+				quota_window: 'utc' as const,
+				allow_deterministic_fallback: true,
+			};
+			const a1 = await runSkillImprover({
+				directory: rootA.dir,
+				config,
+				now: fixedNow(0),
+			});
+			const a2 = await runSkillImprover({
+				directory: rootA.dir,
+				config,
+				now: fixedNow(1),
+			});
+			const b1 = await runSkillImprover({
+				directory: rootB.dir,
+				config,
+				now: fixedNow(2),
+			});
+			expect(a1.ran).toBe(true);
+			expect(a2.ran).toBe(false);
+			expect(a2.reason).toMatch(/quota/i);
+			expect(b1.ran).toBe(true);
+			// Each root carries its own quota file; B's reflects only its own
+			// single run.
+			const quotaB = JSON.parse(
+				readFileSync(resolveQuotaPath(rootB.dir), 'utf-8'),
+			) as { calls_used: number; max_calls: number };
+			expect(quotaB.calls_used).toBe(1);
+			expect(quotaB.max_calls).toBe(1);
+		} finally {
+			rootA.cleanup();
+			rootB.cleanup();
+		}
 	});
 });

--- a/tests/unit/evaluation/runner-failures.test.ts
+++ b/tests/unit/evaluation/runner-failures.test.ts
@@ -15,6 +15,7 @@ import {
 	type RunEvaluationOptions,
 	runEvaluation,
 } from '../../../src/evaluation/runner.js';
+import { safeRmRecursive } from '../../helpers/safe-test-dir';
 
 const originalFingerprint = _internals.captureWorkingTreeFingerprint;
 const originalDisposableWorktree = _internals.withDisposableWorktree;
@@ -47,6 +48,11 @@ async function candidate(
 async function harness(
 	kind: 'builtin' | 'project' = 'project',
 	scorerInput: Record<string, unknown> = { score: 0.75 },
+	// Must be chosen BEFORE computeTaskInputContentHash runs — the scorer
+	// timeout is part of the task's canonical content hash, so mutating
+	// options.tasks[0].scorer.timeoutMs after the harness returns invalidates
+	// the stored task (admitEvaluationTask rejects with a hash mismatch).
+	scorerTimeoutMs = 1_000,
 ): Promise<{ root: string; options: RunEvaluationOptions }> {
 	const root = fs.realpathSync(
 		fs.mkdtempSync(path.join(os.tmpdir(), 'eval-runner-failure-')),
@@ -81,7 +87,7 @@ async function harness(
 			kind,
 			argv:
 				kind === 'project' ? ['fixture/scorer.mjs', 'score.json'] : ['builtin'],
-			timeoutMs: 1_000,
+			timeoutMs: scorerTimeoutMs,
 			scoreRange: [0, 1] as [number, number],
 		},
 		provenance: { origin: 'unit-test', license: 'MIT' },
@@ -101,7 +107,7 @@ async function harness(
 		try {
 			return await run({ path: worktreeRoot, baseSha: baseRef });
 		} finally {
-			fs.rmSync(worktreeRoot, { recursive: true, force: true });
+			safeRmRecursive(worktreeRoot);
 		}
 	};
 	const options: RunEvaluationOptions = {
@@ -221,7 +227,7 @@ describe('evaluation runner failure classification', () => {
 			).toBe(true);
 			expect(calls).toBe(outcome === 'infrastructure_failure' ? 4 : 2);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			safeRmRecursive(root);
 		}
 	});
 
@@ -232,7 +238,17 @@ describe('evaluation runner failure classification', () => {
 			options.executor = async () => new Promise(() => {});
 			const startedAt = performance.now();
 			const run = await runEvaluation(options);
-			expect(performance.now() - startedAt).toBeLessThan(500);
+			// Semantic bound (issue #2478): the deadline under test is 20ms;
+			// the previous <500ms pin flipped on shared-runner stalls (GC/CPU
+			// contention) while the deadline mechanism still worked.
+			// performance.now() is NOT covered by freezeClock (see
+			// docs/testing/test-stability.md "Known limitations"), so the
+			// bound is widened to 5s (250x the deadline). If the per-task
+			// deadline stops firing entirely, the run-level budget aborts the
+			// run (totalTimeoutMs ~1040ms for this config) and the
+			// outcome/failureCode assertions below still fail — the elapsed
+			// bound is a stall absorber, not the breakage detector.
+			expect(performance.now() - startedAt).toBeLessThan(5_000);
 			expect(run.results.every((entry) => entry.outcome === 'timeout')).toBe(
 				true,
 			);
@@ -242,14 +258,19 @@ describe('evaluation runner failure classification', () => {
 				),
 			).toBe(true);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			safeRmRecursive(root);
 		}
 	});
 
 	test('executes a real portable scorer with sibling imports and relative data', async () => {
-		const { root, options } = await harness();
+		const { root, options } = await harness('project', { score: 0.75 }, 8_000);
 		try {
-			options.budgets.maxTaskTimeMs = 3_000;
+			// Real-subprocess budget (issue #2478): this case asserts OUTPUT
+			// classification, not timing. A real scorer's cold boot under
+			// merge-group load can exceed the harness's 1s default, flipping
+			// the outcome to 'timeout'. Give the real child generous budgets;
+			// the mocked-classify cases keep the tight defaults.
+			options.budgets.maxTaskTimeMs = 10_000;
 			_internals.runExternalTool = originalRunExternalTool;
 			const run = await runEvaluation(options);
 			expect(run.status).toBe('complete');
@@ -259,7 +280,7 @@ describe('evaluation runner failure classification', () => {
 			);
 			expect(run.results.every((entry) => entry.score === 0.75)).toBe(true);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			safeRmRecursive(root);
 		}
 	});
 
@@ -277,9 +298,11 @@ describe('evaluation runner failure classification', () => {
 			'scorer-invalid-json',
 		],
 	] as const)('classifies a real portable scorer %s', async (_name, scorerInput, outcome, failureCode) => {
-		const { root, options } = await harness('project', scorerInput);
+		const { root, options } = await harness('project', scorerInput, 8_000);
 		try {
-			options.budgets.maxTaskTimeMs = 3_000;
+			// Real-subprocess budget (issue #2478): see the sibling
+			// 'executes a real portable scorer' case above.
+			options.budgets.maxTaskTimeMs = 10_000;
 			_internals.runExternalTool = originalRunExternalTool;
 			const run = await runEvaluation(options);
 			expect(run.status).toBe('inconclusive');
@@ -290,7 +313,7 @@ describe('evaluation runner failure classification', () => {
 				run.results.every((entry) => entry.failureCode === failureCode),
 			).toBe(true);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			safeRmRecursive(root);
 		}
 	});
 
@@ -311,7 +334,7 @@ describe('evaluation runner failure classification', () => {
 				),
 			).toBe(true);
 		} finally {
-			fs.rmSync(root, { recursive: true, force: true });
+			safeRmRecursive(root);
 		}
 	});
 });

--- a/tests/unit/scripts/gate-utils.test.ts
+++ b/tests/unit/scripts/gate-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { spawnUtf8 } from '../../../scripts/gate-utils';
+import { safeRmRecursive } from '../../helpers/safe-test-dir';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 function timeoutProbe(markerPath: string, aliveDelayMs: number): string[] {
@@ -25,14 +26,22 @@ describe('gate-utils subprocess ownership', () => {
 		const markerPath = path.join(markerDir, 'child-alive.txt');
 		try {
 			const started = performance.now();
-			// Use the same Node probe on every platform. PowerShell cold-start
-			// latency used to race the timeout on Windows before the child had
-			// executed its first statement, testing shell startup rather than
-			// spawnUtf8's timeout/termination contract.
-			const isWindows = process.platform === 'win32';
-			const timeoutMs = isWindows ? 2_000 : 200;
+			// Use the same Node probe and the same 2s timeout budget on every
+			// platform. The non-Windows leg used to probe with 200ms, which
+			// raced child cold-start under merge-group load: the .started
+			// marker requires the child to have executed its first statement
+			// before the kill, and 200ms is not a safe boot budget on shared
+			// runners. Windows already carried 2s for exactly this cold-start
+			// class; unify on it (issue #2478).
+			const timeoutMs = 2_000;
 			const aliveDelayMs = timeoutMs + 250;
-			const maxElapsedMs = isWindows ? 5_000 : 4_000;
+			// Contract-derived bound (issue #2478): the kill fires at
+			// timeoutMs and close handling is bounded by spawnUtf8's 1s kill
+			// grace (KILL_GRACE_MS, scripts/gate-utils.ts). +2s of slack
+			// absorbs runner stalls without weakening the "returns boundedly,
+			// not hanging" guarantee the previous platform-specific magic
+			// numbers attempted.
+			const maxElapsedMs = timeoutMs + 1_000 + 2_000;
 			const result = await spawnUtf8(
 				timeoutProbe(markerPath, aliveDelayMs),
 				process.cwd(),
@@ -48,7 +57,7 @@ describe('gate-utils subprocess ownership', () => {
 			expect(fs.existsSync(`${markerPath}.started`)).toBe(true);
 			expect(fs.existsSync(markerPath)).toBe(false);
 		} finally {
-			fs.rmSync(markerDir, { recursive: true, force: true });
+			safeRmRecursive(markerDir);
 		}
 	});
 

--- a/tests/unit/tools/dispatch-lanes.test.ts
+++ b/tests/unit/tools/dispatch-lanes.test.ts
@@ -66,10 +66,11 @@ async function waitForBatchRecordStatus(
 	batchId: string,
 	expected: string,
 ): Promise<string | undefined> {
-	for (let attempt = 0; attempt < 50; attempt++) {
+	// Attempt-counting, not wall-clock (docs/testing/test-stability.md, #2478).
+	for (let attempt = 0; attempt < 200; attempt++) {
 		const status = findByBatchId(directory, batchId)[0]?.status;
 		if (status === expected) return status;
-		await new Promise((resolve) => setTimeout(resolve, 1));
+		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 	return findByBatchId(directory, batchId)[0]?.status;
 }
@@ -573,7 +574,8 @@ describe('executeDispatchLanes', () => {
 			expect.objectContaining({
 				id: 'hung',
 				status: 'failed',
-				error: 'Lane "hung" session.prompt timed out after 10ms',
+				// #2478/#2362: digits are deadline-derived (9 not 10 under load).
+				error: expect.stringContaining('session.prompt timed out after'),
 			}),
 		]);
 		expect(ops.delete).toHaveBeenCalledWith({ path: { id: 'session-1' } });
@@ -1899,15 +1901,10 @@ describe('executeDispatchLanesAsync and executeCollectLaneResults', () => {
 		expect(ops.delete).toHaveBeenCalledWith({
 			path: { id: 'session-timeout' },
 		});
-		const records = findByBatchId(directory, 'batch-timeout');
-		expect(records[0]).toEqual(
-			expect.objectContaining({
-				status: 'error',
-				result: expect.objectContaining({
-					error:
-						'Lane "runtime" session.promptAsync launch timed out after 10ms',
-				}),
-			}),
+		const record = findByBatchId(directory, 'batch-timeout')[0];
+		expect(record?.status).toBe('error');
+		expect(record?.result?.error).toContain(
+			'session.promptAsync launch timed out after',
 		);
 	});
 


### PR DESCRIPTION
Closes #2478

## Summary

Root-fixes the async/timeout/quota-batch flake family (Workstream C, PR 2 of 3) — **tests + quarantine ledger only, no `src/` changes**:

1. **dispatch-lanes literal elapsed-ms pins (#2362/#2368/#2386)** — the `session.prompt` / `session.promptAsync` timeout messages embed the deadline-derived remaining budget (`deadlineAtMs - now()` from `dispatchWithModelFallback`, baked in before the timeout fires), so under load the digits read `9` instead of the configured `10`; those two pins now assert the message prefix. The two `session.create` pins keep exact-match (their message embeds the configured `timeout_ms` — deterministic; tightened back at maintainer review). The `waitForBatchRecordStatus` 50×1ms polling loop (≈50ms wall budget) became the repo's attempt-counting pattern (200 × 10ms ≥ 2s).
2. **evaluation-runner + gate-utils (#2330/#2416/#2449)** — semantic elapsed bounds (5s around a 20ms deadline; contract-derived `timeout + 1s kill grace + 2s slack` in gate-utils), the non-Windows probe timeout unified to the 2s value Windows already carried for the same child cold-start race, generous budgets for the real-subprocess scorer cases (applied **pre-hash** via a harness parameter — `scorer.timeoutMs` is part of the task's content hash), and all bare `rmSync` cleanups replaced with `safeRmRecursive`.
3. **skill_improver "#2396 batch suppression"** — the issue's quota/batch-order theory is **disproven**. Real root cause: a merge-combination regression — PR #2377's approval-gate enforcement met this test's stale `require_user_approval: true` config, so `runSkillImprover` fast-exited with `ran:false` in both failing queue runs (reproduced deterministically at the exact failing merge commit `71c24caaf`; the second failing run's queue merge was stacked on the first's). Already repaired on main by `75d47bd3c`; the interim quarantine has been hiding a green test since. This PR: injects a per-call `now` (one fixed UTC day, distinct second offsets) closing the genuine UTC-midnight quota-rollover hazard, adds a **batch-order independence test** (exhausting project root A's quota never suppresses root B, through the registered `runSkillImprover` path), and **removes the quarantine entry** so merge-group validation resumes. Note on ordering: per `docs/testing/test-stability.md`, un-quarantine wants a confirming merge-group run — here removal and validation are atomic in this PR's own queue run, a bounded and deliberate choice given the file is deterministically green on main (verified standalone across two days of main states); this same-PR reading of the policy was reviewed and accepted by the maintainer in the PR review thread (2026-09-03).
4. **Supersedes quarantine-only PR #2455** (closed unmerged; the general ledger was never populated — nothing to revert).

Duplicate-occurrence issues #2386/#2449 close against this root fix per the 2026-09-02 roadmap re-baseline.

Gates: reviewer (Kimi K2.7, 2 rounds) APPROVE; final critic (Kimi K3) APPROVE — full trace in the linked issue comment.

## Invariant audit

- 1 (plugin init):       not touched — diff confined to `tests/`, `scripts/ci/quarantined-integration-tests.txt`, `docs/releases/pending/`; no `src/` changes (verified by `git diff origin/main..HEAD --stat`).
- 2 (runtime portability): not touched — no `src/`, package exports, `package.json#main`, or build-config changes; no `bun:`/`Bun.*` surface introduced.
- 3 (subprocesses):      not touched — production `spawnUtf8` unchanged; test-side probe timeout unified to 2s (the value Windows already validated for the same cold-start race); `KILL_GRACE_MS` verified at `scripts/gate-utils.ts:12`.
- 4 (.swarm containment): not touched — the new batch-order test writes only under two `createSafeTestDir` roots (realpath-canonical, `os.tmpdir()`-contained, `safeRmRecursive` teardown).
- 5 (plan durability):   not touched.
- 6 (test_runner safety): not touched — validation performed via shell per-file runs; no `test_runner` scopes used.
- 7 (test writing):      **touched** — bun:test only; no new `mock.module` (existing `_internals` seams preserved and verified complete: production `_internals` exports all 9 keys, every mutation top-level and restored by afterEach); `safeRmRecursive` for all temp cleanups; attempt-counting per `docs/testing/test-stability.md`; `check:test-file-cap` → 0 ratchet violations (dispatch-lanes.test.ts 2427 lines vs 2430 base — did not grow); `check:test-clock` → 0 new violations; biome clean on touched files.
- 8 (session state):     not touched.
- 9 (guardrails/retry):  not touched.
- 10 (chat/system msg):  not touched.
- 11 (tool registration): not touched.
- 12 (release/cache):    **touched** — release fragment `docs/releases/pending/root-fix-async-timeout-quota-flake-family.md` added; no version files hand-edited (release-please owns them); quarantine metadata requirement (#2477 Check 7) honored — `check:invariants` passes with the emptied integration ledger.

## Test plan

All from the worktree on Windows (bun 1.3.14; known `Temp/.swarm` pollution moved aside first):

- `bun --smol test` each modified file ×3-5 → dispatch-lanes `69 pass/0 fail` (×4), runner-failures `13 pass/0 fail` (×4), gate-utils `3 pass/0 fail` (×4), issue-629 integration `5 pass/0 fail` (×5, includes the new batch-order test).
- Multi-file single-process runs (the #2362 repro mode), randomized order, 9 total runs incl. 5 with `dispatch-lanes.test.ts` always present → `0 fail` every run.
- Fresh 4-file batch post-approval: `90 pass / 0 fail / 385 expect() calls`.
- Falsifiability mutations: (a) batch-order test pointed at a shared root → fails for the expected reason, restored → green; (b) hung-lane prompt mock made to throw a non-timeout error → prefix pin still fails the test (not vacuous), restored → green; (c) pre-fix reproduction at the historical failing merge commit `71c24caaf` → 3 failures with the exact CI signature.
- Gates: `bun run check:test-file-cap` (0 violations), `bun run check:invariants` (all passed), `bun run check:test-clock` (0 new), `bun run drift:check` (no drift), ledger-adjacent `ci-yml-integration` + `check-quarantine-metadata` tests `34 pass/0 fail`.
- CI-only tiers (three-OS matrix, coverage, merge-group integration) validate on this PR's checks — the un-quarantined integration file's first merge-group execution since 2026-08-27 is this PR's own queue run.
