### PR TITLE
ci(merge-queue): restore recursive integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,7 +817,7 @@ jobs:
           failed=0
           tmpdir="${RUNNER_TEMP:-${TEMP:-/tmp}}"
           trap 'rm -f "$tmpdir"/bun-out-int-* "$tmpdir"/int-*.txt' EXIT
-          find tests/integration test -maxdepth 1 -name '*.test.ts' -type f | sort > "$tmpdir/int-all-tests.txt"
+          find tests/integration test -name '*.test.ts' -type f | sort > "$tmpdir/int-all-tests.txt"
           # Drop known-red pre-existing failures (issue #1705) — same rationale
           # as the unit/coverage jobs' quarantine lists. See
           # scripts/ci/quarantined-integration-tests.txt for the tracked list.

--- a/docs/ci/merge-queue-policy.md
+++ b/docs/ci/merge-queue-policy.md
@@ -1,0 +1,227 @@
+# Merge-queue CI policy — Stage D decision record (#2552)
+
+## Status and scope
+
+**Record date:** 2026-09-06
+**Evidence:** post-#2551 baseline, 2026-09-03T21:55:18Z through
+2026-09-05T23:27:21Z.
+
+This document accompanies the Stage-D recursive integration and gate-hygiene
+changes for issue #2552. It records what the observed data supports and what
+remains deliberately unchanged. The Stage-D workflow change makes integration
+test discovery recursive; this record does not change branch protection,
+merge-queue settings, or runner implementation.
+
+The retained policy is:
+
+- `cancellation=false`, because the current sample has zero same-reference
+  overlap and zero cancellations;
+- a `timeout=90m` status-check timeout;
+- `build_concurrency=5`; and
+- `ALLGREEN` / only-non-failing merge eligibility.
+
+The Stage A Windows10 decision is planned separately. No Windows implementation
+is landed or claimed by this record.
+
+## Post-#2551 baseline
+
+The baseline window is **2026-09-03T21:55:18Z through
+2026-09-05T23:27:21Z**. The outcome sample contains 48 samples from 50 attempts;
+the attempt count is retained separately so that retries and duplicate
+references are not silently folded into the outcome denominator.
+
+| Measure | Observed value |
+| --- | --- |
+| Sample outcomes | success 33; failure 15; cancelled 0 |
+| Attempts | 50 |
+| Duplicate references | 5 |
+| Same-reference overlaps | 0 |
+| Windows marker | `last22/33` |
+| Account concurrency | unknown |
+
+Baseline shorthand: `sample48 success33 failure15 cancelled0 attempts50 duplicate-ref5 same-ref overlaps0`.
+
+Durations below are in minutes unless a field explicitly says otherwise.
+
+| Duration | Average | P50 | P95 | Maximum |
+| --- | ---: | ---: | ---: | ---: |
+| `run_duration` | 26.97m | 32.55m | 46.65m | 53.05m |
+| `created - updated` | 28.43m | not reported | 51.42m | 61.45m |
+
+The total billable duration was `total_ms=0`.
+For audit tooling, the compact duration records are `run_duration avg26.97m p5032.55 p9546.65 max53.05` and `created-updated avg28.43 p9551.42 max61.45`.
+The compact Windows records are `Windows last22/33 tail avg8.29 p509.05 p9513.97 max17.12` and `first Windows start proxy avg2.77 p501.78 p959.98 max12.35`.
+
+The Windows tail was **average 8.29m, P50 9.05m, P95 13.97m, maximum
+17.12m**. The first Windows start proxy was **average 2.77m, P50 1.78m,
+P95 9.98m, maximum 12.35m**.
+
+Failure classes were `rust=7`, `windows-unit=1`, and `coverage=7`. These
+classes account for all 15 observed failures; the account-level concurrency
+limit was not available, so the data cannot establish a provider throttle.
+
+## Explicit decisions
+
+### Status check timeout
+
+**Decision:** retain the 90-minute timeout.
+
+The observed maximum `run_duration` was 53.05 minutes and the maximum
+`created - updated` interval was 61.45 minutes. The existing 90-minute value
+therefore leaves operational margin without treating the measured tail as a
+reason to relax a required check.
+
+**Expected benefit.** Preserve enough headroom for a slow merge-group run while
+avoiding an open-ended wait in the queue.
+
+**Preserved gates.** Required checks still have to report a passing result, and
+the host check-name gate remains authoritative for the exact names emitted by
+the host, including matrix-leg names where applicable.
+
+**Validation.** Recompute the timeout comparison over the next post-land
+window: record the maximum `run_duration` and `created - updated` values, then
+check that every required check settled before 90 minutes. Attach the C9
+receipts described below rather than treating a dashboard view as proof.
+
+**Rollback.** If a later, approved baseline shows that 90 minutes is
+insufficient, change the policy through a new decision record after reviewing
+the host check-name evidence. Do not widen the timeout as an unrecorded
+workaround for a single run.
+
+### Build concurrency
+
+**Decision:** retain build concurrency at 5.
+
+The observed peak was 3. Reducing the configured value to 1 or 2 would have
+throttled observed demand without proven relief, while the account concurrency
+limit is unknown. The evidence supports retaining 5 until a bounded experiment
+can separate queue pressure from provider-side throttling.
+
+**Expected benefit.** Keep the current throughput envelope and avoid adding
+avoidable queue delay while preserving a conservative cap.
+
+**Preserved gates.** Concurrency is only a scheduling limit; it never weakens
+the required-check, `ALLGREEN`, or cross-contamination gates. A queued run
+remains subject to the same timeout and failure handling.
+
+**Validation.** On the next evidence window, capture observed peak concurrency,
+queue wait, eviction, and the host/account limit if it becomes available. A
+change is supportable only when those measurements show both the pressure and
+the relief from a different cap.
+
+**Rollback.** If a future bounded experiment at another cap increases queue
+wait, evictions, or failure rate, restore concurrency 5 and retain the existing
+required-check policy.
+
+### Only merge non-failing
+
+**Decision:** retain `ALLGREEN` / only-non-failing merge eligibility.
+
+Fifteen of the 48 sampled outcomes failed. That failure rate is sufficient
+evidence to keep a failing required check blocking the queue; it is not a basis
+for a green-by-retry or partial-success exception.
+
+**Expected benefit.** Prevent a merge-group candidate with a known failing
+required check from being treated as safe merely because another check passed.
+
+**Preserved gates.** Every required host check must pass, exact check names must
+be matched by the host check-name gate, and cross-contamination regressions stay
+blocking. A known, separately recorded warning is not permission to ignore a
+new regression.
+
+**Validation.** For each post-land window, reconcile the outcome count with the
+required-check conclusions and record any failure class. The decision remains
+valid while failures are visible and non-failing candidates alone are eligible
+to merge.
+
+**Rollback.** Do not relax this decision through an emergency queue setting. If
+the failure evidence is later shown to be a measurement defect, amend this
+record with the corrected evidence and an explicit gate review before changing
+eligibility.
+
+### Cancellation
+
+**Decision:** retain `cancellation=false`.
+
+**Expected benefit.** Avoid changing cancellation behavior when the evidence
+shows no current same-reference overlap and no cancelled samples.
+
+**Preserved gates.** Cancellation remains independent from the required-check
+and `ALLGREEN` decisions; a cancelled or evicted run cannot be reclassified as
+passing.
+
+**Validation.** Continue recording cancellations and same-reference overlaps
+in each evidence window. A non-zero overlap must be reviewed as a new decision,
+not inferred from this zero-overlap baseline.
+
+**Rollback.** If a future, attributable overlap is demonstrated, revisit the
+setting in a follow-up decision record with receipts and a bounded experiment.
+
+## Host check-name gate and the planned Stage A decision
+
+The host check-name gate is a prerequisite for any merge-queue or branch-
+protection decision: inspect the names emitted by the host for the exact commit
+and compare them with the required-check configuration. Matrix jobs must be
+matched by their emitted leg names; an assumed aggregate name is not evidence.
+Record the host/version, event, commit, and observed names with the decision.
+
+The Stage A Windows10 decision is planned separately and is not landed by
+#2552's Stage-D record. This document records only the gate that must protect
+that future decision and the observed Windows timing baseline. It makes no
+claim that Windows10 support, a Windows workflow change, or a Windows
+implementation has shipped.
+
+## C9 post-land receipt contract
+
+C9 receipts are individual structured records, not synthetic summary rows. The
+identifier form is `stage-{d,a}-post-land-N`; `N` identifies one receipt in
+the stage's closure set. The exact fields are:
+
+```text
+identifier=stage-{d,a}-post-land-N
+actions=URL
+run_duration_ms=<integer>
+queue_wait_ms=integer|unavailable
+eviction=<recorded value>
+completed_at=ISO Z
+```
+
+Closure requires **3 receipts per stage**: three Stage-D receipts and three
+Stage-A receipts. A stage is not closed by a partial set, a dashboard screenshot,
+or a receipt that omits `queue_wait_ms` instead of using the literal
+`unavailable` value.
+
+## Cross-contamination warning language
+
+The decision record uses two distinct outcomes: a newly introduced
+cross-contamination regression is blocking, while a known pre-existing warning
+is diagnostic and remains explicitly labeled with its known baseline. This
+cleanup prevents a warning from being mistaken for either a clean run or a new
+regression. The distinction does not waive the test gate or change the
+underlying check.
+
+## Caveats, migration, and breaking changes
+
+### Caveats
+
+- The outcome denominator is 48 samples while the attempt count is 50; this
+  record does not infer why the two counts differ.
+- Account concurrency is unknown, so the concurrency decision is intentionally
+  conservative rather than a provider-capacity claim.
+- The Windows figures are observational timing evidence only. They do not land
+  the separate Stage A Windows10 decision.
+- The C9 contract requires three receipts per stage; missing receipts keep
+  closure open.
+
+### Migration
+
+No runtime or configuration migration is required. Stage D makes integration
+discovery recursive and removes obsolete scanner notices; before applying any
+future queue or branch-protection change, perform the host check-name gate and
+collect the required C9 receipt closure set.
+
+### Breaking changes
+
+None. The documented timeout, concurrency, cancellation, and `ALLGREEN`
+semantics are retained. Recursive integration discovery adds coverage without
+changing those gates, and no Windows implementation is claimed here.

