### PR TITLE
ci: start integration and smoke after quality instead of behind the unit matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1001,9 +1001,13 @@ jobs:
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.
   # CI-004: does not wait for `unit` or `integration`. Smoke builds its own
-  # package from source and consumes nothing from either job; the remaining
-  # `needs` are kept because they are cheap and finish long before smoke's
-  # own build. Do NOT add `if: always()` here — a skipped prerequisite must
+  # package from source and consumes nothing from either job. The remaining
+  # `needs` are kept: package-check and php-validation are short, and
+  # rust-sandbox-runner measured ~76 s with a warm cargo cache (its timeout is
+  # 30 min) — it now gates smoke's START, so a cold cache or a broken Rust
+  # build delays smoke instead of running beside it. If that ever shows up in
+  # run timings, move rust-sandbox-runner out of smoke's needs rather than
+  # adding a job-level if. Do NOT add `if: always()` here — a skipped prerequisite must
   # still skip smoke, which is the required-check eviction class PR #2313 hit.
   smoke:
     needs: [detect-release, package-check, php-validation, rust-sandbox-runner]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,8 +769,16 @@ jobs:
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success
   # to satisfy required checks without doing work. Also skipped for release-please.
+  # CI-004: starts after `quality`, NOT behind the unit matrix. This job checks
+  # out, installs and runs from source; it consumes no artifact or output from
+  # `unit` (the only needs.unit.* reference in this file is unit-passed's
+  # `needs.unit.result`). Serialising it behind the 20-25 min Windows unit
+  # shards only lengthened the merge-group critical path — measured as a
+  # ~25 min tail after `unit` finished on a 59 min run. Every required check
+  # still has to pass; only the ordering changed.
+  # tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts pins this.
   integration:
-    needs: [detect-release, unit]
+    needs: [detect-release, quality]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -992,8 +1000,13 @@ jobs:
         run: ./target/release/swarm-sandbox-runner.exe --probe
 
   # Merge-queue-only: on pull_request all steps are skipped, job reports success.
+  # CI-004: does not wait for `unit` or `integration`. Smoke builds its own
+  # package from source and consumes nothing from either job; the remaining
+  # `needs` are kept because they are cheap and finish long before smoke's
+  # own build. Do NOT add `if: always()` here — a skipped prerequisite must
+  # still skip smoke, which is the required-check eviction class PR #2313 hit.
   smoke:
-    needs: [detect-release, unit, integration, package-check, php-validation, rust-sandbox-runner]
+    needs: [detect-release, package-check, php-validation, rust-sandbox-runner]
     strategy:
       fail-fast: false
       matrix:

--- a/docs/releases/pending/ci-merge-queue-critical-path.md
+++ b/docs/releases/pending/ci-merge-queue-critical-path.md
@@ -1,0 +1,10 @@
+### CI: integration and smoke no longer wait behind the unit matrix
+
+In merge-group runs the `integration` and `smoke` jobs were sequenced after
+the 18-cell `unit` matrix even though they check out, install and run from
+source and consume nothing from it. On a measured 59-minute merge-group run
+that serialisation was a ~25-minute tail after `unit` finished. Both jobs now
+start after `quality`, alongside the unit shards, following the same CI-004
+pattern the repository already applies to coverage. Every required check
+still has to pass; only the ordering changed. A test pins the new `needs`
+lists. No configuration or migration changes.

--- a/docs/releases/pending/ci-merge-queue-critical-path.md
+++ b/docs/releases/pending/ci-merge-queue-critical-path.md
@@ -1,4 +1,4 @@
-### CI: integration and smoke no longer wait behind the unit matrix
+# CI: integration and smoke no longer wait behind the unit matrix
 
 In merge-group runs the `integration` and `smoke` jobs were sequenced after
 the 18-cell `unit` matrix even though they check out, install and run from

--- a/docs/releases/pending/ci-two-tier-sharding.md
+++ b/docs/releases/pending/ci-two-tier-sharding.md
@@ -13,7 +13,7 @@ The CI pipeline (`ci.yml`) was restructured to reduce PR feedback time from ~40 
 ## Why
 
 1. **Cascading CI restarts:** When one PR merges, branch updates cascade to all open PRs, each restarting a 40+ min CI run. Enabling the merge queue (see below) stops the cascades entirely.
