### PR TITLE
ci(detect-release): anchor the merge-group release predicate to the commit subject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,11 @@ jobs:
           #   "chore(main): release X.Y.Z"                                (squash)
           # This predicate is the single point of control for the whole
           # required-check set: when it says "release", every job skips its
-          # steps and reports success. It must therefore never match a
-          # non-release commit. The previous form grepped the FULL message (%B)
+          # steps and reports success. It must therefore never match a group
+          # whose HEAD is not a release merge. (A merge-queue group can batch
+          # other PRs behind the release PR; those ride along on the skip. That
+          # is pre-existing and independent of this predicate's form.)
+          # The previous form grepped the FULL message (%B)
           # for the unanchored token 'release-please--', so a PR whose
           # description merely mentioned that branch — or carried a body line
           # beginning "chore(main): release" — made a non-release merge group

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,28 @@ jobs:
             exit 0
           fi
           # Inspect ONLY the merge-group head commit (-1), not a window of
-          # history. The queued merge commit is "Merge pull request #N from
-          # <owner>/release-please--..." with the release commit "chore(main):
-          # release X.Y.Z" in its body, so its full message (%B) identifies a
-          # release merge. Two traps this avoids:
+          # history, and ONLY its subject line (%s), with both alternatives
+          # anchored. The queued merge commit's subject is either
+          #   "Merge pull request #N from <owner>/release-please--..."  (merge)
+          #   "chore(main): release X.Y.Z"                                (squash)
+          # This predicate is the single point of control for the whole
+          # required-check set: when it says "release", every job skips its
+          # steps and reports success. It must therefore never match a
+          # non-release commit. The previous form grepped the FULL message (%B)
+          # for the unanchored token 'release-please--', so a PR whose
+          # description merely mentioned that branch — or carried a body line
+          # beginning "chore(main): release" — made a non-release merge group
+          # skip every test while every required check reported green.
+          # tests/unit/scripts/ci/ci-detect-release-predicate.test.ts pins the
+          # literal below and runs positive and negative controls against it.
+          # Two older traps this HEAD-only form also avoids:
           #   1. The release commit is the merge commit's SECOND parent, so it
           #      is absent from the first-parent history the shallow merge-queue
           #      checkout traverses — the old "git log --max-count=10" grep for
           #      the release subject silently missed it and ran the full suite.
           #   2. A 10-commit window false-positives: a recent release MERGE
-          #      ("Merge pull request ... release-please--...") lingers in the
-          #      window of later, non-release PRs and would wrongly skip them.
-          # HEAD-only is both robust (no traversal) and specific (this group).
-          if [[ "$EVENT" == "merge_group" ]] && git log -1 --format='%B' | grep -qE 'release-please--|^chore\(main\): release'; then
+          #      lingers in the window of later, non-release PRs.
+          if [[ "$EVENT" == "merge_group" ]] && git log -1 --format='%s' | grep -qE '^Merge pull request #[0-9]+ from [^/ ]+/release-please--|^chore\(main\): release '; then
             echo "is-release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/docs/releases/pending/ci-detect-release-anchor.md
+++ b/docs/releases/pending/ci-detect-release-anchor.md
@@ -1,0 +1,12 @@
+### CI: the merge-queue release predicate no longer skips tests for non-release merges
+
+The `detect-release` job decides whether a merge group is a release-please
+merge; when it says yes, every CI job skips its steps and reports success.
+Its check grepped the full commit message for the unanchored token
+`release-please--`, so a pull request whose description mentioned that branch
+name, or contained a body line beginning `chore(main): release`, caused a
+non-release merge group to skip the entire suite while every required check
+reported green. The predicate now inspects only the commit subject and matches
+the two genuine release shapes with anchored patterns. A table-driven test
+pins the literal and runs positive and negative controls. No configuration or
+migration changes.

