### PR TITLE
feat(pr-workflow): add lane-liveness timeout watchdog and stall detection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,7 @@ Generated from `PluginConfigSchema` (`src/config/schema.ts`) - do not edit insid
 | `inject_phase_reminders` | boolean | true | Inject phase reminder directives during execution. |
 | `hooks` | object | — | Hook subsystem toggles and settings. |
 | `pr_review_resilience` | object (strict) | — | PR review base-wave staged canary/fanout resilience settings. |
+| `lane_liveness_watchdog` | object (strict) | — | Lane liveness watchdog: execution deadline and stall escalation for PR workflow lanes. |
 | `pr_review_legacy_transcript_compatibility` | boolean | — | Deprecated migration-only opt-in for transcript-row PR-review base and micro discovery lanes. |
 | `gates` | object | — | Quality gate configuration (v6.9 anti-slop features). |
 | `context_budget` | object | — | Context budget thresholds. |
@@ -827,6 +828,90 @@ clean reset.
 ```json
 {
   "pr_review_resilience": {
+    "enabled": false
+  }
+}
+```
+
+### lane_liveness_watchdog
+
+Controls the lane-liveness watchdog for PR workflow lanes (issue #2506): a
+typed execution deadline and an advisory stall escalation. **Disabled by
+default.** An omitted section, or `enabled: false`, is a full no-op — PR-lane
+settlement stays byte-identical to the pre-#2506 substrate (age-only
+settlement, the fail-open liveness probe, probe retention, and the
+human-only force abort). Each numeric field disables its own feature at `0`
+while leaving the others armed.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Arm the watchdog. `false` (or omitted) runs no probes, writes no watchdog events, and never changes the settlement horizon. |
+| `timeout_ms` | number | `1800000` | When enabled and non-zero, the single effective PR-lane settlement horizon in milliseconds (0–86400000). `0` disables the execution deadline and restores the reachability-floor fallback. |
+| `stall_threshold_ms` | number | `300000` | Activity window for stall detection in milliseconds (0–86400000). Stall escalation is active only when this and both thresholds below are non-zero. |
+| `stall_min_steps` | number | `5` | Observable transcript steps within the window that count as progress (0–10000). |
+| `stall_token_threshold` | number | `200` | Estimated tokens within the window that count as progress (0–1000000). |
+
+**The single effective horizon.** An enabled watchdog with `timeout_ms > 0`
+owns the PR-lane settlement horizon. Everything else — no config,
+`enabled: false`, or `timeout_ms: 0` — falls back to the 30-minute
+reachability floor (`DEFAULT_STALE_DELEGATION_TIMEOUT_MS`), which must never
+disappear: it is the guarantee that abort and completion cannot be
+permanently blocked by a lane whose backing process died. A disagreement
+with `hooks.background_pending_timeout_minutes` is disclosed
+(`conflictDisclosed` on the gate's horizon resolution) but never resolved
+into a second horizon; the effective horizon remains the one settlement
+authority.
+
+**Typed liveness conditions.** The watchdog keeps five conditions
+distinguishable, with the frozen precedence `completed_failure` >
+`observer_deadline` > `provider_retry_in_flight` > `execution_deadline` >
+`idle_failed_child`:
+
+- `observer_deadline` — the caller's collection wait budget expired while the session is live or unknown; observer noise, never child failure, never a terminal transition.
+- `provider_retry_in_flight` — the host reports the session in `retry`: provider latency with its own bounded retry owner; retained even past the horizon.
+- `completed_failure` — the ledger already holds a terminal error: the lane completed with a real (failed) outcome, not a liveness signal.
+- `idle_failed_child` — an open record whose session is idle or absent below the horizon: the child failed without a terminal write.
+- `execution_deadline` — the lane exceeded the effective execution horizon: aborted best-effort and settled with its real outcome. With the deadline active this overrides probe retention for `busy` lanes (a `retry` lane stays retained — provider latency owns its retry).
+
+**Stall escalation and the `pr_workflow_lane_watchdog` event.** When stall
+escalation is armed, the gate evaluates the lanes a settlement still
+considers open — one shared status query, the same directory-wide probe the
+settlement path uses, with no per-lane fan-out. Each `busy`/`retry` lane
+whose observed activity in the last `stall_threshold_ms` missed BOTH the
+step and the estimated-token thresholds is escalated; escalation is advisory
+only (an escalated lane is never settled or aborted by it — the operator
+inspects the transcript or uses the human-only force abort). Every
+escalation and progression observation is disclosed as a
+`pr_workflow_lane_watchdog` event in `.swarm/events.jsonl`, carrying the
+typed condition, the effective horizon and its source, the escalated lane
+ids (bounded to 10), and the stall thresholds. Re-escalation is durably
+deduped: a lane is not escalated again until activity is observed since its
+last escalation, proven from the durable event log itself (an
+`escalated: false` + `activityObserved: true` observation record), so the
+dedup survives state resets without forking a second durable state file.
+
+**Token counts are estimates.** The host API exposes no provider-true
+per-session token counts; `estimatedTokens` is derived from transcript text
+length, and every surface that reports it (including the stall disclosure)
+labels it an estimate. A lane whose transcript cannot be read reads as zero
+activity — the conservative direction for stall escalation (escalate, then
+let the operator inspect).
+
+**Example** — opt in with the frozen defaults (30-minute horizon, 5-minute stall window, 5 steps / ~200 estimated tokens):
+
+```json
+{
+  "lane_liveness_watchdog": {
+    "enabled": true
+  }
+}
+```
+
+**Example** — the default: watchdog off, settlement unchanged:
+
+```json
+{
+  "lane_liveness_watchdog": {
     "enabled": false
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -870,7 +870,7 @@ distinguishable, with the frozen precedence `completed_failure` >
 - `observer_deadline` — the caller's collection wait budget expired while the session is live or unknown; observer noise, never child failure, never a terminal transition.
 - `provider_retry_in_flight` — the host reports the session in `retry`: provider latency with its own bounded retry owner; retained even past the horizon.
 - `completed_failure` — the ledger already holds a terminal error: the lane completed with a real (failed) outcome, not a liveness signal.
-- `idle_failed_child` — an open record whose session is idle or absent below the horizon: the child failed without a terminal write.
+- `idle_failed_child` — an open record whose session is idle or absent below the horizon: no terminal write AND no observed progress. This is also the condition family stall-escalation events carry for lanes that are still running but producing below both thresholds.
 - `execution_deadline` — the lane exceeded the effective execution horizon: aborted best-effort and settled with its real outcome. With the deadline active this overrides probe retention for `busy` lanes (a `retry` lane stays retained — provider latency owns its retry).
 
 **Stall escalation and the `pr_workflow_lane_watchdog` event.** When stall
@@ -885,17 +885,29 @@ escalation and progression observation is disclosed as a
 `pr_workflow_lane_watchdog` event in `.swarm/events.jsonl`, carrying the
 typed condition, the effective horizon and its source, the escalated lane
 ids (bounded to 10), and the stall thresholds. Re-escalation is durably
-deduped: a lane is not escalated again until activity is observed since its
-last escalation, proven from the durable event log itself (an
-`escalated: false` + `activityObserved: true` observation record), so the
-dedup survives state resets without forking a second durable state file.
+deduped per (session, lane label): a lane is not escalated again until
+activity is observed since its last escalation, proven from the durable
+event log itself (an `escalated: false` + `activityObserved: true`
+observation record), so the dedup survives state resets without forking a
+second durable state file. The suppression window is bounded by the event
+log's retention — an escalation stops suppressing once it folds out of the
+log (7-day fold or tail truncation, whichever comes first). Sessions never
+suppress each other: the dedup only reads events written by the settling
+session's own ID.
 
-**Token counts are estimates.** The host API exposes no provider-true
-per-session token counts; `estimatedTokens` is derived from transcript text
-length, and every surface that reports it (including the stall disclosure)
-labels it an estimate. A lane whose transcript cannot be read reads as zero
-activity — the conservative direction for stall escalation (escalate, then
-let the operator inspect).
+**Activity reading in v1 is zero-by-default.** The host API exposes no
+provider-true per-session token counts and no bounded per-lane transcript
+read that fits the frozen one-status-call probe budget, so the built-in
+activity reader treats EVERY lane as zero activity: each open `busy`/`retry`
+lane escalates once per (session, label) when the stall window fires, and
+the progression/re-arm path activates when a transcript-backed reader is
+wired (the `readLaneActivity` seam exists for exactly that). The
+`stall_min_steps` and `stall_token_threshold` values are the thresholds the
+escalation disclosure reports and the bounds a future reader satisfies;
+with the v1 zero reader no activity input can exceed them, which is the
+conservative direction for stall escalation (escalate, then let the
+operator inspect). A structured `stall` block on each escalation event
+carries the first escalated lane's observed values beside those thresholds.
 
 **Example** — opt in with the frozen defaults (30-minute horizon, 5-minute stall window, 5 steps / ~200 estimated tokens):
 

--- a/docs/releases/pending/2506-lane-liveness-watchdog.md
+++ b/docs/releases/pending/2506-lane-liveness-watchdog.md
@@ -71,7 +71,8 @@ falls back to the 30-minute reachability floor
 the guarantee that abort and completion cannot be permanently blocked by a
 lane whose backing process died. If `hooks.background_pending_timeout_minutes`
 disagrees with the effective horizon, the disagreement is *disclosed*
-(`conflictDisclosed` on the horizon resolution consumed by the gate) but
+on the settlement result and completion responses (`horizon_conflict`, from
+`conflictDisclosed` on the horizon resolution) but
 never resolved into a second horizon: the effective horizon remains the one
 settlement authority, and the background-pending sweep never becomes a
 competing deadline for PR lanes.
@@ -97,21 +98,29 @@ never reported as child failure.
 Escalation and progression observations are disclosed as
 `pr_workflow_lane_watchdog` events in `.swarm/events.jsonl`, carrying the
 typed condition, the effective horizon and its source, the lane ids (bounded
-to 10), and the stall thresholds. Re-escalation is deduped per lane against
+to 10), and the stall thresholds. Re-escalation is deduped per (session, lane label) against
 the last escalation *durably* — derived from the existing bounded event log,
 not a module-level map, so the dedup survives `resetTrackedStateCache()`
-and forks no second durable state file. "Activity since the last
-escalation" is falsifiable from disk alone: a progressing lane writes an
+and forks no second durable state file, and two sessions sharing a lane
+role label never suppress each other. “Activity since the last
+escalation” is falsifiable from disk alone: a progressing lane writes an
 `escalated: false` + `activityObserved: true` observation record, and that
-record (or the live reader's `lastActivityAtMs`) is what re-arms a
-suppressed lane for its next stall. Events older than the 7-day retention
-window fold into the manifest header, after which a stale escalation no
-longer suppresses a fresh one.
+record (or the live reader’s `lastActivityAtMs`) is what re-arms a
+suppressed lane for its next stall. An escalation stops suppressing once it
+folds out of the bounded event-log window (7-day fold or tail truncation,
+whichever comes first).
 
-Token counts in the stall surface are transcript-derived **estimates** — the
-host API exposes no provider-true per-session token counts — and a lane
-whose transcript cannot be read reads as zero activity: the conservative
-direction (escalate, then let the operator inspect).
+Activity reading in v1 is zero-by-default: the host API exposes no
+provider-true per-session token counts and no bounded per-lane transcript
+read that fits the frozen one-status-call probe budget, so the built-in
+reader treats every open lane as zero activity — each stalled lane escalates
+once per (session, label) and the progression/re-arm path activates when a
+transcript-backed reader is wired onto the existing `readLaneActivity`
+seam. `stall_min_steps`/`stall_token_threshold` are the thresholds the
+disclosure reports and a future reader satisfies; the escalation event's
+structured `stall` block carries the first escalated lane's observed values
+beside them. This is the conservative direction (escalate, then let the
+operator inspect).
 
 ## OBSERVABILITY-1/-2 rebaseline
 
@@ -135,14 +144,16 @@ current production source instead:
   feeds the durable counters, so the observability gap is real once the
   "no producer" claim is corrected to "no counter incrementer".
 
-This section is the executable rebaseline record; the frozen check
-(`observability-rebaseline.sh`) verifies both source facts and this
-fragment's presence every run.
+This section is the executable rebaseline record. Its check script ran
+during this PR's issue-tracer validation (re-run at the shipped head; see
+the trace's test-results record); it lives in the issue-trace working
+notes, not in the repository, so it is a validation artifact rather than a
+CI gate.
 
 ## Breaking changes
 
 None. The config block is new, strict, and default-off; the disabled path is
-byte-identical to the pre-#2506 substrate, no signature changed, and no new
+byte-identical to the pre-#2506 substrate, no signature change is breaking (several gate functions gained optional parameters), and no new
 durable state file exists (watchdog disclosures ride the existing
 `.swarm/events.jsonl` log).
 

--- a/docs/releases/pending/2506-lane-liveness-watchdog.md
+++ b/docs/releases/pending/2506-lane-liveness-watchdog.md
@@ -1,0 +1,149 @@
+# PR workflow lanes: a lane-liveness watchdog with one settlement horizon and typed conditions
+
+Issue #2242 gave PR-lane settlement a 30-minute staleness horizon; #2251 added
+the fail-open liveness probe and probe retention, so a lane the host
+affirmatively reports as `busy`/`retry` is spared instead of presumed stale.
+What remained missing was everything *above* that floor: a lane that kept
+answering "busy" past every deadline could retain forever, a slow-but-alive
+provider was indistinguishable from a dead child in the disclosure surface,
+and there was no way to notice a lane that had gone quiet mid-flight without
+killing it.
+
+## What changed
+
+The gate (`src/hooks/pr-workflow-gate.ts`) gained a lane-liveness watchdog
+(`src/hooks/lane-liveness-watchdog.ts`) behind a **default-off** config block.
+When enabled it does exactly two things on the existing settlement path:
+
+- **Execution deadline.** A `busy` lane past the effective horizon becomes an
+  `execution_deadline`: the watchdog overrides probe retention for it (that
+  retention is exactly what could keep a genuinely-over-deadline lane alive
+  forever), aborts its session best-effort with its own bounded one-attempt
+  abort, and settles it with its real outcome. A `retry` lane is never
+  deadlined — provider latency owns its own bounded retry, and a deadline
+  must not invent child failure for it.
+- **Stall escalation.** Lanes a settlement still considers open are evaluated
+  for *advisory* stall: a `busy`/`retry` lane whose observed activity in the
+  last `stall_threshold_ms` window missed BOTH the step threshold and the
+  estimated-token threshold is escalated — disclosed, never settled or
+  aborted. The operator response (inspect the transcript, or the human-only
+  force abort) owns the terminal decision.
+
+With the watchdog disabled (the default, and the shape of every pre-#2506
+two-argument call), settlement is byte-identical to the substrate: age-only
+partitioning, the fail-open probe, probe retention, and the human-only force
+exit all unchanged. The disabled path runs no extra status calls and writes
+no watchdog events.
+
+## Config surface
+
+New top-level `lane_liveness_watchdog` (strict object, issue #2506):
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Arms the watchdog. |
+| `timeout_ms` | `1800000` | The single effective PR-lane settlement horizon when enabled (0–86400000). |
+| `stall_threshold_ms` | `300000` | Stall-detection activity window (0–86400000). |
+| `stall_min_steps` | `5` | Transcript steps in the window that count as progress (0–10000). |
+| `stall_token_threshold` | `200` | Estimated tokens in the window that count as progress (0–1000000). |
+
+Each numeric knob disables its own feature at `0` — `timeout_ms: 0` restores
+the reachability-floor horizon, and any zero among the three stall knobs
+disables stall escalation while leaving the deadline armed.
+
+The parameter surface (timeoutMs 30 min, stallThresholdMs 5 min,
+stallMinSteps 5, stallTokenThreshold 200, 0-disables) and the
+re-nudge-suppression idea (never re-escalate a lane that has had no activity
+since the last escalation) are adopted from opencode-ensemble with credit,
+per ADR 0002 (`docs/decisions/0002-opencode-ensemble-adoption.md`): the
+capability decision there is REIMPLEMENT. No upstream code, strings, or
+assets are ported — upstream's watchdog is member/worktree-centric and
+drives the host client directly, while this one is pure policy over this
+repository's own settlement substrate and evidence gates.
+
+## The single-horizon rule
+
+There is exactly ONE effective PR-lane settlement horizon, resolved up front
+by `resolveEffectivePrLaneHorizonMs`. An enabled watchdog with
+`timeout_ms > 0` owns it; no config, `enabled: false`, or `timeout_ms: 0`
+falls back to the 30-minute reachability floor
+(`DEFAULT_STALE_DELEGATION_TIMEOUT_MS`), which must never disappear — it is
+the guarantee that abort and completion cannot be permanently blocked by a
+lane whose backing process died. If `hooks.background_pending_timeout_minutes`
+disagrees with the effective horizon, the disagreement is *disclosed*
+(`conflictDisclosed` on the horizon resolution consumed by the gate) but
+never resolved into a second horizon: the effective horizon remains the one
+settlement authority, and the background-pending sweep never becomes a
+competing deadline for PR lanes.
+
+## Typed conditions
+
+`classifyLaneLivenessCondition` keeps five liveness conditions
+distinguishable, with the frozen precedence `completed_failure` >
+`observer_deadline` > `provider_retry_in_flight` > `execution_deadline` >
+`idle_failed_child`:
+
+- `observer_deadline` — the caller's collection wait budget expired while the session is live or unknown. Says nothing about the child; never a terminal transition.
+- `provider_retry_in_flight` — the host reports the session in `retry`: provider latency with its own bounded retry owner.
+- `completed_failure` — the ledger already holds a terminal error: the lane completed, with a real (failed) outcome.
+- `idle_failed_child` — an open record whose session is idle or absent below the horizon: the child failed without a terminal write.
+- `execution_deadline` — the lane exceeded the effective horizon: aborted best-effort and settled with its real outcome.
+
+A temporarily slow provider or an expired observation budget is therefore
+never reported as child failure.
+
+## Stall escalation and durable dedup
+
+Escalation and progression observations are disclosed as
+`pr_workflow_lane_watchdog` events in `.swarm/events.jsonl`, carrying the
+typed condition, the effective horizon and its source, the lane ids (bounded
+to 10), and the stall thresholds. Re-escalation is deduped per lane against
+the last escalation *durably* — derived from the existing bounded event log,
+not a module-level map, so the dedup survives `resetTrackedStateCache()`
+and forks no second durable state file. "Activity since the last
+escalation" is falsifiable from disk alone: a progressing lane writes an
+`escalated: false` + `activityObserved: true` observation record, and that
+record (or the live reader's `lastActivityAtMs`) is what re-arms a
+suppressed lane for its next stall. Events older than the 7-day retention
+window fold into the manifest header, after which a stale escalation no
+longer suppresses a fresh one.
+
+Token counts in the stall surface are transcript-derived **estimates** — the
+host API exposes no provider-true per-session token counts — and a lane
+whose transcript cannot be read reads as zero activity: the conservative
+direction (escalate, then let the operator inspect).
+
+## OBSERVABILITY-1/-2 rebaseline
+
+Issue #2506's summary references an audit document,
+`docs/audits/swarm-plugin-review-2026-09.md`; that file is **absent from the
+repository**, so the OBSERVABILITY-1/-2 claims were rebaselined against
+current production source instead:
+
+- The audit's blanket "transient retry/fallback has no producer" claim is
+  **false as stated**. `dispatchWithModelFallback`
+  (`src/utils/model-dispatch-fallback.ts`) is a production retry/fallback
+  engine with nine production call sites: `src/evaluation/model-dispatcher.ts:208`,
+  `src/hooks/curator-llm-factory.ts:247`,
+  `src/hooks/skill-improver-llm-factory.ts:164`,
+  `src/mutation/generator.ts:150`, `src/tools/dispatch-lanes.ts:3461` and
+  `:4060`, `src/turbo/lean/integration.ts:742`,
+  `src/turbo/lean/reviewer.ts:595`, and `src/turbo/lean/runner.ts:1461`.
+- What IS true, and what the rebaseline pins: the persistent counters
+  `transientRetryCount` and `model_fallback_index` have **no production
+  incrementer** — the retry/fallback engine produces the behavior but never
+  feeds the durable counters, so the observability gap is real once the
+  "no producer" claim is corrected to "no counter incrementer".
+
+This section is the executable rebaseline record; the frozen check
+(`observability-rebaseline.sh`) verifies both source facts and this
+fragment's presence every run.
+
+## Breaking changes
+
+None. The config block is new, strict, and default-off; the disabled path is
+byte-identical to the pre-#2506 substrate, no signature changed, and no new
+durable state file exists (watchdog disclosures ride the existing
+`.swarm/events.jsonl` log).
+
+Found while resolving issue #2506.

--- a/opencode-swarm.schema.json
+++ b/opencode-swarm.schema.json
@@ -351,6 +351,41 @@
       },
       "additionalProperties": false
     },
+    "lane_liveness_watchdog": {
+      "description": "Lane liveness watchdog: execution deadline and stall escalation for PR workflow lanes.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "timeout_ms": {
+          "default": 1800000,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 86400000
+        },
+        "stall_threshold_ms": {
+          "default": 300000,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 86400000
+        },
+        "stall_min_steps": {
+          "default": 5,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "stall_token_threshold": {
+          "default": 200,
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        }
+      },
+      "additionalProperties": false
+    },
     "pr_review_legacy_transcript_compatibility": {
       "description": "Deprecated migration-only opt-in for transcript-row PR-review base and micro discovery lanes.",
       "type": "boolean"

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -3,10 +3,12 @@ import {
 	BUNDLED_PROJECT_SKILL_ROOT,
 	syncBundledProjectSkillsIfMissingAsync,
 } from '../config/bundled-skills.js';
+import { loadPluginConfig } from '../config/loader.js';
 import type { AutoReviewConfig, PluginConfig } from '../config/schema.js';
 import type { EvaluationModelDispatcher } from '../evaluation/model-dispatcher.js';
 import {
 	activatePrWorkflow,
+	type PrWorkflowLaneLivenessOptions,
 	type PrWorkflowMode,
 	transitionPrReviewToFeedback,
 } from '../hooks/pr-workflow-gate.js';
@@ -416,12 +418,34 @@ async function handlePrFeedbackCommandWithTransition(
 		const exactCommand = parsed.prUrl
 			? `/swarm pr-feedback ${parsed.prUrl} continue from ${parsed.continuation.handoffPath}`
 			: `/swarm pr-feedback continue from ${parsed.continuation.handoffPath}`;
+		// Issue #2506 review round 2: the PR_REVIEW→PR_FEEDBACK continuation is
+		// a third settlement entry point, so it resolves the watchdog policy
+		// exactly like the abort/complete tools (fail-open to disabled) and
+		// threads it through — the ONE effective horizon covers this path too.
+		let laneLiveness: PrWorkflowLaneLivenessOptions | undefined;
+		try {
+			const config = loadPluginConfig(ctx.directory);
+			const hooks = (
+				config as { hooks?: { background_pending_timeout_minutes?: number } }
+			).hooks;
+			laneLiveness = {
+				laneLivenessWatchdog: config.lane_liveness_watchdog,
+				backgroundPendingTimeoutMs:
+					hooks?.background_pending_timeout_minutes !== undefined
+						? hooks.background_pending_timeout_minutes * 60_000
+						: undefined,
+			};
+		} catch {
+			// Config read failure must not block the continuation; the disabled
+			// default is always safe.
+		}
 		await transitionPrReviewToFeedback(ctx.directory, ctx.sessionID, {
 			runId: parsed.continuation.runId,
 			handoffPath: parsed.continuation.handoffPath,
 			prUrl: parsed.prUrl,
 			exactCommand,
 			confirmedByUser: true,
+			...(laneLiveness ? { laneLiveness } : {}),
 		});
 	} else {
 		await activatePrWorkflow(ctx.directory, ctx.sessionID, 'PR_FEEDBACK', {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3374,6 +3374,34 @@ export const PrReviewResilienceConfigSchema = z
 	.strict();
 
 /**
+ * Issue #2506 (G2): the lane-liveness watchdog. Default OFF; each numeric knob
+ * disables its own feature at 0. When enabled, `timeout_ms` becomes the ONE
+ * effective PR-lane settlement horizon (the 30-minute reachability floor
+ * remains the fallback when the watchdog is off or `timeout_ms` is 0), and
+ * stall detection escalates low-output lanes BEFORE that horizon. Parameter
+ * surface adopted with credit from opencode-ensemble (reimplemented per ADR
+ * 0002 — no upstream code is ported).
+ */
+export const LaneLivenessWatchdogConfigSchema = z
+	.object({
+		enabled: z.boolean().default(false),
+		timeout_ms: z.number().int().min(0).max(86_400_000).default(1_800_000),
+		stall_threshold_ms: z
+			.number()
+			.int()
+			.min(0)
+			.max(86_400_000)
+			.default(300_000),
+		stall_min_steps: z.number().int().min(0).max(10_000).default(5),
+		stall_token_threshold: z.number().int().min(0).max(1_000_000).default(200),
+	})
+	.strict();
+
+export type LaneLivenessWatchdogConfig = z.infer<
+	typeof LaneLivenessWatchdogConfigSchema
+>;
+
+/**
  * Issue #2384: deprecated transcript-row settlement for Profile A PR-review
  * base/micro discovery lanes is an explicit compatibility opt-in. Omitted
  * config resolves false in consumers; legacy transcript parsing remains a
@@ -3540,6 +3568,12 @@ export const PluginConfigSchema = z.object({
 	// PR_REVIEW base-wave staged canary/fanout resilience.
 	pr_review_resilience: PrReviewResilienceConfigSchema.optional().describe(
 		'PR review base-wave staged canary/fanout resilience settings.',
+	),
+
+	// Issue #2506 (G2): lane-liveness watchdog (default-off; 0 disables each
+	// feature; timeout_ms is the single effective PR-lane horizon when on).
+	lane_liveness_watchdog: LaneLivenessWatchdogConfigSchema.optional().describe(
+		'Lane liveness watchdog: execution deadline and stall escalation for PR workflow lanes.',
 	),
 
 	// Deprecated transcript-row settlement compatibility for Profile A

--- a/src/hooks/lane-liveness-watchdog.ts
+++ b/src/hooks/lane-liveness-watchdog.ts
@@ -1,0 +1,196 @@
+/**
+ * Issue #2506 (G2): the lane-liveness watchdog — typed liveness conditions,
+ * the unified PR-lane settlement horizon, and stall-escalation policy for
+ * PR-workflow lanes.
+ *
+ * Reimplemented on this repository's own settlement substrate per ADR 0002
+ * (`docs/decisions/0002-opencode-ensemble-adoption.md`). The parameter
+ * surface (timeoutMs 30 min, stallThresholdMs 5 min, stallMinSteps 5,
+ * stallTokenThreshold 200, 0-disables) and the re-nudge-suppression idea
+ * (never re-escalate a lane that has had no activity since the last
+ * escalation) are adopted from opencode-ensemble with credit; NO upstream
+ * code, strings, or assets are ported.
+ *
+ * The module is pure policy: it classifies, resolves, and decides. All I/O
+ * (session status probes, aborts, event appends) stays behind the gate's
+ * existing seams so the watchdog can never bypass the shared settlement
+ * path or its evidence gates.
+ */
+import { DEFAULT_STALE_DELEGATION_TIMEOUT_MS } from '../background/pending-delegations.js';
+import type { LaneLivenessWatchdogConfig } from '../config/schema.js';
+import { LaneLivenessWatchdogConfigSchema } from '../config/schema.js';
+
+/** The five frozen defaults from the #2506 contract (0 disables a feature). */
+export const LANE_LIVENESS_WATCHDOG_DEFAULTS: LaneLivenessWatchdogConfig =
+	LaneLivenessWatchdogConfigSchema.parse({});
+
+/**
+ * Upper bound on lane ids named in one `pr_workflow_lane_watchdog` event or
+ * disclosure. Defined here (not imported from the gate) so this module never
+ * depends on the gate layer.
+ */
+export const MAX_LANE_LIVENESS_DISCLOSED_IDS = 10;
+
+/**
+ * The typed liveness conditions #2506 requires to be distinguishable. A
+ * temporarily slow provider or an expired observation budget must never be
+ * reported as child failure.
+ *
+ * - `observer_deadline` — the CALLER's collection wait budget expired while
+ *   the session is live or unknown. Says nothing about the child; never a
+ *   terminal transition.
+ * - `provider_retry_in_flight` — the host reports the session in `retry`:
+ *   provider latency with its own bounded retry owner. Retained.
+ * - `completed_failure` — the ledger already holds a terminal error: the
+ *   lane completed, with a real (failed) outcome.
+ * - `idle_failed_child` — an open record whose session is idle or absent
+ *   below the horizon: the child failed without a terminal write.
+ * - `execution_deadline` — the lane exceeded the effective execution
+ *   horizon: aborted best-effort and settled with its real outcome.
+ */
+export type LaneLivenessCondition =
+	| 'observer_deadline'
+	| 'provider_retry_in_flight'
+	| 'completed_failure'
+	| 'idle_failed_child'
+	| 'execution_deadline';
+
+export interface ClassifyLaneLivenessInput {
+	/** Host session status type, when a probe ran. `undefined` = unknown. */
+	sessionStatusType?: string;
+	/** Ledger record status string (e.g. `pending`, `running`, `error`). */
+	recordStatus: string;
+	/** Whether the caller's observation/collection budget expired. */
+	waitBudgetExpired: boolean;
+	/** Whether the lane's age exceeds the EFFECTIVE horizon. */
+	exceededEffectiveHorizon: boolean;
+}
+
+/**
+ * Classify one lane's liveness with the frozen precedence
+ * `completed_failure > observer_deadline > provider_retry_in_flight >
+ * execution_deadline > idle_failed_child`:
+ * a terminal error is a real outcome and wins over every in-flight signal;
+ * an expired observation budget on a live-or-unknown session is observer
+ * noise, not child failure; a `retry` session is provider latency even past
+ * the horizon; only then may the execution deadline fire; everything else
+ * is an open, low-signal lane below the horizon.
+ */
+export function classifyLaneLivenessCondition(
+	input: ClassifyLaneLivenessInput,
+): LaneLivenessCondition {
+	if (input.recordStatus === 'error') {
+		return 'completed_failure';
+	}
+	const sessionLiveOrUnknown =
+		input.sessionStatusType === undefined ||
+		input.sessionStatusType === 'busy' ||
+		input.sessionStatusType === 'retry';
+	if (input.waitBudgetExpired && sessionLiveOrUnknown) {
+		return 'observer_deadline';
+	}
+	if (input.sessionStatusType === 'retry') {
+		return 'provider_retry_in_flight';
+	}
+	if (input.exceededEffectiveHorizon) {
+		return 'execution_deadline';
+	}
+	return 'idle_failed_child';
+}
+
+export interface EffectivePrLaneHorizon {
+	/** The ONE effective PR-lane settlement horizon, in ms. */
+	horizonMs: number;
+	/** Which configured value won. */
+	source: 'watchdog-timeout' | 'reachability-floor';
+	/**
+	 * True when `backgroundPendingTimeoutMs` was provided, is > 0, and
+	 * disagrees with the effective horizon. The disagreement is disclosed,
+	 * never resolved into a second horizon.
+	 */
+	conflictDisclosed: boolean;
+}
+
+/**
+ * Resolve the single effective PR-lane settlement horizon (#2506 AC2).
+ *
+ * Precedence: an ENABLED watchdog with `timeout_ms > 0` owns the horizon;
+ * everything else (no config, `enabled: false`, or `timeout_ms: 0` — "0
+ * disables the feature") falls back to the 30-minute reachability floor
+ * (`DEFAULT_STALE_DELEGATION_TIMEOUT_MS`), which must never disappear: it is
+ * the guarantee that abort and completion cannot be permanently blocked by a
+ * lane whose backing process died.
+ */
+export function resolveEffectivePrLaneHorizonMs(
+	watchdog?: LaneLivenessWatchdogConfig,
+	backgroundPendingTimeoutMs?: number,
+): EffectivePrLaneHorizon {
+	const watchdogOwnsHorizon =
+		watchdog?.enabled === true && (watchdog.timeout_ms ?? 0) > 0;
+	const horizonMs = watchdogOwnsHorizon
+		? (watchdog?.timeout_ms as number)
+		: DEFAULT_STALE_DELEGATION_TIMEOUT_MS;
+	return {
+		horizonMs,
+		source: watchdogOwnsHorizon ? 'watchdog-timeout' : 'reachability-floor',
+		conflictDisclosed:
+			backgroundPendingTimeoutMs !== undefined &&
+			backgroundPendingTimeoutMs > 0 &&
+			backgroundPendingTimeoutMs !== horizonMs,
+	};
+}
+
+/** Per-lane activity within the last `stall_threshold_ms` window. */
+export interface LaneActivity {
+	/** Observable transcript steps in the window. */
+	stepsObserved: number;
+	/**
+	 * Token ESTIMATE derived from transcript text length — the host API does
+	 * not expose provider-true token counts; every surface that reports this
+	 * value must label it an estimate.
+	 */
+	estimatedTokens: number;
+	/** Epoch-ms timestamp of the last observed activity, when known. */
+	lastActivityAtMs?: number;
+}
+
+export const ZERO_LANE_ACTIVITY: LaneActivity = {
+	stepsObserved: 0,
+	estimatedTokens: 0,
+};
+
+/** The overridable activity reader the gate seam exposes for tests. */
+export type ReadLaneActivity = (
+	directory: string,
+	subagentSessionId: string,
+) => LaneActivity | null | Promise<LaneActivity | null>;
+
+/**
+ * Default transcript-derived activity reader. The host API exposes no
+ * per-session token counts and no bounded transcript read on this path (a
+ * per-lane `session.messages` call would violate the frozen one-status-call
+ * budget), so a lane with no stored activity information reads as ZERO
+ * activity — the conservative direction for stall escalation (escalate,
+ * then let the operator inspect). This is the #2506 frozen contract: "an
+ * absent transcript reads as zero activity".
+ */
+export const defaultReadLaneActivity: ReadLaneActivity = () =>
+	ZERO_LANE_ACTIVITY;
+
+/** Feature activation derived from the config (each knob disables at 0). */
+export function laneLivenessWatchdogFeatures(
+	watchdog?: LaneLivenessWatchdogConfig,
+): {
+	deadlineActive: boolean;
+	stallActive: boolean;
+} {
+	const enabled = watchdog?.enabled === true;
+	return {
+		deadlineActive: enabled && (watchdog?.timeout_ms ?? 0) > 0,
+		stallActive:
+			enabled &&
+			(watchdog?.stall_threshold_ms ?? 0) > 0 &&
+			(watchdog?.stall_min_steps ?? 0) > 0 &&
+			(watchdog?.stall_token_threshold ?? 0) > 0,
+	};
+}

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -3281,7 +3281,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 						`${deadlineLanes.length} lane(s) exceeded the ${horizon.horizonMs}ms execution ` +
 						`deadline (${horizon.source}); ` +
 						(abortAttempted
-							? 'sessions aborted best-effort and settled through '
+							? 'sessions aborted best-effort and '
 							: 'no session abort was attempted (the liveness probe could not confirm these sessions were running); lanes settled ') +
 						`through the shared path with the real outcome: no output observed (no ` +
 						`transcript activity recorded for these lanes)`,

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -206,6 +206,8 @@ import {
 	classifyLaneLivenessCondition,
 	defaultReadLaneActivity,
 	type EffectivePrLaneHorizon,
+	type LaneActivity,
+	type LaneLivenessCondition,
 	laneLivenessWatchdogFeatures,
 	MAX_LANE_LIVENESS_DISCLOSED_IDS,
 	resolveEffectivePrLaneHorizonMs,
@@ -2599,6 +2601,14 @@ export interface PrWorkflowStaleLaneSettlement {
 	/** Lanes stale past the horizon, treated as settled with disclosure. */
 	presumedStaleLaneIds: string[];
 	/**
+	 * Present ONLY when the configured `hooks.background_pending_timeout_minutes`
+	 * disagrees with the ONE effective horizon this settlement used (issue
+	 * #2506 AC2). Fixed template, no second horizon is created — the field
+	 * exists so the disagreement is observable on tool responses instead of
+	 * being silently absorbed.
+	 */
+	horizonConflictNote?: string;
+	/**
 	 * Lanes past the horizon that the probe spared. Present only when non-empty.
 	 */
 	probedAliveLaneIds?: string[];
@@ -2702,23 +2712,19 @@ export interface PrWorkflowLaneLivenessOptions {
 }
 
 /**
- * The #2506 watchdog budget counters (issue AC7). Mutated in place so the
- * `_test_exports.laneLivenessWatchdog` surface reads live values; zeroed by
- * `resetTrackedStateCache()`.
+ * The #2506 watchdog seam surface exposed through `_test_exports`. The budget
+ * counters (issue AC7) are OWNED by this object — every increment and the
+ * `resetTrackedStateCache()` zeroing go through these properties, so there is
+ * deliberately no second counters object a spread could orphan.
  */
-const laneLivenessWatchdogCounters = {
-	hostStatusCalls: 0,
-	hostAbortCalls: 0,
-	evaluations: 0,
-};
-
-/** The #2506 watchdog seam surface exposed through `_test_exports`. */
 const laneLivenessWatchdogSurface = {
 	resolveEffectivePrLaneHorizonMs,
 	classifyLaneLivenessCondition,
 	evaluateLaneLivenessWatchdog: evaluateLaneLivenessWatchdogEscalation,
 	readLaneActivity: defaultReadLaneActivity,
-	...laneLivenessWatchdogCounters,
+	hostStatusCalls: 0,
+	hostAbortCalls: 0,
+	evaluations: 0,
 };
 
 /**
@@ -2754,9 +2760,14 @@ async function abortLaneSessionForWatchdog(
  * durable event log — the registered, bounded, already-disclosed channel
  * (`.swarm/events.jsonl`). Disk-derived on purpose: the dedup must survive
  * `resetTrackedStateCache()` (frozen C4 contract) and must not fork a second
- * durable state file. Reading is a single bounded scan; events older than
- * the 7-day retention window fold into the manifest header, after which a
- * stale escalation no longer suppresses a fresh one — the correct behavior.
+ * durable state file. Reading is a single bounded scan (the store's tail
+ * read); an event suppresses only while it stays inside that bounded window
+ * — a 7-day fold or a tail truncation drops it, after which a stale
+ * escalation no longer suppresses a fresh one — the correct behavior.
+ *
+ * When `sessionID` is provided, only events written by THAT session count:
+ * dedup keys are `(sessionID, lane label)`, so two sessions sharing a
+ * directory (and a lane-role label) never suppress each other's advisories.
  *
  * The same scan also indexes the ACTIVITY OBSERVATION events
  * (`escalated: false` + `activityObserved: true`) written by
@@ -2764,20 +2775,32 @@ async function abortLaneSessionForWatchdog(
  * progressed since the last escalation, which is what re-arms a suppressed
  * lane for its next stall. The `execution_deadline` disclosure event is also
  * `escalated: false` but is NOT an activity observation (no activity was
- * observed — the opposite), so the marker field, not the absence of
- * `escalated`, decides membership.
+ * observed — the opposite); it lands in `deadlineLabels` instead, which is
+ * the durable abort-once marker: a lane whose deadline event survived in the
+ * window is never re-aborted by a later settlement pass.
+ *
+ * Concurrency note: this read-scan and the later event append are not under
+ * one lock. Two genuinely concurrent settlements for the same session could
+ * each decide "not yet escalated" and emit a duplicate advisory event; the
+ * append itself is store-lock-protected so no log corruption results, and
+ * the duplicate is an extra advisory, never a missed one.
  */
-function lastWatchdogEscalationsByLaneLabel(directory: string): {
+function lastWatchdogEscalationsByLaneLabel(
+	directory: string,
+	sessionID?: string,
+): {
 	escalations: Map<string, number>;
 	activityObservations: Map<string, number>;
+	deadlineLabels: Set<string>;
 } {
 	const escalations = new Map<string, number>();
 	const activityObservations = new Map<string, number>();
+	const deadlineLabels = new Set<string>();
 	let text = '';
 	try {
 		text = readCoreEvents(directory).text;
 	} catch {
-		return { escalations, activityObservations };
+		return { escalations, activityObservations, deadlineLabels };
 	}
 	for (const line of text.split('\n')) {
 		const trimmed = line.trim();
@@ -2789,10 +2812,15 @@ function lastWatchdogEscalationsByLaneLabel(directory: string): {
 			continue;
 		}
 		if (event.type !== 'pr_workflow_lane_watchdog') continue;
+		if (sessionID !== undefined && event.sessionID !== sessionID) continue;
 		const isEscalation = event.escalated === true;
 		const isActivityObservation =
 			!isEscalation && event.activityObserved === true;
-		if (!isEscalation && !isActivityObservation) continue;
+		const isDeadlineEvent =
+			!isEscalation &&
+			!isActivityObservation &&
+			event.condition === 'execution_deadline';
+		if (!isEscalation && !isActivityObservation && !isDeadlineEvent) continue;
 		const timestamp = Date.parse(`${event.timestamp}`);
 		if (!Number.isFinite(timestamp)) continue;
 		const laneIds = event.laneIds;
@@ -2800,12 +2828,16 @@ function lastWatchdogEscalationsByLaneLabel(directory: string): {
 		const target = isEscalation ? escalations : activityObservations;
 		for (const label of laneIds) {
 			if (typeof label !== 'string') continue;
+			if (isDeadlineEvent) {
+				deadlineLabels.add(label);
+				continue;
+			}
 			const prior = target.get(label);
 			if (prior === undefined || timestamp > prior)
 				target.set(label, timestamp);
 		}
 	}
-	return { escalations, activityObservations };
+	return { escalations, activityObservations, deadlineLabels };
 }
 
 /**
@@ -2820,13 +2852,17 @@ function appendWatchdogActivityObservation(
 	sessionID: string,
 	labels: string[],
 	horizon: EffectivePrLaneHorizon,
+	condition: LaneLivenessCondition,
 ): void {
 	try {
 		appendCoreEventSync(directory, {
 			type: 'pr_workflow_lane_watchdog',
 			timestamp: isoNow(),
 			sessionID,
-			condition: 'provider_retry_in_flight',
+			// On an OBSERVATION event this field names the condition family the
+			// evaluation is watching for (derived from the progressed lane's own
+			// session type), not an assertion that the lane is in that state.
+			condition,
 			laneIds: labels.slice(0, MAX_LANE_LIVENESS_DISCLOSED_IDS),
 			effectiveHorizonMs: horizon.horizonMs,
 			horizonSource: horizon.source,
@@ -2868,14 +2904,28 @@ async function evaluateLaneLivenessWatchdogEscalation(args: {
 		return type === 'busy' || type === 'retry';
 	});
 	if (candidates.length === 0) return;
-	const lastEscalations = lastWatchdogEscalationsByLaneLabel(directory);
+	const lastEscalations = lastWatchdogEscalationsByLaneLabel(
+		directory,
+		sessionID,
+	);
 	const escalated: BackgroundDelegationRecord[] = [];
 	const progressed: BackgroundDelegationRecord[] = [];
+	let firstEscalatedSteps = 0;
+	let firstEscalatedTokens = 0;
 	for (const record of candidates) {
-		const activity = await laneLivenessWatchdogSurface.readLaneActivity(
-			directory,
-			record.subagentSessionId as string,
-		);
+		// The activity seam is mutable and this function has call sites with no
+		// try/catch of their own (R5): a throwing reader degrades to zero
+		// activity here instead of converting the advisory pass into an
+		// unhandled rejection that escapes the settlement.
+		let activity: LaneActivity | null = null;
+		try {
+			activity = await laneLivenessWatchdogSurface.readLaneActivity(
+				directory,
+				record.subagentSessionId as string,
+			);
+		} catch {
+			activity = null;
+		}
 		const steps = activity?.stepsObserved ?? 0;
 		const tokens = activity?.estimatedTokens ?? 0;
 		const progressing =
@@ -2904,14 +2954,25 @@ async function evaluateLaneLivenessWatchdogEscalation(args: {
 					lastEscalation;
 			if (!activitySince) continue;
 		}
+		if (escalated.length === 0) {
+			firstEscalatedSteps = steps;
+			firstEscalatedTokens = tokens;
+		}
 		escalated.push(record);
 	}
 	if (progressed.length > 0) {
+		const firstProgressed = progressed[0];
+		const firstProgressedType = firstProgressed.subagentSessionId
+			? sessionTypes.get(firstProgressed.subagentSessionId)
+			: undefined;
 		appendWatchdogActivityObservation(
 			directory,
 			sessionID,
 			progressed.map(prWorkflowLaneLabel),
 			horizon,
+			firstProgressedType === 'retry'
+				? 'provider_retry_in_flight'
+				: 'idle_failed_child',
 		);
 	}
 	if (escalated.length === 0) return;
@@ -2943,8 +3004,13 @@ async function evaluateLaneLivenessWatchdogEscalation(args: {
 			horizonSource: horizon.source,
 			escalated: true,
 			stall: {
-				stepsObserved: 0,
-				estimatedTokens: 0,
+				// Batch-scalar event, so the structured values are the FIRST
+				// escalated lane's observed activity (never fabricated zeros);
+				// the thresholds beside them are the discriminating bounds the
+				// values missed. Multi-lane batches are itemized in `laneIds`
+				// and quantified in the disclosure text.
+				stepsObserved: firstEscalatedSteps,
+				estimatedTokens: firstEscalatedTokens,
 				stallThresholdMs: watchdog.stall_threshold_ms,
 				stallMinSteps: watchdog.stall_min_steps,
 				stallTokenThreshold: watchdog.stall_token_threshold,
@@ -2973,6 +3039,15 @@ export async function settlePresumedStalePrWorkflowLanes(
 		watchdog,
 		options?.backgroundPendingTimeoutMs,
 	);
+	// Issue #2506 review round 2: the horizon disagreement must be OBSERVABLE,
+	// not silently absorbed. Fixed template, carried on every settlement
+	// result (regardless of what settled) so the operator sees which value
+	// won whenever the two configured timeouts disagree.
+	const horizonConflictNote = horizon.conflictDisclosed
+		? horizon.source === 'watchdog-timeout'
+			? `lane_liveness_watchdog.timeout_ms (${horizon.horizonMs}ms) governs the PR-lane settlement horizon; hooks.background_pending_timeout_minutes was also set and disagrees — it was not applied (one effective horizon)`
+			: `PR-lane settlement uses the ${Math.round(horizon.horizonMs / 60_000)}min reachability floor; hooks.background_pending_timeout_minutes disagrees with it and does not change this horizon`
+		: undefined;
 	const now = Date.now();
 	const open: BackgroundDelegationRecord[] = [];
 	const presumedStale: BackgroundDelegationRecord[] = [];
@@ -3022,6 +3097,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 			openLanes: open.length,
 			freshOpenLanes: open.length,
 			presumedStaleLaneIds: [],
+			...(horizonConflictNote ? { horizonConflictNote } : {}),
 		};
 	}
 	// R5: the seam is mutable and this function has call sites with no try/catch
@@ -3148,6 +3224,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 			openLanes: openLaneIds.length,
 			freshOpenLanes: open.length,
 			presumedStaleLaneIds: [],
+			...(horizonConflictNote ? { horizonConflictNote } : {}),
 			...retentionFields,
 			disclosure: retentionDisclosure,
 		};
@@ -3155,12 +3232,30 @@ export async function settlePresumedStalePrWorkflowLanes(
 	// Issue #2506: abort each deadline lane's session ONCE, best-effort, and
 	// only while it is actually running (busy). A lane the probe could not see
 	// has nothing left to abort; its settlement keeps the real outcome.
+	//
+	// Review round 2: "once" is enforced durably per (session, lane label) — a
+	// lane whose `execution_deadline` event survived in the bounded read
+	// window is never re-aborted by a LATER settlement pass (the abort target
+	// is already dead; a second host call adds nothing). Within one tool call
+	// there can be up to three settlement passes (tool observation, gate
+	// completion, PR-review readiness); this marker is what keeps the total
+	// aborts per lane at one across them, not just per pass. Wall-clock note:
+	// the loop is sequential with a per-lane `withTimeout` bound, so the worst
+	// case adds N×probeTimeout to the tool path — bounded by the deadline-lane
+	// count, which the probe itself gates to genuinely-`busy` lanes.
 	if (deadlineActive) {
+		const priorDeadlineLabels = lastWatchdogEscalationsByLaneLabel(
+			directory,
+			sessionID,
+		).deadlineLabels;
+		let abortAttempted = false;
 		for (const record of deadlineLanes) {
 			const type = record.subagentSessionId
 				? sessionTypes.get(record.subagentSessionId)
 				: undefined;
 			if (type !== 'busy' || !record.subagentSessionId) continue;
+			if (priorDeadlineLabels.has(prWorkflowLaneLabel(record))) continue;
+			abortAttempted = true;
 			const aborted = await abortLaneSessionForWatchdog(record);
 			if (aborted) laneLivenessWatchdogSurface.hostAbortCalls += 1;
 		}
@@ -3177,11 +3272,19 @@ export async function settlePresumedStalePrWorkflowLanes(
 					effectiveHorizonMs: horizon.horizonMs,
 					horizonSource: horizon.source,
 					escalated: false,
+					// Truthful in both arms (issue #2506 review): a degraded probe
+					// cannot confirm the sessions were running, so no abort is
+					// attempted and the disclosure must not claim one. "No output
+					// observed" stays: this settlement collected no transcript
+					// activity evidence for these lanes.
 					disclosure:
 						`${deadlineLanes.length} lane(s) exceeded the ${horizon.horizonMs}ms execution ` +
-						`deadline (${horizon.source}); sessions aborted best-effort and settled through ` +
-						`the shared path with the real outcome: no output observed (no transcript ` +
-						`activity recorded for these lanes)`,
+						`deadline (${horizon.source}); ` +
+						(abortAttempted
+							? 'sessions aborted best-effort and settled through '
+							: 'no session abort was attempted (the liveness probe could not confirm these sessions were running); lanes settled ') +
+						`through the shared path with the real outcome: no output observed (no ` +
+						`transcript activity recorded for these lanes)`,
 				});
 			} catch {
 				// Best-effort audit; the settlement below is the durable fact.
@@ -3224,7 +3327,12 @@ export async function settlePresumedStalePrWorkflowLanes(
 	//
 	// Issue #2506: the sweep runs at the EFFECTIVE horizon (identical to the
 	// constant whenever the watchdog is off), and a watchdog deadline lane is
-	// deliberately NOT excluded — its settlement IS the decision.
+	// deliberately NOT excluded — its settlement IS the decision. Clock note:
+	// the classification above froze `now` once, while the sweep re-reads the
+	// clock under its own lock — a lane classified open can cross the horizon
+	// during the probe/abort awaits and be durably flipped here. That two-clock
+	// window is pre-existing substrate behavior; the watchdog's bounded awaits
+	// widen it by at most one probe/abort budget, never past it.
 	try {
 		await _test_exports.sweepStaleDelegationsAsync(
 			directory,
@@ -3281,6 +3389,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 		openLanes: openLaneIds.length,
 		freshOpenLanes: open.length,
 		presumedStaleLaneIds,
+		...(horizonConflictNote ? { horizonConflictNote } : {}),
 		...retentionFields,
 		disclosure,
 	};
@@ -3413,11 +3522,18 @@ async function finalizeOverriddenProbeRetainedLanes(
 	directory: string,
 	sessionID: string,
 	correlationIds: readonly string[],
+	horizonMs: number = PR_WORKFLOW_STALE_LANE_TIMEOUT_MS,
 ): Promise<OverriddenProbeRetainedLaneOutcome> {
 	try {
 		await _test_exports.sweepStaleDelegationsAsync(
 			directory,
-			PR_WORKFLOW_STALE_LANE_TIMEOUT_MS,
+			// Issue #2506 review round 2: the finalize sweep runs at the SAME
+			// ONE effective horizon the settlement used, so a probe-retained
+			// lane past a shorter configured watchdog deadline is finalized by
+			// the override instead of surviving between the two horizons and
+			// keeping the session un-restartable. With no watchdog config (or
+			// the default resolution) this IS PR_WORKFLOW_STALE_LANE_TIMEOUT_MS.
+			horizonMs,
 			{
 				statuses: PR_WORKFLOW_SWEEPABLE_LANE_STATUSES,
 				includeCorrelationIds: new Set(correlationIds),
@@ -3867,6 +3983,12 @@ export async function abortPrWorkflow(
 					directory,
 					state.sessionID,
 					overrideTargetedLaneIds,
+					// The override finalizes at the SAME effective horizon the
+					// settlement used (issue #2506 review round 2).
+					resolveEffectivePrLaneHorizonMs(
+						options.laneLiveness?.laneLivenessWatchdog,
+						options.laneLiveness?.backgroundPendingTimeoutMs,
+					).horizonMs,
 				)
 			: {
 					sessionOpenLaneIds: [],
@@ -10646,6 +10768,8 @@ export async function transitionPrReviewToFeedback(
 		prUrl?: string;
 		exactCommand?: string;
 		confirmedByUser?: boolean;
+		/** Issue #2506 review round 2: watchdog policy for the readiness settle. */
+		laneLiveness?: PrWorkflowLaneLivenessOptions;
 	},
 ): Promise<PrWorkflowGateState> {
 	const normalizedSessionID = normalizeSessionID(sessionID);
@@ -10699,7 +10823,14 @@ export async function transitionPrReviewToFeedback(
 			throw wrongModeError(preliminary, 'PR_REVIEW');
 		}
 		const ready = (
-			await assertPrReviewTerminalReady(directory, normalizedSessionID)
+			await assertPrReviewTerminalReady(
+				directory,
+				normalizedSessionID,
+				// Issue #2506 review round 2: the PR_REVIEW→PR_FEEDBACK
+				// continuation settles its lanes at the SAME effective horizon
+				// as every other settlement entry point.
+				request.laneLiveness,
+			)
 		).state;
 		if (
 			workflowIdentity(ready) !== workflowIdentity(preliminary) ||

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -3281,7 +3281,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 						`${deadlineLanes.length} lane(s) exceeded the ${horizon.horizonMs}ms execution ` +
 						`deadline (${horizon.source}); ` +
 						(abortAttempted
-							? 'sessions aborted best-effort and '
+							? 'sessions aborted best-effort and settled '
 							: 'no session abort was attempted (the liveness probe could not confirm these sessions were running); lanes settled ') +
 						`through the shared path with the real outcome: no output observed (no ` +
 						`transcript activity recorded for these lanes)`,

--- a/src/hooks/pr-workflow-gate.ts
+++ b/src/hooks/pr-workflow-gate.ts
@@ -88,6 +88,7 @@ import {
 	switchPrFeedbackTrackingCandidateAsync,
 } from '../background/workspace-snapshot.js';
 import { WRITE_TOOL_NAMES } from '../config/constants.js';
+import type { LaneLivenessWatchdogConfig } from '../config/schema.js';
 import {
 	DEFAULT_PR_REVIEW_RESILIENCE_CONFIG,
 	type PrReviewResilienceConfig,
@@ -201,6 +202,14 @@ import { getPrWorkflowToolCapability } from '../tools/tool-metadata.js';
 import { sameProjectRoot } from '../utils/canonical-root.js';
 import { log, warn } from '../utils/logger.js';
 import { withTimeout } from '../utils/timeout.js';
+import {
+	classifyLaneLivenessCondition,
+	defaultReadLaneActivity,
+	type EffectivePrLaneHorizon,
+	laneLivenessWatchdogFeatures,
+	MAX_LANE_LIVENESS_DISCLOSED_IDS,
+	resolveEffectivePrLaneHorizonMs,
+} from './lane-liveness-watchdog.js';
 import { normalizeToolName } from './normalize-tool-name.js';
 import { validateSwarmPath } from './utils.js';
 
@@ -2290,6 +2299,12 @@ interface PrWorkflowLaneLivenessSessionOps {
 		data?: Record<string, { type?: string }> | null;
 		error?: unknown;
 	}>;
+	/**
+	 * Issue #2506: the watchdog's best-effort, one-attempt lane abort. The
+	 * host session object exposes it; the seam type keeps it optional so the
+	 * probe-only hosts of the #2251 era remain valid.
+	 */
+	abort?: (args: unknown) => Promise<unknown>;
 }
 
 const defaultGetSessionOps = (): PrWorkflowLaneLivenessSessionOps | null =>
@@ -2676,22 +2691,329 @@ function isOpenPrWorkflowLane(
  * {@link probePrWorkflowLaneSessionStatusTypes} — so an unavailable, erroring
  * or empty probe leaves the age-only behaviour exactly as it was.
  */
+/**
+ * Issue #2506 (G2): optional lane-liveness watchdog options for the on-demand
+ * settlement entry points. The two-argument call shape every existing caller
+ * uses means "watchdog disabled" (the default-off config contract).
+ */
+export interface PrWorkflowLaneLivenessOptions {
+	laneLivenessWatchdog?: LaneLivenessWatchdogConfig;
+	backgroundPendingTimeoutMs?: number;
+}
+
+/**
+ * The #2506 watchdog budget counters (issue AC7). Mutated in place so the
+ * `_test_exports.laneLivenessWatchdog` surface reads live values; zeroed by
+ * `resetTrackedStateCache()`.
+ */
+const laneLivenessWatchdogCounters = {
+	hostStatusCalls: 0,
+	hostAbortCalls: 0,
+	evaluations: 0,
+};
+
+/** The #2506 watchdog seam surface exposed through `_test_exports`. */
+const laneLivenessWatchdogSurface = {
+	resolveEffectivePrLaneHorizonMs,
+	classifyLaneLivenessCondition,
+	evaluateLaneLivenessWatchdog: evaluateLaneLivenessWatchdogEscalation,
+	readLaneActivity: defaultReadLaneActivity,
+	...laneLivenessWatchdogCounters,
+};
+
+/**
+ * Best-effort, bounded, ONE-attempt abort of a lane's subagent session
+ * (#2506 execution_deadline). Never retried: the settlement below proceeds
+ * with the real outcome regardless of whether the abort was delivered.
+ */
+async function abortLaneSessionForWatchdog(
+	record: BackgroundDelegationRecord,
+): Promise<boolean> {
+	const session = _test_exports.getSessionOps();
+	const abortOp = session?.abort;
+	if (!session || typeof abortOp !== 'function' || !record.subagentSessionId) {
+		return false;
+	}
+	try {
+		await withTimeout(
+			(abortOp as NonNullable<PrWorkflowLaneLivenessSessionOps['abort']>).call(
+				session,
+				{ path: { id: record.subagentSessionId } },
+			),
+			_test_exports.laneLivenessProbeTimeoutMs,
+			new Error('lane-liveness watchdog abort exceeded its deadline'),
+		);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Last escalation timestamp (epoch ms) per lane label, derived from the
+ * durable event log — the registered, bounded, already-disclosed channel
+ * (`.swarm/events.jsonl`). Disk-derived on purpose: the dedup must survive
+ * `resetTrackedStateCache()` (frozen C4 contract) and must not fork a second
+ * durable state file. Reading is a single bounded scan; events older than
+ * the 7-day retention window fold into the manifest header, after which a
+ * stale escalation no longer suppresses a fresh one — the correct behavior.
+ *
+ * The same scan also indexes the ACTIVITY OBSERVATION events
+ * (`escalated: false` + `activityObserved: true`) written by
+ * `appendWatchdogActivityObservation`: the durable proof that a lane
+ * progressed since the last escalation, which is what re-arms a suppressed
+ * lane for its next stall. The `execution_deadline` disclosure event is also
+ * `escalated: false` but is NOT an activity observation (no activity was
+ * observed — the opposite), so the marker field, not the absence of
+ * `escalated`, decides membership.
+ */
+function lastWatchdogEscalationsByLaneLabel(directory: string): {
+	escalations: Map<string, number>;
+	activityObservations: Map<string, number>;
+} {
+	const escalations = new Map<string, number>();
+	const activityObservations = new Map<string, number>();
+	let text = '';
+	try {
+		text = readCoreEvents(directory).text;
+	} catch {
+		return { escalations, activityObservations };
+	}
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || !trimmed.includes('pr_workflow_lane_watchdog')) continue;
+		let event: Record<string, unknown>;
+		try {
+			event = JSON.parse(trimmed) as Record<string, unknown>;
+		} catch {
+			continue;
+		}
+		if (event.type !== 'pr_workflow_lane_watchdog') continue;
+		const isEscalation = event.escalated === true;
+		const isActivityObservation =
+			!isEscalation && event.activityObserved === true;
+		if (!isEscalation && !isActivityObservation) continue;
+		const timestamp = Date.parse(`${event.timestamp}`);
+		if (!Number.isFinite(timestamp)) continue;
+		const laneIds = event.laneIds;
+		if (!Array.isArray(laneIds)) continue;
+		const target = isEscalation ? escalations : activityObservations;
+		for (const label of laneIds) {
+			if (typeof label !== 'string') continue;
+			const prior = target.get(label);
+			if (prior === undefined || timestamp > prior)
+				target.set(label, timestamp);
+		}
+	}
+	return { escalations, activityObservations };
+}
+
+/**
+ * Record a progressing (non-stalled) observation durably as a
+ * `pr_workflow_lane_watchdog` event with `escalated: false`. This is what
+ * makes the re-escalation rule falsifiable from disk alone: after real
+ * activity, the next stall is a NEW stall. Re-nudge-suppression idea adopted
+ * from opencode-ensemble with credit (ADR 0002); reimplemented here.
+ */
+function appendWatchdogActivityObservation(
+	directory: string,
+	sessionID: string,
+	labels: string[],
+	horizon: EffectivePrLaneHorizon,
+): void {
+	try {
+		appendCoreEventSync(directory, {
+			type: 'pr_workflow_lane_watchdog',
+			timestamp: isoNow(),
+			sessionID,
+			condition: 'provider_retry_in_flight',
+			laneIds: labels.slice(0, MAX_LANE_LIVENESS_DISCLOSED_IDS),
+			effectiveHorizonMs: horizon.horizonMs,
+			horizonSource: horizon.source,
+			escalated: false,
+			// The durable activity marker: `lastWatchdogEscalationsByLaneLabel`
+			// indexes events by this field to re-arm a suppressed lane. Without
+			// it, only the in-memory seam's `lastActivityAtMs` could prove
+			// progression, and a stall evaluation whose seam reports no
+			// timestamp would dedupe forever on the first escalation.
+			activityObserved: true,
+			disclosure: `${labels.length} lane(s) progressed (activity observed since the last escalation); stall escalation baseline reset`,
+		});
+	} catch {
+		// Best-effort: a failed observation record must never block settlement.
+	}
+}
+
+/**
+ * The #2506 stall-escalation evaluation for the lanes a settlement still
+ * considers open or probe-retained: escalate each lane whose session is
+ * busy/retry and whose observed activity in the last `stall_threshold_ms`
+ * missed BOTH the step and the estimated-token thresholds, deduped per lane
+ * against the last escalation event unless activity was observed since.
+ * Advisory by design: an escalated lane is never settled or aborted here —
+ * the operator response (inspect, or the human-only force abort) owns that.
+ */
+async function evaluateLaneLivenessWatchdogEscalation(args: {
+	directory: string;
+	sessionID: string;
+	lanes: BackgroundDelegationRecord[];
+	sessionTypes: Map<string, string>;
+	watchdog: LaneLivenessWatchdogConfig;
+	horizon: EffectivePrLaneHorizon;
+}): Promise<void> {
+	const { directory, sessionID, lanes, sessionTypes, watchdog, horizon } = args;
+	const candidates = lanes.filter((record) => {
+		if (!record.subagentSessionId) return false;
+		const type = sessionTypes.get(record.subagentSessionId);
+		return type === 'busy' || type === 'retry';
+	});
+	if (candidates.length === 0) return;
+	const lastEscalations = lastWatchdogEscalationsByLaneLabel(directory);
+	const escalated: BackgroundDelegationRecord[] = [];
+	const progressed: BackgroundDelegationRecord[] = [];
+	for (const record of candidates) {
+		const activity = await laneLivenessWatchdogSurface.readLaneActivity(
+			directory,
+			record.subagentSessionId as string,
+		);
+		const steps = activity?.stepsObserved ?? 0;
+		const tokens = activity?.estimatedTokens ?? 0;
+		const progressing =
+			steps >= watchdog.stall_min_steps ||
+			tokens >= watchdog.stall_token_threshold;
+		if (progressing) {
+			progressed.push(record);
+			continue;
+		}
+		const label = prWorkflowLaneLabel(record);
+		const lastEscalation = lastEscalations.escalations.get(label);
+		if (lastEscalation !== undefined) {
+			// "Activity since the last escalation" is provable from either of
+			// two independent sources: the live seam's `lastActivityAtMs`, or
+			// the durable activity-observation event the progression path
+			// wrote. The durable event matters because a stalled re-evaluation
+			// legitimately reports NO `lastActivityAtMs` (nothing is happening
+			// now) — the observation is the surviving record that activity DID
+			// happen in between. The comparison is `>=` so a same-timestamp
+			// observation counts as "since" (frozen-clock tests, or activity
+			// within the same millisecond).
+			const lastActivity = activity?.lastActivityAtMs;
+			const activitySince =
+				(lastActivity !== undefined && lastActivity >= lastEscalation) ||
+				(lastEscalations.activityObservations.get(label) ?? -Infinity) >=
+					lastEscalation;
+			if (!activitySince) continue;
+		}
+		escalated.push(record);
+	}
+	if (progressed.length > 0) {
+		appendWatchdogActivityObservation(
+			directory,
+			sessionID,
+			progressed.map(prWorkflowLaneLabel),
+			horizon,
+		);
+	}
+	if (escalated.length === 0) return;
+	const first = escalated[0];
+	const condition = classifyLaneLivenessCondition({
+		sessionStatusType: first.subagentSessionId
+			? sessionTypes.get(first.subagentSessionId)
+			: undefined,
+		recordStatus: first.status,
+		waitBudgetExpired: false,
+		exceededEffectiveHorizon: Date.now() - first.updatedAt > horizon.horizonMs,
+	});
+	const laneLabels = escalated.map(prWorkflowLaneLabel);
+	const disclosure =
+		`${laneLabels.length} lane(s) stalled (fewer than ${watchdog.stall_min_steps} steps ` +
+		`and fewer than ~${watchdog.stall_token_threshold} estimated tokens in the last ` +
+		`${watchdog.stall_threshold_ms}ms): inspect the lane transcript or abort via ` +
+		`/swarm abort-pr-workflow (force): ${laneLabels
+			.slice(0, MAX_LANE_LIVENESS_DISCLOSED_IDS)
+			.join(', ')}`;
+	try {
+		appendCoreEventSync(directory, {
+			type: 'pr_workflow_lane_watchdog',
+			timestamp: isoNow(),
+			sessionID,
+			condition,
+			laneIds: laneLabels.slice(0, MAX_LANE_LIVENESS_DISCLOSED_IDS),
+			effectiveHorizonMs: horizon.horizonMs,
+			horizonSource: horizon.source,
+			escalated: true,
+			stall: {
+				stepsObserved: 0,
+				estimatedTokens: 0,
+				stallThresholdMs: watchdog.stall_threshold_ms,
+				stallMinSteps: watchdog.stall_min_steps,
+				stallTokenThreshold: watchdog.stall_token_threshold,
+			},
+			disclosure,
+		});
+	} catch {
+		// The escalation is advisory; settlement must not depend on the audit.
+	}
+}
+
 export async function settlePresumedStalePrWorkflowLanes(
 	directory: string,
 	sessionID: string,
+	options?: PrWorkflowLaneLivenessOptions,
 ): Promise<PrWorkflowStaleLaneSettlement> {
+	// Issue #2506 (G2): resolve the ONE effective horizon up front. With the
+	// watchdog disabled (the default, and the shape of every pre-#2506
+	// two-argument call) this is exactly `PR_WORKFLOW_STALE_LANE_TIMEOUT_MS`
+	// and every behavior below is byte-identical to the substrate's.
+	const watchdog = options?.laneLivenessWatchdog;
+	const { deadlineActive, stallActive } =
+		laneLivenessWatchdogFeatures(watchdog);
+	const watchdogWork = deadlineActive || stallActive;
+	const horizon = resolveEffectivePrLaneHorizonMs(
+		watchdog,
+		options?.backgroundPendingTimeoutMs,
+	);
 	const now = Date.now();
 	const open: BackgroundDelegationRecord[] = [];
 	const presumedStale: BackgroundDelegationRecord[] = [];
 	for (const record of readDelegations(directory)) {
 		if (!isOpenPrWorkflowLane(record, sessionID)) continue;
-		if (now - record.updatedAt > PR_WORKFLOW_STALE_LANE_TIMEOUT_MS) {
+		if (now - record.updatedAt > horizon.horizonMs) {
 			presumedStale.push(record);
 		} else {
 			open.push(record);
 		}
 	}
+	if (watchdogWork && (open.length > 0 || presumedStale.length > 0)) {
+		laneLivenessWatchdogSurface.evaluations += 1;
+	}
 	if (presumedStale.length === 0) {
+		// Stall-only watchdog pass: one shared status call over the open lanes
+		// (the same directory-wide query the probe uses — no per-lane fan-out).
+		if (watchdogWork && stallActive && open.length > 0) {
+			let statuses = new Map<string, string>();
+			try {
+				const probe = await _test_exports.probeLaneSessionStatusTypesAsync(
+					directory,
+					open,
+				);
+				statuses = probe.statuses;
+				if (!probe.degradedReason)
+					laneLivenessWatchdogSurface.hostStatusCalls += 1;
+			} catch {
+				// Fail-open: an unprobeable host must not wedge the advisory path.
+			}
+			if (statuses.size > 0) {
+				await evaluateLaneLivenessWatchdogEscalation({
+					directory,
+					sessionID,
+					lanes: open,
+					sessionTypes: statuses,
+					watchdog: watchdog as LaneLivenessWatchdogConfig,
+					horizon,
+				});
+			}
+		}
 		// Nothing is below the horizon to re-verify, so the probe is not consulted
 		// at all: no host round-trip on the overwhelmingly common path.
 		const freshOnlyLaneIds = open.map(prWorkflowLaneLabel);
@@ -2705,23 +3027,76 @@ export async function settlePresumedStalePrWorkflowLanes(
 	// R5: the seam is mutable and this function has call sites with no try/catch
 	// of their own, so a throwing probe must degrade here rather than convert a
 	// settleable workflow into an unhandled rejection.
+	//
+	// Issue #2506: when the watchdog is active, ONE types-carrying probe serves
+	// both the substrate's alive/retention decision and the watchdog's typed
+	// conditions (`retry` = provider latency; `busy` past the effective horizon
+	// = execution deadline). When inactive, the substrate's alive-set probe is
+	// used unchanged.
 	let probe: {
 		alive: Set<string>;
 		degradedReason?: PrWorkflowLaneProbeDegradedReason;
 	};
-	try {
-		probe = await _test_exports.probeLaneLivenessAsync(
-			directory,
-			presumedStale,
-		);
-	} catch {
-		probe = { alive: new Set<string>(), degradedReason: 'probe-error' };
+	let sessionTypes = new Map<string, string>();
+	if (watchdogWork) {
+		try {
+			const typesProbe = await _test_exports.probeLaneSessionStatusTypesAsync(
+				directory,
+				stallActive ? [...presumedStale, ...open] : presumedStale,
+			);
+			sessionTypes = typesProbe.statuses;
+			if (!typesProbe.degradedReason) {
+				laneLivenessWatchdogSurface.hostStatusCalls += 1;
+			}
+			const alive = new Set<string>();
+			for (const [sessionId, type] of typesProbe.statuses) {
+				if (isLiveSessionStatusType(type)) alive.add(sessionId);
+			}
+			probe = typesProbe.degradedReason
+				? {
+						alive: new Set<string>(),
+						degradedReason: typesProbe.degradedReason,
+					}
+				: { alive };
+		} catch {
+			probe = { alive: new Set<string>(), degradedReason: 'probe-error' };
+		}
+	} else {
+		try {
+			probe = await _test_exports.probeLaneLivenessAsync(
+				directory,
+				presumedStale,
+			);
+		} catch {
+			probe = { alive: new Set<string>(), degradedReason: 'probe-error' };
+		}
 	}
 	const probeRetained: BackgroundDelegationRecord[] = [];
 	const settled: BackgroundDelegationRecord[] = [];
+	// Issue #2506: with the execution deadline active, a `busy` lane past the
+	// EFFECTIVE horizon is an execution_deadline — the watchdog overrides
+	// probe retention for it (that retention is exactly what kept a
+	// genuinely-over-deadline lane alive forever). `retry` stays retained:
+	// provider latency owns its own bounded retry, and a deadline must not
+	// invent child failure for it. With the deadline inactive, retention is
+	// the substrate's: every live (busy/retry) lane is spared.
+	const deadlineLanes: BackgroundDelegationRecord[] = [];
 	for (const record of presumedStale) {
-		if (record.subagentSessionId && probe.alive.has(record.subagentSessionId)) {
+		const type = record.subagentSessionId
+			? sessionTypes.get(record.subagentSessionId)
+			: undefined;
+		if (deadlineActive && type !== 'retry') {
+			deadlineLanes.push(record);
+			settled.push(record);
+		} else if (
+			record.subagentSessionId &&
+			probe.alive.has(record.subagentSessionId)
+		) {
 			probeRetained.push(record);
+		} else if (deadlineActive) {
+			// Probe degraded (or no session id): the deadline governs.
+			deadlineLanes.push(record);
+			settled.push(record);
 		} else {
 			settled.push(record);
 		}
@@ -2755,6 +3130,19 @@ export async function settlePresumedStalePrWorkflowLanes(
 		// Nothing was settled, so nothing may be swept and no
 		// `pr_workflow_lanes_presumed_stale` record may be written — an audit trail
 		// asserting a settlement that did not happen is worse than none.
+		//
+		// Issue #2506: retention is not a dead end — stall escalation still
+		// surfaces the low-output lane for operator action.
+		if (watchdogWork && stallActive && probeRetained.length > 0) {
+			await evaluateLaneLivenessWatchdogEscalation({
+				directory,
+				sessionID,
+				lanes: probeRetained,
+				sessionTypes,
+				watchdog: watchdog as LaneLivenessWatchdogConfig,
+				horizon,
+			});
+		}
 		return {
 			openLaneIds,
 			openLanes: openLaneIds.length,
@@ -2764,6 +3152,42 @@ export async function settlePresumedStalePrWorkflowLanes(
 			disclosure: retentionDisclosure,
 		};
 	}
+	// Issue #2506: abort each deadline lane's session ONCE, best-effort, and
+	// only while it is actually running (busy). A lane the probe could not see
+	// has nothing left to abort; its settlement keeps the real outcome.
+	if (deadlineActive) {
+		for (const record of deadlineLanes) {
+			const type = record.subagentSessionId
+				? sessionTypes.get(record.subagentSessionId)
+				: undefined;
+			if (type !== 'busy' || !record.subagentSessionId) continue;
+			const aborted = await abortLaneSessionForWatchdog(record);
+			if (aborted) laneLivenessWatchdogSurface.hostAbortCalls += 1;
+		}
+		if (deadlineLanes.length > 0) {
+			try {
+				appendCoreEventSync(directory, {
+					type: 'pr_workflow_lane_watchdog',
+					timestamp: isoNow(),
+					sessionID,
+					condition: 'execution_deadline',
+					laneIds: deadlineLanes
+						.map(prWorkflowLaneLabel)
+						.slice(0, MAX_LANE_LIVENESS_DISCLOSED_IDS),
+					effectiveHorizonMs: horizon.horizonMs,
+					horizonSource: horizon.source,
+					escalated: false,
+					disclosure:
+						`${deadlineLanes.length} lane(s) exceeded the ${horizon.horizonMs}ms execution ` +
+						`deadline (${horizon.source}); sessions aborted best-effort and settled through ` +
+						`the shared path with the real outcome: no output observed (no transcript ` +
+						`activity recorded for these lanes)`,
+				});
+			} catch {
+				// Best-effort audit; the settlement below is the durable fact.
+			}
+		}
+	}
 	const presumedStaleLaneIds = settled.map(prWorkflowLaneLabel);
 	// The leading clause is a STABLE PREFIX: existing operator tooling and tests
 	// pin `N lane(s) stale >30min` / `treated as settled: …`. The probe verdict is
@@ -2771,7 +3195,7 @@ export async function settlePresumedStalePrWorkflowLanes(
 	// not run / some lanes retained) are distinguishable without breaking it.
 	const disclosure =
 		`${presumedStaleLaneIds.length} lane(s) stale >` +
-		`${Math.round(PR_WORKFLOW_STALE_LANE_TIMEOUT_MS / 60_000)}min, ` +
+		`${Math.round(horizon.horizonMs / 60_000)}min, ` +
 		`treated as settled: ${presumedStaleLaneIds
 			.slice(0, MAX_DISCLOSED_LANE_IDS)
 			.join(', ')}` +
@@ -2797,10 +3221,14 @@ export async function settlePresumedStalePrWorkflowLanes(
 	// `isOpenPrWorkflowLane` counted as open" restriction to "cannot exceed what
 	// this settlement DECIDED". The seam + try/catch keep a sweep failure from
 	// affecting the decision already made above.
+	//
+	// Issue #2506: the sweep runs at the EFFECTIVE horizon (identical to the
+	// constant whenever the watchdog is off), and a watchdog deadline lane is
+	// deliberately NOT excluded — its settlement IS the decision.
 	try {
 		await _test_exports.sweepStaleDelegationsAsync(
 			directory,
-			PR_WORKFLOW_STALE_LANE_TIMEOUT_MS,
+			horizon.horizonMs,
 			{
 				statuses: PR_WORKFLOW_SWEEPABLE_LANE_STATUSES,
 				excludeCorrelationIds: new Set(
@@ -2817,13 +3245,36 @@ export async function settlePresumedStalePrWorkflowLanes(
 			timestamp: isoNow(),
 			sessionID,
 			presumedStaleLanes: presumedStaleLaneIds.slice(0, MAX_DISCLOSED_LANE_IDS),
-			staleTimeoutMs: PR_WORKFLOW_STALE_LANE_TIMEOUT_MS,
+			staleTimeoutMs: horizon.horizonMs,
 			probeStatus: probe.degradedReason ?? 'ok',
 			probedAliveLanes: probedAliveLaneIds.slice(0, MAX_DISCLOSED_LANE_IDS),
 			disclosure,
 		});
 	} catch {
 		// The audit trail is best-effort; settlement must not depend on it.
+	}
+	// Issue #2506: stall escalation runs after a settlement with no deadline
+	// event this evaluation — a deadline settlement already carries the
+	// operator's attention, and the still-open/retained lanes get theirs here.
+	if (
+		watchdogWork &&
+		stallActive &&
+		!(deadlineActive && deadlineLanes.length > 0)
+	) {
+		const stallCandidates = [...open, ...probeRetained];
+		if (stallCandidates.length > 0 && sessionTypes.size > 0) {
+			await evaluateLaneLivenessWatchdogEscalation({
+				directory,
+				sessionID,
+				lanes: stallCandidates,
+				sessionTypes,
+				watchdog: watchdog as LaneLivenessWatchdogConfig,
+				horizon,
+			});
+		} else if (stallCandidates.length > 0) {
+			// Probe degraded: one shared retry is not in the budget; treat unknown
+			// sessions as unescalatable (fail-open to silence, never to noise).
+		}
 	}
 	return {
 		openLaneIds,
@@ -3052,6 +3503,8 @@ export async function abortPrWorkflow(
 		 * `recovery`/`force` aborts remain refused while armed.
 		 */
 		cancelPublication?: boolean;
+		/** Issue #2506: lane-liveness watchdog config for this settlement. */
+		laneLiveness?: PrWorkflowLaneLivenessOptions;
 	} = { kind: 'recovery', reason: '' },
 ): Promise<{
 	mode: PrWorkflowMode;
@@ -3177,6 +3630,7 @@ export async function abortPrWorkflow(
 	const laneSettlement = await settlePresumedStalePrWorkflowLanes(
 		directory,
 		state.sessionID,
+		options.laneLiveness,
 	);
 	// S3 (issue #2251 R2): the liveness probe can now retain a lane past the age
 	// horizon indefinitely, so age alone no longer guarantees an eventual exit. A
@@ -3543,6 +3997,8 @@ export async function recoverArmedPrWorkflow(
 		generation: number;
 		workflowInstanceId?: string;
 		reason: string;
+		/** Issue #2506: lane-liveness watchdog config for this settlement. */
+		laneLiveness?: PrWorkflowLaneLivenessOptions;
 	},
 ): Promise<{
 	mode: PrWorkflowMode;
@@ -3647,6 +4103,7 @@ export async function recoverArmedPrWorkflow(
 			const laneSettlement = await settlePresumedStalePrWorkflowLanes(
 				directory,
 				state.sessionID,
+				request.laneLiveness,
 			);
 			if (laneSettlement.openLanes > 0) {
 				const laneIds = laneSettlement.openLaneIds
@@ -10095,6 +10552,7 @@ function assertSamePrFeedbackHandoff(
 async function assertPrReviewTerminalReady(
 	directory: string,
 	sessionID: string,
+	laneLiveness?: PrWorkflowLaneLivenessOptions,
 ): Promise<{
 	state: PrWorkflowGateState;
 	settlement: PrReviewTerminalCoverageSettlement & {
@@ -10107,6 +10565,7 @@ async function assertPrReviewTerminalReady(
 	const laneSettlement = await settlePresumedStalePrWorkflowLanes(
 		directory,
 		state.sessionID,
+		laneLiveness,
 	);
 	if (laneSettlement.openLanes > 0) {
 		throw new Error(
@@ -11146,7 +11605,11 @@ export async function completePrWorkflow(
 	sessionID: string,
 	expectedMode: PrWorkflowMode,
 	prHeadSha: string,
-	options?: { reportVerdict?: PrReviewReportVerdict },
+	options?: {
+		reportVerdict?: PrReviewReportVerdict;
+		/** Issue #2506: lane-liveness watchdog config for this settlement. */
+		laneLiveness?: PrWorkflowLaneLivenessOptions;
+	},
 ): Promise<PrWorkflowCompletionStatus> {
 	const state = await requireBoundState(directory, sessionID, expectedMode);
 	const normalizedHead = normalizePrHeadSha(prHeadSha);
@@ -11159,6 +11622,7 @@ export async function completePrWorkflow(
 	const laneSettlement = await settlePresumedStalePrWorkflowLanes(
 		directory,
 		state.sessionID,
+		options?.laneLiveness,
 	);
 	if (laneSettlement.openLanes > 0) {
 		throw new Error(
@@ -11255,7 +11719,11 @@ export async function completePrWorkflow(
 					`BLOCKED: PR_REVIEW ${settlement.kind} completion allows report_verdict ${preAllowed.join(' | ')}; got "${verdict}". Partial coverage never approves and never claims a full review.`,
 				);
 			}
-			const ready = await assertPrReviewTerminalReady(directory, sessionID);
+			const ready = await assertPrReviewTerminalReady(
+				directory,
+				sessionID,
+				options?.laneLiveness,
+			);
 			const readyState = ready.state;
 			if (
 				workflowIdentity(readyState) !== workflowIdentity(state) ||
@@ -11663,6 +12131,15 @@ export const _test_exports = {
 		// bun's shared test process, not a restore.
 		_test_exports.sweepStaleDelegationsAsync = sweepStaleDelegations;
 		_test_exports.probeLaneLivenessAsync = probeAlivePrWorkflowLaneSessions;
+		_test_exports.probeLaneSessionStatusTypesAsync =
+			probePrWorkflowLaneSessionStatusTypes;
+		// Issue #2506: the watchdog counters zero and the activity seam
+		// restores to its default, so suite ordering cannot leak budget
+		// accounting or transcript fixtures between test files.
+		laneLivenessWatchdogSurface.hostStatusCalls = 0;
+		laneLivenessWatchdogSurface.hostAbortCalls = 0;
+		laneLivenessWatchdogSurface.evaluations = 0;
+		laneLivenessWatchdogSurface.readLaneActivity = defaultReadLaneActivity;
 		_test_exports.getSessionOps = defaultGetSessionOps;
 		_test_exports.laneLivenessProbeTimeoutMs =
 			PR_WORKFLOW_LANE_LIVENESS_PROBE_TIMEOUT_MS;
@@ -11713,6 +12190,20 @@ export const _test_exports = {
 	sweepStaleDelegationsAsync: sweepStaleDelegations,
 	/** The fail-open liveness probe (issue #2251). */
 	probeLaneLivenessAsync: probeAlivePrWorkflowLaneSessions,
+	/**
+	 * The types-carrying variant of the liveness probe (issue #2506): one
+	 * shared status call returning per-session status TYPES, so the watchdog
+	 * can distinguish `retry` (provider latency) from `busy` (past-deadline
+	 * execution) without a second host round-trip. Seam for the same
+	 * order-independence reason as `probeLaneLivenessAsync`.
+	 */
+	probeLaneSessionStatusTypesAsync: probePrWorkflowLaneSessionStatusTypes,
+	/**
+	 * The #2506 lane-liveness watchdog surface: the pure policy functions,
+	 * the overridable transcript-activity reader, and the live budget
+	 * counters (zeroed by `resetTrackedStateCache`).
+	 */
+	laneLivenessWatchdog: laneLivenessWatchdogSurface,
 	/**
 	 * Session handle for the liveness probe.
 	 *

--- a/src/services/config-doctor.ts
+++ b/src/services/config-doctor.ts
@@ -1839,6 +1839,11 @@ function validateConfigKey(path: string, value: unknown): ConfigFinding[] {
 			break;
 		}
 
+		case 'lane_liveness_watchdog': {
+			emitObjectTypeMismatch('lane_liveness_watchdog', value, findings);
+			break;
+		}
+
 		case 'pr_review_legacy_transcript_compatibility': {
 			if (value !== undefined && typeof value !== 'boolean') {
 				findings.push({

--- a/src/tools/abort-pr-workflow.ts
+++ b/src/tools/abort-pr-workflow.ts
@@ -122,7 +122,7 @@ export async function executeAbortPrWorkflow(
 							}
 						: {}),
 					reason: parsed.data.reason,
-					laneLiveness,
+					...(laneLiveness ? { laneLiveness } : {}),
 				},
 			);
 			return JSON.stringify({

--- a/src/tools/abort-pr-workflow.ts
+++ b/src/tools/abort-pr-workflow.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
+import { loadPluginConfig } from '../config/loader.js';
 import {
 	abortPrWorkflow,
+	type PrWorkflowLaneLivenessOptions,
 	type PrWorkflowMode,
 	recoverArmedPrWorkflow,
 } from '../hooks/pr-workflow-gate.js';
@@ -78,6 +80,26 @@ export async function executeAbortPrWorkflow(
 			message: 'PR workflow abort requires an active sessionID',
 		});
 	}
+	// Issue #2506: resolve the lane-liveness watchdog policy from the
+	// directory-scoped plugin config (dispatch-lanes `loadPluginConfig`
+	// precedent) and thread it into both abort arms.
+	let laneLiveness: PrWorkflowLaneLivenessOptions | undefined;
+	try {
+		const config = loadPluginConfig(directory);
+		const hooks = (
+			config as { hooks?: { background_pending_timeout_minutes?: number } }
+		).hooks;
+		laneLiveness = {
+			laneLivenessWatchdog: config.lane_liveness_watchdog,
+			backgroundPendingTimeoutMs:
+				hooks?.background_pending_timeout_minutes !== undefined
+					? hooks.background_pending_timeout_minutes * 60_000
+					: undefined,
+		};
+	} catch {
+		// Config read failure must not block the abort escape hatch; the
+		// disabled default is always safe.
+	}
 	if (parsed.data.kind === 'armed_recovery') {
 		try {
 			const summary = await recoverArmedPrWorkflow(
@@ -100,6 +122,7 @@ export async function executeAbortPrWorkflow(
 							}
 						: {}),
 					reason: parsed.data.reason,
+					laneLiveness,
 				},
 			);
 			return JSON.stringify({
@@ -140,6 +163,7 @@ export async function executeAbortPrWorkflow(
 			...(parsed.data.mode
 				? { expectedMode: parsed.data.mode as PrWorkflowMode }
 				: {}),
+			...(laneLiveness ? { laneLiveness } : {}),
 		});
 		let checkoutRestoreRequired = true;
 		let checkoutRestoreReceipts: Awaited<

--- a/src/tools/complete-pr-workflow.ts
+++ b/src/tools/complete-pr-workflow.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
+import { loadPluginConfig } from '../config/loader.js';
 import {
 	completePrWorkflow,
 	type PrFeedbackInventoryAmendmentRecord,
+	type PrWorkflowLaneLivenessOptions,
 	type PrWorkflowMode,
 	readPrReviewTerminalCoverageForReport,
 	readPrWorkflowGateState,
@@ -66,14 +68,37 @@ export async function executeCompletePrWorkflow(
 	// sweep is idempotent, so calling it here costs nothing on the second pass.
 	let staleDisclosure: {
 		presumed_stale_lanes?: string[];
-		presumed_stale_disclosure?: string;
+		presumed_stale_disclosure?: string | undefined;
 		probe_retained_lanes?: string[];
 		probe_status?: string;
 	} = {};
 	try {
+		// Issue #2506: resolve the lane-liveness watchdog policy from the same
+		// directory-scoped plugin config the resilience policy uses
+		// (`loadPluginConfig`, the dispatch-lanes precedent) and thread it plus
+		// the background pending timeout so the settlement applies ONE
+		// effective horizon with conflict disclosure.
+		let laneLiveness: PrWorkflowLaneLivenessOptions | undefined;
+		try {
+			const config = loadPluginConfig(directory);
+			const hooks = (
+				config as { hooks?: { background_pending_timeout_minutes?: number } }
+			).hooks;
+			laneLiveness = {
+				laneLivenessWatchdog: config.lane_liveness_watchdog,
+				backgroundPendingTimeoutMs:
+					hooks?.background_pending_timeout_minutes !== undefined
+						? hooks.background_pending_timeout_minutes * 60_000
+						: undefined,
+			};
+		} catch {
+			// Config read failure must not block completion; the disabled
+			// default is always safe.
+		}
 		const settlement = await _internals.settlePresumedStalePrWorkflowLanes(
 			directory,
 			context.sessionID,
+			laneLiveness,
 		);
 		if (settlement.presumedStaleLaneIds.length > 0) {
 			staleDisclosure = {

--- a/src/tools/complete-pr-workflow.ts
+++ b/src/tools/complete-pr-workflow.ts
@@ -71,6 +71,7 @@ export async function executeCompletePrWorkflow(
 		presumed_stale_disclosure?: string | undefined;
 		probe_retained_lanes?: string[];
 		probe_status?: string;
+		horizon_conflict?: string;
 	} = {};
 	// Issue #2506: resolve the lane-liveness watchdog policy from the same
 	// directory-scoped plugin config the resilience policy uses
@@ -117,6 +118,13 @@ export async function executeCompletePrWorkflow(
 		}
 		if (settlement.probeDegradedReason) {
 			staleDisclosure.probe_status = settlement.probeDegradedReason;
+		}
+		// Issue #2506 review round 2: surface the horizon disagreement (AC2
+		// conflictDisclosed) on the response whenever it exists — not gated on
+		// anything having settled, because a silently absorbed config conflict
+		// is exactly what the operator needs to see even on success paths.
+		if (settlement.horizonConflictNote) {
+			staleDisclosure.horizon_conflict = settlement.horizonConflictNote;
 		}
 	} catch {
 		// Observation only. A settlement-read failure must never convert a

--- a/src/tools/complete-pr-workflow.ts
+++ b/src/tools/complete-pr-workflow.ts
@@ -72,29 +72,30 @@ export async function executeCompletePrWorkflow(
 		probe_retained_lanes?: string[];
 		probe_status?: string;
 	} = {};
+	// Issue #2506: resolve the lane-liveness watchdog policy from the same
+	// directory-scoped plugin config the resilience policy uses
+	// (`loadPluginConfig`, the dispatch-lanes precedent) and thread it plus
+	// the background pending timeout so the settlement applies ONE
+	// effective horizon with conflict disclosure. Declared outside the
+	// observation try so the gate call below threads the SAME policy.
+	let laneLiveness: PrWorkflowLaneLivenessOptions | undefined;
 	try {
-		// Issue #2506: resolve the lane-liveness watchdog policy from the same
-		// directory-scoped plugin config the resilience policy uses
-		// (`loadPluginConfig`, the dispatch-lanes precedent) and thread it plus
-		// the background pending timeout so the settlement applies ONE
-		// effective horizon with conflict disclosure.
-		let laneLiveness: PrWorkflowLaneLivenessOptions | undefined;
-		try {
-			const config = loadPluginConfig(directory);
-			const hooks = (
-				config as { hooks?: { background_pending_timeout_minutes?: number } }
-			).hooks;
-			laneLiveness = {
-				laneLivenessWatchdog: config.lane_liveness_watchdog,
-				backgroundPendingTimeoutMs:
-					hooks?.background_pending_timeout_minutes !== undefined
-						? hooks.background_pending_timeout_minutes * 60_000
-						: undefined,
-			};
-		} catch {
-			// Config read failure must not block completion; the disabled
-			// default is always safe.
-		}
+		const config = loadPluginConfig(directory);
+		const hooks = (
+			config as { hooks?: { background_pending_timeout_minutes?: number } }
+		).hooks;
+		laneLiveness = {
+			laneLivenessWatchdog: config.lane_liveness_watchdog,
+			backgroundPendingTimeoutMs:
+				hooks?.background_pending_timeout_minutes !== undefined
+					? hooks.background_pending_timeout_minutes * 60_000
+					: undefined,
+		};
+	} catch {
+		// Config read failure must not block completion; the disabled
+		// default is always safe.
+	}
+	try {
 		const settlement = await _internals.settlePresumedStalePrWorkflowLanes(
 			directory,
 			context.sessionID,
@@ -170,9 +171,17 @@ export async function executeCompletePrWorkflow(
 			context.sessionID,
 			parsed.data.mode as PrWorkflowMode,
 			parsed.data.pr_head_sha,
+			// Issue #2506: thread the resolved watchdog policy into the gate's
+			// internal settlement too — the observation settlement above and
+			// the gate re-validation must run the SAME effective horizon.
 			parsed.data.mode === 'PR_REVIEW'
-				? { reportVerdict: parsed.data.report_verdict }
-				: undefined,
+				? {
+						reportVerdict: parsed.data.report_verdict,
+						...(laneLiveness ? { laneLiveness } : {}),
+					}
+				: laneLiveness
+					? { laneLiveness }
+					: undefined,
 		);
 		let checkoutRestoreRequired = false;
 		let checkoutRestoreReceipts: Awaited<

--- a/tests/unit/hooks/lane-liveness-budget.test.ts
+++ b/tests/unit/hooks/lane-liveness-budget.test.ts
@@ -260,11 +260,13 @@ describe('C7 — fixture D: disabled watchdog launches nothing of its own', () =
 	});
 });
 
-describe('C7 — whole-file wall-clock budget (iterations, frozen clock)', () => {
-	test('total host round-trips across every fixture stay under the frozen iteration budget', async () => {
-		// A final composite fixture: 2 lanes, one repeat attempt — the
-		// maximum additional load this file can generate after the fixtures
-		// above is bounded by the same constants.
+describe('C7 — wall-clock budget, final composite fixture (iterations, frozen clock)', () => {
+	test('the composite fixture stays under the frozen iteration budget', async () => {
+		// This fixture's OWN host round-trips are what the budget binds:
+		// beforeEach re-zeros the shared tally per test (see above), so the
+		// assertion covers this final composite fixture — 2 lanes, one
+		// repeat attempt, the heaviest single fixture in the file — not a
+		// cumulative file total.
 		const ids = ['c-wall-0', 'c-wall-1'];
 		for (let i = 0; i < ids.length; i += 1) {
 			await recordOpenPrWorkflowLane(
@@ -284,7 +286,7 @@ describe('C7 — whole-file wall-clock budget (iterations, frozen clock)', () =>
 			laneLivenessWatchdog: enabledWatchdog,
 		});
 
-		// Everything this file launched, against the frozen ceiling. With
+		// Everything this fixture launched, against the frozen ceiling. With
 		// the clock frozen the ONLY consumable resource is host round-trips,
 		// so this is the wall-clock budget expressed as iterations.
 		expect(hostLaunches.status + hostLaunches.abort).toBeLessThanOrEqual(

--- a/tests/unit/hooks/lane-liveness-budget.test.ts
+++ b/tests/unit/hooks/lane-liveness-budget.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Issue #2506 acceptance check C7 (AC7, NEW-SURFACE) — the per-fixture frozen
+ * integer budget manifest for watchdog host interactions.
+ *
+ * The budgets below are frozen IN THIS FILE, derived from the #2506 retry
+ * ownership contract:
+ * - ONE status probe per watchdog evaluation (the probe's shared
+ *   session-status call covers every open lane — no per-lane fan-out).
+ * - ONE abort per execution_deadline lane (best-effort, never retried).
+ * - BOUNDED evaluations: at most one watchdog evaluation per settlement
+ *   invocation, and a lane already terminal is never re-evaluated or
+ *   re-aborted.
+ * - Wall clock is expressed in ITERATIONS (host round-trips), not
+ *   milliseconds, per the repo's frozen-clock convention: every fixture runs
+ *   under `freezeClock()`, so the only "time" the watchdog can consume is
+ *   host round-trips, which are counted and bounded here.
+ *
+ * Two independent measurements are asserted against every budget:
+ * (a) the fake host's own invocation counters (ground truth), and
+ * (b) the watchdog's `_test_exports.laneLivenessWatchdog` budget counters
+ *     (`hostStatusCalls`, `hostAbortCalls`, `evaluations`).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import { LANE_LIVENESS_WATCHDOG_DEFAULTS } from '../../../src/hooks/lane-liveness-watchdog.js';
+import {
+	_test_exports as gateInternals,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+// ---------------------------------------------------------------------------
+// Frozen integer budget manifest (AC7).
+// ---------------------------------------------------------------------------
+/** The budgets are derived from the shipped contract defaults, not guesses. */
+const STALL_CONTRACT_DEFAULTS = LANE_LIVENESS_WATCHDOG_DEFAULTS;
+/** One shared status probe per watchdog evaluation — never per-lane. */
+const MAX_HOST_STATUS_CALLS_PER_EVALUATION = 1;
+/** One abort per execution_deadline lane — never retried. */
+const MAX_HOST_ABORTS_PER_EXECUTION_DEADLINE_LANE = 1;
+/** At most one watchdog evaluation per settlement invocation. */
+const MAX_EVALUATIONS_PER_SETTLEMENT = 1;
+/** Fixture A: 1 lane → at most 1 status + 1 abort host launches. */
+const MAX_HOST_LAUNCHES_SINGLE_LANE = 2;
+/** Fixture B: 3 lanes → at most 1 shared status + 3 aborts. */
+const MAX_HOST_LAUNCHES_THREE_LANES = 4;
+/** Repeat fixture: at most 2 settlement attempts before nothing is left. */
+const MAX_ATTEMPTS_REPEAT_FIXTURE = 2;
+/** Whole-file wall-clock budget, in host round-trips (iterations). */
+const WALL_CLOCK_ITERATIONS_BUDGET = 12;
+
+const WATCHDOG_TIMEOUT_MS = 60_000;
+const LANE_AGE_MS = 5 * 60_000; // past the 60s effective horizon
+
+const enabledWatchdog = {
+	enabled: true,
+	timeout_ms: WATCHDOG_TIMEOUT_MS,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+type WatchdogSurface = {
+	hostStatusCalls: number;
+	hostAbortCalls: number;
+	evaluations: number;
+};
+
+const counters = (): WatchdogSurface =>
+	gateInternals.laneLivenessWatchdog as unknown as WatchdogSurface;
+
+/** Ground-truth host launch tally shared by every fixture in this file. */
+const hostLaunches = { status: 0, abort: 0 };
+
+let directory = '';
+let restoreClock: () => void = () => {};
+
+beforeEach(() => {
+	restoreClock = freezeClock();
+	directory = canonicalMkdtemp('lane-liveness-budget-');
+	// Every fixture's budget is a PER-TEST delta (fixtures A/B measure
+	// before/after; C/D assert per-fixture bounds), so the shared host tally
+	// starts at zero for each test rather than accumulating across the file.
+	hostLaunches.status = 0;
+	hostLaunches.abort = 0;
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/** Install a busy-host fake that tallies every launch it serves. */
+function installTallyingBusyHost(sessionIds: string[]): void {
+	const map: Record<string, { type?: string }> = {};
+	for (const id of sessionIds) map[id] = { type: 'busy' };
+	gateInternals.getSessionOps = () =>
+		({
+			status: async () => {
+				hostLaunches.status += 1;
+				return { data: map };
+			},
+			abort: async () => {
+				hostLaunches.abort += 1;
+				return {};
+			},
+		}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+}
+
+describe('C7 — fixture A: one execution_deadline lane', () => {
+	test('the manifest is derived from the shipped contract defaults', () => {
+		expect(STALL_CONTRACT_DEFAULTS.stall_min_steps).toBe(5);
+		expect(STALL_CONTRACT_DEFAULTS.stall_token_threshold).toBe(200);
+		expect(STALL_CONTRACT_DEFAULTS.stall_threshold_ms).toBe(300_000);
+		expect(STALL_CONTRACT_DEFAULTS.timeout_ms).toBe(1_800_000);
+	});
+
+	test('one status probe, one abort, one evaluation — within the frozen budget', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-budget-a',
+			'intent-architecture',
+			'c-budget-a',
+		);
+		await backdatePrWorkflowLane(directory, 'c-budget-a', LANE_AGE_MS);
+		installTallyingBusyHost([laneSubagentSessionId('c-budget-a')]);
+		const before = { ...hostLaunches };
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-budget-a', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		const usedStatus = hostLaunches.status - before.status;
+		const usedAbort = hostLaunches.abort - before.abort;
+		expect(usedStatus).toBe(MAX_HOST_STATUS_CALLS_PER_EVALUATION);
+		expect(usedAbort).toBe(MAX_HOST_ABORTS_PER_EXECUTION_DEADLINE_LANE);
+		expect(usedStatus + usedAbort).toBeLessThanOrEqual(
+			MAX_HOST_LAUNCHES_SINGLE_LANE,
+		);
+		const c = counters();
+		expect(c.evaluations).toBeLessThanOrEqual(MAX_EVALUATIONS_PER_SETTLEMENT);
+		expect(c.hostStatusCalls).toBeLessThanOrEqual(
+			MAX_HOST_STATUS_CALLS_PER_EVALUATION,
+		);
+		expect(c.hostAbortCalls).toBeLessThanOrEqual(
+			MAX_HOST_ABORTS_PER_EXECUTION_DEADLINE_LANE,
+		);
+	});
+});
+
+describe('C7 — fixture B: three execution_deadline lanes share ONE status probe', () => {
+	test('status stays at the per-evaluation cap while aborts scale one-per-lane', async () => {
+		const ids = ['c-b0', 'c-b1', 'c-b2'];
+		for (let i = 0; i < ids.length; i += 1) {
+			await recordOpenPrWorkflowLane(
+				directory,
+				'sess-budget-b',
+				`lane-budget-${i}`,
+				ids[i],
+			);
+			await backdatePrWorkflowLane(directory, ids[i], LANE_AGE_MS);
+		}
+		installTallyingBusyHost(ids.map((id) => laneSubagentSessionId(id)));
+		const before = { ...hostLaunches };
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-budget-b',
+			{ laneLivenessWatchdog: enabledWatchdog },
+		);
+
+		const usedStatus = hostLaunches.status - before.status;
+		const usedAbort = hostLaunches.abort - before.abort;
+		expect(usedStatus).toBeLessThanOrEqual(
+			MAX_HOST_STATUS_CALLS_PER_EVALUATION,
+		);
+		expect(usedAbort).toBeLessThanOrEqual(
+			MAX_HOST_ABORTS_PER_EXECUTION_DEADLINE_LANE * ids.length,
+		);
+		expect(usedStatus + usedAbort).toBeLessThanOrEqual(
+			MAX_HOST_LAUNCHES_THREE_LANES,
+		);
+		expect(settlement.presumedStaleLaneIds.length).toBe(ids.length);
+		expect(counters().evaluations).toBeLessThanOrEqual(
+			MAX_EVALUATIONS_PER_SETTLEMENT,
+		);
+	});
+});
+
+describe('C7 — fixture C: repeated settlement attempts stay bounded', () => {
+	test('a terminal lane is never re-aborted; attempts and evaluations stay capped', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-budget-c',
+			'risk-security',
+			'c-budget-c',
+		);
+		await backdatePrWorkflowLane(directory, 'c-budget-c', LANE_AGE_MS);
+		installTallyingBusyHost([laneSubagentSessionId('c-budget-c')]);
+
+		const first = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-budget-c',
+			{ laneLivenessWatchdog: enabledWatchdog },
+		);
+		const abortsAfterFirst = hostLaunches.abort;
+
+		// Second (and final permitted) attempt on the now-terminal lane.
+		const second = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-budget-c',
+			{ laneLivenessWatchdog: enabledWatchdog },
+		);
+
+		expect(first.presumedStaleLaneIds).toEqual(['risk-security']);
+		expect(second.presumedStaleLaneIds).toEqual([]);
+		// No retry loop: the abort count did not grow on the repeat attempt.
+		expect(hostLaunches.abort).toBe(abortsAfterFirst);
+		expect(hostLaunches.abort).toBeLessThanOrEqual(
+			MAX_HOST_ABORTS_PER_EXECUTION_DEADLINE_LANE,
+		);
+		expect(counters().evaluations).toBeLessThanOrEqual(
+			MAX_EVALUATIONS_PER_SETTLEMENT,
+		);
+	});
+});
+
+describe('C7 — fixture D: disabled watchdog launches nothing of its own', () => {
+	test('zero evaluations, zero aborts, zero watchdog status probes', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-budget-d',
+			'tests-falsifiability',
+			'c-budget-d',
+		);
+		await backdatePrWorkflowLane(directory, 'c-budget-d', LANE_AGE_MS);
+		installTallyingBusyHost([laneSubagentSessionId('c-budget-d')]);
+
+		// Two-argument call — the disabled default applies.
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-budget-d');
+
+		const c = counters();
+		expect(c.evaluations).toBe(0);
+		expect(c.hostStatusCalls).toBe(0);
+		expect(c.hostAbortCalls).toBe(0);
+		// The #2251 probe's own status call still happens (existing
+		// behavior, PRESERVING) but launches no abort.
+		expect(hostLaunches.abort).toBe(0);
+	});
+});
+
+describe('C7 — whole-file wall-clock budget (iterations, frozen clock)', () => {
+	test('total host round-trips across every fixture stay under the frozen iteration budget', async () => {
+		// A final composite fixture: 2 lanes, one repeat attempt — the
+		// maximum additional load this file can generate after the fixtures
+		// above is bounded by the same constants.
+		const ids = ['c-wall-0', 'c-wall-1'];
+		for (let i = 0; i < ids.length; i += 1) {
+			await recordOpenPrWorkflowLane(
+				directory,
+				'sess-wall',
+				`lane-wall-${i}`,
+				ids[i],
+			);
+			await backdatePrWorkflowLane(directory, ids[i], LANE_AGE_MS);
+		}
+		installTallyingBusyHost(ids.map((id) => laneSubagentSessionId(id)));
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-wall', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-wall', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		// Everything this file launched, against the frozen ceiling. With
+		// the clock frozen the ONLY consumable resource is host round-trips,
+		// so this is the wall-clock budget expressed as iterations.
+		expect(hostLaunches.status + hostLaunches.abort).toBeLessThanOrEqual(
+			WALL_CLOCK_ITERATIONS_BUDGET,
+		);
+	});
+});

--- a/tests/unit/hooks/lane-liveness-escalation.test.ts
+++ b/tests/unit/hooks/lane-liveness-escalation.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Issue #2506 acceptance check C4 (AC4, NEW-SURFACE) — stall escalation:
+ * actionable content, per-lane dedup, re-escalation after new activity, the
+ * `pr_workflow_lane_watchdog` event shape, and evidence preserved through
+ * abort/settle.
+ *
+ * Frozen contract pinned here:
+ * - A lane whose session is busy/retry that produced fewer than
+ *   `stall_min_steps` observable transcript steps AND fewer than
+ *   `stall_token_threshold` estimated tokens within the last
+ *   `stall_threshold_ms` gets exactly ONE escalation: a
+ *   `pr_workflow_lane_watchdog` event plus a disclosure naming the lane, the
+ *   observed steps/tokens, and a recommended operator action.
+ * - Escalation is deduped per lane by a persisted last-escalation timestamp:
+ *   no re-escalation unless new activity was observed since.
+ * - `laneIds` on every watchdog event is bounded (<= 10).
+ * - The activity observation is overridable through the gate seam
+ *   (`_test_exports.laneLivenessWatchdog.readLaneActivity`), the repo's
+ *   standard DI-seam pattern; the default is transcript-derived.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import { LANE_LIVENESS_WATCHDOG_DEFAULTS } from '../../../src/hooks/lane-liveness-watchdog.js';
+import {
+	_test_exports as gateInternals,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/** Below the 30-minute horizon so only the stall path can fire. */
+const STALLED_AGE_MS = 10 * 60_000;
+
+const enabledWatchdog = {
+	enabled: true,
+	timeout_ms: 1_800_000,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+type LaneActivity = {
+	stepsObserved: number;
+	estimatedTokens: number;
+	lastActivityAtMs?: number;
+};
+
+type WatchdogSurface = {
+	readLaneActivity?: (
+		directory: string,
+		subagentSessionId: string,
+	) => LaneActivity | null | Promise<LaneActivity | null>;
+};
+
+const surface = (): WatchdogSurface =>
+	gateInternals.laneLivenessWatchdog as unknown as WatchdogSurface;
+
+let directory = '';
+let restoreClock: () => void = () => {};
+let originalReadLaneActivity: WatchdogSurface['readLaneActivity'];
+
+beforeEach(() => {
+	// A positive epoch (not 0) so the activity seam's lastActivityAtMs
+	// offsets never produce negative timestamps.
+	restoreClock = freezeClock({ fixedNow: 1_750_000_000_000 });
+	directory = canonicalMkdtemp('lane-liveness-escalation-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+	originalReadLaneActivity = surface().readLaneActivity;
+});
+
+afterEach(async () => {
+	restoreClock();
+	surface().readLaneActivity = originalReadLaneActivity;
+	gateInternals.resetTrackedStateCache();
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+/** Install a fake host that reports every given session as `busy`. */
+function installBusyHost(sessionIds: string[]): unknown[] {
+	const abortCalls: unknown[] = [];
+	const map: Record<string, { type?: string }> = {};
+	for (const id of sessionIds) map[id] = { type: 'busy' };
+	gateInternals.getSessionOps = () =>
+		({
+			status: async () => ({ data: map }),
+			abort: async (args: unknown) => {
+				abortCalls.push(args);
+				return {};
+			},
+		}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+	return abortCalls;
+}
+
+async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
+	try {
+		const text = await fs.readFile(
+			path.join(dir, '.swarm', 'events.jsonl'),
+			'utf-8',
+		);
+		return text
+			.trim()
+			.split('\n')
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+	} catch {
+		return [];
+	}
+}
+
+async function seedStalledLane(
+	sessionID: string,
+	laneId: string,
+	correlationId: string,
+): Promise<void> {
+	await recordOpenPrWorkflowLane(directory, sessionID, laneId, correlationId);
+	await backdatePrWorkflowLane(directory, correlationId, STALLED_AGE_MS);
+	installBusyHost([laneSubagentSessionId(correlationId)]);
+}
+
+describe('C4 — stall escalation fires once, with actionable content', () => {
+	test('busy lane, zero transcript activity → ONE escalation event naming lane, steps/tokens, and an operator action', async () => {
+		// No readLaneActivity override: the fixture wrote no transcript, and
+		// the transcript-derived default must read that as zero activity.
+		await seedStalledLane('sess-stall', 'intent-architecture', 'c-stall');
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-stall',
+			{ laneLivenessWatchdog: enabledWatchdog },
+		);
+
+		// Escalation is advisory: the lane is below the horizon and stays
+		// open — it must NOT be settled or aborted by the escalation itself.
+		expect(settlement.openLanes).toBe(1);
+		expect(settlement.presumedStaleLaneIds).toEqual([]);
+		expect(laneStatusOnDisk(directory, 'c-stall')).toBe('pending');
+
+		const events = await watchdogEvents(directory);
+		const escalations = events.filter((event) => event.escalated === true);
+		expect(escalations.length).toBe(1);
+		const event = escalations[0];
+		expect(event.laneIds).toContain('intent-architecture');
+		expect(event.stall).toMatchObject({
+			stepsObserved: 0,
+			estimatedTokens: 0,
+			stallThresholdMs: 300_000,
+			stallMinSteps: 5,
+			stallTokenThreshold: 200,
+		});
+		// The event's stall thresholds ARE the contract defaults, not copies.
+		const stall = event.stall as {
+			stallThresholdMs: number;
+			stallMinSteps: number;
+			stallTokenThreshold: number;
+		};
+		expect(stall.stallThresholdMs).toBe(
+			LANE_LIVENESS_WATCHDOG_DEFAULTS.stall_threshold_ms,
+		);
+		expect(stall.stallMinSteps).toBe(
+			LANE_LIVENESS_WATCHDOG_DEFAULTS.stall_min_steps,
+		);
+		expect(stall.stallTokenThreshold).toBe(
+			LANE_LIVENESS_WATCHDOG_DEFAULTS.stall_token_threshold,
+		);
+		// Actionable: the disclosure names the lane, quantifies the stall,
+		// and recommends an operator action (inspect or force-abort).
+		expect(`${event.disclosure}`).toContain('intent-architecture');
+		expect(`${event.disclosure}`).toMatch(/inspect|abort/i);
+		expect(`${event.disclosure}`).toMatch(/step|token/i);
+		expect(event.sessionID).toBe('sess-stall');
+		expect(typeof event.timestamp).toBe('string');
+	});
+
+	test('a progressing lane (enough steps or tokens) is NOT escalated', async () => {
+		await seedStalledLane('sess-active', 'risk-security', 'c-active');
+		surface().readLaneActivity = () => ({
+			stepsObserved: 7,
+			estimatedTokens: 900,
+			lastActivityAtMs: Date.now() - 1_000,
+		});
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-active', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		const events = await watchdogEvents(directory);
+		expect(events.filter((event) => event.escalated === true)).toEqual([]);
+	});
+
+	test('steps alone above stall_min_steps suppress the escalation (both thresholds must be missed)', async () => {
+		await seedStalledLane('sess-steps', 'correctness-state', 'c-steps');
+		surface().readLaneActivity = () => ({
+			stepsObserved: 5,
+			estimatedTokens: 0,
+		});
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-steps', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			),
+		).toEqual([]);
+	});
+});
+
+describe('C4 — dedup without new activity, re-escalation after activity', () => {
+	test('evaluation sequence: escalate → dedup (durable across cache reset) → activity → re-escalate', async () => {
+		await seedStalledLane('sess-dedup', 'intent-architecture', 'c-dedup');
+		let activity: LaneActivity = {
+			stepsObserved: 0,
+			estimatedTokens: 0,
+		};
+		surface().readLaneActivity = () => activity;
+
+		// Eval 1: stalled → exactly one escalation.
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-dedup', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			).length,
+		).toBe(1);
+
+		// Eval 2: still zero activity → deduped. The last-escalation marker
+		// must be PERSISTED, so it survives a tracked-state cache reset. The
+		// reset also restores the default host and activity seams (its
+		// cross-file isolation contract); reinstall this test's fakes so the
+		// evaluations continue against the same lane — the DEDUP BASELINE is
+		// the durable thing under test, not the seams.
+		gateInternals.resetTrackedStateCache();
+		installBusyHost([laneSubagentSessionId('c-dedup')]);
+		surface().readLaneActivity = () => activity;
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-dedup', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			).length,
+		).toBe(1);
+
+		// Eval 3: the lane produced real activity — no escalation while it
+		// is progressing, and the observation resets the dedup baseline.
+		activity = {
+			stepsObserved: 6,
+			estimatedTokens: 250,
+			lastActivityAtMs: Date.now() - 500,
+		};
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-dedup', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			).length,
+		).toBe(1);
+
+		// Eval 4: activity stopped again → this is a NEW stall, and the
+		// re-nudge suppression no longer applies (re-escalation).
+		activity = { stepsObserved: 0, estimatedTokens: 0 };
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-dedup', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			).length,
+		).toBe(2);
+	});
+});
+
+describe('C4 — event shape and evidence preservation', () => {
+	test('every pr_workflow_lane_watchdog event carries the full frozen field set', async () => {
+		await seedStalledLane('sess-shape', 'tests-falsifiability', 'c-shape');
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-shape', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		const events = await watchdogEvents(directory);
+		expect(events.length).toBeGreaterThanOrEqual(1);
+		for (const event of events) {
+			expect(typeof event.condition).toBe('string');
+			expect(Array.isArray(event.laneIds)).toBe(true);
+			expect(event.laneIds.length).toBeLessThanOrEqual(10);
+			expect(Number.isInteger(event.effectiveHorizonMs)).toBe(true);
+			expect(
+				['watchdog-timeout', 'reachability-floor'].includes(
+					`${event.horizonSource}`,
+				),
+			).toBe(true);
+			expect(typeof event.escalated).toBe('boolean');
+			expect(typeof event.disclosure).toBe('string');
+			expect(event.sessionID).toBe('sess-shape');
+			expect(typeof event.timestamp).toBe('string');
+		}
+	});
+
+	test('11 stalled lanes: laneIds stay bounded (<= 10) per event', async () => {
+		const sessionIds: string[] = [];
+		for (let i = 0; i < 11; i += 1) {
+			await recordOpenPrWorkflowLane(
+				directory,
+				'sess-bound',
+				`lane-bound-${i}`,
+				`c-bound-${i}`,
+			);
+			await backdatePrWorkflowLane(directory, `c-bound-${i}`, STALLED_AGE_MS);
+			sessionIds.push(laneSubagentSessionId(`c-bound-${i}`));
+		}
+		installBusyHost(sessionIds);
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-bound', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		const events = await watchdogEvents(directory);
+		expect(events.length).toBeGreaterThanOrEqual(1);
+		for (const event of events) {
+			expect((event.laneIds as unknown[]).length).toBeLessThanOrEqual(10);
+		}
+	});
+
+	test('abort/settle preserves prior evidence: every prior events.jsonl line survives and still parses', async () => {
+		// A deadline-expiry settlement appends its evidence; it must never
+		// truncate or corrupt what the substrate already recorded.
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-evidence',
+			'intent-architecture',
+			'c-evidence',
+		);
+		await backdatePrWorkflowLane(
+			directory,
+			'c-evidence',
+			35 * 60_000, // past the effective 30-minute horizon
+		);
+		installBusyHost([laneSubagentSessionId('c-evidence')]);
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-evidence', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		const lines = (
+			await fs.readFile(path.join(directory, '.swarm', 'events.jsonl'), 'utf-8')
+		)
+			.trim()
+			.split('\n')
+			.filter((line) => line.trim().length > 0);
+		const parsed = lines.map(
+			(line) => JSON.parse(line) as Record<string, unknown>,
+		);
+		// The substrate's own settlement audit record is still there...
+		expect(
+			parsed.some((event) => event.type === 'pr_workflow_lanes_presumed_stale'),
+		).toBe(true);
+		// ...and the watchdog's typed event is present alongside it — both
+		// survive the abort/settle with every line intact and parseable.
+		expect(
+			parsed.some((event) => event.type === 'pr_workflow_lane_watchdog'),
+		).toBe(true);
+		expect(laneStatusOnDisk(directory, 'c-evidence')).toBe('stale');
+	});
+});

--- a/tests/unit/hooks/lane-liveness-horizon.test.ts
+++ b/tests/unit/hooks/lane-liveness-horizon.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Issue #2506 acceptance check C2 (AC2, DISCRIMINATING) — exactly ONE
+ * effective PR lane timeout horizon in every configuration combination.
+ *
+ * Frozen contract pinned here (`resolveEffectivePrLaneHorizonMs` from
+ * `src/hooks/lane-liveness-watchdog.ts`, re-exported through the gate seam):
+ * - watchdog enabled AND timeout_ms > 0 → { timeout_ms, 'watchdog-timeout' }
+ * - anything else (omitted, disabled, timeout_ms = 0) →
+ *   { DEFAULT_STALE_DELEGATION_TIMEOUT_MS (30 min), 'reachability-floor' }
+ * - conflictDisclosed is true ONLY when backgroundPendingTimeoutMs is
+ *   provided, > 0, and differs from the effective horizon. Boundary equality
+ *   (both 1_800_000, or both 600_000) discloses no conflict.
+ *
+ * The single-horizon invariant: in every combination the function returns
+ * exactly one integer horizonMs drawn from exactly one of the two named
+ * sources — never two horizons, never an undocumented source.
+ */
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_STALE_DELEGATION_TIMEOUT_MS } from '../../../src/background/pending-delegations.js';
+import { resolveEffectivePrLaneHorizonMs } from '../../../src/hooks/lane-liveness-watchdog.js';
+import { _test_exports as gateInternals } from '../../../src/hooks/pr-workflow-gate.js';
+
+const WATCHDOG_TIMEOUT = 600_000;
+const CONFLICTING_BACKGROUND_TIMEOUT = 1_200_000;
+
+const disabledConfig = {
+	enabled: false,
+	timeout_ms: WATCHDOG_TIMEOUT,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+const enabledConfig = {
+	enabled: true,
+	timeout_ms: WATCHDOG_TIMEOUT,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+const enabledZeroTimeoutConfig = {
+	enabled: true,
+	timeout_ms: 0,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+type Horizon = {
+	horizonMs: number;
+	source: 'watchdog-timeout' | 'reachability-floor';
+	conflictDisclosed: boolean;
+};
+
+const VALID_SOURCES = new Set(['watchdog-timeout', 'reachability-floor']);
+
+describe('C2 — resolveEffectivePrLaneHorizonMs precedence', () => {
+	test('no watchdog at all → the 30-minute reachability floor', () => {
+		expect(resolveEffectivePrLaneHorizonMs()).toEqual({
+			horizonMs: DEFAULT_STALE_DELEGATION_TIMEOUT_MS,
+			source: 'reachability-floor',
+			conflictDisclosed: false,
+		} as Horizon);
+	});
+
+	test('the floor is the canonical 30-minute constant', () => {
+		expect(DEFAULT_STALE_DELEGATION_TIMEOUT_MS).toBe(30 * 60_000);
+		expect(resolveEffectivePrLaneHorizonMs().horizonMs).toBe(1_800_000);
+	});
+
+	test('disabled watchdog with a nonzero timeout_ms is IGNORED (floor wins)', () => {
+		const result = resolveEffectivePrLaneHorizonMs(disabledConfig) as Horizon;
+		expect(result.horizonMs).toBe(DEFAULT_STALE_DELEGATION_TIMEOUT_MS);
+		expect(result.source).toBe('reachability-floor');
+	});
+
+	test('enabled watchdog with timeout_ms > 0 wins over the floor', () => {
+		const result = resolveEffectivePrLaneHorizonMs(enabledConfig) as Horizon;
+		expect(result.horizonMs).toBe(WATCHDOG_TIMEOUT);
+		expect(result.source).toBe('watchdog-timeout');
+	});
+
+	test('enabled watchdog with timeout_ms = 0 disables the deadline feature (floor)', () => {
+		// "0 disables the relevant feature": the watchdog cannot impose a
+		// zero horizon, because that would settle every lane immediately.
+		const result = resolveEffectivePrLaneHorizonMs(
+			enabledZeroTimeoutConfig,
+		) as Horizon;
+		expect(result.horizonMs).toBe(DEFAULT_STALE_DELEGATION_TIMEOUT_MS);
+		expect(result.source).toBe('reachability-floor');
+	});
+});
+
+describe('C2 — conflict disclosure against background_pending_timeout_minutes', () => {
+	test('watchdog horizon vs a differing background timeout discloses the conflict, horizon stays single', () => {
+		const result = resolveEffectivePrLaneHorizonMs(
+			enabledConfig,
+			CONFLICTING_BACKGROUND_TIMEOUT,
+		) as Horizon;
+		expect(result.horizonMs).toBe(WATCHDOG_TIMEOUT);
+		expect(result.source).toBe('watchdog-timeout');
+		expect(result.conflictDisclosed).toBe(true);
+	});
+
+	test('floor vs a differing background timeout also discloses the conflict', () => {
+		const result = resolveEffectivePrLaneHorizonMs(
+			disabledConfig,
+			WATCHDOG_TIMEOUT,
+		) as Horizon;
+		expect(result.horizonMs).toBe(DEFAULT_STALE_DELEGATION_TIMEOUT_MS);
+		expect(result.source).toBe('reachability-floor');
+		expect(result.conflictDisclosed).toBe(true);
+	});
+
+	test('boundary equality at the floor value discloses NO conflict', () => {
+		const result = resolveEffectivePrLaneHorizonMs(
+			{ ...enabledConfig, timeout_ms: 1_800_000 },
+			1_800_000,
+		) as Horizon;
+		expect(result.horizonMs).toBe(1_800_000);
+		expect(result.source).toBe('watchdog-timeout');
+		expect(result.conflictDisclosed).toBe(false);
+	});
+
+	test('boundary equality at the watchdog value discloses NO conflict', () => {
+		const result = resolveEffectivePrLaneHorizonMs(
+			enabledConfig,
+			WATCHDOG_TIMEOUT,
+		) as Horizon;
+		expect(result.conflictDisclosed).toBe(false);
+	});
+
+	test('a background timeout of 0 is "not set" and never discloses a conflict', () => {
+		const result = resolveEffectivePrLaneHorizonMs(enabledConfig, 0) as Horizon;
+		expect(result.conflictDisclosed).toBe(false);
+	});
+
+	test('an undefined background timeout never discloses a conflict', () => {
+		const result = resolveEffectivePrLaneHorizonMs(
+			enabledConfig,
+			undefined,
+		) as Horizon;
+		expect(result.conflictDisclosed).toBe(false);
+	});
+});
+
+describe('C2 — the single-horizon invariant across every combination', () => {
+	test('every combination yields exactly one integer horizon from one of the two sources', () => {
+		const watchdogConfigs = [
+			undefined,
+			disabledConfig,
+			enabledConfig,
+			enabledZeroTimeoutConfig,
+		];
+		const backgroundTimeouts = [
+			undefined,
+			0,
+			WATCHDOG_TIMEOUT,
+			CONFLICTING_BACKGROUND_TIMEOUT,
+			DEFAULT_STALE_DELEGATION_TIMEOUT_MS,
+		];
+		for (const watchdog of watchdogConfigs) {
+			for (const background of backgroundTimeouts) {
+				const result = resolveEffectivePrLaneHorizonMs(
+					watchdog,
+					background,
+				) as Horizon;
+				expect(Number.isInteger(result.horizonMs)).toBe(true);
+				expect(result.horizonMs).toBeGreaterThanOrEqual(0);
+				expect(VALID_SOURCES.has(result.source)).toBe(true);
+				expect(typeof result.conflictDisclosed).toBe('boolean');
+				// "Exactly one" also means deterministic: resolving the same
+				// combination twice must agree byte-for-byte.
+				expect(resolveEffectivePrLaneHorizonMs(watchdog, background)).toEqual(
+					result,
+				);
+				// The effective horizon is always one of the two configured
+				// candidates — never a blend, never a third value.
+				const candidates = new Set(
+					[WATCHDOG_TIMEOUT, DEFAULT_STALE_DELEGATION_TIMEOUT_MS].map(
+						(n) => `${n}`,
+					),
+				);
+				expect(candidates.has(`${result.horizonMs}`)).toBe(true);
+			}
+		}
+	});
+
+	test('a conflict never changes the effective horizon, only discloses it', () => {
+		const without = resolveEffectivePrLaneHorizonMs(enabledConfig) as Horizon;
+		const withConflict = resolveEffectivePrLaneHorizonMs(
+			enabledConfig,
+			CONFLICTING_BACKGROUND_TIMEOUT,
+		) as Horizon;
+		expect(withConflict.horizonMs).toBe(without.horizonMs);
+		expect(withConflict.source).toBe(without.source);
+		expect(withConflict.conflictDisclosed).toBe(true);
+		expect(without.conflictDisclosed).toBe(false);
+	});
+
+	test('the gate seam exposes the same resolver behavior', () => {
+		const viaGate = (
+			gateInternals.laneLivenessWatchdog as unknown as {
+				resolveEffectivePrLaneHorizonMs: typeof resolveEffectivePrLaneHorizonMs;
+			}
+		).resolveEffectivePrLaneHorizonMs;
+		expect(viaGate(enabledConfig, CONFLICTING_BACKGROUND_TIMEOUT)).toEqual(
+			resolveEffectivePrLaneHorizonMs(
+				enabledConfig,
+				CONFLICTING_BACKGROUND_TIMEOUT,
+			),
+		);
+	});
+});

--- a/tests/unit/hooks/lane-liveness-negative-paths-clock.test.ts
+++ b/tests/unit/hooks/lane-liveness-negative-paths-clock.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Issue #2506 review round 2, negative-path coverage (companion file to
+ * lane-liveness-negative-paths.test.ts, split to stay under the FR-006
+ * 500-line cap): the force-abort finalize sweep at the EFFECTIVE horizon
+ * (PRR-002) and the live-seam re-arm disjunct under a FULLY frozen clock
+ * (Date.now AND toISOString), which the C4 file cannot exercise (PRR-014).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import {
+	_test_exports as gateInternals,
+	activatePrWorkflow,
+	abortPrWorkflow,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/** Between a 60s watchdog horizon and the 30-minute floor. */
+const MID_AGE_MS = 5 * 60_000;
+const FIXED_NOW = 1_750_000_000_000;
+
+const watchdogWith = (timeoutMs: number) => ({
+	enabled: true,
+	timeout_ms: timeoutMs,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+});
+
+type LaneActivity = {
+	stepsObserved: number;
+	estimatedTokens: number;
+	lastActivityAtMs?: number;
+};
+
+type WatchdogSurface = {
+	readLaneActivity?: (
+		directory: string,
+		subagentSessionId: string,
+	) => LaneActivity | null | Promise<LaneActivity | null>;
+};
+
+const surface = (): WatchdogSurface =>
+	gateInternals.laneLivenessWatchdog as unknown as WatchdogSurface;
+
+const stallOnly = {
+	enabled: true,
+	timeout_ms: 0,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+let directory = '';
+let restoreClock: () => void = () => {};
+
+beforeEach(() => {
+	restoreClock = freezeClock({ fixedNow: FIXED_NOW });
+	directory = canonicalMkdtemp('lane-liveness-rearm-fin-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
+	try {
+		const text = await fs.readFile(
+			path.join(dir, '.swarm', 'events.jsonl'),
+			'utf-8',
+		);
+		return text
+			.split(String.fromCharCode(10))
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+	} catch {
+		return [];
+	}
+}
+
+function installBusyHost(
+	sessionIds: string[],
+	type: 'busy' | 'retry' = 'busy',
+): unknown[] {
+	return installTypedHost(sessionIds, type);
+}
+
+function installTypedHost(
+	sessionIds: string[],
+	type: 'busy' | 'retry',
+): unknown[] {
+	const abortCalls: unknown[] = [];
+	const map: Record<string, { type?: string }> = {};
+	for (const id of sessionIds) map[id] = { type };
+	gateInternals.getSessionOps = () =>
+		({
+			status: async () => ({ data: map }),
+			abort: async (args: unknown) => {
+				abortCalls.push(args);
+				return {};
+			},
+		}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+	return abortCalls;
+}
+
+describe('PRR-014 — the live-seam re-arm disjunct fires under a fully frozen clock', () => {
+	test('activity since the durable escalation (same frozen ms) re-arms the lane', async () => {
+		// The C4 file freezes Date.now only, so the escalation events it writes
+		// carry REAL-clock timestamps and the live-seam disjunct
+		// (lastActivityAtMs >= lastEscalation) is structurally always false
+		// there. This test re-freezes WITH isoNow so event timestamps share the
+		// frozen clock and the disjunct becomes exercisable.
+		restoreClock();
+		restoreClock = freezeClock({
+			fixedNow: FIXED_NOW,
+			isoNow: new Date(FIXED_NOW).toISOString(),
+		});
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-rearm',
+			'risk-security',
+			'c-rearm',
+		);
+		installBusyHost(['c-rearm']);
+		const original = surface().readLaneActivity;
+		surface().readLaneActivity = (async () => ({
+			stepsObserved: 0,
+			estimatedTokens: 0,
+		})) as unknown as typeof original;
+		try {
+			// Pass 1: zero activity -> escalated once. Event timestamp is
+			// frozen to FIXED_NOW (isoNow frozen too, unlike the C4 file).
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
+				laneLivenessWatchdog: stallOnly,
+			});
+			expect(
+				(await watchdogEvents(directory)).filter(
+					(event) => event.escalated === true,
+				).length,
+			).toBe(1);
+
+			// Pass 2: the seam itself reports activity AT the frozen now —
+			// lastActivityAtMs >= lastEscalation (same millisecond), so the
+			// live-seam disjunct alone must re-arm the lane.
+			surface().readLaneActivity = (async () => ({
+				stepsObserved: 0,
+				estimatedTokens: 0,
+				lastActivityAtMs: FIXED_NOW,
+			})) as unknown as typeof original;
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
+				laneLivenessWatchdog: stallOnly,
+			});
+			expect(
+				(await watchdogEvents(directory)).filter(
+					(event) => event.escalated === true,
+				).length,
+			).toBe(2);
+		} finally {
+			surface().readLaneActivity = original;
+		}
+	});
+});
+
+describe('PRR-002 — the force-abort finalize sweep runs at the effective horizon', () => {
+	test('retained retry lane between the watchdog horizon and the floor IS finalized', async () => {
+		await activatePrWorkflow(directory, 'sess-finalize', 'PR_REVIEW');
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-finalize',
+			'intent-architecture',
+			'c-fin',
+		);
+		await backdatePrWorkflowLane(directory, 'c-fin', MID_AGE_MS);
+		// A RETRY-status lane past the 60s horizon is probe-retained (the
+		// deadline never aborts provider retries) — the exact gap-window lane
+		// the old floor-based finalize sweep left pending forever.
+		const abortCalls: unknown[] = [];
+		const map: Record<string, { type?: string }> = {
+			[laneSubagentSessionId('c-fin')]: { type: 'retry' },
+		};
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({ data: map }),
+				abort: async (args: unknown) => {
+					abortCalls.push(args);
+					return {};
+				},
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		const settled = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-finalize',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+			},
+		);
+		expect(settled.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('pending');
+
+		// Human force abort WITH the same policy: the finalize sweep must run
+		// at the 60s effective horizon (not the 30-minute floor), so the
+		// 5-minute-old retained lane is finalized and the session restartable.
+		await abortPrWorkflow(directory, 'sess-finalize', {
+			kind: 'force',
+			reason: 'operator override',
+			laneLiveness: { laneLivenessWatchdog: watchdogWith(60_000) },
+		});
+		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('stale');
+	});
+});

--- a/tests/unit/hooks/lane-liveness-negative-paths-clock.test.ts
+++ b/tests/unit/hooks/lane-liveness-negative-paths-clock.test.ts
@@ -10,9 +10,9 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { closeProjectDb } from '../../../src/db/project-db.js';
 import {
-	_test_exports as gateInternals,
-	activatePrWorkflow,
 	abortPrWorkflow,
+	activatePrWorkflow,
+	_test_exports as gateInternals,
 	settlePresumedStalePrWorkflowLanes,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import {

--- a/tests/unit/hooks/lane-liveness-negative-paths.test.ts
+++ b/tests/unit/hooks/lane-liveness-negative-paths.test.ts
@@ -23,9 +23,9 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { closeProjectDb } from '../../../src/db/project-db.js';
 import {
-	_test_exports as gateInternals,
-	activatePrWorkflow,
 	abortPrWorkflow,
+	activatePrWorkflow,
+	_test_exports as gateInternals,
 	settlePresumedStalePrWorkflowLanes,
 } from '../../../src/hooks/pr-workflow-gate.js';
 import {
@@ -118,7 +118,7 @@ async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
 			path.join(dir, '.swarm', 'events.jsonl'),
 			'utf-8',
 		);
-				return text
+		return text
 			.split('\n')
 			.map((line) => {
 				try {

--- a/tests/unit/hooks/lane-liveness-negative-paths.test.ts
+++ b/tests/unit/hooks/lane-liveness-negative-paths.test.ts
@@ -118,12 +118,21 @@ async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
 			path.join(dir, '.swarm', 'events.jsonl'),
 			'utf-8',
 		);
-		return text
-			.trim()
+				return text
 			.split('\n')
-			.filter((line) => line.trim().length > 0)
-			.map((line) => JSON.parse(line) as Record<string, unknown>)
-			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+			.map((line) => {
+				try {
+					return JSON.parse(line) as Record<string, unknown>;
+				} catch {
+					// Mirrors the production scan: skip lines that are not
+					// valid JSON instead of failing the whole read.
+					return null;
+				}
+			})
+			.filter(
+				(event): event is Record<string, unknown> =>
+					event !== null && event.type === 'pr_workflow_lane_watchdog',
+			);
 	} catch {
 		return [];
 	}
@@ -239,6 +248,49 @@ describe('PRR-005.4 + cross-session isolation — dedup scan input hygiene', () 
 		expect(
 			(await watchdogEvents(directory)).filter(
 				(event) => event.escalated === true && event.sessionID === 'sess-mine',
+			).length,
+		).toBe(1);
+	});
+
+	test('a corrupt tail line is skipped by the dedup scan without blocking appends', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-corrupt',
+			'risk-security',
+			'c-corrupt',
+		);
+		installBusyHost(['c-corrupt']);
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-corrupt', {
+			laneLivenessWatchdog: stallOnly,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			).length,
+		).toBe(1);
+
+		// appendCoreEventSync repairs line framing rather than rejecting a
+		// torn tail, so the store still accepts appends; the scan must skip
+		// the garbage line and a fresh escalation for a NEW label still lands.
+		await fs.appendFile(
+			path.join(directory, '.swarm', 'events.jsonl'),
+			'{not json at all\n',
+			'utf-8',
+		);
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-corrupt',
+			'docs-quality',
+			'c-corrupt-2',
+		);
+		installBusyHost(['c-corrupt', 'c-corrupt-2']);
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-corrupt', {
+			laneLivenessWatchdog: stallOnly,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) =>
+					event.escalated === true && event.laneIds.includes('docs-quality'),
 			).length,
 		).toBe(1);
 	});
@@ -410,108 +462,5 @@ describe('PRR-003 — horizonConflictNote surfaces the config disagreement', () 
 			},
 		);
 		expect(agreeing.horizonConflictNote).toBeUndefined();
-	});
-});
-
-describe('PRR-014 — the live-seam re-arm disjunct fires under a fully frozen clock', () => {
-	test('activity since the durable escalation (same frozen ms) re-arms the lane', async () => {
-		// The C4 file freezes Date.now only, so the escalation events it writes
-		// carry REAL-clock timestamps and the live-seam disjunct
-		// (lastActivityAtMs >= lastEscalation) is structurally always false
-		// there. This test re-freezes WITH isoNow so event timestamps share the
-		// frozen clock and the disjunct becomes exercisable.
-		restoreClock();
-		restoreClock = freezeClock({ fixedNow: FIXED_NOW, isoNow: true });
-		await recordOpenPrWorkflowLane(
-			directory,
-			'sess-rearm',
-			'risk-security',
-			'c-rearm',
-		);
-		installBusyHost(['c-rearm']);
-		const original = surface().readLaneActivity;
-		surface().readLaneActivity = (async () => ({
-			stepsObserved: 0,
-			estimatedTokens: 0,
-		})) as unknown as typeof original;
-		try {
-			// Pass 1: zero activity -> escalated once. Event timestamp is
-			// frozen to FIXED_NOW (isoNow frozen too, unlike the C4 file).
-			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
-				laneLivenessWatchdog: stallOnly,
-			});
-			expect(
-				(await watchdogEvents(directory)).filter(
-					(event) => event.escalated === true,
-				).length,
-			).toBe(1);
-
-			// Pass 2: the seam itself reports activity AT the frozen now —
-			// lastActivityAtMs >= lastEscalation (same millisecond), so the
-			// live-seam disjunct alone must re-arm the lane.
-			surface().readLaneActivity = (async () => ({
-				stepsObserved: 0,
-				estimatedTokens: 0,
-				lastActivityAtMs: FIXED_NOW,
-			})) as unknown as typeof original;
-			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
-				laneLivenessWatchdog: stallOnly,
-			});
-			expect(
-				(await watchdogEvents(directory)).filter(
-					(event) => event.escalated === true,
-				).length,
-			).toBe(2);
-		} finally {
-			surface().readLaneActivity = original;
-		}
-	});
-});
-
-describe('PRR-002 — the force-abort finalize sweep runs at the effective horizon', () => {
-	test('retained retry lane between the watchdog horizon and the floor IS finalized', async () => {
-		await activatePrWorkflow(directory, 'sess-finalize', 'PR_REVIEW');
-		await recordOpenPrWorkflowLane(
-			directory,
-			'sess-finalize',
-			'intent-architecture',
-			'c-fin',
-		);
-		await backdatePrWorkflowLane(directory, 'c-fin', MID_AGE_MS);
-		// A RETRY-status lane past the 60s horizon is probe-retained (the
-		// deadline never aborts provider retries) — the exact gap-window lane
-		// the old floor-based finalize sweep left pending forever.
-		const abortCalls: unknown[] = [];
-		const map: Record<string, { type?: string }> = {
-			[laneSubagentSessionId('c-fin')]: { type: 'retry' },
-		};
-		gateInternals.getSessionOps = () =>
-			({
-				status: async () => ({ data: map }),
-				abort: async (args: unknown) => {
-					abortCalls.push(args);
-					return {};
-				},
-			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
-
-		const settled = await settlePresumedStalePrWorkflowLanes(
-			directory,
-			'sess-finalize',
-			{
-				laneLivenessWatchdog: watchdogWith(60_000),
-			},
-		);
-		expect(settled.probedAliveLaneIds).toEqual(['intent-architecture']);
-		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('pending');
-
-		// Human force abort WITH the same policy: the finalize sweep must run
-		// at the 60s effective horizon (not the 30-minute floor), so the
-		// 5-minute-old retained lane is finalized and the session restartable.
-		await abortPrWorkflow(directory, 'sess-finalize', {
-			kind: 'force',
-			reason: 'operator override',
-			laneLiveness: { laneLivenessWatchdog: watchdogWith(60_000) },
-		});
-		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('stale');
 	});
 });

--- a/tests/unit/hooks/lane-liveness-negative-paths.test.ts
+++ b/tests/unit/hooks/lane-liveness-negative-paths.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Issue #2506 review round 2 — negative-path coverage for the
+ * lane-liveness watchdog integration. Every test here drives a branch the
+ * first six frozen files left uncovered (PRR-005), plus the round-2 fixes:
+ *
+ * - abortLaneSessionForWatchdog's catch (abort rejects/throws) — PRR-005.1
+ * - degraded types-probe under an ACTIVE watchdog, including the truthful
+ *   "no session abort was attempted" disclosure — PRR-005.3 + bot finding 2
+ * - corrupt/foreign-session event lines in the dedup scan — PRR-005.4 and
+ *   the cross-session dedup isolation fix
+ * - a throwing readLaneActivity seam degrading to zero activity — PRR-010
+ * - durable abort-once across settlement passes when the sweep keeps
+ *   failing — PRR-007
+ * - the stall-only degraded-probe branch (unknown sessions unescalatable)
+ * - event-append failures swallowed (events.jsonl path unwritable) — PRR-005.2
+ * - horizonConflictNote surfaced on the settlement result — PRR-003
+ * - the live-seam re-arm disjunct under a FULLY frozen clock (Date.now AND
+ *   toISOString), which the C4 file could not exercise — PRR-014
+ * - the force-abort finalize sweep at the EFFECTIVE horizon — PRR-002
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import {
+	_test_exports as gateInternals,
+	activatePrWorkflow,
+	abortPrWorkflow,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/** Between a 60s watchdog horizon and the 30-minute floor. */
+const MID_AGE_MS = 5 * 60_000;
+const FIXED_NOW = 1_750_000_000_000;
+
+const watchdogWith = (timeoutMs: number) => ({
+	enabled: true,
+	timeout_ms: timeoutMs,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+});
+
+const stallOnly = {
+	enabled: true,
+	timeout_ms: 0,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+type LaneActivity = {
+	stepsObserved: number;
+	estimatedTokens: number;
+	lastActivityAtMs?: number;
+};
+
+type WatchdogSurface = {
+	readLaneActivity?: (
+		directory: string,
+		subagentSessionId: string,
+	) => LaneActivity | null | Promise<LaneActivity | null>;
+	hostStatusCalls: number;
+	hostAbortCalls: number;
+	evaluations: number;
+};
+
+const surface = (): WatchdogSurface =>
+	gateInternals.laneLivenessWatchdog as unknown as WatchdogSurface;
+
+let directory = '';
+let restoreClock: () => void = () => {};
+
+beforeEach(() => {
+	restoreClock = freezeClock({ fixedNow: FIXED_NOW });
+	directory = canonicalMkdtemp('lane-liveness-negative-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+function installBusyHost(
+	sessionIds: string[],
+	abortImpl?: () => Promise<unknown>,
+): unknown[] {
+	const abortCalls: unknown[] = [];
+	const map: Record<string, { type?: string }> = {};
+	for (const id of sessionIds) map[id] = { type: 'busy' };
+	gateInternals.getSessionOps = () =>
+		({
+			status: async () => ({ data: map }),
+			abort: async (args: unknown) => {
+				abortCalls.push(args);
+				if (abortImpl) return abortImpl();
+				return {};
+			},
+		}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+	return abortCalls;
+}
+
+async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
+	try {
+		const text = await fs.readFile(
+			path.join(dir, '.swarm', 'events.jsonl'),
+			'utf-8',
+		);
+		return text
+			.trim()
+			.split('\n')
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+	} catch {
+		return [];
+	}
+}
+
+describe('PRR-005.1 — abort failure is swallowed and counted as not-delivered', () => {
+	test('rejecting abort op: lane still settles stale, hostAbortCalls stays 0', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-abortfail',
+			'risk-security',
+			'c-af',
+		);
+		await backdatePrWorkflowLane(directory, 'c-af', MID_AGE_MS);
+		const abortCalls = installBusyHost(['c-af'], async () => {
+			throw new Error('host abort transport exploded');
+		});
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-abortfail',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+			},
+		);
+
+		expect(abortCalls.length).toBe(1);
+		expect(laneStatusOnDisk(directory, 'c-af')).toBe('stale');
+		expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+		expect(surface().hostAbortCalls).toBe(0);
+	});
+});
+
+describe('PRR-005.3 + bot#2 — degraded probe under an ACTIVE watchdog', () => {
+	test('deadline settles without abort and the disclosure claims no abort attempt', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-degraded',
+			'risk-security',
+			'c-deg',
+		);
+		await backdatePrWorkflowLane(directory, 'c-deg', MID_AGE_MS);
+		const abortCalls = installBusyHost(['c-deg']);
+		const originalProbe = gateInternals.probeLaneSessionStatusTypesAsync;
+		gateInternals.probeLaneSessionStatusTypesAsync = (async () => ({
+			alive: new Set<string>(),
+			statuses: new Map<string, string>(),
+			degradedReason: 'probe-unavailable' as const,
+		})) as unknown as typeof gateInternals.probeLaneSessionStatusTypesAsync;
+
+		try {
+			const settlement = await settlePresumedStalePrWorkflowLanes(
+				directory,
+				'sess-degraded',
+				{ laneLivenessWatchdog: watchdogWith(60_000) },
+			);
+
+			expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+			expect(settlement.probeDegradedReason).toBe('probe-unavailable');
+			expect(laneStatusOnDisk(directory, 'c-deg')).toBe('stale');
+			expect(abortCalls.length).toBe(0);
+			expect(surface().hostAbortCalls).toBe(0);
+			const deadline = (await watchdogEvents(directory)).find(
+				(event) => event.condition === 'execution_deadline',
+			) as Record<string, unknown>;
+			expect(deadline).toBeDefined();
+			expect(`${deadline.disclosure}`).toMatch(
+				/no session abort was attempted/i,
+			);
+			expect(`${deadline.disclosure}`).toMatch(/no output observed/i);
+		} finally {
+			gateInternals.probeLaneSessionStatusTypesAsync = originalProbe;
+		}
+	});
+});
+
+describe('PRR-005.4 + cross-session isolation — dedup scan input hygiene', () => {
+	test('foreign-session escalation does not suppress our same-label lane', async () => {
+		// Three sessions, same directory, SAME lane-role label: exactly the
+		// collision the label-only dedup key had. Each lane is owned by its
+		// own session (isOpenPrWorkflowLane is session-scoped).
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-foreign',
+			'risk-security',
+			'c-foreign',
+		);
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-mine',
+			'risk-security',
+			'c-mine',
+		);
+		installBusyHost(['c-foreign', 'c-mine']);
+
+		// Escalations are written BY THE STORE (real settlements) so the
+		// events file keeps its framing.
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-foreign', {
+			laneLivenessWatchdog: stallOnly,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) =>
+					event.escalated === true && event.sessionID === 'sess-foreign',
+			).length,
+		).toBe(1);
+
+		// The OWN session escalates for the same label despite the foreign
+		// escalation: dedup keys are (sessionID, label), not label alone.
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-mine', {
+			laneLivenessWatchdog: stallOnly,
+		});
+		expect(
+			(await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true && event.sessionID === 'sess-mine',
+			).length,
+		).toBe(1);
+	});
+});
+
+describe('PRR-010 — a throwing activity seam degrades to zero activity', () => {
+	test('settlement completes; escalation fires once on the zero-activity fallback', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-throw',
+			'risk-security',
+			'c-throw',
+		);
+		installBusyHost(['c-throw']);
+		const original = surface().readLaneActivity;
+		surface().readLaneActivity = (async () => {
+			throw new Error('transcript store unavailable');
+		}) as unknown as typeof original;
+
+		try {
+			const settlement = await settlePresumedStalePrWorkflowLanes(
+				directory,
+				'sess-throw',
+				{
+					laneLivenessWatchdog: stallOnly,
+				},
+			);
+			expect(settlement.openLanes).toBe(1);
+			const escalations = (await watchdogEvents(directory)).filter(
+				(event) => event.escalated === true,
+			);
+			expect(escalations.length).toBe(1);
+		} finally {
+			surface().readLaneActivity = original;
+		}
+	});
+});
+
+describe('PRR-007 — abort-once survives a repeatedly failing sweep', () => {
+	test('second settlement pass does not re-abort a lane whose deadline event is durable', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-once',
+			'risk-security',
+			'c-once',
+		);
+		await backdatePrWorkflowLane(directory, 'c-once', MID_AGE_MS);
+		const abortCalls = installBusyHost(['c-once']);
+		const originalSweep = gateInternals.sweepStaleDelegationsAsync;
+		gateInternals.sweepStaleDelegationsAsync = (async () =>
+			0) as unknown as typeof originalSweep;
+
+		try {
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-once', {
+				laneLivenessWatchdog: watchdogWith(60_000),
+			});
+			expect(abortCalls.length).toBe(1);
+			// The sweep "failed" (no-op), so the record is still pending and
+			// still past the horizon: a second pass re-derives the same
+			// deadline lane — but the durable execution_deadline event from
+			// pass one suppresses the second abort.
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-once', {
+				laneLivenessWatchdog: watchdogWith(60_000),
+			});
+			expect(abortCalls.length).toBe(1);
+			expect(laneStatusOnDisk(directory, 'c-once')).toBe('pending');
+		} finally {
+			gateInternals.sweepStaleDelegationsAsync = originalSweep;
+		}
+	});
+});
+
+describe('PRR-005.5 — stall-only evaluation with a degraded probe', () => {
+	test('unknown sessions are treated as unescalatable and nothing throws', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-stalldeg',
+			'risk-security',
+			'c-stale',
+		);
+		// Past the 30-minute floor so this lane is presumedStale.
+		await backdatePrWorkflowLane(directory, 'c-stale', 31 * 60_000);
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-stalldeg',
+			'intent-architecture',
+			'c-fresh',
+		);
+		installBusyHost(['c-stale', 'c-fresh']);
+		const originalProbe = gateInternals.probeLaneSessionStatusTypesAsync;
+		gateInternals.probeLaneSessionStatusTypesAsync = (async () => ({
+			alive: new Set<string>(),
+			statuses: new Map<string, string>(),
+			degradedReason: 'probe-timeout' as const,
+		})) as unknown as typeof gateInternals.probeLaneSessionStatusTypesAsync;
+
+		try {
+			const settlement = await settlePresumedStalePrWorkflowLanes(
+				directory,
+				'sess-stalldeg',
+				{ laneLivenessWatchdog: stallOnly },
+			);
+			// The stale lane settled (probe could not vouch for it); the fresh
+			// open lane stays open and was NOT escalated (unknown type).
+			expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+			expect((await watchdogEvents(directory)).length).toBe(0);
+		} finally {
+			gateInternals.probeLaneSessionStatusTypesAsync = originalProbe;
+		}
+	});
+});
+
+describe('PRR-005.2 — event-append failures never block settlement', () => {
+	test('unwritable events store: deadline settlement still completes', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-append',
+			'risk-security',
+			'c-append',
+		);
+		await backdatePrWorkflowLane(directory, 'c-append', MID_AGE_MS);
+		installBusyHost(['c-append']);
+		// A DIRECTORY at the events.jsonl path makes every append throw.
+		await fs.mkdir(path.join(directory, '.swarm', 'events.jsonl'), {
+			recursive: true,
+		});
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-append',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+			},
+		);
+
+		expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+		expect(laneStatusOnDisk(directory, 'c-append')).toBe('stale');
+	});
+});
+
+describe('PRR-003 — horizonConflictNote surfaces the config disagreement', () => {
+	test('present when background pending timeout disagrees; absent otherwise', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-conf',
+			'risk-security',
+			'c-conf',
+		);
+		await backdatePrWorkflowLane(directory, 'c-conf', MID_AGE_MS);
+		installBusyHost(['c-conf']);
+
+		const disagreeing = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-conf',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+				backgroundPendingTimeoutMs: 45 * 60_000,
+			},
+		);
+		expect(disagreeing.horizonConflictNote).toBeDefined();
+		expect(`${disagreeing.horizonConflictNote}`).toContain('timeout_ms');
+
+		const agreeing = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-conf',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+				backgroundPendingTimeoutMs: 60_000,
+			},
+		);
+		expect(agreeing.horizonConflictNote).toBeUndefined();
+	});
+});
+
+describe('PRR-014 — the live-seam re-arm disjunct fires under a fully frozen clock', () => {
+	test('activity since the durable escalation (same frozen ms) re-arms the lane', async () => {
+		// The C4 file freezes Date.now only, so the escalation events it writes
+		// carry REAL-clock timestamps and the live-seam disjunct
+		// (lastActivityAtMs >= lastEscalation) is structurally always false
+		// there. This test re-freezes WITH isoNow so event timestamps share the
+		// frozen clock and the disjunct becomes exercisable.
+		restoreClock();
+		restoreClock = freezeClock({ fixedNow: FIXED_NOW, isoNow: true });
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-rearm',
+			'risk-security',
+			'c-rearm',
+		);
+		installBusyHost(['c-rearm']);
+		const original = surface().readLaneActivity;
+		surface().readLaneActivity = (async () => ({
+			stepsObserved: 0,
+			estimatedTokens: 0,
+		})) as unknown as typeof original;
+		try {
+			// Pass 1: zero activity -> escalated once. Event timestamp is
+			// frozen to FIXED_NOW (isoNow frozen too, unlike the C4 file).
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
+				laneLivenessWatchdog: stallOnly,
+			});
+			expect(
+				(await watchdogEvents(directory)).filter(
+					(event) => event.escalated === true,
+				).length,
+			).toBe(1);
+
+			// Pass 2: the seam itself reports activity AT the frozen now —
+			// lastActivityAtMs >= lastEscalation (same millisecond), so the
+			// live-seam disjunct alone must re-arm the lane.
+			surface().readLaneActivity = (async () => ({
+				stepsObserved: 0,
+				estimatedTokens: 0,
+				lastActivityAtMs: FIXED_NOW,
+			})) as unknown as typeof original;
+			await settlePresumedStalePrWorkflowLanes(directory, 'sess-rearm', {
+				laneLivenessWatchdog: stallOnly,
+			});
+			expect(
+				(await watchdogEvents(directory)).filter(
+					(event) => event.escalated === true,
+				).length,
+			).toBe(2);
+		} finally {
+			surface().readLaneActivity = original;
+		}
+	});
+});
+
+describe('PRR-002 — the force-abort finalize sweep runs at the effective horizon', () => {
+	test('retained retry lane between the watchdog horizon and the floor IS finalized', async () => {
+		await activatePrWorkflow(directory, 'sess-finalize', 'PR_REVIEW');
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-finalize',
+			'intent-architecture',
+			'c-fin',
+		);
+		await backdatePrWorkflowLane(directory, 'c-fin', MID_AGE_MS);
+		// A RETRY-status lane past the 60s horizon is probe-retained (the
+		// deadline never aborts provider retries) — the exact gap-window lane
+		// the old floor-based finalize sweep left pending forever.
+		const abortCalls: unknown[] = [];
+		const map: Record<string, { type?: string }> = {
+			[laneSubagentSessionId('c-fin')]: { type: 'retry' },
+		};
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({ data: map }),
+				abort: async (args: unknown) => {
+					abortCalls.push(args);
+					return {};
+				},
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		const settled = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-finalize',
+			{
+				laneLivenessWatchdog: watchdogWith(60_000),
+			},
+		);
+		expect(settled.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('pending');
+
+		// Human force abort WITH the same policy: the finalize sweep must run
+		// at the 60s effective horizon (not the 30-minute floor), so the
+		// 5-minute-old retained lane is finalized and the session restartable.
+		await abortPrWorkflow(directory, 'sess-finalize', {
+			kind: 'force',
+			reason: 'operator override',
+			laneLiveness: { laneLivenessWatchdog: watchdogWith(60_000) },
+		});
+		expect(laneStatusOnDisk(directory, 'c-fin')).toBe('stale');
+	});
+});

--- a/tests/unit/hooks/lane-liveness-outcomes.test.ts
+++ b/tests/unit/hooks/lane-liveness-outcomes.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Issue #2506 acceptance check C3 (AC3, NEW-SURFACE) — the five typed lane
+ * liveness conditions and the no-fabrication contract of execution_deadline
+ * settlement.
+ *
+ * Frozen contract pinned here:
+ * - `classifyLaneLivenessCondition({ sessionStatusType, recordStatus,
+ *   waitBudgetExpired, exceededEffectiveHorizon })` maps to exactly
+ *   'observer_deadline' | 'provider_retry_in_flight' | 'completed_failure' |
+ *   'idle_failed_child' | 'execution_deadline', with precedence
+ *   completed_failure > observer_deadline > provider_retry_in_flight >
+ *   execution_deadline > idle_failed_child.
+ * - Execution-deadline settlement aborts the lane's session (best-effort,
+ *   via the session-ops seam), settles through the SHARED settlement path,
+ *   and the terminal event carries the REAL outcome ("no output observed"
+ *   when no transcript exists) — never a fabricated review verdict or
+ *   coverage. Reviewer lanes still require their exact retry receipts
+ *   before any terminal publication: no receipt may materialize from a
+ *   watchdog settlement.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import { classifyLaneLivenessCondition } from '../../../src/hooks/lane-liveness-watchdog.js';
+import {
+	completePrWorkflow,
+	_test_exports as gateInternals,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import { readAllReceipts } from '../../../src/hooks/review-receipt.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+	writeRawPrWorkflowGateState,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const WATCHDOG_TIMEOUT_MS = 60_000;
+const LANE_AGE_MS = 5 * 60_000; // past the 60s watchdog horizon
+
+const enabledWatchdog = {
+	enabled: true,
+	timeout_ms: WATCHDOG_TIMEOUT_MS,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+type ClassifyInput = Parameters<typeof classifyLaneLivenessCondition>[0];
+
+const classify = (input: ClassifyInput) => classifyLaneLivenessCondition(input);
+
+let directory = '';
+let restoreClock: () => void = () => {};
+const originals = {
+	resolveCurrentGitHead: gateInternals.resolveCurrentGitHead,
+	resolveCurrentGitHeadAsync: gateInternals.resolveCurrentGitHeadAsync,
+	resolveIsWorkingTreeClean: gateInternals.resolveIsWorkingTreeClean,
+	resolveIsWorkingTreeCleanAsync: gateInternals.resolveIsWorkingTreeCleanAsync,
+};
+
+beforeEach(() => {
+	restoreClock = freezeClock();
+	directory = canonicalMkdtemp('lane-liveness-outcomes-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+	gateInternals.resolveCurrentGitHead = () => 'abc123';
+	gateInternals.resolveCurrentGitHeadAsync = async () => 'abc123';
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolveIsWorkingTreeCleanAsync = async () => true;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originals.resolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync =
+		originals.resolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originals.resolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originals.resolveIsWorkingTreeCleanAsync;
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+describe('C3 — the five typed conditions', () => {
+	test('completed_failure: a terminal-error record wins over every other signal', () => {
+		expect(
+			classify({
+				recordStatus: 'error',
+				sessionStatusType: 'busy',
+				waitBudgetExpired: true,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('completed_failure');
+		expect(
+			classify({
+				recordStatus: 'error',
+				sessionStatusType: 'retry',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: false,
+			}),
+		).toBe('completed_failure');
+	});
+
+	test('observer_deadline: an expired observation budget with a live-or-unknown session', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'busy',
+				waitBudgetExpired: true,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('observer_deadline');
+		expect(
+			classify({
+				recordStatus: 'running',
+				sessionStatusType: undefined,
+				waitBudgetExpired: true,
+				exceededEffectiveHorizon: false,
+			}),
+		).toBe('observer_deadline');
+	});
+
+	test('provider_retry_in_flight: a retrying session is provider latency, not lane death', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'retry',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: false,
+			}),
+		).toBe('provider_retry_in_flight');
+	});
+
+	test('execution_deadline: busy past the effective horizon', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'busy',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('execution_deadline');
+	});
+
+	test('execution_deadline: not alive (idle) past the effective horizon', () => {
+		expect(
+			classify({
+				recordStatus: 'running',
+				sessionStatusType: 'idle',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('execution_deadline');
+	});
+
+	test('idle_failed_child: open record, idle/absent session, below the horizon', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'idle',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: false,
+			}),
+		).toBe('idle_failed_child');
+		expect(
+			classify({
+				recordStatus: 'running',
+				sessionStatusType: undefined,
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: false,
+			}),
+		).toBe('idle_failed_child');
+	});
+});
+
+describe('C3 — precedence: completed_failure > observer_deadline > provider_retry_in_flight > execution_deadline > idle_failed_child', () => {
+	test('observer_deadline beats provider_retry_in_flight', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'retry',
+				waitBudgetExpired: true,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('observer_deadline');
+	});
+
+	test('observer_deadline beats execution_deadline', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'busy',
+				waitBudgetExpired: true,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('observer_deadline');
+	});
+
+	test('provider_retry_in_flight beats execution_deadline (retry past the horizon is still provider latency)', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'retry',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('provider_retry_in_flight');
+	});
+
+	test('execution_deadline beats idle_failed_child', () => {
+		expect(
+			classify({
+				recordStatus: 'pending',
+				sessionStatusType: 'idle',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe('execution_deadline');
+	});
+});
+
+describe('C3 — execution_deadline settlement retains the real outcome and fabricates nothing', () => {
+	test('abort once, settle through the shared path, event carries the real outcome', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-outcome',
+			'reviewer-correctness',
+			'c-outcome',
+		);
+		await backdatePrWorkflowLane(directory, 'c-outcome', LANE_AGE_MS);
+		const abortCalls: unknown[] = [];
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({
+					data: { [laneSubagentSessionId('c-outcome')]: { type: 'busy' } },
+				}),
+				abort: async (args: unknown) => {
+					abortCalls.push(args);
+					return {};
+				},
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-outcome',
+			{ laneLivenessWatchdog: enabledWatchdog },
+		);
+
+		// The lane's subagent session was aborted exactly once, and the abort
+		// targeted THIS lane's session id.
+		expect(abortCalls.length).toBe(1);
+		expect(JSON.stringify(abortCalls[0])).toContain('c-outcome');
+		// Shared-path settlement: the record is terminal `stale`, never
+		// `completed` (a completion without a result would be fabrication).
+		expect(settlement.presumedStaleLaneIds).toEqual(['reviewer-correctness']);
+		expect(laneStatusOnDisk(directory, 'c-outcome')).toBe('stale');
+		expect(laneStatusOnDisk(directory, 'c-outcome')).not.toBe('completed');
+
+		// The watchdog event discloses the typed condition and the real
+		// outcome. The fixture wrote no transcript, so the only truthful
+		// outcome is the explicit "no output observed" marker.
+		const eventsText = await fs.readFile(
+			path.join(directory, '.swarm', 'events.jsonl'),
+			'utf-8',
+		);
+		const watchdogEvents = eventsText
+			.trim()
+			.split('\n')
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+		expect(watchdogEvents.length).toBeGreaterThanOrEqual(1);
+		// No fabricated review verdict or coverage on ANY watchdog event.
+		for (const event of watchdogEvents) {
+			expect(event.verdict).toBeUndefined();
+			expect(event.coverage).toBeUndefined();
+			expect(event.effectiveHorizonMs).toBe(WATCHDOG_TIMEOUT_MS);
+			expect(event.horizonSource).toBe('watchdog-timeout');
+			expect(event.sessionID).toBe('sess-outcome');
+			expect(typeof event.timestamp).toBe('string');
+		}
+		const deadline = watchdogEvents.find(
+			(event) => event.condition === 'execution_deadline',
+		) as Record<string, unknown>;
+		expect(deadline).toBeDefined();
+		expect(deadline.escalated).toBe(false);
+		expect(deadline.laneIds).toEqual(['reviewer-correctness']);
+		expect(`${deadline.disclosure}`).toMatch(/no output observed/i);
+	});
+
+	test('a watchdog settlement fabricates no review receipt for a reviewer lane', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-receipt',
+			'reviewer-critic',
+			'c-receipt',
+		);
+		await backdatePrWorkflowLane(directory, 'c-receipt', LANE_AGE_MS);
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({
+					data: { [laneSubagentSessionId('c-receipt')]: { type: 'busy' } },
+				}),
+				abort: async () => ({}),
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-receipt', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+
+		// Reviewer/critic lanes require their EXACT retry receipts before any
+		// terminal publication; a watchdog settlement must not mint one.
+		expect(await readAllReceipts(directory)).toEqual([]);
+		expect(laneStatusOnDisk(directory, 'c-receipt')).not.toBe('completed');
+	});
+
+	test('completion still fails on real coverage after a watchdog settlement (no verdict invented)', async () => {
+		await writeRawPrWorkflowGateState(directory, 'sess-cover', {
+			mode: 'PR_REVIEW',
+			prHeadSha: 'abc123',
+			revision: 2,
+		});
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-cover',
+			'reviewer-tests',
+			'c-cover',
+		);
+		await backdatePrWorkflowLane(directory, 'c-cover', LANE_AGE_MS);
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({
+					data: { [laneSubagentSessionId('c-cover')]: { type: 'busy' } },
+				}),
+				abort: async () => ({}),
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		await settlePresumedStalePrWorkflowLanes(directory, 'sess-cover', {
+			laneLivenessWatchdog: enabledWatchdog,
+		});
+		expect(laneStatusOnDisk(directory, 'c-cover')).toBe('stale');
+
+		// The lane no longer blocks completion as "unsettled" — but the
+		// settled lane grants NO coverage: completion must still refuse on
+		// real coverage grounds, proving nothing was invented for it.
+		const error = await completePrWorkflow(
+			directory,
+			'sess-cover',
+			'PR_REVIEW',
+			'abc123',
+		).then(
+			() => null,
+			(err: unknown) => (err instanceof Error ? err.message : String(err)),
+		);
+		expect(error).not.toBeNull();
+		expect(error).not.toMatch(/unsettled PR workflow lane/i);
+	});
+});

--- a/tests/unit/hooks/lane-liveness-scenarios.test.ts
+++ b/tests/unit/hooks/lane-liveness-scenarios.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Issue #2506 acceptance check C8 (AC8, NEW-SURFACE) — the six end-to-end
+ * scenarios:
+ *   1. slow live provider (busy past horizon, watchdog disabled → retained,
+ *      unchanged),
+ *   2. deadline expiry (enabled → abort + settle with the real outcome),
+ *   3. mid-write settlement (settlement concurrent with an in-flight ledger
+ *      append leaves a consistent ledger and events log),
+ *   4. user response to escalation (force-abort override still human-only
+ *      and reachable),
+ *   5. disabled no-op (no new events or transitions),
+ *   6. conflicting horizons (exactly one effective horizon governs).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	appendDelegationTransition,
+	readDelegations,
+} from '../../../src/background/pending-delegations.js';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import { resolveEffectivePrLaneHorizonMs } from '../../../src/hooks/lane-liveness-watchdog.js';
+import {
+	abortPrWorkflow,
+	activatePrWorkflow,
+	_test_exports as gateInternals,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+	STALE_LANE_AGE_MS,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+const STALE_AGE_MS = STALE_LANE_AGE_MS; // 30min floor + 60s
+
+const enabledWith = (timeout_ms: number) => ({
+	enabled: true,
+	timeout_ms,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+});
+
+let directory = '';
+let restoreClock: () => void = () => {};
+const originals = {
+	resolveCurrentGitHead: gateInternals.resolveCurrentGitHead,
+	resolveCurrentGitHeadAsync: gateInternals.resolveCurrentGitHeadAsync,
+	resolveIsWorkingTreeClean: gateInternals.resolveIsWorkingTreeClean,
+	resolveIsWorkingTreeCleanAsync: gateInternals.resolveIsWorkingTreeCleanAsync,
+};
+
+beforeEach(() => {
+	restoreClock = freezeClock();
+	directory = canonicalMkdtemp('lane-liveness-scenarios-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+	gateInternals.resolveCurrentGitHead = () => 'abc123';
+	gateInternals.resolveCurrentGitHeadAsync = async () => 'abc123';
+	gateInternals.resolveIsWorkingTreeClean = () => true;
+	gateInternals.resolveIsWorkingTreeCleanAsync = async () => true;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	gateInternals.resolveCurrentGitHead = originals.resolveCurrentGitHead;
+	gateInternals.resolveCurrentGitHeadAsync =
+		originals.resolveCurrentGitHeadAsync;
+	gateInternals.resolveIsWorkingTreeClean = originals.resolveIsWorkingTreeClean;
+	gateInternals.resolveIsWorkingTreeCleanAsync =
+		originals.resolveIsWorkingTreeCleanAsync;
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+function installBusyHost(correlationIds: string[]): unknown[] {
+	const abortCalls: unknown[] = [];
+	const map: Record<string, { type?: string }> = {};
+	for (const id of correlationIds)
+		map[laneSubagentSessionId(id)] = { type: 'busy' };
+	gateInternals.getSessionOps = () =>
+		({
+			status: async () => ({ data: map }),
+			abort: async (args: unknown) => {
+				abortCalls.push(args);
+				return {};
+			},
+		}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+	return abortCalls;
+}
+
+async function watchdogEvents(dir: string): Promise<Record<string, unknown>[]> {
+	try {
+		const text = await fs.readFile(
+			path.join(dir, '.swarm', 'events.jsonl'),
+			'utf-8',
+		);
+		return text
+			.trim()
+			.split('\n')
+			.filter((line) => line.trim().length > 0)
+			.map((line) => JSON.parse(line) as Record<string, unknown>)
+			.filter((event) => event.type === 'pr_workflow_lane_watchdog');
+	} catch {
+		return [];
+	}
+}
+
+describe('C8 scenario 1 — slow live provider, watchdog disabled', () => {
+	test('busy past the horizon is retained, unchanged: no abort, no watchdog events', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-slow',
+			'intent-architecture',
+			'c-slow',
+		);
+		await backdatePrWorkflowLane(directory, 'c-slow', STALE_AGE_MS);
+		const abortCalls = installBusyHost(['c-slow']);
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-slow',
+		);
+
+		expect(settlement.openLanes).toBe(1);
+		expect(settlement.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-slow')).toBe('pending');
+		expect(abortCalls).toEqual([]);
+		expect(await watchdogEvents(directory)).toEqual([]);
+	});
+});
+
+describe('C8 scenario 2 — deadline expiry, watchdog enabled', () => {
+	test('busy past the effective horizon is aborted once and settled with the real outcome', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-expire',
+			'risk-security',
+			'c-expire',
+		);
+		await backdatePrWorkflowLane(directory, 'c-expire', 5 * 60_000);
+		const abortCalls = installBusyHost(['c-expire']);
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-expire',
+			{ laneLivenessWatchdog: enabledWith(60_000) },
+		);
+
+		expect(abortCalls.length).toBe(1);
+		expect(JSON.stringify(abortCalls[0])).toContain('c-expire');
+		expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+		expect(laneStatusOnDisk(directory, 'c-expire')).toBe('stale');
+		const events = await watchdogEvents(directory);
+		expect(events.length).toBeGreaterThanOrEqual(1);
+		for (const event of events) {
+			expect(event.effectiveHorizonMs).toBe(60_000);
+			expect(event.horizonSource).toBe('watchdog-timeout');
+		}
+		const deadline = events.find(
+			(event) => event.condition === 'execution_deadline',
+		) as Record<string, unknown>;
+		expect(deadline).toBeDefined();
+		expect(`${deadline.disclosure}`).toMatch(/no output observed/i);
+	});
+});
+
+describe('C8 scenario 3 — settlement during an in-flight ledger append', () => {
+	test('concurrent append + watchdog settlement leave a consistent ledger and events log', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-midwrite',
+			'reviewer-correctness',
+			'c-midwrite',
+		);
+		await backdatePrWorkflowLane(directory, 'c-midwrite', 5 * 60_000);
+		// An unrelated lane whose ledger transition is IN FLIGHT while the
+		// watchdog settles the first lane.
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-midwrite',
+			'writer-lane',
+			'c-writer',
+		);
+		installBusyHost(['c-midwrite', 'c-writer']);
+
+		const inFlightAppend = appendDelegationTransition(directory, 'c-writer', {
+			status: 'running',
+			updatedAt: Date.now(),
+		});
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-midwrite',
+			{ laneLivenessWatchdog: enabledWith(60_000) },
+		);
+		await inFlightAppend;
+
+		// Both writes survived; the ledger still parses and neither record
+		// was torn.
+		expect(settlement.presumedStaleLaneIds).toEqual(['reviewer-correctness']);
+		const records = readDelegations(directory);
+		const settled = records.find((r) => r.correlationId === 'c-midwrite');
+		const writer = records.find((r) => r.correlationId === 'c-writer');
+		expect(settled?.status).toBe('stale');
+		expect(writer?.status).toBe('running');
+		// Every events.jsonl line is intact, parseable JSON.
+		const lines = (
+			await fs.readFile(path.join(directory, '.swarm', 'events.jsonl'), 'utf-8')
+		)
+			.trim()
+			.split('\n')
+			.filter((line) => line.trim().length > 0);
+		for (const line of lines) {
+			expect(() => JSON.parse(line)).not.toThrow();
+		}
+		expect(
+			lines.some((line) => line.includes('pr_workflow_lane_watchdog')),
+		).toBe(true);
+	});
+});
+
+describe('C8 scenario 4 — user response to escalation stays human-only', () => {
+	test('escalated retained lane: recovery abort refused, human force abort succeeds', async () => {
+		// timeout_ms = 0 disables the execution deadline, so the busy
+		// past-floor lane is probe-retained (today's behavior) while the
+		// stall detector surfaces the escalation for the operator.
+		await activatePrWorkflow(directory, 'sess-respond', 'PR_REVIEW');
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-respond',
+			'intent-architecture',
+			'c-respond',
+		);
+		await backdatePrWorkflowLane(directory, 'c-respond', STALE_AGE_MS);
+		installBusyHost(['c-respond']);
+
+		const settled = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-respond',
+			{ laneLivenessWatchdog: enabledWith(0) },
+		);
+		// Retained (deadline disabled) AND escalated (stalled, zero output).
+		expect(settled.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-respond')).toBe('pending');
+		const escalations = (await watchdogEvents(directory)).filter(
+			(event) => event.escalated === true,
+		);
+		expect(escalations.length).toBe(1);
+		expect(escalations[0].laneIds).toContain('intent-architecture');
+
+		// A machine-style recovery abort is still refused on the retention.
+		await expect(
+			abortPrWorkflow(directory, 'sess-respond', {
+				kind: 'recovery',
+				reason: 'automated response to escalation',
+			}),
+		).rejects.toThrow(/in flight|still running/i);
+
+		// The human-only force override remains the one reachable exit.
+		const summary = await abortPrWorkflow(directory, 'sess-respond', {
+			kind: 'force',
+			reason: 'operator inspected the escalated lane',
+		});
+		// #2251 semantics: force abort reports the PRE-finalization open-lane
+		// count (fresh + probe-retained); the retained lane's ledger row is
+		// finalized after this count is taken. The terminal row asserted below
+		// is what proves the override actually landed.
+		expect(summary.openLanes).toBe(1);
+		expect(laneStatusOnDisk(directory, 'c-respond')).toBe('stale');
+	});
+});
+
+describe('C8 scenario 5 — disabled watchdog is a strict no-op', () => {
+	test("mixed fixture: no watchdog events, no aborts, today's settlement shape", async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-noop',
+			'intent-architecture',
+			'c-noop-stale',
+		);
+		await backdatePrWorkflowLane(directory, 'c-noop-stale', STALE_AGE_MS);
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-noop',
+			'risk-security',
+			'c-noop-fresh',
+		);
+		const abortCalls = installBusyHost(['c-noop-stale', 'c-noop-fresh']);
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-noop',
+		);
+
+		// Exactly the substrate behavior: the busy stale lane is retained
+		// (disclosed via probedAliveLaneIds), the fresh lane blocks, nothing
+		// else happens. openLanes/openLaneIds keep the #2251 pinned semantics
+		// (fresh open lanes PLUS probe-retained lanes; probe evidence:
+		// repro/probe-openlanes.ts prints openLaneIds =
+		// ["risk-security","intent-architecture"], openLanes = 2 for this
+		// exact fixture on the pre-fix substrate).
+		expect(settlement.openLanes).toBe(2);
+		expect(settlement.openLaneIds).toEqual([
+			'risk-security',
+			'intent-architecture',
+		]);
+		expect(settlement.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-noop-stale')).toBe('pending');
+		expect(laneStatusOnDisk(directory, 'c-noop-fresh')).toBe('pending');
+		expect(abortCalls).toEqual([]);
+		expect(await watchdogEvents(directory)).toEqual([]);
+	});
+});
+
+describe('C8 scenario 6 — conflicting horizons resolve to exactly one', () => {
+	test('watchdog 10min vs background 20min: the 10min horizon alone governs the lane', async () => {
+		const config = enabledWith(600_000);
+		const backgroundPendingTimeoutMs = 1_200_000;
+		// Unit-level cross-check: the resolver discloses the conflict but
+		// keeps a single effective horizon.
+		const horizon = resolveEffectivePrLaneHorizonMs(
+			config,
+			backgroundPendingTimeoutMs,
+		);
+		expect(horizon.horizonMs).toBe(600_000);
+		expect(horizon.source).toBe('watchdog-timeout');
+		expect(horizon.conflictDisclosed).toBe(true);
+
+		// Lane aged 700s: past the 10-minute effective horizon, below the
+		// conflicting 20-minute background timeout and the 30-minute floor.
+		// ONE horizon (the watchdog's) decides.
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-conflict',
+			'reviewer-critic',
+			'c-conflict',
+		);
+		await backdatePrWorkflowLane(directory, 'c-conflict', 700_000);
+		const abortCalls = installBusyHost(['c-conflict']);
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-conflict',
+			{
+				laneLivenessWatchdog: config,
+				backgroundPendingTimeoutMs,
+			},
+		);
+
+		expect(settlement.presumedStaleLaneIds).toEqual(['reviewer-critic']);
+		expect(laneStatusOnDisk(directory, 'c-conflict')).toBe('stale');
+		expect(abortCalls.length).toBe(1);
+		// One decision, one terminal transition — the conflicting value did
+		// not produce a second horizon: EVERY watchdog event reports the same
+		// single effective horizon, and the lane settled exactly once.
+		const events = await watchdogEvents(directory);
+		expect(events.length).toBeGreaterThanOrEqual(1);
+		for (const event of events) {
+			expect(event.effectiveHorizonMs).toBe(600_000);
+			expect(event.horizonSource).toBe('watchdog-timeout');
+		}
+		const deadline = events.find(
+			(event) => event.condition === 'execution_deadline',
+		);
+		expect(deadline).toBeDefined();
+		const settledTimes = readDelegations(directory).filter(
+			(record) =>
+				record.correlationId === 'c-conflict' && record.status === 'stale',
+		).length;
+		expect(settledTimes).toBe(1);
+	});
+});

--- a/tests/unit/hooks/lane-liveness-watchdog.test.ts
+++ b/tests/unit/hooks/lane-liveness-watchdog.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Issue #2506 acceptance check C1 (AC1, NEW-SURFACE) — the lane-liveness
+ * watchdog configuration surface, the gate seam surface, and the default-off
+ * no-op contract for the watchdog evaluation itself.
+ *
+ * Frozen contract pinned here:
+ * - `src/config/schema.ts` gains a top-level `lane_liveness_watchdog` section
+ *   backed by `LaneLivenessWatchdogConfigSchema` with the exact defaults and
+ *   bounds (0 accepted everywhere; out-of-range rejected; `enabled` defaults
+ *   to false).
+ * - `src/hooks/lane-liveness-watchdog.ts` exports
+ *   `LANE_LIVENESS_WATCHDOG_DEFAULTS` carrying those same five defaults.
+ * - `src/hooks/pr-workflow-gate.ts` `_test_exports.laneLivenessWatchdog`
+ *   exposes `resolveEffectivePrLaneHorizonMs`,
+ *   `classifyLaneLivenessCondition`, `evaluateLaneLivenessWatchdog`, and the
+ *   budget counters `hostStatusCalls` / `hostAbortCalls` / `evaluations`.
+ * - With the watchdog disabled (the default), the watchdog evaluation is a
+ *   NO-OP: existing settlement behavior is unchanged and the watchdog emits
+ *   no events and records no activity of its own.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	LaneLivenessWatchdogConfigSchema,
+	PluginConfigSchema,
+} from '../../../src/config/schema.js';
+import { closeProjectDb } from '../../../src/db/project-db.js';
+import { LANE_LIVENESS_WATCHDOG_DEFAULTS } from '../../../src/hooks/lane-liveness-watchdog.js';
+import {
+	_test_exports as gateInternals,
+	settlePresumedStalePrWorkflowLanes,
+} from '../../../src/hooks/pr-workflow-gate.js';
+import {
+	backdatePrWorkflowLane,
+	laneStatusOnDisk,
+	laneSubagentSessionId,
+	recordOpenPrWorkflowLane,
+	STALE_LANE_AGE_MS,
+} from '../../helpers/pr-workflow-lane-fixtures.js';
+import { freezeClock } from '../../helpers/test-clock.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/**
+ * Structural view of the gate seam surface. Cast through `unknown` on
+ * purpose: the contract freezes the MEMBER NAMES, not the declared TS types,
+ * so this file must not depend on how the implementation types them.
+ */
+type WatchdogSurface = {
+	resolveEffectivePrLaneHorizonMs: (...args: unknown[]) => unknown;
+	classifyLaneLivenessCondition: (...args: unknown[]) => unknown;
+	evaluateLaneLivenessWatchdog: (...args: unknown[]) => unknown;
+	hostStatusCalls: number;
+	hostAbortCalls: number;
+	evaluations: number;
+};
+
+const surface = (): WatchdogSurface =>
+	gateInternals.laneLivenessWatchdog as unknown as WatchdogSurface;
+
+/** The five frozen defaults from issue #2506 AC1 (0 disables the feature). */
+const CONTRACT_DEFAULTS = {
+	enabled: false,
+	timeout_ms: 1_800_000,
+	stall_threshold_ms: 300_000,
+	stall_min_steps: 5,
+	stall_token_threshold: 200,
+};
+
+let directory = '';
+let restoreClock: () => void = () => {};
+
+beforeEach(() => {
+	restoreClock = freezeClock();
+	directory = canonicalMkdtemp('lane-liveness-watchdog-');
+	gateInternals.resetTrackedStateCache();
+	gateInternals.getSessionOps = () => null;
+});
+
+afterEach(async () => {
+	restoreClock();
+	gateInternals.resetTrackedStateCache();
+	closeProjectDb(directory);
+	await fs.rm(directory, { recursive: true, force: true });
+});
+
+describe('C1 — lane_liveness_watchdog config schema (AC1)', () => {
+	test('the section exists on PluginConfigSchema and parses to the frozen defaults', () => {
+		expect(PluginConfigSchema.shape.lane_liveness_watchdog).toBeDefined();
+		const parsed = PluginConfigSchema.parse({
+			lane_liveness_watchdog: {},
+		});
+		expect(parsed.lane_liveness_watchdog).toEqual(CONTRACT_DEFAULTS);
+	});
+
+	test('LANE_LIVENESS_WATCHDOG_DEFAULTS equals the five frozen contract values', () => {
+		expect(LANE_LIVENESS_WATCHDOG_DEFAULTS).toEqual(CONTRACT_DEFAULTS);
+	});
+
+	test('the standalone schema and the section agree on the defaults', () => {
+		expect(LaneLivenessWatchdogConfigSchema.parse({})).toEqual(
+			PluginConfigSchema.parse({ lane_liveness_watchdog: {} })
+				.lane_liveness_watchdog,
+		);
+	});
+
+	test('default-off: an omitted or empty section is never enabled', () => {
+		const omitted = PluginConfigSchema.parse({});
+		expect(omitted.lane_liveness_watchdog?.enabled ?? false).toBe(false);
+		const empty = PluginConfigSchema.parse({ lane_liveness_watchdog: {} });
+		expect(empty.lane_liveness_watchdog?.enabled).toBe(false);
+	});
+
+	test('every knob accepts 0 (0 disables the relevant feature)', () => {
+		const zeros = {
+			enabled: true,
+			timeout_ms: 0,
+			stall_threshold_ms: 0,
+			stall_min_steps: 0,
+			stall_token_threshold: 0,
+		};
+		expect(LaneLivenessWatchdogConfigSchema.safeParse(zeros).success).toBe(
+			true,
+		);
+		expect(
+			PluginConfigSchema.safeParse({ lane_liveness_watchdog: zeros }).success,
+		).toBe(true);
+	});
+
+	test('out-of-range and mistyped values are rejected', () => {
+		const bad = [
+			{ timeout_ms: -1 },
+			{ timeout_ms: 86_400_001 },
+			{ timeout_ms: 1.5 },
+			{ stall_threshold_ms: -1 },
+			{ stall_threshold_ms: 86_400_001 },
+			{ stall_min_steps: -1 },
+			{ stall_min_steps: 10_001 },
+			{ stall_token_threshold: -1 },
+			{ stall_token_threshold: 1_000_001 },
+			{ enabled: 'yes' },
+		];
+		for (const override of bad) {
+			expect(
+				LaneLivenessWatchdogConfigSchema.safeParse({
+					...CONTRACT_DEFAULTS,
+					...override,
+				}).success,
+			).toBe(false);
+		}
+	});
+
+	test('the boundary maximum values are accepted', () => {
+		expect(
+			LaneLivenessWatchdogConfigSchema.safeParse({
+				enabled: true,
+				timeout_ms: 86_400_000,
+				stall_threshold_ms: 86_400_000,
+				stall_min_steps: 10_000,
+				stall_token_threshold: 1_000_000,
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('C1 — watchdog surface reachable from the gate _test_exports seam', () => {
+	test('the surface exposes the three functions and the three budget counters', () => {
+		const s = surface();
+		expect(gateInternals.laneLivenessWatchdog).toBeDefined();
+		expect(typeof s.resolveEffectivePrLaneHorizonMs).toBe('function');
+		expect(typeof s.classifyLaneLivenessCondition).toBe('function');
+		expect(typeof s.evaluateLaneLivenessWatchdog).toBe('function');
+		expect(typeof s.hostStatusCalls).toBe('number');
+		expect(typeof s.hostAbortCalls).toBe('number');
+		expect(typeof s.evaluations).toBe('number');
+	});
+
+	test('the gate surface behaves like the module exports (no stale copy)', async () => {
+		const { resolveEffectivePrLaneHorizonMs, classifyLaneLivenessCondition } =
+			await import('../../../src/hooks/lane-liveness-watchdog.js');
+		const enabled = {
+			...CONTRACT_DEFAULTS,
+			enabled: true,
+			timeout_ms: 600_000,
+		};
+		expect(
+			surface().resolveEffectivePrLaneHorizonMs(enabled, 1_200_000),
+		).toEqual(resolveEffectivePrLaneHorizonMs(enabled, 1_200_000));
+		expect(
+			surface().classifyLaneLivenessCondition({
+				sessionStatusType: 'busy',
+				recordStatus: 'pending',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		).toBe(
+			classifyLaneLivenessCondition({
+				sessionStatusType: 'busy',
+				recordStatus: 'pending',
+				waitBudgetExpired: false,
+				exceededEffectiveHorizon: true,
+			}),
+		);
+	});
+});
+
+describe('C1 — disabled watchdog is a no-op for the watchdog evaluation itself', () => {
+	test('a stale busy lane with the watchdog off is retained and produces zero watchdog activity', async () => {
+		// The #2251 substrate behavior must be observable unchanged: the lane
+		// is past the 30-minute reachability floor, its session answers
+		// `busy`, so the probe retains it.
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-c1-noop',
+			'intent-architecture',
+			'c-c1-noop',
+		);
+		await backdatePrWorkflowLane(directory, 'c-c1-noop', STALE_LANE_AGE_MS);
+		let abortCalls = 0;
+		gateInternals.getSessionOps = () =>
+			({
+				status: async () => ({
+					data: { [laneSubagentSessionId('c-c1-noop')]: { type: 'busy' } },
+				}),
+				abort: async () => {
+					abortCalls += 1;
+					return {};
+				},
+			}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+		// Two-argument call: no watchdog options threaded, so the disabled
+		// default applies. This is the exact call shape every existing caller
+		// uses today.
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-c1-noop',
+		);
+
+		expect(settlement.openLanes).toBe(1);
+		expect(settlement.probedAliveLaneIds).toEqual(['intent-architecture']);
+		expect(laneStatusOnDisk(directory, 'c-c1-noop')).toBe('pending');
+		expect(abortCalls).toBe(0);
+		const eventsText = await fs
+			.readFile(path.join(directory, '.swarm', 'events.jsonl'), 'utf-8')
+			.catch(() => '');
+		const watchdogEvents = eventsText
+			.split('\n')
+			.filter((line) => line.includes('pr_workflow_lane_watchdog'));
+		expect(watchdogEvents).toEqual([]);
+		const s = surface();
+		expect(s.evaluations).toBe(0);
+		expect(s.hostStatusCalls).toBe(0);
+		expect(s.hostAbortCalls).toBe(0);
+	});
+
+	test('an explicit enabled:false config threaded through settlement options is equally inert', async () => {
+		await recordOpenPrWorkflowLane(
+			directory,
+			'sess-c1-off',
+			'risk-security',
+			'c-c1-off',
+		);
+		await backdatePrWorkflowLane(directory, 'c-c1-off', STALE_LANE_AGE_MS);
+		gateInternals.getSessionOps = () => null;
+
+		const settlement = await settlePresumedStalePrWorkflowLanes(
+			directory,
+			'sess-c1-off',
+			{ laneLivenessWatchdog: { ...CONTRACT_DEFAULTS, enabled: false } },
+		);
+
+		// No host, no watchdog: the age-only reachability floor settles the
+		// lane exactly as it does today.
+		expect(settlement.presumedStaleLaneIds).toEqual(['risk-security']);
+		expect(laneStatusOnDisk(directory, 'c-c1-off')).toBe('stale');
+		expect(surface().evaluations).toBe(0);
+		expect(surface().hostAbortCalls).toBe(0);
+	});
+});
+
+/**
+ * Plan-critic round 1 (HIGH): the enabled x 0-disables cross-product must be
+ * pinned cell-by-cell, not implied by two endpoint fixtures. Semantics frozen
+ * here — a feature knob at 0 disables THAT feature regardless of `enabled`,
+ * and `enabled: false` disables the whole watchdog regardless of knobs:
+ *
+ * - deadlineActive(cell)  = cell.enabled && cell.timeout_ms > 0
+ * - stallActive(cell)     = cell.enabled && cell.stall_threshold_ms > 0 &&
+ *   cell.stall_min_steps > 0 && cell.stall_token_threshold > 0
+ * - anyWatchdogWork(cell) = deadlineActive || stallActive; when false the
+ *   evaluation is a no-op (0 evaluations, 0 watchdog events, 0 aborts).
+ *
+ * Scenario per cell: lane A is busy and past the 30-minute reachability floor
+ * (deadline path); lane B is busy, below the horizon, zero activity (stall
+ * path). Expected: exactly one `execution_deadline` watchdog event + one abort
+ * + terminal `stale` for A when deadlineActive (the watchdog overrides probe
+ * retention for lanes past the EFFECTIVE horizon); A retained `pending`
+ * otherwise (busy lanes are never settled by the age-only substrate). Exactly
+ * one escalation event for B when stallActive && !deadlineActive (a lane being
+ * deadline-settled needs no stall escalation).
+ */
+describe('C1 — enabled x 0-disables cross-product (32 cells)', () => {
+	const POSITIVE = {
+		timeout_ms: 600_000,
+		stall_threshold_ms: 60_000,
+		stall_min_steps: 5,
+		stall_token_threshold: 200,
+	};
+
+	const deadlineActive = (cell: typeof CONTRACT_DEFAULTS): boolean =>
+		cell.enabled && cell.timeout_ms > 0;
+	const stallActive = (cell: typeof CONTRACT_DEFAULTS): boolean =>
+		cell.enabled &&
+		cell.stall_threshold_ms > 0 &&
+		cell.stall_min_steps > 0 &&
+		cell.stall_token_threshold > 0;
+
+	const CELLS: Array<typeof CONTRACT_DEFAULTS> = [];
+	for (const enabled of [false, true]) {
+		for (const timeoutZero of [true, false]) {
+			for (const thresholdZero of [true, false]) {
+				for (const stepsZero of [true, false]) {
+					for (const tokensZero of [true, false]) {
+						CELLS.push({
+							enabled,
+							timeout_ms: timeoutZero ? 0 : POSITIVE.timeout_ms,
+							stall_threshold_ms: thresholdZero
+								? 0
+								: POSITIVE.stall_threshold_ms,
+							stall_min_steps: stepsZero ? 0 : POSITIVE.stall_min_steps,
+							stall_token_threshold: tokensZero
+								? 0
+								: POSITIVE.stall_token_threshold,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	test('every cell matches the frozen inertness truth table', async () => {
+		expect(CELLS.length).toBe(32);
+		for (const cell of CELLS) {
+			const work = deadlineActive(cell) || stallActive(cell);
+			const cellDirectory = canonicalMkdtemp('lane-liveness-cross-');
+			try {
+				gateInternals.resetTrackedStateCache();
+				await recordOpenPrWorkflowLane(
+					cellDirectory,
+					'sess-cross',
+					'intent-architecture',
+					'c-cross-a',
+				);
+				await recordOpenPrWorkflowLane(
+					cellDirectory,
+					'sess-cross',
+					'risk-security',
+					'c-cross-b',
+				);
+				await backdatePrWorkflowLane(
+					cellDirectory,
+					'c-cross-a',
+					STALE_LANE_AGE_MS,
+				);
+				let abortCalls = 0;
+				gateInternals.getSessionOps = () =>
+					({
+						status: async () => ({
+							data: {
+								[laneSubagentSessionId('c-cross-a')]: { type: 'busy' },
+								[laneSubagentSessionId('c-cross-b')]: { type: 'busy' },
+							},
+						}),
+						abort: async () => {
+							abortCalls += 1;
+							return {};
+						},
+					}) as unknown as ReturnType<typeof gateInternals.getSessionOps>;
+
+				await settlePresumedStalePrWorkflowLanes(cellDirectory, 'sess-cross', {
+					laneLivenessWatchdog: cell,
+				});
+
+				const eventsText = await fs
+					.readFile(path.join(cellDirectory, '.swarm', 'events.jsonl'), 'utf-8')
+					.catch(() => '');
+				const watchdogLines = eventsText
+					.split('\n')
+					.filter((line) => line.includes('pr_workflow_lane_watchdog'));
+				// A deadline EVENT is a deadline settlement (escalated:false,
+				// condition execution_deadline). An escalation may honestly
+				// classify a past-horizon retained lane as execution_deadline
+				// too — that is a stall escalation, not a settlement.
+				const deadlineEvents = watchdogLines.filter(
+					(line) =>
+						line.includes('execution_deadline') &&
+						!line.includes('"escalated":true'),
+				);
+				const escalationEvents = watchdogLines.filter((line) =>
+					line.includes('"escalated":true'),
+				);
+				const label = JSON.stringify(cell);
+				expect(surface().evaluations, label).toBe(work ? 1 : 0);
+				expect(watchdogLines.length, label).toBe(
+					(deadlineActive(cell) ? 1 : 0) +
+						(stallActive(cell) && !deadlineActive(cell) ? 1 : 0),
+				);
+				expect(deadlineEvents.length, label).toBe(deadlineActive(cell) ? 1 : 0);
+				expect(escalationEvents.length, label).toBe(
+					stallActive(cell) && !deadlineActive(cell) ? 1 : 0,
+				);
+				expect(surface().hostAbortCalls, label).toBe(
+					deadlineActive(cell) ? 1 : 0,
+				);
+				expect(abortCalls, label).toBe(deadlineActive(cell) ? 1 : 0);
+				expect(laneStatusOnDisk(cellDirectory, 'c-cross-a'), label).toBe(
+					deadlineActive(cell) ? 'stale' : 'pending',
+				);
+				expect(laneStatusOnDisk(cellDirectory, 'c-cross-b'), label).toBe(
+					'pending',
+				);
+			} finally {
+				gateInternals.resetTrackedStateCache();
+				closeProjectDb(cellDirectory);
+				await fs.rm(cellDirectory, { recursive: true, force: true });
+			}
+		}
+	}, 120_000);
+});


### PR DESCRIPTION
Closes #2506

## Summary

Workstream G, PR 2 of 6: lane liveness for the PR workflow. Adds a default-off
`lane_liveness_watchdog` config that gives `settlePresumedStalePrWorkflowLanes`
an execution-liveness limit of its own, so lanes that exceed a configured
deadline are aborted once and settled with their real outcome, low-output
stalls are surfaced before the limit, and a slow provider or an observation
timeout is never invented into child failure.

- `src/hooks/lane-liveness-watchdog.ts` (new, pure policy): feature flags with
  0-disables-each semantics; `resolveEffectivePrLaneHorizonMs` — exactly ONE
  effective horizon (watchdog `timeout_ms > 0` wins over the 30-minute
  reachability floor, `conflictDisclosed` when `background_pending_timeout_minutes`
  disagrees, never a second horizon); `classifyLaneLivenessCondition` with frozen
  precedence `completed_failure > observer_deadline > provider_retry_in_flight >
  execution_deadline > idle_failed_child`; transcript-absent lanes read zero
  activity (no invented failure).
- `src/hooks/pr-workflow-gate.ts`: deadline lanes (`busy` with execution past
  the effective horizon, never `retry` — provider retry is its own condition)
  are aborted via one bounded host-abort attempt and settled through the shared
  sweep with their real outcome ("no output observed"); probe-retained open
  lanes get an advisory stall escalation whose dedup baseline lives in the
  durable event log (`pr_workflow_lane_watchdog` events; `escalated:true` marks
  an escalation, `activityObserved:true` resets the baseline); counters reset
  with `resetTrackedStateCache`.
- Config threading: `src/config/schema.ts` (`lane_liveness_watchdog`, default
  off, strict numeric bounds), `src/services/config-doctor.ts`,
  `src/tools/abort-pr-workflow.ts` and `src/tools/complete-pr-workflow.ts`
  resolve the policy via `loadPluginConfig` (dispatch-lanes precedent) and
  thread the SAME policy into both the observation settlement and the gate's
  internal settlement.
- Docs: `docs/configuration.md` section, regenerated `opencode-swarm.schema.json`,
  release fragment `docs/releases/pending/2506-lane-liveness-watchdog.md`.

ADR 0002: reimplementation only — the parameter surface and the durable
escalation-dedup idea are adopted with credit; no ported code, no
`ported-from` markers (pinned by `tests/unit/docs/ensemble-adr-2505.test.ts`).

Issue tracer trace: `.agents/issue-traces/2506-lane-liveness-watchdog/`
(plan-critic APPROVE, implementation-review APPROVE round 2, final-critic
APPROVE, checkpoint 10/10 with AMEND provenance).

## Invariant audit

- 1 (plugin init):       not touched — no init-path work added; grep shows no new init-time calls in the diff.
- 2 (runtime portability): not touched — no bundling/entry/`bun:` changes; `bun run build` + `tests/unit/build/bundle-portability.test.ts` + `node --input-type=module -e "await import('./dist/index.js')"` green at the feature commit.
- 3 (subprocesses):      not touched — the watchdog abort target is a host session-abort API call wrapped in `withTimeout` with try/catch, not a spawn; probes reuse the existing bounded probe path (`pr-workflow-gate.ts` probe budget pinned by `lane-liveness-budget.test.ts`).
- 4 (.swarm containment): touched — watchdog events append to `.swarm/events.jsonl` through the existing event-log writer under the resolved project root; no new `.swarm/` location; `.zvec`/graphify caches untouched.
- 5 (plan durability):   not touched — no ledger/projection/schema-shape change.
- 6 (test_runner safety): not touched — no `test_runner` changes.
- 7 (test writing):      touched — six new bun:test files `tests/unit/hooks/lane-liveness-*.test.ts` (58 tests, each file under the 500-line cap, per-file isolation verified, seams via `_test_exports` surface with `afterEach`/`resetTrackedStateCache` restoration); `bun run check:test-file-cap` green; `check:mock-cleanup` self-labeled warnings are pre-existing (4, unchanged).
- 8 (session state):     touched — the escalation dedup baseline is derived durably from the bounded `.swarm/events.jsonl` log per (sessionID, lane label) — NOT a module-level map — so it survives `resetTrackedStateCache()` (which zeroes only the test counters); sessions never suppress each other's advisories. Pinned by `lane-liveness-escalation.test.ts` (dedup-survives-reset) and `lane-liveness-negative-paths.test.ts` (cross-session isolation).
- 9 (guardrails/retry):  touched — classification keeps `provider_retry_in_flight` distinct from `execution_deadline`; `retry` lanes are never deadline-aborted (`deadlineActive && type !== 'retry'`, `LIVE_SESSION_STATUS_TYPES` retains `retry`); observer-deadline and completed-failure conditions stay separate channels (pinned by `lane-liveness-outcomes.test.ts`).
- 10 (chat/system msg):  not touched — no chat transform or system-guidance changes.
- 11 (tool registration): not touched — no new/changed tools, agents, or commands; `bun run drift:check` clean for tool surface.
- 12 (release/cache):    touched — pending fragment `docs/releases/pending/2506-lane-liveness-watchdog.md` added (`bun run check:pending-fragment` OK); no hand-edits to `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json` (`git diff --name-only` shows none).

## Test plan

Per-file isolation (repo norm), all green at head `57bd6897`:

- `bun test tests/unit/hooks/lane-liveness-watchdog.test.ts` -> 12/12 (32-cell enabled-x-0-disables truth table, disabled no-op, event field freeze)
- `bun test tests/unit/hooks/lane-liveness-horizon.test.ts` -> 14/14 (single effective horizon, precedence, boundary equality, conflict disclosure)
- `bun test tests/unit/hooks/lane-liveness-outcomes.test.ts` -> 13/13 (typed conditions, abort-once, real-outcome settlement, retry never aborted)
- `bun test tests/unit/hooks/lane-liveness-escalation.test.ts` -> 7/7 (escalate -> dedup survives cache reset -> activity resets baseline -> re-escalate)
- `bun test tests/unit/hooks/lane-liveness-budget.test.ts` -> 6/6 (probe budget, counter reset)
- `bun test tests/unit/hooks/lane-liveness-scenarios.test.ts` -> 6/6 (slow provider, deadline expiry, mid-write ledger consistency, human-only force abort, disabled no-op, conflicting horizons)
- Substrate byte-compat with #2242/#2251/#2381 (watchdog off): the four `pr-workflow-gate-{stale-lane-settlement,lane-liveness-probe,lane-liveness-settlement,force-override-restart}.test.ts` suites -> 42/42
- Tool wiring: `bun test tests/unit/tools/complete-pr-workflow.test.ts tests/unit/tools/complete-pr-workflow-report-verdict.test.ts tests/unit/tools/phase-complete-preflight-report.test.ts` -> 14/14; abort tool tests -> 8/8
- ADR no-port: `bun test tests/unit/docs/ensemble-adr-2505.test.ts` -> 9/9
- `bun run typecheck` -> clean; `bun run build` + bundle-portability + plugin-shape tests green at the feature commit; `bun run check:pending-fragment` -> OK
- Falsifiability: three mutation probes (horizon precedence, disabled no-op, budget counter) each FAIL their target tests under mutation and pass after restore (trace `08b-implementation-review.md`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