-2. **CI duration:** The critical path through quality → unit (3-OS matrix, 140+ sequential files) → integration → smoke was 40+ minutes. Sharding and the two-tier split bring PR feedback to ~12 minutes.
+2. **CI duration:** The critical path through quality → unit (3-OS matrix, 140+ sequential files) → integration → smoke was 40+ minutes. Sharding and the two-tier split bring PR feedback to ~12 minutes. (That unit-matrix serialisation of `integration` and `smoke` was later removed — see the merge-queue critical-path change, PR #2551.)
 
 ## Migration steps (admin required)
 

--- a/tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts
+++ b/tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts
@@ -7,13 +7,21 @@ import { fileURLToPath } from 'node:url';
  * out, install and run from source; neither consumes an artifact or output
  * from `unit`, so serialising them behind the unit matrix only lengthened the
  * merge-group wall time (a measured ~25 min tail after `unit` on a 59 min
- * run). These assertions keep the two jobs anchored on `quality` so the
- * serialisation cannot silently return. `unit-passed` is the one legitimate
- * consumer of `needs.unit.result` and is deliberately not asserted here.
+ * run). These assertions keep the two jobs anchored on `quality`, pin the
+ * full `needs` lists (plus `unit-passed`'s `[unit]` gate, the one legitimate
+ * `needs.unit.result` consumer) so the serialisation cannot silently return.
+ * Skipped prerequisites must still skip these jobs, so a job-level
+ * `if: always()` is forbidden here too.
  */
 const CI_YML = fileURLToPath(
 	new URL('../../../../.github/workflows/ci.yml', import.meta.url),
 );