--- a/tests/unit/scripts/ci/ci-detect-release-predicate.test.ts
+++ b/tests/unit/scripts/ci/ci-detect-release-predicate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The merge-group `detect-release` predicate in ci.yml is the single point
+ * of control for the entire required-check set: when it reports a release,
+ * every job skips its steps and reports success. It must therefore match the
+ * two genuine release-merge subject shapes and nothing else. This test pins
+ * the literal in ci.yml and runs positive and negative controls through it,
+ * so the regex cannot drift back to an unanchored full-message grep.
+ */
+const CI_YML = fileURLToPath(
+	new URL('../../../../.github/workflows/ci.yml', import.meta.url),
+);
+
+const EXPECTED_PREDICATE =
+	"git log -1 --format='%s' | grep -qE '^Merge pull request #[0-9]+ from [^/ ]+/release-please--|^chore\\(main\\): release '";
+
+function readPredicate(): { line: string; regex: RegExp } {
+	const source = readFileSync(CI_YML, 'utf8');
+	const line = source
+		.split('\n')
+		.find((l) => l.includes('git log -1 --format=') && l.includes('grep -qE'));
+	if (!line)
+		throw new Error('detect-release predicate line not found in ci.yml');
+	const literal = /grep -qE '([^']+)'/.exec(line)?.[1];
+	if (!literal) throw new Error('could not extract the grep literal');
+	return { line, regex: new RegExp(literal) };
+}
+
+describe('ci.yml detect-release predicate (merge-group required-check gate)', () => {
+	test('is anchored to the commit subject, not the full message', () => {
+		const { line } = readPredicate();
+		expect(line).toContain(EXPECTED_PREDICATE);
+		expect(line).not.toContain("--format='%B'");
+	});
+
+	const positive = [
+		'Merge pull request #2544 from ZaxbyHub/release-please--branches--main--components--opencode-swarm',
+		'chore(main): release 7.164.6',
+	];
+	const negative = [
+		'Merge pull request #2599 from ZaxbyHub/fix-thing',
+		'Revert "chore(main): release 7.164.6"',
+		'feat(release): add chore(main): release helper',
+		'Merge pull request #1 from evil owner/release-please--x',
+		'docs: mention release-please--branches--main in CONTRIBUTING',
+	];
+
+	test.each(positive)('matches a genuine release subject: %s', (subject) => {
+		expect(readPredicate().regex.test(subject)).toBe(true);
+	});
+
+	test.each(negative)('rejects a non-release subject: %s', (subject) => {
+		expect(readPredicate().regex.test(subject)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- **This is a CI-bypass fix, not a performance change.** The `detect-release` job is the single point of control for the entire required-check set: when it reports a release, every job skips its steps and reports success. Its merge-group check grepped the **full commit message** (`%B`) for the unanchored token `release-please--`, so a merge group whose PR description merely mentioned that branch name, or carried a body line beginning `chore(main): release`, skipped the whole suite while every required check reported green.
- Reproduced against the live pattern: a body containing `Rebased after release-please--branches--main moved.` → MATCH; a body line `chore(main): release notes were regenerated` → MATCH. Neither is a release.
- The predicate now inspects only the **subject** (`%s`) and matches the two genuine release shapes with anchored alternatives: `^Merge pull request #[0-9]+ from [^/ ]+/release-please--` (merge-commit form, single-token owner segment) and `^chore\(main\): release ` (squash form, trailing space). The `pull_request`-tier check on `github.head_ref` is unchanged.
- New table-driven test `tests/unit/scripts/ci/ci-detect-release-predicate.test.ts` pins the literal in `ci.yml` and runs 2 positive and 5 negative controls through it (both release forms match; a non-release merge subject, a revert of a release, a `feat(release): …` subject, an owner segment containing a space, and a docs subject mentioning the branch all reject).
- Failure direction of the fix is the safe one: if release-please changes its subject shape, a genuine release merge runs the full suite (wasted minutes) instead of a non-release merge skipping it (zero tests, green checks).

Found by an independent critic pass over a set of merge-queue latency proposals (audit report `docs/audits/swarm-plugin-review-2026-09.md`, finding TESTSCI-13 lineage; the earlier `git log --max-count=10` form had been replaced by a HEAD-only `%B` grep that fixed the traversal trap but kept the anchoring defect).

## Invariant audit

- 1 (plugin init): not touched — no `src/` change.
- 2 (runtime portability): not touched — no `src/` change.
- 3 (subprocesses): not touched — no subprocess call sites changed; the workflow step is shell, unchanged in form.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation used explicit `bun test <file>` invocations.
- 7 (test writing): touched — one new `bun:test` file (57 lines, under the FR-006 cap), no `mock.module`, no real clock, reads `ci.yml` via `import.meta.url`; `check:test-file-cap` and `check:test-clock` pass with zero new violations; formatted with the pinned Biome 2.3.14 and `bun run lint:ci` clean across 4,176 files.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tool, command, agent or skill change.
- 12 (release/cache): touched — `docs/releases/pending/ci-detect-release-anchor.md` added (`check:pending-fragment` OK); version, changelog and manifest untouched.

Workflow hygiene: every third-party `uses:` in `ci.yml` remains pinned to a 40-character SHA (verified by a structural parse of the edited file); no job added or removed; every `needs` still resolves.

## Test plan

- [x] `bun test tests/unit/scripts/ci/ci-detect-release-predicate.test.ts` — 8 pass, 0 fail
- [x] `bun test tests/unit/scripts/ci/` (all ci.yml shape suites) — 53 pass, 0 fail
- [x] Structural parse of the edited `ci.yml`: all `needs` resolve, all `uses:` SHA-pinned, no job dropped
- [x] Live-regex reproduction of the two false positives, and the six-subject control table against the replacement (2 match, 4 reject) — run in bash with `grep -qE`
- [x] `bun run lint:ci` — clean (pinned Biome 2.3.14)
- [x] `bun run check:test-file-cap`, `bun run check:test-clock`, `bun run check:pending-fragment` — pass
- [ ] CI on this PR (pull_request tier runs the `detect-release` job's branch-name path; the merge-group path is exercised when this PR enters the queue — expected outcome: full suite runs, `is-release=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JPGCDoovMhy7e56ngjFFL

---
_Generated by [Claude Code](https://claude.ai/code/session_014JPGCDoovMhy7e56ngjFFL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

