### PR TITLE
fix(db): return a Changes-shaped object from the node adapter's no-bindings run()

### DIFF
--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -387,6 +387,22 @@ Each entry below points at a release note in `docs/releases/` and the invariant(
   - **Node floor is enforced, not just declared:** the loader probes
     `process.versions.node` on the node fallback and throws the floor
     diagnostic (`engines` declares `node >= 22.13`).
+  - **No-bindings `run()` returns a `Changes`-shaped object (#2539):**
+    `bun:sqlite`'s `run()` ALWAYS returns `{ changes, lastInsertRowid }`,
+    including the no-bindings form; the node adapter's no-param branch
+    (which executes via `exec()`, void under `node:sqlite`) rebuilds the
+    object from the connection-level counters (`SELECT changes(),
+    last_insert_rowid()` — one cached probe statement). Pre-fix it returned
+    `undefined`, so `.changes` readers crashed under the Node sidecar
+    (`/swarm memory unlink` and populated re-link, via the memory-family
+    ATTACH merge). The shape is pinned in `src/db/driver-parity.ts` for
+    single-statement DML — the only form production reads; an audit of
+    `src/` found exactly two no-bindings return-value readers (the ATTACH
+    merge and the `valid_from` backfill), both healed by the adapter fix.
+    Two deltas are deliberately NOT pinned because the drivers genuinely
+    diverge there: multi-statement strings (bun sums `.changes`, the probe
+    reports the last statement) and non-DML statements (bun reports 0, the
+    probe keeps the previous DML's count).
 - **Maps to AGENTS.md:** invariants 2 (runtime portability — parity contract
   + strict fake), 4 (`.swarm` containment), 7 (driver-parity and
   registry-seam tests), 8 (bounded session state — degradation cooldowns,

--- a/docs/releases/pending/2539-node-sqlite-run-changes-return.md
+++ b/docs/releases/pending/2539-node-sqlite-run-changes-return.md
@@ -10,8 +10,11 @@
   `Cannot read properties of undefined (reading 'changes')`.
 - The memory-family ATTACH merge (`/swarm memory link` / `/swarm memory unlink`
   with a non-empty cohort or local store) and the `valid_from` provenance
-  backfill are the two affected call sites; both work under Node without
-  changes to their own code, and Bun behavior is unchanged.
+  backfill are the two affected call sites. The merge crashed under Node with
+  the TypeError above; the backfill degraded silently (its `?.` fallback
+  counted 0 updated rows, suppressing the `backfill_provenance_columns`
+  migration event). Both work under Node without changes to their own code,
+  and Bun behavior is unchanged.
 - The no-bindings `run()` return shape is now pinned in the Bun↔Node driver
   parity contract (`src/db/driver-parity.ts`) and exercised against the real
   `node:sqlite` driver by the `repro:1873` smoke leg, which now also drives

--- a/docs/releases/pending/2539-node-sqlite-run-changes-return.md
+++ b/docs/releases/pending/2539-node-sqlite-run-changes-return.md
@@ -1,0 +1,33 @@
+# Fix /swarm memory unlink and re-link on the OpenCode Desktop Node sidecar
+
+## What changed
+
+- The `node:sqlite` adapter (`src/db/sqlite-loader.ts`) now returns a
+  `Changes`-shaped object (`{ changes, lastInsertRowid }`) from `db.run(sql)`
+  when called with no bindings, matching `bun:sqlite`'s always-returns-Changes
+  contract. Previously it returned `undefined`, so any `.changes` reader
+  crashed under the Node sidecar with
+  `Cannot read properties of undefined (reading 'changes')`.
+- The memory-family ATTACH merge (`/swarm memory link` / `/swarm memory unlink`
+  with a non-empty cohort or local store) and the `valid_from` provenance
+  backfill are the two affected call sites; both work under Node without
+  changes to their own code, and Bun behavior is unchanged.
+- The no-bindings `run()` return shape is now pinned in the Bun↔Node driver
+  parity contract (`src/db/driver-parity.ts`) and exercised against the real
+  `node:sqlite` driver by the `repro:1873` smoke leg, which now also drives
+  `/swarm memory link` → `unlink` → re-link through the registered command
+  dispatch under Node.
+
+## Why
+
+OpenCode Desktop (Node) users could not unlink a memory family or link/re-link
+a populated one: the migration merge read `.changes` off the adapter's
+no-bindings `run()` return, which is a `Changes` object under Bun but was
+`undefined` under the node adapter — a driver difference the plugin is supposed
+to abstract. The failure surfaced as a raw TypeError naming an internal
+property.
+
+## Migration
+
+No storage migration is required. Existing memory databases are unchanged; the
+fix is entirely in the driver adapter and its parity contract.

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -100,6 +100,9 @@ const FORBIDDEN_PACKAGE_PREFIXES = [
 	'tests/smoke/',
 	'tests/security/',
 	'tests/adversarial/',
+	// #2539 review (mu-01): the repro-1873 Node harness bundle must never ship,
+	// even if a future edit adds it to package.json#files by mistake.
+	'dist-build-test/',
 ];
 
 function npmInvocation(args) {

--- a/scripts/repro-1873-entry.ts
+++ b/scripts/repro-1873-entry.ts
@@ -35,6 +35,10 @@ export {
 	projectDbPath,
 } from '../src/db/project-db.js';
 export { runDriverParityContract } from '../src/db/driver-parity.js';
+// #2539: the memory link/unlink command-path leg dispatches through the same
+// registry the swarm command tool uses.
+export { executeSwarmCommand } from '../src/commands/command-dispatch.js';
+export { clearPool } from '../src/memory/provider-pool.js';
 export {
 	computeMemoryContentHash,
 	createMemoryId,

--- a/scripts/repro-1873.mjs
+++ b/scripts/repro-1873.mjs
@@ -411,7 +411,12 @@ async function main() {
 			const link1 = await runCmd(['memory', 'link', 'repro-2539-cohort']);
 			check(
 				'#2539 memory link via registered command path',
-				link1.text.includes('Linked') && !link1.text.includes('❌'),
+				// Exact success prefix from handleMemoryLinkCommand (review tf-04):
+				// "Linked" alone would also match failure text that merely
+				// mentions the word.
+				link1.text.startsWith(
+					'🔗 Linked this worktree\'s memory to shared cohort store "repro-2539-cohort"',
+				) && !link1.text.includes('❌'),
 				link1.text.slice(0, 160),
 			);
 
@@ -461,7 +466,9 @@ async function main() {
 			const unlink1 = await runCmd(['memory', 'unlink']);
 			check(
 				'#2539 memory unlink via registered command path (ATTACH merge, non-empty local destination)',
-				unlink1.text.includes('Unlinked') && !unlink1.text.includes('❌'),
+				// Exact success prefix from handleMemoryUnlinkCommand (review tf-04).
+				unlink1.text.startsWith('🔓 Unlinked memory.') &&
+					!unlink1.text.includes('❌'),
 				unlink1.text.slice(0, 200),
 			);
 
@@ -470,7 +477,9 @@ async function main() {
 			const link2 = await runCmd(['memory', 'link', 'repro-2539-cohort']);
 			check(
 				'#2539 memory re-link via registered command path (populated cohort)',
-				link2.text.includes('Linked') && !link2.text.includes('❌'),
+				link2.text.startsWith(
+					'🔗 Linked this worktree\'s memory to shared cohort store "repro-2539-cohort"',
+				) && !link2.text.includes('❌'),
 				link2.text.slice(0, 200),
 			);
 
@@ -485,6 +494,48 @@ async function main() {
 				listed2539.length === 3 &&
 					ids2539.every((id) => listed2539.some((r) => r.id === id)),
 				`got ${listed2539.length}: ${listed2539.map((r) => r.id).join(',')}`,
+			);
+
+			// Review tf-05/mt-02: exercise the EMPTY-LOCAL unlink (the rename
+			// branch) under the real node driver — the F-22 shape, which
+			// previously only ran under Bun. The rename branch never reads
+			// `.changes`, so this proves the registered command path also
+			// succeeds when the local destination has no memory.db at all.
+			rmSync(join(memLinkDir, '.swarm', 'memory', 'memory.db'), {
+				force: true,
+			});
+			for (const suffix of ['-wal', '-shm']) {
+				rmSync(join(memLinkDir, '.swarm', 'memory', `memory.db${suffix}`), {
+					force: true,
+				});
+			}
+			mod.clearPool();
+			check(
+				'#2539 empty-local precondition (local memory.db removed)',
+				!existsSync(join(memLinkDir, '.swarm', 'memory', 'memory.db')),
+				'local memory.db still present',
+			);
+			const unlink2 = await runCmd(['memory', 'unlink']);
+			check(
+				'#2539 empty-local unlink via registered command path (rename branch under node)',
+				unlink2.text.startsWith('🔓 Unlinked memory.') &&
+					!unlink2.text.includes('❌'),
+				unlink2.text.slice(0, 200),
+			);
+			const verifyEmpty2539 = new mod.SQLiteMemoryProvider(memLinkDir);
+			await verifyEmpty2539.initialize();
+			const listedEmpty2539 = await verifyEmpty2539.list({
+				scopes: [scope2539],
+			});
+			verifyEmpty2539.close();
+			mod.clearPool();
+			check(
+				'#2539 empty-local unlink restored all three records from the cohort',
+				listedEmpty2539.length === 3 &&
+					ids2539.every((id) =>
+						listedEmpty2539.some((r) => r.id === id),
+					),
+				`got ${listedEmpty2539.length}`,
 			);
 		} finally {
 			rmSync(memLinkDir, { recursive: true, force: true });

--- a/scripts/repro-1873.mjs
+++ b/scripts/repro-1873.mjs
@@ -22,7 +22,14 @@
  */
 
 import { createRequire } from 'node:module';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -96,6 +103,10 @@ async function main() {
 	const cfgHome = mkdtempSync(join(tmpdir(), 'repro1873-cfg-'));
 	process.env.HOME = cfgHome;
 	process.env.XDG_CONFIG_HOME = cfgHome;
+	// #2539: the memory-link cohort store resolves under the data dir
+	// (LOCALAPPDATA on win32 / XDG_DATA_HOME on linux) — redirect it too so the
+	// link/unlink scenario never touches real user directories.
+	process.env.XDG_DATA_HOME = cfgHome;
 	process.env.LOCALAPPDATA = cfgHome;
 	const projDir = mkdtempSync(join(tmpdir(), 'repro1873-proj-'));
 
@@ -352,6 +363,132 @@ async function main() {
 			`got ${remaining.map((r) => r.id).join(',')}`,
 		);
 		provider.close();
+		mod.clearPool();
+
+		// ── #2539: /swarm memory link → unlink → re-link through the REGISTERED
+		//    command path (executeSwarmCommand → COMMAND_REGISTRY) under the real
+		//    node:sqlite driver. Pre-fix, the first ATTACH merge crashed with
+		//    `Cannot read properties of undefined (reading 'changes')` because the
+		//    adapter's no-bindings run() returned undefined where bun:sqlite
+		//    returns a Changes object. ──
+		const memLinkDir = mkdtempSync(join(tmpdir(), 'repro1873-memlink-'));
+		try {
+			mkdirSync(join(memLinkDir, '.opencode'), { recursive: true });
+			writeFileSync(
+				join(memLinkDir, '.opencode', 'opencode-swarm.json'),
+				JSON.stringify({
+					memory: { enabled: true, link: { enabled: true } },
+				}),
+				'utf-8',
+			);
+			const scope2539 = { type: 'workspace', workspaceId: 'repro-2539-ws' };
+			const runCmd = (tokens) =>
+				mod.executeSwarmCommand({
+					directory: memLinkDir,
+					tokens,
+					agents: {},
+					sessionID: 'repro-2539',
+				});
+
+			// Seed two records into the LOCAL store (pre-link).
+			const seed2539 = new mod.SQLiteMemoryProvider(memLinkDir);
+			await seed2539.initialize();
+			const recA2539 = makeRecord(mod, {
+				kind: 'project_fact',
+				scope: scope2539,
+				text: '2539 seed record A for link unlink relink',
+			});
+			const recB2539 = makeRecord(mod, {
+				kind: 'project_fact',
+				scope: scope2539,
+				text: '2539 seed record B for link unlink relink',
+			});
+			await seed2539.upsert(recA2539);
+			await seed2539.upsert(recB2539);
+			seed2539.close();
+			mod.clearPool();
+
+			const link1 = await runCmd(['memory', 'link', 'repro-2539-cohort']);
+			check(
+				'#2539 memory link via registered command path',
+				link1.text.includes('Linked') && !link1.text.includes('❌'),
+				link1.text.slice(0, 160),
+			);
+
+			// The cohort store must resolve under the ISOLATED cfg home — never
+			// the real user data dir. cfgHome only contains what this harness
+			// wrote, so the walk is tiny.
+			const cohortDbs = [];
+			(function walk2539(dir) {
+				for (const ent of readdirSync(dir, { withFileTypes: true })) {
+					const p = join(dir, ent.name);
+					if (ent.isDirectory()) walk2539(p);
+					else if (ent.name === 'memory.db' && p.includes('repro-2539-cohort')) {
+						cohortDbs.push(p);
+					}
+				}
+			})(cfgHome);
+			check(
+				'#2539 cohort store resolves under the isolated config home',
+				cohortDbs.length === 1,
+				`found: ${cohortDbs.join(', ')}`,
+			);
+
+			// Seed a third record AFTER link — the provider follows the link
+			// pointer, so it lands in the COHORT and the next merge has exactly
+			// one new row for the local store to absorb (non-zero .changes).
+			const cohortSeed = new mod.SQLiteMemoryProvider(memLinkDir);
+			await cohortSeed.initialize();
+			const recC2539 = makeRecord(mod, {
+				kind: 'project_fact',
+				scope: scope2539,
+				text: '2539 seed record C added while linked',
+			});
+			await cohortSeed.upsert(recC2539);
+			cohortSeed.close();
+			mod.clearPool();
+
+			// stageSqliteDb COPIES (never moves) the source DB, so the local
+			// memory.db must still exist here — proving the unlink destination is
+			// NON-EMPTY and the ATTACH-merge branch (the pre-fix crash path) is
+			// the one taken, not the empty-destination rename.
+			check(
+				'#2539 local memory.db survived link (unlink destination is non-empty)',
+				existsSync(join(memLinkDir, '.swarm', 'memory', 'memory.db')),
+				'local memory.db missing — scenario no longer exercises the ATTACH merge',
+			);
+
+			const unlink1 = await runCmd(['memory', 'unlink']);
+			check(
+				'#2539 memory unlink via registered command path (ATTACH merge, non-empty local destination)',
+				unlink1.text.includes('Unlinked') && !unlink1.text.includes('❌'),
+				unlink1.text.slice(0, 200),
+			);
+
+			// Re-link: unlink never deletes the cohort store, so this merge also
+			// takes the ATTACH branch with both sides non-empty.
+			const link2 = await runCmd(['memory', 'link', 'repro-2539-cohort']);
+			check(
+				'#2539 memory re-link via registered command path (populated cohort)',
+				link2.text.includes('Linked') && !link2.text.includes('❌'),
+				link2.text.slice(0, 200),
+			);
+
+			const verify2539 = new mod.SQLiteMemoryProvider(memLinkDir);
+			await verify2539.initialize();
+			const listed2539 = await verify2539.list({ scopes: [scope2539] });
+			verify2539.close();
+			mod.clearPool();
+			const ids2539 = [recA2539.id, recB2539.id, recC2539.id];
+			check(
+				'#2539 all three records survive the link→unlink→re-link round trip',
+				listed2539.length === 3 &&
+					ids2539.every((id) => listed2539.some((r) => r.id === id)),
+				`got ${listed2539.length}: ${listed2539.map((r) => r.id).join(',')}`,
+			);
+		} finally {
+			rmSync(memLinkDir, { recursive: true, force: true });
+		}
 	} catch (err) {
 		const msg = err && err.message ? err.message : String(err);
 		failures.push(`uncaught: ${msg}`);

--- a/src/db/driver-parity.ts
+++ b/src/db/driver-parity.ts
@@ -18,10 +18,14 @@
  *   run() always returns `{ changes, lastInsertRowid }`; the node adapter
  *   rebuilds it from connection-level counters after exec(). `.changes` is
  *   pinned for single-statement DML only (the form production code reads).
- *   Two deltas are deliberately NOT pinned: multi-statement strings (bun SUMS
- *   `.changes` across statements, changes() reports the last one) and non-DML
- *   statements (bun reports 0, changes() keeps the previous DML's count) —
- *   the two drivers genuinely diverge there and no production reader exists.
+ *   The SHAPE is pinned for every form (cases 4/4b/4c). Three value deltas
+ *   are deliberately NOT pinned because the drivers genuinely diverge and no
+ *   production reader exists: multi-statement strings (bun SUMS `.changes`
+ *   across statements, changes() reports the last one), non-DML statements
+ *   (bun reports 0, changes() keeps the previous DML's count), and
+ *   trigger-amplified DML (bun's run() INCLUDES trigger-fired rows while
+ *   SQL changes() — what the adapter probe reads — EXCLUDES them; live-probed:
+ *   1 direct + 1 trigger row → bun {changes: 2}, adapter 1).
  * - Multi-statement strings only through the no-parameter `run(sql)` path
  *   (which routes to `exec` on both drivers).
  * - Transaction + SAVEPOINT nesting round trip.
@@ -136,11 +140,21 @@ export function runDriverParityContract(
 
 	// 4. Multi-statement strings via the no-parameter run() path (exec on both
 	//    drivers) — the form the v14+ single-statement migrations also use.
-	//    The return value is deliberately NOT asserted here: bun aggregates
+	//    The return VALUE is deliberately NOT asserted: bun aggregates
 	//    `.changes` across statements while the node adapter's changes() probe
 	//    reports the last statement only (an intentionally unpinned delta).
-	db.run(
+	//    The return SHAPE is pinned below (driver-agnostic) so a future
+	//    adapter regression back to `undefined` cannot hide behind this case.
+	const multiRun = db.run(
 		"DELETE FROM parity_probe; INSERT INTO parity_probe (key, value) VALUES ('multi', 'exec');",
+	);
+	expectTruthy(
+		multiRun != null &&
+			typeof multiRun === 'object' &&
+			typeof multiRun.changes === 'number' &&
+			(typeof multiRun.lastInsertRowid === 'number' ||
+				typeof multiRun.lastInsertRowid === 'bigint'),
+		'multi-statement no-bindings run() must return a Changes-shaped object (issue #2539)',
 	);
 	const multi = db
 		.query<{ value: string }, [string]>(
@@ -204,6 +218,22 @@ export function runDriverParityContract(
 	expectTruthy(
 		bound?.changes === 1,
 		`with-bindings run() .changes must stay 1, got ${String(bound?.changes)}`,
+	);
+
+	// 4c. SHAPE-only pins for the two documented value-unpinned deltas. The
+	//     VALUES diverge by design (multi-statement: bun sums vs probe's last
+	//     statement; non-DML: bun 0 vs probe's previous DML count) and are NOT
+	//     asserted — but the returned object must be Changes-shaped on BOTH
+	//     drivers, so a future adapter regression to `undefined` fails here
+	//     even on the unpinned paths.
+	const nonDml = db.run('SELECT 1');
+	expectTruthy(
+		nonDml != null &&
+			typeof nonDml === 'object' &&
+			typeof nonDml.changes === 'number' &&
+			(typeof nonDml.lastInsertRowid === 'number' ||
+				typeof nonDml.lastInsertRowid === 'bigint'),
+		'non-DML no-bindings run() must return a Changes-shaped object (issue #2539)',
 	);
 
 	// 5. Pragmas the foundation relies on.

--- a/src/db/driver-parity.ts
+++ b/src/db/driver-parity.ts
@@ -14,6 +14,14 @@
  *   many values as the statement has placeholders. `node:sqlite` rejects a
  *   mismatched count (`SQLITE_RANGE`); `bun:sqlite` tolerates some lax forms.
  *   Portable code never relies on the lax form.
+ * - NO-BINDINGS run() RETURNS A Changes-SHAPED OBJECT (#2539): bun:sqlite's
+ *   run() always returns `{ changes, lastInsertRowid }`; the node adapter
+ *   rebuilds it from connection-level counters after exec(). `.changes` is
+ *   pinned for single-statement DML only (the form production code reads).
+ *   Two deltas are deliberately NOT pinned: multi-statement strings (bun SUMS
+ *   `.changes` across statements, changes() reports the last one) and non-DML
+ *   statements (bun reports 0, changes() keeps the previous DML's count) —
+ *   the two drivers genuinely diverge there and no production reader exists.
  * - Multi-statement strings only through the no-parameter `run(sql)` path
  *   (which routes to `exec` on both drivers).
  * - Transaction + SAVEPOINT nesting round trip.
@@ -128,6 +136,9 @@ export function runDriverParityContract(
 
 	// 4. Multi-statement strings via the no-parameter run() path (exec on both
 	//    drivers) — the form the v14+ single-statement migrations also use.
+	//    The return value is deliberately NOT asserted here: bun aggregates
+	//    `.changes` across statements while the node adapter's changes() probe
+	//    reports the last statement only (an intentionally unpinned delta).
 	db.run(
 		"DELETE FROM parity_probe; INSERT INTO parity_probe (key, value) VALUES ('multi', 'exec');",
 	);
@@ -137,6 +148,63 @@ export function runDriverParityContract(
 		)
 		.get('multi');
 	expectTruthy(multi?.value === 'exec', 'multi-statement exec path failed');
+
+	// 4b. No-bindings run() returns a Changes-shaped object (#2539). Under bun
+	//     this is native; under the node adapter the no-param branch executes
+	//     via exec() (void) and rebuilds the object from connection-level
+	//     counters. Pre-fix the adapter returned undefined here, so
+	//     `.changes` readers (the memory-family ATTACH merge) threw
+	//     `Cannot read properties of undefined (reading 'changes')`.
+	//     Pinned for single-statement DML only — the form production reads.
+	const inserted = db.run(
+		"INSERT INTO parity_probe (key, value) VALUES ('changes-a', '1'), ('changes-b', '2')",
+	);
+	expectTruthy(
+		inserted != null && typeof inserted === 'object',
+		'no-bindings run() must return a Changes-shaped object (issue #2539)',
+	);
+	expectTruthy(
+		typeof inserted?.changes === 'number' && inserted.changes === 2,
+		`no-bindings run() .changes must count modified rows, got ${String(
+			inserted?.changes,
+		)} (issue #2539)`,
+	);
+	expectTruthy(
+		typeof inserted?.lastInsertRowid === 'number' ||
+			typeof inserted?.lastInsertRowid === 'bigint',
+		'no-bindings run() .lastInsertRowid must be number | bigint (issue #2539)',
+	);
+	// INSERT OR IGNORE that inserts nothing reports 0 — the exact
+	// memory-family ATTACH-merge shape (INSERT OR IGNORE … SELECT * FROM staged).
+	const ignored = db.run(
+		"INSERT OR IGNORE INTO parity_probe (key, value) VALUES ('changes-a', 'duplicate')",
+	);
+	expectTruthy(
+		ignored?.changes === 0,
+		`INSERT OR IGNORE with 0 inserts must report .changes === 0, got ${String(
+			ignored?.changes,
+		)} (issue #2539)`,
+	);
+	// DML matching no rows reports 0.
+	const updatedNone = db.run(
+		"UPDATE parity_probe SET value = 'x' WHERE key = 'no-such-key'",
+	);
+	expectTruthy(
+		updatedNone?.changes === 0,
+		`no-bindings UPDATE matching no rows must report .changes === 0, got ${String(
+			updatedNone?.changes,
+		)} (issue #2539)`,
+	);
+	// The with-bindings form is unchanged by #2539 (statement.run's native
+	// return on both drivers).
+	const bound = db.run('INSERT INTO parity_probe (key, value) VALUES (?, ?)', [
+		'changes-bound',
+		'3',
+	]);
+	expectTruthy(
+		bound?.changes === 1,
+		`with-bindings run() .changes must stay 1, got ${String(bound?.changes)}`,
+	);
 
 	// 5. Pragmas the foundation relies on.
 	const journal = db

--- a/src/db/sqlite-loader.test.ts
+++ b/src/db/sqlite-loader.test.ts
@@ -68,6 +68,12 @@ function makeFake() {
 		get(...params: unknown[]): unknown {
 			this.checkStrictParamCount(params);
 			calls.stmtGet.push({ sql: this.sql, params });
+			// #2539: model the real driver's answer to the adapter's changes
+			// probe (`SELECT changes() AS c, last_insert_rowid() AS r` — the
+			// ALIASED shape; the adapter reads `c`/`r`, not `changes`).
+			if (this.sql.startsWith('SELECT changes()')) {
+				return { c: 1, r: 1 };
+			}
 			return { sql: this.sql, op: 'get' };
 		}
 		all(...params: unknown[]): unknown[] {
@@ -208,8 +214,37 @@ describe('createNodeDatabaseCtor — adapter translation', () => {
 			':x:',
 		) as unknown as AdapterDb;
 		db.run('PRAGMA foreign_keys = ON;');
-		expect(calls.exec).toEqual(['PRAGMA foreign_keys = ON;']);
-		expect(calls.prepared).toEqual([]);
+		db.run('PRAGMA foreign_keys = OFF;');
+		expect(calls.exec).toEqual([
+			'PRAGMA foreign_keys = ON;',
+			'PRAGMA foreign_keys = OFF;',
+		]);
+		// #2539: the only prepared statement is the cached changes probe —
+		// user SQL never reaches prepare() on the no-param path, and the probe
+		// is prepared exactly once across both calls.
+		expect(calls.prepared).toEqual([
+			'SELECT changes() AS c, last_insert_rowid() AS r',
+		]);
+	});
+
+	test('run(sql) with no params returns a Changes-shaped object (#2539)', () => {
+		const { FakeDatabaseSync, calls } = makeFake();
+		const db = new (createNodeDatabaseCtor(FakeDatabaseSync))(
+			':x:',
+		) as unknown as AdapterDb;
+		// bun:sqlite run() ALWAYS returns { changes, lastInsertRowid } — the
+		// pre-fix adapter returned undefined here, crashing `.changes` readers
+		// (the memory-family ATTACH merge) under the Node sidecar.
+		const result = db.run('PRAGMA foreign_keys = ON;') as {
+			changes: number;
+			lastInsertRowid: number | bigint;
+		};
+		expect(result).toEqual({ changes: 1, lastInsertRowid: 1 });
+		expect(typeof result.changes).toBe('number');
+		db.run('PRAGMA foreign_keys = OFF;');
+		// The probe is served from the instance statement cache: a second
+		// no-param run() prepares nothing new.
+		expect(calls.prepared).toHaveLength(1);
 	});
 
 	test('run(sql, [params]) prepares once and binds the array', () => {

--- a/src/db/sqlite-loader.test.ts
+++ b/src/db/sqlite-loader.test.ts
@@ -33,7 +33,7 @@ interface FakeCalls {
 	closed: number;
 }
 
-function makeFake() {
+function makeFake(probeRow: { c: number; r: number } = { c: 1, r: 1 }) {
 	const calls: FakeCalls = {
 		exec: [],
 		prepared: [],
@@ -70,9 +70,13 @@ function makeFake() {
 			calls.stmtGet.push({ sql: this.sql, params });
 			// #2539: model the real driver's answer to the adapter's changes
 			// probe (`SELECT changes() AS c, last_insert_rowid() AS r` — the
-			// ALIASED shape; the adapter reads `c`/`r`, not `changes`).
-			if (this.sql.startsWith('SELECT changes()')) {
-				return { c: 1, r: 1 };
+			// ALIASED shape; the adapter reads `c`/`r`, not `changes`). EXACT
+			// match on the probe text (review finding tf-02): a prefix match
+			// would silently answer `{c,r}` to unrelated future test SQL
+			// starting with the same text. The exact string is itself
+			// regression-guarded by the routing assertion further down.
+			if (this.sql === 'SELECT changes() AS c, last_insert_rowid() AS r') {
+				return { ...probeRow };
 			}
 			return { sql: this.sql, op: 'get' };
 		}
@@ -245,6 +249,23 @@ describe('createNodeDatabaseCtor — adapter translation', () => {
 		// The probe is served from the instance statement cache: a second
 		// no-param run() prepares nothing new.
 		expect(calls.prepared).toHaveLength(1);
+	});
+
+	test('run(sql) with no params maps the aliased probe columns correctly (#2539, review tf-03/mt-01)', () => {
+		// Distinct probe values prove the adapter reads the ALIASED columns
+		// (c → .changes, r → .lastInsertRowid) and applies the documented
+		// conversions (Number for .changes, pass-through for .lastInsertRowid)
+		// — the unit leg would catch a swapped/wrong-property regression, not
+		// just the undefined-return class.
+		const { FakeDatabaseSync } = makeFake({ c: 3, r: 7 });
+		const db = new (createNodeDatabaseCtor(FakeDatabaseSync))(
+			':x:',
+		) as unknown as AdapterDb;
+		const result = db.run('PRAGMA journal_mode = WAL;') as {
+			changes: number;
+			lastInsertRowid: number | bigint;
+		};
+		expect(result).toEqual({ changes: 3, lastInsertRowid: 7 });
 	});
 
 	test('run(sql, [params]) prepares once and binds the array', () => {

--- a/src/db/sqlite-loader.ts
+++ b/src/db/sqlite-loader.ts
@@ -105,17 +105,41 @@ export function createNodeDatabaseCtor(
 			return stmt;
 		}
 
+		/**
+		 * bun:sqlite's `run()` ALWAYS returns a `Changes` object — including the
+		 * no-bindings form (`node_modules/bun-types/sqlite.d.ts:186`). node:sqlite's
+		 * `exec()` returns void, so after executing the SQL the adapter rebuilds the
+		 * object from SQLite's connection-level counters via this probe, executed on
+		 * the SAME connection. Fixed SQL text → served from the instance statement
+		 * cache (prepared once per DB handle; each call is one cached `.get()`).
+		 * #2539: the memory-family ATTACH merge reads `.changes` off this return.
+		 */
+		private static readonly CHANGES_PROBE_SQL =
+			'SELECT changes() AS c, last_insert_rowid() AS r';
+
 		run(sql: string, ...rest: unknown[]): unknown {
 			// bun:sqlite `db.run(sql)` executes SQL with no bindings; `db.run(sql, [p…])`
 			// binds an array (callers always pass ONE array), and `db.run(sql, a, b)` binds
-			// spread args. Callers ignore the return value. The no-param path uses exec():
-			// both node:sqlite's exec() and bun:sqlite's run() execute ALL semicolon-
-			// separated statements, so the two drivers behave identically here. Every caller
-			// passes a single statement anyway (the memory provider pre-splits migrations
-			// via splitSql; project-db/global-db each pass a single-statement migration).
+			// spread args. The no-param path uses exec(): both node:sqlite's exec() and
+			// bun:sqlite's run() execute ALL semicolon-separated statements, so the two
+			// drivers behave identically here. Every caller passes a single statement
+			// anyway (the memory provider pre-splits migrations via splitSql;
+			// project-db/global-db each pass a single-statement migration).
 			if (rest.length === 0) {
 				this.raw.exec(sql);
-				return undefined;
+				// `.changes` matches bun for single-statement DML — the only form
+				// production code reads (both readers are single-statement: the
+				// memory-family ATTACH merge and the valid_from backfill). Two
+				// intentionally-unpinned deltas remain (documented in
+				// src/db/driver-parity.ts): (a) multi-statement strings — bun SUMS
+				// `.changes` across statements while changes() reports the last one;
+				// (b) non-DML statements (SELECT/BEGIN/SAVEPOINT/DDL) — bun reports
+				// 0, changes() keeps the previous DML's count. Both drivers count
+				// trigger-fired rows identically.
+				const row = this.statement(
+					NodeSqliteDatabase.CHANGES_PROBE_SQL,
+				).get() as { c: number | bigint; r: number | bigint } | undefined;
+				return { changes: Number(row?.c ?? 0), lastInsertRowid: row?.r ?? 0 };
 			}
 			const params =
 				rest.length === 1 && Array.isArray(rest[0])

--- a/src/db/sqlite-loader.ts
+++ b/src/db/sqlite-loader.ts
@@ -127,15 +127,18 @@ export function createNodeDatabaseCtor(
 			// project-db/global-db each pass a single-statement migration).
 			if (rest.length === 0) {
 				this.raw.exec(sql);
-				// `.changes` matches bun for single-statement DML — the only form
-				// production code reads (both readers are single-statement: the
-				// memory-family ATTACH merge and the valid_from backfill). Two
+				// `.changes` matches bun for single-statement DML without triggers —
+				// the only form production code reads (both readers are
+				// single-statement: the memory-family ATTACH merge and the valid_from
+				// backfill; no trigger exists on their tables). Three
 				// intentionally-unpinned deltas remain (documented in
 				// src/db/driver-parity.ts): (a) multi-statement strings — bun SUMS
 				// `.changes` across statements while changes() reports the last one;
 				// (b) non-DML statements (SELECT/BEGIN/SAVEPOINT/DDL) — bun reports
-				// 0, changes() keeps the previous DML's count. Both drivers count
-				// trigger-fired rows identically.
+				// 0, changes() keeps the previous DML's count; (c) trigger-amplified
+				// DML — bun's run() INCLUDES trigger-fired rows while the SQL
+				// changes() this probe reads EXCLUDES them (live-probed both drivers:
+				// 1 direct + 1 trigger row → bun {changes: 2}, probe changes() = 1).
 				const row = this.statement(
 					NodeSqliteDatabase.CHANGES_PROBE_SQL,
 				).get() as { c: number | bigint; r: number | bigint } | undefined;


### PR DESCRIPTION
Closes #2539

## Summary

`db.run(sql)` with **no bindings** returned `undefined` under the `node:sqlite`
adapter (`DatabaseSync.exec()` returns void) but a `Changes` object under
`bun:sqlite`. The memory-family ATTACH merge reads `.changes` off that return
(`src/memory/memory-family-migration.ts:317-320`), so on the OpenCode Desktop Node
sidecar `/swarm memory unlink` and any populated re-link / second-worktree link
failed with `Cannot read properties of undefined (reading 'changes')`. A second
site (`src/memory/sqlite-provider.ts:2356-2364`, the `valid_from` backfill) used
`?.` and silently counted 0. An exhaustive `src/` audit found exactly these two
no-bindings return-value readers; both are healed by the adapter fix, and Bun
behavior is unchanged (the loader's Bun path is untouched).

- **Adapter fix** (`src/db/sqlite-loader.ts`): the no-bindings branch, after
  `exec()`, rebuilds `{ changes, lastInsertRowid }` from SQLite's connection-level
  counters via one cached probe statement (`SELECT changes() AS c,
  last_insert_rowid() AS r`, prepared once per DB handle through the existing
  statement cache, executed on the same connection). `.changes` matches bun for
  single-statement DML — the only form production code reads. Two deltas are
  documented but deliberately unpinned (the drivers genuinely diverge; no
  production reader): multi-statement `.changes` aggregation, and non-DML
  staleness (`changes()` keeps the previous DML's count where bun reports 0).
- **Parity pin** (`src/db/driver-parity.ts`, case 4b): no-bindings run returns a
  Changes-shaped object; 2-row INSERT → `.changes === 2`; `INSERT OR IGNORE`
  0-insert → 0 (the exact ATTACH-merge shape); UPDATE matching none → 0;
  with-bindings INSERT → 1 (unchanged). Executed against the real `bun:sqlite`
  driver in unit tests and the real `node:sqlite` driver in the merge-queue smoke
  leg (`repro:1873`).
- **Registered-command-path leg** (`scripts/repro-1873.mjs` + entry barrel): a new
  scenario drives `/swarm memory link` → `unlink` → re-link under real Node through
  `executeSwarmCommand` (the same registry dispatch the swarm command tool uses),
  proves the unlink destination is non-empty at runtime (so the ATTACH-merge branch
  is the one taken — this is the pre-fix crash path), and verifies all three seeded
  records survive the round trip. Pre-fix, this scenario fails at the first ATTACH
  merge with the issue's exact TypeError.
- **Docs**: the parity-contract scope delta is added to the `#2480` entry in
  `docs/engineering-invariants.md`; a release fragment ships in
  `docs/releases/pending/2539-node-sqlite-run-changes-return.md`.

A follow-up hardening commit (`7e075ac56`) addresses every finding from the PR
review passes and the two external review comments: the trigger-fired-row
`.changes` delta is now documented accurately (bun's `run()` includes
trigger-fired rows; the SQL `changes()` the adapter probe reads excludes them —
live-probed on both drivers), the multi-statement and non-DML return shapes are
pinned (values stay deliberately unpinned), the fake probe matches exactly and
a distinct-value alias-mapping unit test was added, the repro scenario gained
the empty-local unlink (rename branch) leg under real Node with exact-prefix
command assertions, `dist-build-test/` is mechanically forbidden in the
published package, and the release fragment now distinguishes the merge crash
from the backfill's silent degradation. The branch also merges `origin/main` to
resolve the FR-006 ratchet's base drift on
`tests/unit/tools/dispatch-lanes.test.ts` (main #2542 shrank it 2430→2427).

Pre-fix reproduction on pristine `origin/main` (real `node:sqlite`, Node v24):
`mergeStagedSqlite` threw the issue's exact error; Bun control resolved
`{merged: 1, skipped: 0}`. Post-fix the same harness resolves identically to Bun.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; diff is
  sqlite-loader internals, parity contract, harness scripts, docs.
- 2 (runtime portability): touched — core. Evidence: `bun run repro:1873` PASSES
  under real Node with the new parity case and the #2539 command scenario;
  `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"`
  → `NODE ESM IMPORT OK`; `tests/unit/build/bundle-portability.test.ts` (10),
  `bundle-plugin-shape.test.ts` (2), `bundle-node-load.test.ts` (1) all pass; no
  new `bun:` resolution (probe is plain SQL inside the sanctioned loader).
- 3 (subprocesses): not touched — no spawn changes.
- 4 (.swarm containment): not touched — the repro scenario writes only under
  `mkdtemp` dirs (existing harness pattern; env-redirected data home asserted to
  contain the cohort store); no tool/hook write-path changes.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — `src/db/sqlite-loader.test.ts` extended (428 lines,
  under the FR-006 500 cap; no `mock.module`, uses the existing injection seam);
  parity pin added; `check:mock-cleanup`, `check:invariants` (mock-allowlist
  ratchet), `check:test-file-cap`, `check:test-tmpdir` all PASS.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tool/command/agent changes
  (`scripts/check-tool-registration.ts` PASS, `bun run drift:check` finds only the
  pre-existing `opencode-swarm.schema.json` staleness that also reproduces on
  pristine `origin/main`; excluded from this diff as out of scope).
- 12 (release/cache): touched — `docs/releases/pending/2539-node-sqlite-run-changes-return.md`
  shipped (`check:pending-fragment` PASS); no version files hand-edited.

## Test plan

All run locally on Windows (Bun 1.3.x, Node v24.16.0), at HEAD `7e075ac56`
(includes the review-feedback hardening commit and the `origin/main` merge):

- `bun run repro:1873` — **PASS** under real Node: full existing suite plus
  nine `#2539` checks (link, cohort-home isolation, local-DB-survival proof,
  ATTACH-merge unlink, populated re-link, 3-record round trip, and the
  empty-local unlink rename-branch leg with data restoration), and the extended
  driver-parity contract (no-bindings shape pins incl. multi-statement and
  non-DML forms).
- `bun test src/db/sqlite-loader.test.ts tests/unit/db/driver-parity.test.ts tests/unit/commands/memory-link.test.ts tests/unit/memory/outcome-provider-migration.test.ts tests/unit/memory/memory-family-outcome-collision.test.ts`
  — 38 pass, 0 fail (incl. the alias-mapping test with distinct probe values).
- All 10 `tests/unit/db/*.test.ts` per-file — 0 failures.
- `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"`
  → OK; bundle-portability / plugin-shape / bundle-node-load tests — pass.
- `bun run typecheck`, `bunx biome ci .` — clean.
- All 21 CI quality-job gates enumerated from `.github/workflows/ci.yml` and run
  locally — all PASS (incl. `check:test-file-cap` after the base-drift merge).

Pre-existing (proven on a pristine `origin/main` worktree, not inherited by this
PR): `bun test tests/unit/build/` as a directory co-run fails 9 tests that pass in
isolation (mock co-run pollution; CI runs per-file), and `drift:check`'s
`opencode-swarm.schema.json` staleness soft-warn.

Review gates (swarm): plan critic (Kimi K3) NEEDS_REVISION → revised → re-critic
APPROVE; implementation reviewer (Kimi K2.7, fresh context) APPROVE on this commit
with zero blocking findings; final critic (Kimi K3, fresh context) APPROVE on the
same commit, HEAD byte-confirmed identical post-approval.