+
+// CRLF-normalize: Windows checkouts can hold CRLF working copies while the
+// committed file is LF (.gitattributes eol=lf); assertions must hold on both.
+function readText(path: string): string {
+	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+}
 
 function extractJob(yml: string, jobId: string): string {
 	const start = yml.indexOf(`\n  ${jobId}:\n`);
@@ -23,30 +31,47 @@ function extractJob(yml: string, jobId: string): string {
 	return next < 0 ? rest : rest.slice(0, next + 1);
 }
 
+function extractNeedsLine(job: string): string {
+	const match = job.match(/needs: \[[^\]]*\]/);
+	if (!match) throw new Error('needs: [...] list not found in job slice');
+	return match[0];
+}
+
 describe('ci.yml merge-group critical path — CI-004 for integration and smoke', () => {
-	const yml = readFileSync(CI_YML, 'utf8');
-	const integration = extractJob(yml, 'integration');
-	const smoke = extractJob(yml, 'smoke');
+	const yml = readText(CI_YML);
 
 	test('integration starts after quality instead of waiting for the unit matrix', () => {
-		expect(integration).toContain('needs: [detect-release, quality]');
+		const integration = extractJob(yml, 'integration');
+		expect(extractNeedsLine(integration)).toBe(
+			'needs: [detect-release, quality]',
+		);
 		expect(integration).not.toMatch(/needs: \[[^\]]*\bunit\b/);
 	});
 
 	test('smoke does not wait for unit or integration', () => {
-		expect(smoke).toContain(
+		const smoke = extractJob(yml, 'smoke');
+		expect(extractNeedsLine(smoke)).toBe(
 			'needs: [detect-release, package-check, php-validation, rust-sandbox-runner]',
 		);
 		expect(smoke).not.toMatch(/needs: \[[^\]]*\b(unit|integration)\b/);
 	});
 
 	test('neither job reads a needs.unit.* value it no longer declares', () => {
+		const integration = extractJob(yml, 'integration');
+		const smoke = extractJob(yml, 'smoke');
 		expect(integration).not.toMatch(/needs\.unit\./);
 		expect(smoke).not.toMatch(/needs\.(unit|integration)\./);
 	});
 
+	test('unit-passed keeps gating on the unit matrix', () => {
+		const unitPassed = extractJob(yml, 'unit-passed');
+		expect(extractNeedsLine(unitPassed)).toBe('needs: [unit]');
+	});
+
 	test('neither job gained a job-level if: always() (skipped prerequisites must still skip)', () => {
-		expect(integration).not.toMatch(/^ {4}if: always\(\)/m);
-		expect(smoke).not.toMatch(/^ {4}if: always\(\)/m);
+		const integration = extractJob(yml, 'integration');
+		const smoke = extractJob(yml, 'smoke');
+		expect(integration).not.toMatch(/^ {4}if:[^\n]*\balways\s*\(\)/m);
+		expect(smoke).not.toMatch(/^ {4}if:[^\n]*\balways\s*\(\)/m);
 	});
 });

--- a/tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts
+++ b/tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * CI-004 for the merge-group critical path. `integration` and `smoke` check
+ * out, install and run from source; neither consumes an artifact or output
+ * from `unit`, so serialising them behind the unit matrix only lengthened the
+ * merge-group wall time (a measured ~25 min tail after `unit` on a 59 min
+ * run). These assertions keep the two jobs anchored on `quality` so the
+ * serialisation cannot silently return. `unit-passed` is the one legitimate
+ * consumer of `needs.unit.result` and is deliberately not asserted here.
+ */
+const CI_YML = fileURLToPath(
+	new URL('../../../../.github/workflows/ci.yml', import.meta.url),
+);
+
+function extractJob(yml: string, jobId: string): string {
+	const start = yml.indexOf(`\n  ${jobId}:\n`);
+	if (start < 0) throw new Error(`job '${jobId}' not found in ci.yml`);
+	const rest = yml.slice(start + 1);
+	const next = rest.slice(1).search(/\n {2}[a-z][\w-]*:\n/);
+	return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
+describe('ci.yml merge-group critical path — CI-004 for integration and smoke', () => {
+	const yml = readFileSync(CI_YML, 'utf8');
+	const integration = extractJob(yml, 'integration');
+	const smoke = extractJob(yml, 'smoke');
+
+	test('integration starts after quality instead of waiting for the unit matrix', () => {
+		expect(integration).toContain('needs: [detect-release, quality]');
+		expect(integration).not.toMatch(/needs: \[[^\]]*\bunit\b/);
+	});
+
+	test('smoke does not wait for unit or integration', () => {
+		expect(smoke).toContain(
+			'needs: [detect-release, package-check, php-validation, rust-sandbox-runner]',
+		);
+		expect(smoke).not.toMatch(/needs: \[[^\]]*\b(unit|integration)\b/);
+	});
+
+	test('neither job reads a needs.unit.* value it no longer declares', () => {
+		expect(integration).not.toMatch(/needs\.unit\./);
+		expect(smoke).not.toMatch(/needs\.(unit|integration)\./);
+	});
+
+	test('neither job gained a job-level if: always() (skipped prerequisites must still skip)', () => {
+		expect(integration).not.toMatch(/^ {4}if: always\(\)/m);
+		expect(smoke).not.toMatch(/^ {4}if: always\(\)/m);
+	});
+});


### PR DESCRIPTION
## Summary

- In merge-group runs, `integration` declared `needs: [detect-release, unit]` and `smoke` declared `needs: [detect-release, unit, integration, package-check, php-validation, rust-sandbox-runner]`, but **neither consumes anything from `unit` or from each other**: both check out, install and run from source, the only `download-artifact` in the workflow is `coverage`'s, and the only `needs.unit.*` reference is `unit-passed`'s `needs.unit.result`. The sequencing was pure ordering.
- Measured cost on merge-group run 33121096970 (59m23s, 38 jobs): `unit` finished at 22:40:37Z and the run ended at 23:05:30Z — a **~25-minute serial tail** that this change overlaps onto the unit matrix. Expected gain ~20–24 minutes per successful merge group; the exact figure should be read from `run_duration_ms` on the next few groups, not assumed.
- Both jobs now anchor on `quality` — the same CI-004 pattern this repository already applies to `coverage-shard` (which the existing `ci-coverage-sharding.test.ts` guards). `smoke` keeps `package-check`, `php-validation` and `rust-sandbox-runner` as prerequisites because they are cheap and finish before smoke's own build.
- **No `if: always()` was added.** A skipped prerequisite must still skip `smoke`; the alternative is the required-check-never-reports eviction class this repository diagnosed on PR #2313. The new test asserts its absence.
- New test `tests/unit/scripts/ci/ci-merge-queue-critical-path.test.ts` pins both `needs` lists, asserts neither job reads a `needs.unit.*` / `needs.integration.*` value it no longer declares, and asserts no job-level `if: always()`.
- **What to watch after landing:** peak concurrency. Right after `quality` this run already requests ~29 jobs against GitHub's concurrent-job caps, and `unit` alone asks for 6 macOS shards against the hard limit of 5 concurrent macOS jobs on plans below Enterprise. Moving `smoke` (3 OSes) earlier adds one more macOS job to that contention; it may give back a few minutes on the macOS leg. This PR is deliberately the only CI change in flight so the effect is attributable — compare `run_duration_ms` before and after, and if the macOS unit shards get slower, the follow-up is to trim macOS shards, not to revert the ordering.

Validated by an independent critic pass over five merge-queue latency proposals; this was one of two that survived (the other is the `detect-release` anchoring fix in the sibling PR). Three others were overturned or deferred and are recorded in the follow-up issue.

## Invariant audit

- 1 (plugin init): not touched — no `src/` change.
- 2 (runtime portability): not touched — no `src/` change.
- 3 (subprocesses): not touched.
- 4 (.swarm containment): not touched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — validation used explicit `bun test` invocations.
- 7 (test writing): touched — one new `bun:test` file (77 lines), no `mock.module`, no real clock, self-contained job extractor; `check:test-file-cap` and `check:test-clock` zero new violations; pinned Biome 2.3.14 format, `bun run lint:ci` clean.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched.
- 12 (release/cache): touched — `docs/releases/pending/ci-merge-queue-critical-path.md` added (`check:pending-fragment` OK); version, changelog and manifest untouched.

Workflow hygiene: every third-party `uses:` remains SHA-pinned; no job added or removed; every `needs` resolves (structural parse of the edited file). The existing "no dangling needs references" suite in `ci-coverage-sharding.test.ts` passes: neither job references a `needs.<job>.*` value it no longer declares.

## Test plan

- [x] `bun test tests/unit/scripts/ci/` — 58 pass, 0 fail (new suite plus the three existing ci.yml shape suites; re-validated on a CRLF Windows checkout after ef8e7e6)
- [x] Structural parse of the edited `ci.yml`: `integration needs=[detect-release, quality]`, `smoke needs=[detect-release, package-check, php-validation, rust-sandbox-runner]`, `unit-passed needs=[unit]` unchanged, all `uses:` SHA-pinned, no job dropped
- [x] `bun run lint:ci` — clean
- [x] `bun run check:test-file-cap`, `bun run check:test-clock`, `bun run check:pending-fragment` — pass
- [ ] CI on this PR (pull_request tier: `integration`/`smoke` steps are skipped by design and the jobs report success — unchanged)
- [ ] First merge-group run after landing: confirm `integration` and `smoke` start while `unit` shards are still running, and record `run_duration_ms` against the 59m23s baseline


## Review fixes (ef8e7e6)

An independent swarm-pr-review run validated seven findings against this PR (handoff: .zcode/pr-review/pr2551-20260903/feedback-handoff.md). All are closed:

- **PRR-001 (high, fixed):** the new pin test read ci.yml without CRLF normalization and failed `unit (windows-latest, 6)` deterministically (run 33787885615) because Windows checkouts materialize the file as CRLF. The test now CRLF-normalizes its read (sibling-suite convention), extraction moved inside test bodies so failures name the test, both needs lists are pinned exactly, `unit-passed`'s `[unit]` gate is pinned, and the if-always guard catches `if: ${{ always() }}`/compound variants.
- **PRR-003 (low, fixed):** the ci-two-tier-sharding critical-path sentence now notes this PR supersedes the old ordering.
- **PRR-004 (low, fixed):** exact needs pins + unit-passed pin (part of the test rewrite).
- **PRR-006 (info, fixed):** release fragment heading aligned to the sibling h1 convention.
- **PRR-005 (low, watch):** macOS concurrency contention stays the documented watch item above; judge from post-merge `run_duration_ms`.
- **PRR-007 (info, follow-up):** pre-existing .gitattributes UTF-8 BOM defect (defeats eol=lf at checkout on Windows) filed as #2554.
- **PRR-002 (rejected):** the PR #2313 eviction-class citation is correct — its timeline shows repeated merge-queue removals.

Both fix gates passed on the exact diff: independent reviewer APPROVE + final critic APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JPGCDoovMhy7e56ngjFFL

---
_Generated by [Claude Code](https://claude.ai/code/session_014JPGCDoovMhy7e56ngjFFL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