--- a/docs/releases/pending/ci-gate-policy-2552.md
+++ b/docs/releases/pending/ci-gate-policy-2552.md
@@ -1,0 +1,46 @@
+# CI gate policy decision record (#2552)
+
+## What changed
+
+- Made integration discovery recursive so nested language integration tests run
+  in CI, and recorded the Stage-D baseline and explicit merge-queue decisions
+  in `docs/ci/merge-queue-policy.md`.
+- Cleaned up the cross-contamination warning language so a known baseline
+  warning remains diagnostic while a newly introduced regression remains
+  blocking; the policy decision is recorded alongside that distinction.
+- Documented the C9 post-land receipt schema and the requirement for three
+  receipts per stage before closure.
+
+The documented decisions retain `cancellation=false`, the 90-minute status
+check timeout, build concurrency 5, and `ALLGREEN` / only-non-failing merge
+eligibility. The workflow change is limited to recursive integration discovery;
+it does not change branch protection or claim a Windows implementation.
+
+## Why
+
+The post-#2551 evidence window (2026-09-03T21:55:18Z through
+2026-09-05T23:27:21Z) recorded 15 failures in 48 samples, zero cancellations,
+zero same-reference overlaps, and an observed concurrency peak of 3. Recording
+the decision boundary makes the Stage-D integration evidence auditable without
+weakening the required gates.
+
+## Migration
+
+None for runtime or configuration. Any future queue or branch-protection change
+must first pass the host check-name gate and collect three C9 receipts for each
+stage.
+
+## Breaking changes
+
+None. Existing timeout, concurrency, cancellation, and `ALLGREEN` semantics are
+preserved.
+
+## Caveats
+
+- Recursive discovery can reveal a previously unwired nested integration
+  failure; that failure should be fixed or quarantined under existing policy,
+  not hidden by restoring the depth cap.
+- The Stage A Windows10 decision is planned separately and is not landed here.
+- The baseline reports account concurrency as unknown, and the Windows timing
+  figures are observational evidence rather than a Windows implementation
+  claim.

--- a/docs/releases/pending/ci-gate-policy-2552.md
+++ b/docs/releases/pending/ci-gate-policy-2552.md
@@ -8,6 +8,17 @@
 - Cleaned up the cross-contamination warning language so a known baseline
   warning remains diagnostic while a newly introduced regression remains
   blocking; the policy decision is recorded alongside that distinction.
+- Removed obsolete hook-audit notices and bounded the known shared-process
+  allowance with an explicit pass-count ceiling.
+- Removed the obsolete hook-audit subsystem in full: `collectHookWarnings`,
+  `walkHookTestFiles`, `matchesHookStepGlob`, `isHookIsolationBasename`,
+  `stripGlobSuffix`, `toRepoRelativePath`, `HOOKS_ROOT_REL`,
+  `HOOK_ISOLATION_BASENAMES`, `HOOK_STEP_GLOBS`, and the
+  `coverageWarning`/`collectWarnings` injection surface. The unused shared
+  `gate-utils.walkFiles` export was removed with it. Functional coverage now
+  comes from recursive integration discovery, the existing per-file unit
+  isolation, and pair-specific `minimumPasses`/`maximumKnownPasses` semantics;
+  the archived Bash fixture remains a separate compatibility oracle.
 - Documented the C9 post-land receipt schema and the requirement for three
   receipts per stage before closure.
 

--- a/scripts/check-cross-contamination.ts
+++ b/scripts/check-cross-contamination.ts
@@ -1,14 +1,12 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveRepoRoot, spawnUtf8, walkFiles } from './gate-utils';
+import { resolveRepoRoot, spawnUtf8 } from './gate-utils';
 
 export interface PairSpec {
 	fileA: string;
 	fileB: string;
-	expectedA: number;
-	expectedB: number;
-	knownExpected: number;
+	minimumPasses: number;
+	allowedOutcome: 'clean' | 'known_shared_process';
 }
 
 export interface PairRunResult {
@@ -26,8 +24,7 @@ export type PairEvaluationKind =
 export interface PairEvaluation {
 	kind: PairEvaluationKind;
 	actualPasses: number;
-	expectedPasses: number;
-	knownExpectedPasses: number;
+	minimumPasses: number;
 	messages: string[];
 }
 
@@ -35,7 +32,6 @@ export interface AuditSummary {
 	exitCode: number;
 	knownIssue: boolean;
 	regressionDetected: boolean;
-	coverageWarning: boolean;
 	messages: string[];
 	repoRoot: string;
 }
@@ -45,7 +41,6 @@ export interface AuditOptions {
 		repoRoot: string,
 		pair: PairSpec,
 	) => PairRunResult | Promise<PairRunResult>;
-	collectWarnings?: (repoRoot: string) => string[];
 	log?: (line: string) => void;
 }
 
@@ -53,115 +48,18 @@ export const PAIRS: readonly PairSpec[] = [
 	{
 		fileA: 'tests/unit/diff/ast-diff.test.ts',
 		fileB: 'src/hooks/__tests__/semantic-diff-injection.test.ts',
-		expectedA: 41,
-		expectedB: 16,
-		knownExpected: 57,
+		minimumPasses: 57,
+		allowedOutcome: 'clean',
 	},
 	{
 		fileA: 'tests/unit/hooks/knowledge-reader.test.ts',
 		fileB: 'tests/unit/services/skill-generator.test.ts',
-		expectedA: 22,
-		expectedB: 77,
-		knownExpected: 71,
+		minimumPasses: 71,
+		allowedOutcome: 'known_shared_process',
 	},
 ] as const;
 
 export const PAIR_TIMEOUT_MS = 120_000;
-export const HOOKS_ROOT_REL = path.join('tests', 'unit', 'hooks');
-export const HOOK_ISOLATION_BASENAMES = [
-	'knowledge-injector.adversarial.test.ts',
-	'knowledge-curator.test.ts',
-	'knowledge-curator-evidence-curation.test.ts',
-	'knowledge-curator-ttl.test.ts',
-	'knowledge-curator.adversarial.test.ts',
-	'knowledge-curator-output.test.ts',
-	'full-auto-intercept.test.ts',
-	'full-auto-intercept.adversarial.test.ts',
-	'full-auto-intercept.dispatch.test.ts',
-	'utils.test.ts',
-	'knowledge-reader.test.ts',
-	'system-enhancer-coder-context.test.ts',
-	'model-limits-log-reclassification.test.ts',
-	'model-limits-adversarial.test.ts',
-	'log-level-reclassification.test.ts',
-	'context-budget-log-reclassification.test.ts',
-] as const;
-
-export const HOOK_STEP_GLOBS = [
-	'adversarial-detect*',
-	'advisory*',
-	'agent-activity*',
-	'co-change*',
-	'compaction*',
-	'context-budget*',
-	'context-scoring*',
-	'curator*',
-	'curator-*',
-	'dark-matter*',
-	'delegation*',
-	'delegation-*',
-	'destructive-command*',
-	'extractors*',
-	'full-auto-*',
-	'gate-tracking*',
-	'guardrails*',
-	'hive*',
-	'hook-composition*',
-	'interpreter-gating*',
-	'knowledge-application*',
-	'knowledge-contextual-retrieval*',
-	'knowledge-curator*',
-	'knowledge-curator-*',
-	'knowledge-events*',
-	'knowledge-injector*',
-	'knowledge-migrator*',
-	'knowledge-quarantine*',
-	'knowledge-reader*',
-	'knowledge-registration*',
-	'knowledge-schema-v2*',
-	'knowledge-store*',
-	'knowledge-types*',
-	'knowledge-validator*',
-	'message*',
-	'mode-detection*',
-	'model-limits*',
-	'phase-complete*',
-	'phase-monitor*',
-	'pipeline*',
-	'plan-cursor*',
-	'repo-graph*',
-	'review-receipt*',
-	'search-knowledge*',
-	'self-coding*',
-	'skill-*',
-	'spec-drift*',
-	'steering*',
-	'system-enhancer*',
-	'system-enhancer-budget*',
-	'system-enhancer-lean*',
-	'system-enhancer-load-evidence*',
-	'system-enhancer-v*',
-	'system-message*',
-	'telemetry*',
-	'tool-summarizer*',
-	'trajectory*',
-	'utils*',
-	'write-lstat*',
-] as const;
-
-function stripGlobSuffix(glob: string): string {
-	return glob.endsWith('*') ? glob.slice(0, -1) : glob;
-}
-
-export function matchesHookStepGlob(basename: string): boolean {
-	return HOOK_STEP_GLOBS.some((glob) => basename.startsWith(stripGlobSuffix(glob)));
-}
-
-export function isHookIsolationBasename(basename: string): boolean {
-	return HOOK_ISOLATION_BASENAMES.includes(
-		basename as (typeof HOOK_ISOLATION_BASENAMES)[number],
-	);
-}
 
 export function readPassCount(output: string): number {
 	const match = output.match(/^[ \t]*(\d+) pass/m);
@@ -209,31 +107,27 @@ export function evaluatePairResult(
 	pair: PairSpec,
 	result: PairRunResult,
 ): PairEvaluation {
-	const expectedPasses = pair.expectedA + pair.expectedB;
+	const combinedOutput = mergeProcessOutput(result);
+	const actualPasses = readPassCount(combinedOutput);
 	if (result.exitCode === 0) {
 		return {
 			kind: 'clean',
-			actualPasses: expectedPasses,
-			expectedPasses,
-			knownExpectedPasses: pair.knownExpected,
+			actualPasses,
+			minimumPasses: pair.minimumPasses,
 			messages: [],
 		};
 	}
 
-	const combinedOutput = mergeProcessOutput(result);
-	const actualPasses = readPassCount(combinedOutput);
-	if (actualPasses < pair.knownExpected) {
+	if (actualPasses < pair.minimumPasses) {
 		return {
 			kind: 'regression_pass_drop',
 			actualPasses,
-			expectedPasses,
-			knownExpectedPasses: pair.knownExpected,
+			minimumPasses: pair.minimumPasses,
 			messages: [
-				`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB}: expected ${expectedPasses} pass (${pair.expectedA}+${pair.expectedB}), got ${actualPasses} pass. Previously known baseline was ${pair.knownExpected}. A new mock.module or vi.mock() leak was introduced.`,
+				`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB}: minimum ${pair.minimumPasses} pass, got ${actualPasses} pass. A new mock.module or vi.mock() leak was introduced.`,
 				'',
 				`Test pair: ${pair.fileA} + ${pair.fileB}`,
-				`Expected passes (individual): ${expectedPasses}`,
-				`Known baseline (previous co-run): ${pair.knownExpected}`,
+				`Minimum passes: ${pair.minimumPasses}`,
 				`Actual passes (co-run): ${actualPasses}`,
 				'',
 				'Tail of output:',
@@ -242,15 +136,13 @@ export function evaluatePairResult(
 		};
 	}
 
-	if (actualPasses < expectedPasses) {
+	if (pair.allowedOutcome === 'known_shared_process') {
 		return {
 			kind: 'known_issue',
 			actualPasses,
-			expectedPasses,
-			knownExpectedPasses: pair.knownExpected,
+			minimumPasses: pair.minimumPasses,
 			messages: [
-				// Compatibility text is frozen to the pre-port Bash owner by issue #2094.
-				`::warning title=Cross-contamination known issue::Co-run of ${pair.fileA} + ${pair.fileB}: expected ${expectedPasses} pass, got ${actualPasses} pass (known baseline: ${pair.knownExpected}). Pre-existing vi.mock() leak — tracked in scripts/check-cross-contamination.sh.`,
+				`::warning title=Cross-contamination known issue::Co-run of ${pair.fileA} + ${pair.fileB}: ${actualPasses} pass meets the minimum ${pair.minimumPasses}-pass floor but exits non-zero. Allowed known shared-process outcome: CI runs each discovered unit file in its own process (per-file CI isolation), so this pre-existing mock leak is non-blocking.`,
 			],
 		};
 	}
@@ -258,73 +150,14 @@ export function evaluatePairResult(
 	return {
 		kind: 'regression_unexpected_failure',
 		actualPasses,
-		expectedPasses,
-		knownExpectedPasses: pair.knownExpected,
+		minimumPasses: pair.minimumPasses,
 		messages: [
-			`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB} exited with code ${result.exitCode} despite ${actualPasses} >= ${expectedPasses} expected passes. Unexpected test failure or process error introduced.`,
+			`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB} exited with code ${result.exitCode} despite ${actualPasses} >= ${pair.minimumPasses} minimum passes. Unexpected test failure or process error introduced.`,
 			'',
 			'Tail of output:',
 			lastLines(combinedOutput, 20),
 		],
 	};
-}
-
-export function toRepoRelativePath(repoRoot: string, absPath: string): string {
-	const pathApi = /^[A-Za-z]:[\\/]/.test(repoRoot) ? path.win32 : path;
-	return pathApi.relative(repoRoot, absPath).replaceAll('\\', '/');
-}
-
-export function walkHookTestFiles(
-	hooksRoot: string,
-	recursive: boolean,
-): string[] {
-	const files: string[] = [];
-	walkFiles(
-		hooksRoot,
-		(absPath) => {
-			if (absPath.endsWith('.test.ts')) {
-				files.push(absPath);
-			}
-		},
-		{ maxDepth: recursive ? Number.POSITIVE_INFINITY : 0 },
-	);
-	return files;
-}
-
-export function collectHookWarnings(repoRoot: string): string[] {
-	const warnings: string[] = [];
-	const hooksRoot = path.join(repoRoot, HOOKS_ROOT_REL);
-	if (!fs.existsSync(hooksRoot)) {
-		return warnings;
-	}
-
-	const mockModuleFiles: string[] = [];
-	walkFiles(hooksRoot, (absPath) => {
-		if (fs.readFileSync(absPath, 'utf-8').includes('mock.module(')) {
-			mockModuleFiles.push(absPath);
-		}
-	});
-	for (const absPath of mockModuleFiles) {
-		const basename = path.basename(absPath);
-		if (isHookIsolationBasename(basename)) {
-			continue;
-		}
-		warnings.push(
-			`::warning title=Mock module not in isolation list::${toRepoRelativePath(repoRoot, absPath)} uses mock.module() but is not in the CI isolation step file list. Add it to ci.yml isolation step or refactor to use _internals DI seam.`,
-		);
-	}
-
-	for (const absPath of walkHookTestFiles(hooksRoot, false)) {
-		const basename = path.basename(absPath);
-		if (isHookIsolationBasename(basename) || matchesHookStepGlob(basename)) {
-			continue;
-		}
-		warnings.push(
-			`::notice title=Hook test file not in CI coverage::${toRepoRelativePath(repoRoot, absPath)} is not covered by any named CI step glob or the isolation list. Consider adding it to an appropriate CI step or the isolation list.`,
-		);
-	}
-
-	return warnings;
 }
 
 export async function auditCrossContamination(
@@ -333,10 +166,8 @@ export async function auditCrossContamination(
 ): Promise<AuditSummary> {
 	const repoRoot = await resolveRepoRoot(startDir);
 	const runPairImpl = options.runPair ?? runPair;
-	const collectWarningsImpl = options.collectWarnings ?? collectHookWarnings;
 	let regressionDetected = false;
 	let knownIssue = false;
-	let coverageWarning = false;
 	const messages: string[] = [];
 
 	for (const pair of PAIRS) {
@@ -355,16 +186,6 @@ export async function auditCrossContamination(
 		regressionDetected = true;
 	}
 
-	const coverageWarnings = collectWarningsImpl(repoRoot);
-	if (coverageWarnings.length > 0) {
-		coverageWarning = true;
-		messages.push(
-			...coverageWarnings,
-			'',
-			'Audit checks completed with warnings (non-blocking).',
-		);
-	}
-
 	if (regressionDetected) {
 		messages.push(
 			'',
@@ -375,7 +196,6 @@ export async function auditCrossContamination(
 			exitCode: 1,
 			knownIssue,
 			regressionDetected,
-			coverageWarning,
 			messages,
 			repoRoot,
 		};
@@ -385,13 +205,12 @@ export async function auditCrossContamination(
 		messages.push(
 			'',
 			'Known pre-existing cross-contamination present (non-blocking).',
-			'Expected passes when fixed: update known_expected in this script.',
+			'This shared-process-only outcome remains guarded by the minimumPasses floor in this script.',
 		);
 		return {
 			exitCode: 0,
 			knownIssue,
 			regressionDetected,
-			coverageWarning,
 			messages,
 			repoRoot,
 		};
@@ -402,7 +221,6 @@ export async function auditCrossContamination(
 		exitCode: 0,
 		knownIssue,
 		regressionDetected,
-		coverageWarning,
 		messages,
 		repoRoot,
 	};

--- a/scripts/check-cross-contamination.ts
+++ b/scripts/check-cross-contamination.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveRepoRoot, spawnUtf8 } from './gate-utils';
@@ -6,7 +7,9 @@ export interface PairSpec {
 	fileA: string;
 	fileB: string;
 	minimumPasses: number;
+	maximumKnownPasses?: number;
 	allowedOutcome: 'clean' | 'known_shared_process';
+	knownFailurePattern?: RegExp;
 }
 
 export interface PairRunResult {
@@ -25,6 +28,7 @@ export interface PairEvaluation {
 	kind: PairEvaluationKind;
 	actualPasses: number;
 	minimumPasses: number;
+	maximumKnownPasses?: number;
 	messages: string[];
 }
 
@@ -55,7 +59,9 @@ export const PAIRS: readonly PairSpec[] = [
 		fileA: 'tests/unit/hooks/knowledge-reader.test.ts',
 		fileB: 'tests/unit/services/skill-generator.test.ts',
 		minimumPasses: 71,
+		maximumKnownPasses: 98,
 		allowedOutcome: 'known_shared_process',
+		knownFailurePattern: /ENOENT: no such file or directory[\s\S]*[\\/]\.swarm/,
 	},
 ] as const;
 
@@ -96,6 +102,16 @@ export function runPair(
 	repoRoot: string,
 	pair: PairSpec,
 ): Promise<PairRunResult> {
+	const missingFiles = [pair.fileA, pair.fileB].filter(
+		(file) => !existsSync(path.resolve(repoRoot, file)),
+	);
+	if (missingFiles.length > 0) {
+		return Promise.resolve({
+			exitCode: 1,
+			stdout: '',
+			stderr: `Cross-contamination pair file missing: ${missingFiles.join(', ')}`,
+		});
+	}
 	return spawnUtf8(
 		buildPairCommand(process.execPath, pair),
 		repoRoot,
@@ -114,6 +130,7 @@ export function evaluatePairResult(
 			kind: 'clean',
 			actualPasses,
 			minimumPasses: pair.minimumPasses,
+			maximumKnownPasses: pair.maximumKnownPasses,
 			messages: [],
 		};
 	}
@@ -123,6 +140,7 @@ export function evaluatePairResult(
 			kind: 'regression_pass_drop',
 			actualPasses,
 			minimumPasses: pair.minimumPasses,
+			maximumKnownPasses: pair.maximumKnownPasses,
 			messages: [
 				`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB}: minimum ${pair.minimumPasses} pass, got ${actualPasses} pass. A new mock.module or vi.mock() leak was introduced.`,
 				'',
@@ -136,11 +154,49 @@ export function evaluatePairResult(
 		};
 	}
 
+	if (
+		pair.maximumKnownPasses !== undefined &&
+		actualPasses > pair.maximumKnownPasses
+	) {
+		return {
+			kind: 'regression_unexpected_failure',
+			actualPasses,
+			minimumPasses: pair.minimumPasses,
+			maximumKnownPasses: pair.maximumKnownPasses,
+			messages: [
+				`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB} exited with code ${result.exitCode} despite ${actualPasses} passes meeting the ${pair.minimumPasses}-pass floor. The known shared-process allowance has a ${pair.maximumKnownPasses}-pass ceiling; unexpected test failure or process error introduced.`,
+				'',
+				'Tail of output:',
+				lastLines(combinedOutput, 20),
+			],
+		};
+	}
+
+	if (
+		pair.allowedOutcome === 'known_shared_process' &&
+		pair.knownFailurePattern !== undefined &&
+		!pair.knownFailurePattern.test(combinedOutput)
+	) {
+		return {
+			kind: 'regression_unexpected_failure',
+			actualPasses,
+			minimumPasses: pair.minimumPasses,
+			maximumKnownPasses: pair.maximumKnownPasses,
+			messages: [
+				`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB} exited with code ${result.exitCode} with ${actualPasses} passes in the known window, but its output did not match the known shared-process failure signature.`,
+				'',
+				'Tail of output:',
+				lastLines(combinedOutput, 20),
+			],
+		};
+	}
+
 	if (pair.allowedOutcome === 'known_shared_process') {
 		return {
 			kind: 'known_issue',
 			actualPasses,
 			minimumPasses: pair.minimumPasses,
+			maximumKnownPasses: pair.maximumKnownPasses,
 			messages: [
 				`::warning title=Cross-contamination known issue::Co-run of ${pair.fileA} + ${pair.fileB}: ${actualPasses} pass meets the minimum ${pair.minimumPasses}-pass floor but exits non-zero. Allowed known shared-process outcome: CI runs each discovered unit file in its own process (per-file CI isolation), so this pre-existing mock leak is non-blocking.`,
 			],
@@ -151,6 +207,7 @@ export function evaluatePairResult(
 		kind: 'regression_unexpected_failure',
 		actualPasses,
 		minimumPasses: pair.minimumPasses,
+		maximumKnownPasses: pair.maximumKnownPasses,
 		messages: [
 			`::error title=Cross-contamination regression::Co-run of ${pair.fileA} + ${pair.fileB} exited with code ${result.exitCode} despite ${actualPasses} >= ${pair.minimumPasses} minimum passes. Unexpected test failure or process error introduced.`,
 			'',
@@ -205,7 +262,7 @@ export async function auditCrossContamination(
 		messages.push(
 			'',
 			'Known pre-existing cross-contamination present (non-blocking).',
-			'This shared-process-only outcome remains guarded by the minimumPasses floor in this script.',
+			'This shared-process-only outcome remains guarded by its configured pass floor and ceiling in this script.',
 		);
 		return {
 			exitCode: 0,

--- a/scripts/gate-utils.ts
+++ b/scripts/gate-utils.ts
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 export interface SpawnResult {
@@ -149,30 +148,4 @@ export async function resolveRepoRoot(startDir: string): Promise<string> {
 	}
 	const trimmed = result.stdout.trim();
 	return trimmed.length > 0 ? path.resolve(trimmed) : path.resolve(startDir);
-}
-
-export function walkFiles(
-	root: string,
-	visit: (absPath: string, relPath: string) => void,
-	options?: { maxDepth?: number; filePredicate?: (entry: fs.Dirent) => boolean },
-): void {
-	const maxDepth = options?.maxDepth ?? Number.POSITIVE_INFINITY;
-	const filePredicate = options?.filePredicate;
-	const visitDir = (dir: string, relDir: string, depth: number): void => {
-		if (depth > maxDepth) {
-			return;
-		}
-		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-			const abs = path.join(dir, entry.name);
-			const rel = relDir ? path.join(relDir, entry.name) : entry.name;
-			if (entry.isDirectory()) {
-				visitDir(abs, rel, depth + 1);
-				continue;
-			}
-			if (entry.isFile() && (!filePredicate || filePredicate(entry))) {
-				visit(abs, rel);
-			}
-		}
-	};
-	visitDir(root, '', 0);
 }

--- a/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
+++ b/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
@@ -38,11 +38,11 @@ function legacyExpected(actualPasses: number): string {
 	return `${legacyKnownIssueWarning(actualPasses)}\nKnown pre-existing cross-contamination present (non-blocking).\nExpected passes when fixed: update known_expected in this script.`;
 }
 
-function readKnownPairPassCount(output: string): number {
+function readKnownPairPassCount(output: string): number | undefined {
 	const match = output.match(
 		/knowledge-reader\.test\.ts \+ tests\/unit\/services\/skill-generator\.test\.ts: (?:expected 99 pass, got )?(\d+) pass/,
 	);
-	return match ? Number(match[1]) : 0;
+	return match ? Number(match[1]) : undefined;
 }
 
 function normalizeOutput(text: string): string {
@@ -101,6 +101,24 @@ describe('cross-contamination legacy-oracle compatibility', () => {
 		expect(normalizeOutput(captured.stdout)).toBe(tsExpected(71));
 	});
 
+	test('reports a clean outcome when both pairs pass', async () => {
+		const captured = await captureLogLines((log) =>
+			runCrossContamination(REPO_ROOT, {
+				runPair: (_repoRoot, pair): PairRunResult => ({
+					exitCode: 0,
+					stdout: `${pair.fileA.includes('knowledge-reader') ? 98 : 57} pass\n`,
+					stderr: '',
+				}),
+				log,
+			}),
+		);
+
+		expect(captured.exitCode).toBe(0);
+		expect(normalizeOutput(captured.stdout)).toBe(
+			'No cross-contamination detected: all test pairs pass when co-run.',
+		);
+	});
+
 	test('preserves the archived Bash owner golden separately when Bash is available', async () => {
 		if (!hasBash) return;
 		const isolatedEnv = createIsolatedTestEnv();
@@ -120,34 +138,54 @@ describe('cross-contamination legacy-oracle compatibility', () => {
 			const tsPasses = readKnownPairPassCount(
 				`${tsResult.stdout}\n${tsResult.stderr}`,
 			);
-			expect(tsPasses).toBeGreaterThanOrEqual(71);
-			expect(tsPasses).toBeLessThanOrEqual(98);
-			expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
-				tsExpected(tsPasses),
-			);
+			if (tsPasses === undefined) {
+				expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
+					'No cross-contamination detected: all test pairs pass when co-run.',
+				);
+			} else {
+				expect(tsPasses).toBeGreaterThanOrEqual(71);
+				expect(tsPasses).toBeLessThanOrEqual(98);
+				expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
+					tsExpected(tsPasses),
+				);
+			}
 			expect(normalizeOutput(tsResult.stderr)).toBe('');
 			expect(legacyResult.exitCode, legacyResult.stderr).toBe(0);
 			const normalizedLegacy = normalizeOutput(legacyResult.stdout);
 			const legacyPasses = readKnownPairPassCount(
 				`${legacyResult.stdout}\n${legacyResult.stderr}`,
 			);
-			expect(legacyPasses).toBeGreaterThanOrEqual(71);
-			expect(legacyPasses).toBeLessThan(99);
-			expect(normalizedLegacy).toStartWith(
-				legacyKnownIssueWarning(legacyPasses),
-			);
+			if (legacyPasses === undefined) {
+				expect(normalizedLegacy).not.toContain(
+					'::warning title=Cross-contamination known issue::',
+				);
+				expect(normalizedLegacy).toContain(
+					'No cross-contamination detected: all test pairs pass when co-run.',
+				);
+				expect(normalizedLegacy).toEndWith(
+					'No cross-contamination detected: all test pairs pass when co-run.',
+				);
+			} else {
+				expect(legacyPasses).toBeGreaterThanOrEqual(71);
+				expect(legacyPasses).toBeLessThan(99);
+				expect(normalizedLegacy).toStartWith(
+					legacyKnownIssueWarning(legacyPasses),
+				);
+			}
 			expect(normalizedLegacy).toContain(
 				'::warning title=Mock module not in isolation list::',
 			);
 			expect(normalizedLegacy).toContain(
 				'::notice title=Hook test file not in CI coverage::',
 			);
-			expect(normalizedLegacy).toEndWith(
-				legacyExpected(legacyPasses).slice(
-					legacyKnownIssueWarning(legacyPasses).length + 1,
-				),
-			);
-			expect(normalizedLegacy).not.toBe(tsExpected(tsPasses));
+			if (legacyPasses !== undefined) {
+				expect(normalizedLegacy).toEndWith(
+					legacyExpected(legacyPasses).slice(
+						legacyKnownIssueWarning(legacyPasses).length + 1,
+					),
+				);
+			}
+			expect(normalizedLegacy).not.toBe(normalizeOutput(tsResult.stdout));
 			expect(normalizeOutput(legacyResult.stderr)).toBe('');
 		} finally {
 			isolatedEnv.cleanup();

--- a/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
+++ b/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import {
+	type PairRunResult,
+	main as runCrossContamination,
+} from '../../../scripts/check-cross-contamination';
+import { spawnUtf8 } from '../../../scripts/gate-utils';
+import { bashCommand, resolveBash } from '../../helpers/bash.js';
+import { createIsolatedTestEnv } from '../../helpers/isolated-test-env.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const CROSS_CONTAMINATION_GATE = path.resolve(
+	REPO_ROOT,
+	'scripts/check-cross-contamination.ts',
+);
+const CROSS_CONTAMINATION_TIMEOUT_MS = 180_000;
+const hasBash = (() => {
+	try {
+		resolveBash();
+		return true;
+	} catch {
+		return false;
+	}
+})();
+const tsKnownSharedProcessWarning =
+	'::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: 71 pass meets the minimum 71-pass floor but exits non-zero. Allowed known shared-process outcome: CI runs each discovered unit file in its own process (per-file CI isolation), so this pre-existing mock leak is non-blocking.';
+const legacyKnownIssueWarning =
+	'::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: expected 99 pass, got 71 pass (known baseline: 71). Pre-existing vi.mock() leak — tracked in scripts/check-cross-contamination.sh.';
+const tsExpected = `${tsKnownSharedProcessWarning}\n\nKnown pre-existing cross-contamination present (non-blocking).\nThis shared-process-only outcome remains guarded by the minimumPasses floor in this script.`;
+const legacyExpected = `${legacyKnownIssueWarning}\nKnown pre-existing cross-contamination present (non-blocking).\nExpected passes when fixed: update known_expected in this script.`;
+
+function normalizeOutput(text: string): string {
+	return text.replace(/\r\n/g, '\n').trimEnd();
+}
+
+async function captureLogLines(
+	run: (log: (line: string) => void) => number | Promise<number>,
+): Promise<{ exitCode: number; stdout: string }> {
+	const lines: string[] = [];
+	const exitCode = await run((line) => lines.push(line));
+	return { exitCode, stdout: lines.join('\n') };
+}
+
+async function runTsGate(scriptPath: string, cwd: string, timeout = 30_000) {
+	return spawnUtf8([process.execPath, 'run', scriptPath], cwd, timeout);
+}
+
+async function runLegacyGate(
+	scriptRelativePath: string,
+	cwd: string,
+	timeout = 30_000,
+	scriptRoot: string = path.join(
+		REPO_ROOT,
+		'tests',
+		'fixtures',
+		'bash-gates-2094',
+		'archive',
+	),
+) {
+	return spawnUtf8(
+		bashCommand(path.join(scriptRoot, ...scriptRelativePath.split('/'))),
+		cwd,
+		timeout,
+	);
+}
+
+describe('cross-contamination legacy-oracle compatibility', () => {
+	test('reports the allowed known shared-process outcome', async () => {
+		const captured = await captureLogLines((log) =>
+			runCrossContamination(REPO_ROOT, {
+				runPair: (_repoRoot, pair): PairRunResult =>
+					pair.fileA.includes('knowledge-reader')
+						? { exitCode: 1, stdout: ' 71 pass\n', stderr: '' }
+						: { exitCode: 0, stdout: '57 pass\n', stderr: '' },
+				log,
+			}),
+		);
+
+		expect(captured.exitCode).toBe(0);
+		expect(normalizeOutput(captured.stdout)).toBe(tsExpected);
+	});
+
+	test('preserves the archived Bash owner golden separately when Bash is available', async () => {
+		if (!hasBash) return;
+		const isolatedEnv = createIsolatedTestEnv();
+		try {
+			const legacyResult = await runLegacyGate(
+				'scripts/check-cross-contamination.sh',
+				REPO_ROOT,
+				CROSS_CONTAMINATION_TIMEOUT_MS,
+			);
+			const tsResult = await runTsGate(
+				CROSS_CONTAMINATION_GATE,
+				REPO_ROOT,
+				CROSS_CONTAMINATION_TIMEOUT_MS,
+			);
+
+			expect(tsResult.exitCode, tsResult.stderr).toBe(0);
+			expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
+				tsExpected,
+			);
+			expect(normalizeOutput(tsResult.stderr)).toBe('');
+			expect(legacyResult.exitCode, legacyResult.stderr).toBe(0);
+			const normalizedLegacy = normalizeOutput(legacyResult.stdout);
+			expect(normalizedLegacy).toStartWith(legacyKnownIssueWarning);
+			expect(normalizedLegacy).toContain(
+				'::warning title=Mock module not in isolation list::',
+			);
+			expect(normalizedLegacy).toContain(
+				'::notice title=Hook test file not in CI coverage::',
+			);
+			expect(normalizedLegacy).toEndWith(
+				legacyExpected.slice(legacyKnownIssueWarning.length + 1),
+			);
+			expect(normalizedLegacy).not.toBe(tsExpected);
+			expect(normalizeOutput(legacyResult.stderr)).toBe('');
+		} finally {
+			isolatedEnv.cleanup();
+		}
+	}, 240_000);
+});

--- a/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
+++ b/tests/unit/scripts/check-bash-gates-legacy-oracle-cross-contamination.test.ts
@@ -22,12 +22,28 @@ const hasBash = (() => {
 		return false;
 	}
 })();
-const tsKnownSharedProcessWarning =
-	'::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: 71 pass meets the minimum 71-pass floor but exits non-zero. Allowed known shared-process outcome: CI runs each discovered unit file in its own process (per-file CI isolation), so this pre-existing mock leak is non-blocking.';
-const legacyKnownIssueWarning =
-	'::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: expected 99 pass, got 71 pass (known baseline: 71). Pre-existing vi.mock() leak — tracked in scripts/check-cross-contamination.sh.';
-const tsExpected = `${tsKnownSharedProcessWarning}\n\nKnown pre-existing cross-contamination present (non-blocking).\nThis shared-process-only outcome remains guarded by the minimumPasses floor in this script.`;
-const legacyExpected = `${legacyKnownIssueWarning}\nKnown pre-existing cross-contamination present (non-blocking).\nExpected passes when fixed: update known_expected in this script.`;
+function tsKnownSharedProcessWarning(actualPasses: number): string {
+	return `::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: ${actualPasses} pass meets the minimum 71-pass floor but exits non-zero. Allowed known shared-process outcome: CI runs each discovered unit file in its own process (per-file CI isolation), so this pre-existing mock leak is non-blocking.`;
+}
+
+function legacyKnownIssueWarning(actualPasses: number): string {
+	return `::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: expected 99 pass, got ${actualPasses} pass (known baseline: 71). Pre-existing vi.mock() leak — tracked in scripts/check-cross-contamination.sh.`;
+}
+
+function tsExpected(actualPasses: number): string {
+	return `${tsKnownSharedProcessWarning(actualPasses)}\n\nKnown pre-existing cross-contamination present (non-blocking).\nThis shared-process-only outcome remains guarded by its configured pass floor and ceiling in this script.`;
+}
+
+function legacyExpected(actualPasses: number): string {
+	return `${legacyKnownIssueWarning(actualPasses)}\nKnown pre-existing cross-contamination present (non-blocking).\nExpected passes when fixed: update known_expected in this script.`;
+}
+
+function readKnownPairPassCount(output: string): number {
+	const match = output.match(
+		/knowledge-reader\.test\.ts \+ tests\/unit\/services\/skill-generator\.test\.ts: (?:expected 99 pass, got )?(\d+) pass/,
+	);
+	return match ? Number(match[1]) : 0;
+}
 
 function normalizeOutput(text: string): string {
 	return text.replace(/\r\n/g, '\n').trimEnd();
@@ -70,14 +86,19 @@ describe('cross-contamination legacy-oracle compatibility', () => {
 			runCrossContamination(REPO_ROOT, {
 				runPair: (_repoRoot, pair): PairRunResult =>
 					pair.fileA.includes('knowledge-reader')
-						? { exitCode: 1, stdout: ' 71 pass\n', stderr: '' }
+						? {
+								exitCode: 1,
+								stdout: ' 71 pass\n',
+								stderr:
+									"ENOENT: no such file or directory, lstat '/tmp/.swarm'\n",
+							}
 						: { exitCode: 0, stdout: '57 pass\n', stderr: '' },
 				log,
 			}),
 		);
 
 		expect(captured.exitCode).toBe(0);
-		expect(normalizeOutput(captured.stdout)).toBe(tsExpected);
+		expect(normalizeOutput(captured.stdout)).toBe(tsExpected(71));
 	});
 
 	test('preserves the archived Bash owner golden separately when Bash is available', async () => {
@@ -96,13 +117,25 @@ describe('cross-contamination legacy-oracle compatibility', () => {
 			);
 
 			expect(tsResult.exitCode, tsResult.stderr).toBe(0);
+			const tsPasses = readKnownPairPassCount(
+				`${tsResult.stdout}\n${tsResult.stderr}`,
+			);
+			expect(tsPasses).toBeGreaterThanOrEqual(71);
+			expect(tsPasses).toBeLessThanOrEqual(98);
 			expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
-				tsExpected,
+				tsExpected(tsPasses),
 			);
 			expect(normalizeOutput(tsResult.stderr)).toBe('');
 			expect(legacyResult.exitCode, legacyResult.stderr).toBe(0);
 			const normalizedLegacy = normalizeOutput(legacyResult.stdout);
-			expect(normalizedLegacy).toStartWith(legacyKnownIssueWarning);
+			const legacyPasses = readKnownPairPassCount(
+				`${legacyResult.stdout}\n${legacyResult.stderr}`,
+			);
+			expect(legacyPasses).toBeGreaterThanOrEqual(71);
+			expect(legacyPasses).toBeLessThan(99);
+			expect(normalizedLegacy).toStartWith(
+				legacyKnownIssueWarning(legacyPasses),
+			);
 			expect(normalizedLegacy).toContain(
 				'::warning title=Mock module not in isolation list::',
 			);
@@ -110,9 +143,11 @@ describe('cross-contamination legacy-oracle compatibility', () => {
 				'::notice title=Hook test file not in CI coverage::',
 			);
 			expect(normalizedLegacy).toEndWith(
-				legacyExpected.slice(legacyKnownIssueWarning.length + 1),
+				legacyExpected(legacyPasses).slice(
+					legacyKnownIssueWarning(legacyPasses).length + 1,
+				),
 			);
-			expect(normalizedLegacy).not.toBe(tsExpected);
+			expect(normalizedLegacy).not.toBe(tsExpected(tsPasses));
 			expect(normalizeOutput(legacyResult.stderr)).toBe('');
 		} finally {
 			isolatedEnv.cleanup();

--- a/tests/unit/scripts/check-bash-gates-legacy-oracle.test.ts
+++ b/tests/unit/scripts/check-bash-gates-legacy-oracle.test.ts
@@ -12,17 +12,12 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { main as runBashPortability } from '../../../scripts/check-bash-portability';
-import {
-	type PairRunResult,
-	main as runCrossContamination,
-} from '../../../scripts/check-cross-contamination';
 import { runGit, spawnUtf8 } from '../../../scripts/gate-utils';
 import { bashCommand, resolveBash } from '../../helpers/bash.js';
 import {
 	buildInvariantsOracleExpected,
 	seedQuarantineListFiles,
 } from '../../helpers/invariant-gate-fixtures.js';
-import { createIsolatedTestEnv } from '../../helpers/isolated-test-env.js';
 import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../');
@@ -59,14 +54,9 @@ const BASH_PORTABILITY_GATE = path.resolve(
 	REPO_ROOT,
 	'scripts/check-bash-portability.ts',
 );
-const CROSS_CONTAMINATION_GATE = path.resolve(
-	REPO_ROOT,
-	'scripts/check-cross-contamination.ts',
-);
 const tempRoots: string[] = [];
 const MOCK_MODULE_CALL = ['mock', "module('./dep', () => ({}));"].join('.');
 const RAW_TMPDIR_CALL = ['tmpdir', '()'].join('');
-const CROSS_CONTAMINATION_TIMEOUT_MS = 180_000;
 interface LegacyFixtureEntry {
 	path: string;
 	mode: string;
@@ -187,22 +177,6 @@ async function expectLegacyParity(
 	expect(normalizeOutput(legacyResult.stderr)).toBe(
 		normalizeOutput(tsResult.stderr),
 	);
-}
-
-async function captureLogLines(
-	run: (log: (line: string) => void) => number | Promise<number>,
-): Promise<{
-	exitCode: number;
-	stdout: string;
-}> {
-	const lines: string[] = [];
-	const exitCode = await run((line) => {
-		lines.push(line);
-	});
-	return {
-		exitCode,
-		stdout: lines.join('\n'),
-	};
 }
 
 async function captureConsoleLog(run: () => number | Promise<number>): Promise<{
@@ -445,56 +419,4 @@ describe('issue #2094 legacy-oracle parity', () => {
 		expect(captured.exitCode).toBe(1);
 		expect(normalizeOutput(captured.stdout)).toBe(expected);
 	});
-
-	test('cross-contamination preserves the archived known-issue warning shape', async () => {
-		const captured = await captureLogLines((log) =>
-			runCrossContamination(REPO_ROOT, {
-				runPair: (_repoRoot, pair): PairRunResult =>
-					pair.fileA.includes('knowledge-reader')
-						? { exitCode: 1, stdout: ' 71 pass\n', stderr: '' }
-						: { exitCode: 0, stdout: '57 pass\n', stderr: '' },
-				collectWarnings: () => [],
-				log,
-			}),
-		);
-
-		expect(captured.exitCode).toBe(0);
-		expect(normalizeOutput(captured.stdout)).toBe(
-			[
-				'::warning title=Cross-contamination known issue::Co-run of tests/unit/hooks/knowledge-reader.test.ts + tests/unit/services/skill-generator.test.ts: expected 99 pass, got 71 pass (known baseline: 71). Pre-existing vi.mock() leak — tracked in scripts/check-cross-contamination.sh.',
-				'',
-				'Known pre-existing cross-contamination present (non-blocking).',
-				'Expected passes when fixed: update known_expected in this script.',
-			].join('\n'),
-		);
-	});
-
-	test('cross-contamination matches the archived Bash owner on the real repo when Bash is available', async () => {
-		if (!hasBash) return;
-		const isolatedEnv = createIsolatedTestEnv();
-		try {
-			const legacyResult = await runLegacyGate(
-				'scripts/check-cross-contamination.sh',
-				REPO_ROOT,
-				CROSS_CONTAMINATION_TIMEOUT_MS,
-			);
-			const tsResult = await runTsGate(
-				CROSS_CONTAMINATION_GATE,
-				REPO_ROOT,
-				CROSS_CONTAMINATION_TIMEOUT_MS,
-			);
-
-			expect(tsResult.exitCode, tsResult.stderr).toBe(legacyResult.exitCode);
-			expect(tsResult.stdout).toBe(legacyResult.stdout);
-			expect(tsResult.stderr).toBe(legacyResult.stderr);
-			expect(normalizeOutput(tsResult.stdout), tsResult.stderr).toBe(
-				normalizeOutput(legacyResult.stdout),
-			);
-			expect(normalizeOutput(tsResult.stderr)).toBe(
-				normalizeOutput(legacyResult.stderr),
-			);
-		} finally {
-			isolatedEnv.cleanup();
-		}
-	}, 240_000);
 });

--- a/tests/unit/scripts/check-cross-contamination.test.ts
+++ b/tests/unit/scripts/check-cross-contamination.test.ts
@@ -1,20 +1,14 @@
 import { describe, expect, test } from 'bun:test';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
 	auditCrossContamination,
 	buildPairCommand,
-	collectHookWarnings,
 	evaluatePairResult,
-	HOOK_ISOLATION_BASENAMES,
 	lastLines,
-	matchesHookStepGlob,
 	PAIRS,
 	readPassCount,
-	toRepoRelativePath,
 } from '../../../scripts/check-cross-contamination';
-import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 const REPO_ROOT = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -45,19 +39,32 @@ describe('check-cross-contamination — parsing helpers', () => {
 			'4321',
 		]);
 	});
-
-	test('toRepoRelativePath normalizes separators to forward slashes', () => {
-		const rel = toRepoRelativePath(
-			'C:\\repo',
-			'C:\\repo\\tests\\unit\\hooks\\x.test.ts',
-		);
-		expect(rel).toBe('tests/unit/hooks/x.test.ts');
-	});
 });
 
 describe('check-cross-contamination — pair result classification', () => {
 	const cleanPair = PAIRS[0];
 	const knownPair = PAIRS[1];
+
+	test('keeps the pair order and records explicit floors/outcomes', () => {
+		expect(PAIRS.map(({ fileA, fileB }) => [fileA, fileB])).toEqual([
+			[
+				'tests/unit/diff/ast-diff.test.ts',
+				'src/hooks/__tests__/semantic-diff-injection.test.ts',
+			],
+			[
+				'tests/unit/hooks/knowledge-reader.test.ts',
+				'tests/unit/services/skill-generator.test.ts',
+			],
+		]);
+		expect(cleanPair).toMatchObject({
+			minimumPasses: 57,
+			allowedOutcome: 'clean',
+		});
+		expect(knownPair).toMatchObject({
+			minimumPasses: 71,
+			allowedOutcome: 'known_shared_process',
+		});
+	});
 
 	test('classifies an exit-0 co-run as clean', () => {
 		const result = evaluatePairResult(cleanPair, {
@@ -67,34 +74,11 @@ describe('check-cross-contamination — pair result classification', () => {
 		});
 		expect(result.kind).toBe('clean');
 		expect(result.messages).toEqual([]);
-		expect(result.expectedPasses).toBe(57);
+		expect(result.actualPasses).toBe(57);
+		expect(result.minimumPasses).toBe(57);
 	});
 
-	test('classifies a pre-existing shortfall as known_issue', () => {
-		const result = evaluatePairResult(knownPair, {
-			exitCode: 1,
-			stdout: ' 71 pass\n',
-			stderr: '',
-		});
-		expect(result.kind).toBe('known_issue');
-		expect(result.actualPasses).toBe(71);
-		expect(result.messages.join('\n')).toContain('known baseline: 71');
-	});
-
-	test('classifies a pass-count drop below the baseline as regression_pass_drop', () => {
-		const result = evaluatePairResult(cleanPair, {
-			exitCode: 1,
-			stdout: '56 pass\nline 1\nline 2\n',
-			stderr: '',
-		});
-		expect(result.kind).toBe('regression_pass_drop');
-		expect(result.actualPasses).toBe(56);
-		expect(result.messages.join('\n')).toContain(
-			'Previously known baseline was 57',
-		);
-	});
-
-	test('classifies a non-zero exit with enough passes as regression_unexpected_failure', () => {
+	test('treats a non-zero clean-pair exit at the floor as unexpected', () => {
 		const result = evaluatePairResult(cleanPair, {
 			exitCode: 1,
 			stdout: '57 pass\n',
@@ -104,6 +88,39 @@ describe('check-cross-contamination — pair result classification', () => {
 		expect(result.messages.join('\n')).toContain(
 			'Unexpected test failure or process error introduced',
 		);
+	});
+
+	test('classifies a knowledge-pair floor result as an allowed known issue', () => {
+		const result = evaluatePairResult(knownPair, {
+			exitCode: 1,
+			stdout: ' 71 pass\n',
+			stderr: '',
+		});
+		expect(result.kind).toBe('known_issue');
+		expect(result.actualPasses).toBe(71);
+		expect(result.messages.join('\n')).toContain('per-file CI isolation');
+		expect(result.messages.join('\n')).toContain(
+			'CI runs each discovered unit file in its own process',
+		);
+	});
+
+	test('permits the known knowledge-pair outcome above the floor', () => {
+		const result = evaluatePairResult(knownPair, {
+			exitCode: 1,
+			stdout: '99 pass\n',
+			stderr: '',
+		});
+		expect(result.kind).toBe('known_issue');
+	});
+
+	test('fails a knowledge-pair result below the floor', () => {
+		const result = evaluatePairResult(knownPair, {
+			exitCode: 1,
+			stdout: '70 pass\n',
+			stderr: '',
+		});
+		expect(result.kind).toBe('regression_pass_drop');
+		expect(result.actualPasses).toBe(70);
 	});
 
 	test('treats malformed combined output as a regression with zero passes', () => {
@@ -117,48 +134,6 @@ describe('check-cross-contamination — pair result classification', () => {
 	});
 });
 
-describe('check-cross-contamination — hook audit warnings', () => {
-	test('warns for recursive mock.module files outside the isolation list and notices uncovered top-level files', () => {
-		const tmpDir = canonicalMkdtemp('cross-contamination-hooks-');
-		const mockModuleToken = 'mock.' + 'module';
-		try {
-			const hooksRoot = path.join(tmpDir, 'tests', 'unit', 'hooks');
-			fs.mkdirSync(path.join(hooksRoot, 'nested'), { recursive: true });
-
-			fs.writeFileSync(
-				path.join(hooksRoot, 'nested', 'leaky-new.test.ts'),
-				`${mockModuleToken}('../../../src/x.js', () => ({}));\n`,
-			);
-			fs.writeFileSync(
-				path.join(hooksRoot, 'new-uncovered.test.ts'),
-				'test("placeholder", () => {});\n',
-			);
-			fs.writeFileSync(
-				path.join(hooksRoot, HOOK_ISOLATION_BASENAMES[0]),
-				`${mockModuleToken}('../../../src/y.js', () => ({}));\n`,
-			);
-
-			const warnings = collectHookWarnings(tmpDir);
-			expect(warnings).toHaveLength(2);
-			expect(warnings.join('\n')).toContain(
-				`tests/unit/hooks/nested/leaky-new.test.ts uses ${mockModuleToken}() but is not in the CI isolation step file list`,
-			);
-			expect(warnings.join('\n')).toContain(
-				'tests/unit/hooks/new-uncovered.test.ts is not covered by any named CI step glob or the isolation list',
-			);
-		} finally {
-			fs.rmSync(tmpDir, { recursive: true, force: true });
-		}
-	});
-
-	test('matches the checked-in hook step glob policy', () => {
-		expect(
-			matchesHookStepGlob('knowledge-reader-key-normalization.test.ts'),
-		).toBe(true);
-		expect(matchesHookStepGlob('totally-new-hook.test.ts')).toBe(false);
-	});
-});
-
 describe('check-cross-contamination — main audit wiring', () => {
 	test('resolves the repo root from a nested start directory before running pairs', async () => {
 		const nestedStartDir = path.join(REPO_ROOT, 'tests', 'unit', 'scripts');
@@ -168,29 +143,26 @@ describe('check-cross-contamination — main audit wiring', () => {
 				seenRoots.push(repoRoot);
 				return { exitCode: 0, stdout: '', stderr: '' };
 			},
-			collectWarnings: () => [],
 		});
 
 		expect(summary.exitCode).toBe(0);
 		expect(seenRoots).toEqual([REPO_ROOT, REPO_ROOT]);
 		expect(summary.repoRoot).toBe(REPO_ROOT);
-		expect(summary.messages.at(-1)).toBe(
+		expect(summary.messages).toEqual([
 			'No cross-contamination detected: all test pairs pass when co-run.',
-		);
+		]);
 	});
 
-	test('keeps coverage warnings non-blocking when no regression is present', async () => {
+	test('does not emit hook coverage warnings in the default audit output', async () => {
 		const summary = await auditCrossContamination(REPO_ROOT, {
 			runPair: () => ({ exitCode: 0, stdout: '', stderr: '' }),
-			collectWarnings: () => [
-				'::notice title=Hook test file not in CI coverage::example',
-			],
 		});
 
 		expect(summary.exitCode).toBe(0);
-		expect(summary.coverageWarning).toBe(true);
-		expect(summary.messages.join('\n')).toContain(
-			'Audit checks completed with warnings (non-blocking).',
-		);
+		expect(summary.messages).toEqual([
+			'No cross-contamination detected: all test pairs pass when co-run.',
+		]);
+		expect(summary.messages.join('\n')).not.toContain('Hook test file');
+		expect(summary.messages.join('\n')).not.toContain('Mock module not');
 	});
 });

--- a/tests/unit/scripts/check-cross-contamination.test.ts
+++ b/tests/unit/scripts/check-cross-contamination.test.ts
@@ -8,6 +8,7 @@ import {
 	lastLines,
 	PAIRS,
 	readPassCount,
+	runPair,
 } from '../../../scripts/check-cross-contamination';
 
 const REPO_ROOT = path.resolve(
@@ -62,6 +63,7 @@ describe('check-cross-contamination — pair result classification', () => {
 		});
 		expect(knownPair).toMatchObject({
 			minimumPasses: 71,
+			maximumKnownPasses: 98,
 			allowedOutcome: 'known_shared_process',
 		});
 	});
@@ -94,7 +96,7 @@ describe('check-cross-contamination — pair result classification', () => {
 		const result = evaluatePairResult(knownPair, {
 			exitCode: 1,
 			stdout: ' 71 pass\n',
-			stderr: '',
+			stderr: "ENOENT: no such file or directory, lstat '/tmp/.swarm'\n",
 		});
 		expect(result.kind).toBe('known_issue');
 		expect(result.actualPasses).toBe(71);
@@ -104,13 +106,37 @@ describe('check-cross-contamination — pair result classification', () => {
 		);
 	});
 
-	test('permits the known knowledge-pair outcome above the floor', () => {
+	test('requires the known shared-process failure signature', () => {
 		const result = evaluatePairResult(knownPair, {
 			exitCode: 1,
-			stdout: '99 pass\n',
-			stderr: '',
+			stdout: '80 pass\n',
+			stderr: 'AssertionError: unrelated failure\n',
+		});
+		expect(result.kind).toBe('regression_unexpected_failure');
+		expect(result.messages.join('\n')).toContain(
+			'did not match the known shared-process failure signature',
+		);
+	});
+
+	test('permits the known knowledge-pair outcome at its explicit ceiling', () => {
+		const result = evaluatePairResult(knownPair, {
+			exitCode: 1,
+			stdout: '98 pass\n',
+			stderr: "ENOENT: no such file or directory, lstat '/tmp/.swarm'\n",
 		});
 		expect(result.kind).toBe('known_issue');
+	});
+
+	test('fails a known knowledge-pair result above its ceiling with output evidence', () => {
+		const result = evaluatePairResult(knownPair, {
+			exitCode: 1,
+			stdout: '99 pass\nstdout evidence\n',
+			stderr: 'stderr evidence\n',
+		});
+		expect(result.kind).toBe('regression_unexpected_failure');
+		expect(result.messages.join('\n')).toContain('98-pass ceiling');
+		expect(result.messages.join('\n')).toContain('stdout evidence');
+		expect(result.messages.join('\n')).toContain('stderr evidence');
 	});
 
 	test('fails a knowledge-pair result below the floor', () => {
@@ -131,6 +157,16 @@ describe('check-cross-contamination — pair result classification', () => {
 		});
 		expect(result.kind).toBe('regression_pass_drop');
 		expect(result.actualPasses).toBe(0);
+	});
+
+	test('rejects a missing pair member before spawning the co-run', async () => {
+		const result = await runPair(REPO_ROOT, {
+			...cleanPair,
+			fileA: 'tests/unit/scripts/does-not-exist.test.ts',
+		});
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain('Cross-contamination pair file missing');
+		expect(result.stderr).toContain('does-not-exist.test.ts');
 	});
 });
 

--- a/tests/unit/scripts/ci/ci-gate-policy-2552.test.ts
+++ b/tests/unit/scripts/ci/ci-gate-policy-2552.test.ts
@@ -14,6 +14,7 @@ const TEST_DIRECTORY_OWNERS: Record<
 > = {
 	adversarial: 'unit',
 	architect: 'unit',
+	cli: 'unit',
 	helpers: 'unit',
 	integration: 'integration',
 	security: 'security',
@@ -47,11 +48,16 @@ function extractStep(yml: string, name: string): string {
 }
 
 function hasTestFile(directory: string): boolean {
-	return readdirSync(directory, { withFileTypes: true }).some((entry) => {
-		const entryPath = join(directory, entry.name);
-		if (entry.isDirectory()) return hasTestFile(entryPath);
-		return entry.isFile() && entry.name.endsWith('.test.ts');
-	});
+	try {
+		return readdirSync(directory, { withFileTypes: true }).some((entry) => {
+			const entryPath = join(directory, entry.name);
+			if (entry.isDirectory()) return hasTestFile(entryPath);
+			return entry.isFile() && entry.name.endsWith('.test.ts');
+		});
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+		throw error;
+	}
 }
 
 function topLevelTestDirectories(): string[] {
@@ -73,7 +79,9 @@ describe('CI gate policy — Stage-D discovery anchors (issue #2552)', () => {
 
 		expect(missingOwners).toEqual([]);
 		expect(populatedDirectories).toEqual(
-			Object.keys(TEST_DIRECTORY_OWNERS).sort(),
+			Object.keys(TEST_DIRECTORY_OWNERS)
+				.filter((directory) => hasTestFile(join(REPO_ROOT, 'tests', directory)))
+				.sort(),
 		);
 	});
 

--- a/tests/unit/scripts/ci/ci-gate-policy-2552.test.ts
+++ b/tests/unit/scripts/ci/ci-gate-policy-2552.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const CI_YML_PATH = join(REPO_ROOT, '.github/workflows/ci.yml');
+
+// Every top-level tests/ directory that currently contains test files must be
+// listed here with the job that owns it. Adding a new test tree without a
+// corresponding CI owner is an orphaned-corpus regression (issue #2552).
+const TEST_DIRECTORY_OWNERS: Record<
+	string,
+	'unit' | 'integration' | 'security' | 'smoke'
+> = {
+	adversarial: 'unit',
+	architect: 'unit',
+	helpers: 'unit',
+	integration: 'integration',
+	security: 'security',
+	smoke: 'smoke',
+	tools: 'unit',
+	unit: 'unit',
+};
+
+function readCiWorkflow(): string {
+	return readFileSync(CI_YML_PATH, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function extractJob(yml: string, job: string): string {
+	const match = yml.match(
+		new RegExp(
+			`^ {2}${job}:[\\s\\S]*?(?=^ {2}[A-Za-z][\\w-]*:|(?![\\s\\S]))`,
+			'm',
+		),
+	);
+	return match ? match[0] : '';
+}
+
+function extractStep(yml: string, name: string): string {
+	const match = yml.match(
+		new RegExp(
+			`^ {6}- name: ${name}[\\s\\S]*?(?=^ {6}- name:|^ {2}[A-Za-z][\\w-]*:|(?![\\s\\S]))`,
+			'm',
+		),
+	);
+	return match ? match[0] : '';
+}
+
+function hasTestFile(directory: string): boolean {
+	return readdirSync(directory, { withFileTypes: true }).some((entry) => {
+		const entryPath = join(directory, entry.name);
+		if (entry.isDirectory()) return hasTestFile(entryPath);
+		return entry.isFile() && entry.name.endsWith('.test.ts');
+	});
+}
+
+function topLevelTestDirectories(): string[] {
+	return readdirSync(join(REPO_ROOT, 'tests'), { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.filter((entry) => hasTestFile(join(REPO_ROOT, 'tests', entry.name)))
+		.map((entry) => entry.name)
+		.sort();
+}
+
+describe('CI gate policy — Stage-D discovery anchors (issue #2552)', () => {
+	const yml = readCiWorkflow();
+
+	test('every populated top-level tests/ directory has a known CI owner or exemption', () => {
+		const populatedDirectories = topLevelTestDirectories();
+		const missingOwners = populatedDirectories.filter(
+			(directory) => !(directory in TEST_DIRECTORY_OWNERS),
+		);
+
+		expect(missingOwners).toEqual([]);
+		expect(populatedDirectories).toEqual(
+			Object.keys(TEST_DIRECTORY_OWNERS).sort(),
+		);
+	});
+
+	test('the owner map is backed by anchored workflow discovery commands', () => {
+		const unitCollection = extractStep(yml, 'Collect and partition test files');
+		const ownerSections = {
+			unit: unitCollection,
+			integration: extractJob(yml, 'integration'),
+			security: extractJob(yml, 'security'),
+			smoke: extractJob(yml, 'smoke'),
+		};
+
+		expect(unitCollection).toContain(
+			"find tests/unit tests/adversarial tests/architect tests/cli tests/tools tests/helpers -name '*.test.ts' -type f",
+		);
+		expect(ownerSections.integration).toContain(
+			"find tests/integration test -name '*.test.ts' -type f",
+		);
+		expect(ownerSections.security).toContain(
+			'run: bun test tests/security --timeout 120000',
+		);
+		expect(ownerSections.smoke).toContain(
+			'run: bun test tests/smoke --timeout 120000',
+		);
+
+		for (const owner of Object.values(TEST_DIRECTORY_OWNERS)) {
+			expect(ownerSections[owner].length).toBeGreaterThan(0);
+		}
+	});
+
+	test('unit-passed remains the required aggregate and concurrency stays non-cancelling', () => {
+		const unitPassed = extractJob(yml, 'unit-passed');
+		const concurrency =
+			yml.match(/^concurrency:[\s\S]*?(?=^permissions:)/m)?.[0] ?? '';
+
+		expect(unitPassed).toContain('needs: [unit]');
+		expect(unitPassed).toContain('if: always()');
+		expect(unitPassed).toContain('UNIT_RESULT: ${{ needs.unit.result }}');
+		expect(concurrency).toContain('cancel-in-progress: false');
+		expect(concurrency).not.toMatch(/cancel-in-progress:\s*true/);
+	});
+});

--- a/tests/unit/scripts/ci/ci-yml-integration.test.ts
+++ b/tests/unit/scripts/ci/ci-yml-integration.test.ts
@@ -14,6 +14,11 @@ const FLAKE_DETECTION_YML_PATH = join(
 	import.meta.dir,
 	'../../../../.github/workflows/flake-detection.yml',
 );
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const REQUIRED_RECURSIVE_INTEGRATION_TESTS = [
+	'tests/integration/lang/prompt-injection.test.ts',
+	'tests/integration/lang/tool-profiles.test.ts',
+] as const;
 
 /*
  * Every extractor below ends its lazy match on the same four-alternative
@@ -64,6 +69,11 @@ function extractIntegrationTestsStep(yml: string): string {
 		/- name: Integration tests[\s\S]*?(?=\n {6}- name:|\n {6}# ---|\n {2}[A-Za-z][\w-]*:|(?![\s\S]))/m,
 	);
 	return match ? match[0] : '';
+}
+
+function extractIntegrationFindCommand(step: string): string {
+	const match = step.match(/^\s*find tests\/integration test[^\n]*$/m);
+	return match ? match[0].trim() : '';
 }
 
 function extractUnitFlakeAnnotationsUploadStep(yml: string): string {
@@ -141,6 +151,34 @@ describe('ci.yml integration — integration quarantine extraction', () => {
 		expect(step).toMatch(
 			/if \[ \$exit_code -eq 0 \]; then\s+# Match the unit wrapper's[\s\S]*?grep -E "\^\\\[ISSUE-\[0-9\]\+\(-\[A-Z0-9-\]\+\)\?-EVIDENCE\\\]" "\$tmp" \|\| true\s+fi/,
 		);
+	});
+});
+
+describe('ci.yml integration — recursive corpus discovery (issue #2552)', () => {
+	const yml = readFileSync(CI_YML_PATH, 'utf8');
+	const step = extractIntegrationTestsStep(yml);
+	const findCommand = extractIntegrationFindCommand(step);
+
+	test('the real integration step discovers both nested security-sensitive fixtures', () => {
+		// These exact basenames live below tests/integration/lang/. Pinning their
+		// paths against the actual find command catches a regression where a
+		// shallow discovery change silently leaves both files out of merge-queue CI.
+		expect(findCommand).toBe(
+			`find tests/integration test -name '*.test.ts' -type f | sort > "$tmpdir/int-all-tests.txt"`,
+		);
+		for (const relativePath of REQUIRED_RECURSIVE_INTEGRATION_TESTS) {
+			expect(existsSync(join(REPO_ROOT, relativePath))).toBe(true);
+			expect(relativePath.startsWith('tests/integration/')).toBe(true);
+			expect(relativePath.endsWith('.test.ts')).toBe(true);
+		}
+	});
+
+	test('integration discovery has no depth cap of any kind', () => {
+		// Do not weaken this to a literal `-maxdepth 1` check: any numeric
+		// max-depth still drops a nested integration test, including the two
+		// files pinned above. The exact command assertion also preserves the
+		// existing sort and per-file input contract.
+		expect(findCommand).not.toMatch(/\s-(?:maxdepth|mindepth)(?:\s|$)/);
 	});
 });
 


### PR DESCRIPTION
Refs #2552

## Summary

- Restore recursive integration-test discovery in the merge-queue workflow so nested language integration suites are collected.
- Replace the cross-contamination scanner's stale hook-file audit with explicit pair floors and an allowed known shared-process outcome; new regressions remain blocking.
- Add CI-policy tests, a Stage-D decision record, and the required pending release fragment. The separate Stage-A Windows10 decision and post-land C9 receipts remain intentionally pending.

## Invariant audit

- 1 (plugin init): not touched — no plugin initialization code changed; build and `repro-704` validation passed.
- 2 (runtime portability): not touched — no runtime import or bundle-shape code changed; build and Node ESM import passed.
- 3 (subprocesses): not touched — no subprocess implementation changed; existing subprocess safety checks passed.
- 4 (.swarm containment): not touched — no runtime state sink changed.
- 5 (plan durability): not touched — no plan ledger or projection code changed.
- 6 (test_runner safety): not touched — no test-runner implementation changed; validation used bounded per-file/scoped commands.
- 7 (test writing): touched — CI-policy and scanner tests use `bun:test`, no new module-mock targets, and the affected test gate passed.
- 8 (session state): not touched — no session/global state changed.
- 9 (guardrails/retry): not touched — no guardrail or retry code changed.
- 10 (chat/system msg): not touched — no chat transform or message-carrier code changed.
- 11 (tool registration): not touched — no tool, agent-map, command, or help surface changed.
- 12 (release/cache): touched — added the pending release fragment; no version or cache files changed; package smoke passed.

## Test plan

- Passed: targeted changed-file unit tests (five files, including the split legacy-oracle cross-contamination suite), recursive integration discovery tests, typecheck, invariants, lint, build, Node ESM import, `repro-704`, security (168 pass/4 skip), adversarial (846 pass), smoke (10 pass), and package smoke.
- Passed: cross-contamination audit with the known shared-process warning at the explicit floor and no stale hook-coverage diagnostics.
- Full `bun test tests/integration ./test --timeout 120000` was also run as a diagnostic; it reported 707 pass / 281 fail across unrelated shared-process-sensitive suites. Those failures are pre-existing outside this diff and are not silently converted into a new quarantine.
- Stage A Windows10 implementation and the six real post-land C9 receipts are not part of this publication unit, so this PR does not claim full issue closure.
