### PR TITLE
fix(compaction): make disabled compaction safe through the registered host hook

### DIFF
--- a/docs/releases/pending/2533-disabled-compaction-host-hook.md
+++ b/docs/releases/pending/2533-disabled-compaction-host-hook.md
@@ -1,0 +1,29 @@
+## Disabled compaction no longer throws through the registered host hook
+
+Setting the documented opt-out `hooks.compaction=false` used to break every
+session compaction instead of disabling the plugin's compaction enrichment:
+the registered `experimental.session.compacting` wrapper awaited a handler
+that `createCompactionCustomizerHook` omits when the flag is false, so each
+compaction (including the automatic one at context overflow) rejected with
+`TypeError: compactionHook["experimental.session.compacting"] is not a
+function`, which the host does not catch — wedging the session at the context
+limit exactly when compaction was needed most (issue #2533, audit HOOKS-1).
+
+**What changed.** The wrapper now calls the compaction customizer only when
+the factory actually provided it. The wrapper stays registered in every flag
+state because it also carries a flag-independent obligation: the per-turn
+injection-ledger reset (`advanceTurnGeneration`, #2107 §4) that must fire on
+every host compaction — the host still compacts when the plugin's
+customization is disabled. Behavior with `hooks.compaction=true` or absent is
+unchanged: the registered hook still appends exactly one bounded
+`<swarm_compaction_facts>` block to the compaction context.
+
+**Why it matters.** `hooks.compaction` is a documented opt-out
+(`docs/installation.md`); taking it now yields "no plugin enrichment" rather
+than "broken compaction". A census of every other conditionally-registered
+hook confirmed this was the only unguarded site of its class, and a new
+guardrail test boots the real plugin with each gated-hook flag disabled to
+keep it that way. The compaction tests drive the REAL plugin through
+`server()` (the registered host hook), via a new shared
+`tests/helpers/plugin-host.ts` boot helper that the upcoming interrupt/resume
+compaction scenarios (#2585) reuse.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3997,11 +3997,18 @@ async function initializeOpenCodeSwarm(
 			// biome-ignore lint/suspicious/noExplicitAny: Plugin API requires generic hook wrappers
 		) as any,
 
-		// Handle session compaction. The wrapper advances the per-turn injection
-		// ledger generation (#2107 §4): compaction changes the message surface,
-		// so per-turn accounting/dedup state must not survive into the next
-		// request composition. compactionHook's input carries { sessionID }
-		// (src/hooks/compaction-customizer.ts).
+		// Handle session compaction. Two obligations live here, deliberately in
+		// one always-registered wrapper (issue #2533):
+		// 1. Advance the per-turn injection ledger generation (#2107 §4):
+		//    compaction changes the message surface, so per-turn
+		//    accounting/dedup state must not survive into the next request
+		//    composition. This must fire on EVERY host compaction — the host
+		//    still compacts when the plugin's customization is disabled.
+		// 2. Delegate to the compaction customizer, which enriches the summary
+		//    with bounded plan/context facts. createCompactionCustomizerHook
+		//    omits the handler when hooks.compaction is false, so the delegate
+		//    is optional and must never be called unguarded. compactionHook's
+		//    input carries { sessionID } (src/hooks/compaction-customizer.ts).
 		'experimental.session.compacting': (async (
 			input: unknown,
 			output: unknown,
@@ -4010,12 +4017,12 @@ async function initializeOpenCodeSwarm(
 			if (sessionID) {
 				advanceTurnGeneration(sessionID);
 			}
-			await (
-				compactionHook['experimental.session.compacting'] as (
-					input: unknown,
-					output: unknown,
-				) => Promise<void>
-			)(input, output);
+			const delegate = compactionHook['experimental.session.compacting'] as
+				| ((input: unknown, output: unknown) => Promise<void>)
+				| undefined;
+			if (typeof delegate === 'function') {
+				await delegate(input, output);
+			}
 			// biome-ignore lint/suspicious/noExplicitAny: Plugin API requires generic hook wrappers
 		}) as any,
 

--- a/tests/helpers/plugin-host.ts
+++ b/tests/helpers/plugin-host.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import OpenCodeSwarmPlugin from '../../src/index';
+import { canonicalMkdtemp } from './tmpdir';
+
+function ctxFor(directory: string, client: unknown = {}) {
+	return {
+		client,
+		project: {} as unknown,
+		directory,
+		worktree: directory,
+		serverUrl: new URL('http://localhost:3000'),
+		$: {} as unknown,
+	};
+}
+
+/**
+ * Create a throwaway project directory for a real-plugin-host boot. The
+ * `.opencode/` subdir carries the config the plugin loader reads.
+ */
+export function createPluginHostProject(prefix: string): string {
+	const directory = canonicalMkdtemp(prefix);
+	mkdirSync(path.join(directory, '.opencode'), { recursive: true });
+	return directory;
+}
+
+export interface BootedPluginHost {
+	/** The hooks object returned by the plugin's server() — the REGISTERED host hooks. */
+	hooks: Record<string, (...args: unknown[]) => Promise<unknown>>;
+	tool: Record<
+		string,
+		{ execute: (args: unknown, dir: string, ctx: unknown) => Promise<unknown> }
+	>;
+	directory: string;
+}
+
+/**
+ * Boot the REAL plugin (src/index.ts server()) against a fresh temp project
+ * directory and return its registered hooks. This is the fixture for driving
+ * host-hook surfaces through the registered production path rather than by
+ * calling hook factories directly (issue #2533; reused by #2585's
+ * interrupt/restart/compaction scenarios).
+ *
+ * `configOverrides` deep-merge over `{ version_check: false }` in the
+ * project's `.opencode/opencode-swarm.json`. Note the loader also merges the
+ * user-level config; tests that care about a flag must set it explicitly.
+ */
+export async function bootSwarmPluginHost(
+	directory: string,
+	configOverrides: Record<string, unknown> = {},
+	client: unknown = {},
+): Promise<BootedPluginHost> {
+	writeFileSync(
+		path.join(directory, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify({ version_check: false, ...configOverrides }, null, 2),
+	);
+	const result = await (
+		OpenCodeSwarmPlugin as unknown as {
+			server: (
+				ctx: ReturnType<typeof ctxFor>,
+			) => Promise<Record<string, unknown>>;
+		}
+	).server(ctxFor(directory, client));
+	return {
+		hooks: result as unknown as Record<
+			string,
+			(...args: unknown[]) => Promise<unknown>
+		>,
+		tool: (result.tool ?? {}) as Record<
+			string,
+			{
+				execute: (args: unknown, dir: string, ctx: unknown) => Promise<unknown>;
+			}
+		>,
+		directory,
+	};
+}

--- a/tests/helpers/plugin-host.ts
+++ b/tests/helpers/plugin-host.ts
@@ -41,9 +41,11 @@ export interface BootedPluginHost {
  * calling hook factories directly (issue #2533; reused by #2585's
  * interrupt/restart/compaction scenarios).
  *
- * `configOverrides` deep-merge over `{ version_check: false }` in the
- * project's `.opencode/opencode-swarm.json`. Note the loader also merges the
- * user-level config; tests that care about a flag must set it explicitly.
+ * `configOverrides` is shallow-merged over `{ version_check: false }` at the
+ * top level (a nested key like `hooks` replaces that key wholesale), then
+ * written to the project's `.opencode/opencode-swarm.json`. The config loader
+ * itself deep-merges this project config over the user-level config; tests
+ * that care about a flag must set it explicitly.
  */
 export async function bootSwarmPluginHost(
 	directory: string,

--- a/tests/unit/hooks/compaction-host-hook-2533.test.ts
+++ b/tests/unit/hooks/compaction-host-hook-2533.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import OpenCodeSwarmPlugin from '../../../src/index';
+import {
+	beginTurnLedger,
+	clearTurnLedger,
+	getTurnLedgerSummary,
+} from '../../../src/services/injection-budget';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+/**
+ * Issue #2533: the registered `experimental.session.compacting` host hook
+ * must complete with `hooks.compaction=false` (it used to await a handler the
+ * factory omits when disabled), while preserving both the enabled-path facts
+ * injection and the flag-independent #2107 §4 turn-ledger reset.
+ *
+ * Every case drives the REAL plugin through `server()` (the registered host
+ * hook), never the hook factory directly. The equivalent shared boot helper
+ * (tests/helpers/plugin-host.ts) carries the same registered-path fixture for
+ * the class guardrail test and #2585's interrupt/restart/compaction
+ * scenarios; this file keeps its own boot so the regression test stands alone
+ * against future helper changes.
+ */
+
+const SESSION_IDS = [
+	'2533-reg-',
+	'2533-disabled-',
+	'2533-true-',
+	'2533-absent-',
+	'2533-ledger-disabled-',
+	'2533-ledger-enabled-',
+] as const;
+
+afterEach(() => {
+	// Ledger state is module-scoped; clear the sessions this file seeded so a
+	// later co-run test file sees a clean surface.
+	for (const sessionID of SESSION_IDS) {
+		clearTurnLedger(`${sessionID}session`);
+	}
+});
+
+async function bootRegisteredHooks(
+	overrides: Record<string, unknown>,
+): Promise<Record<string, (...args: unknown[]) => Promise<unknown>>> {
+	const directory = canonicalMkdtemp('swarm-2533-');
+	const opencodeDir = path.join(directory, '.opencode');
+	mkdirSync(opencodeDir, { recursive: true });
+	writeFileSync(
+		path.join(opencodeDir, 'opencode-swarm.json'),
+		JSON.stringify({ version_check: false, ...overrides }, null, 2),
+	);
+	const result = await (
+		OpenCodeSwarmPlugin as unknown as {
+			server: (ctx: {
+				client: unknown;
+				project: unknown;
+				directory: string;
+				worktree: string;
+				serverUrl: URL;
+				$: unknown;
+			}) => Promise<Record<string, unknown>>;
+		}
+	).server({
+		client: {},
+		project: {},
+		directory,
+		worktree: directory,
+		serverUrl: new URL('http://localhost:3000'),
+		$: {},
+	});
+	return result as unknown as Record<
+		string,
+		(...args: unknown[]) => Promise<unknown>
+	>;
+}
+
+function factsBlockCount(output: { context: string[] }): number {
+	return output.context.filter((entry) =>
+		entry.includes('<swarm_compaction_facts>'),
+	).length;
+}
+
+describe('registered experimental.session.compacting host hook (#2533)', () => {
+	it('is registered as a function in every flag state', async () => {
+		for (const overrides of [
+			{ hooks: { compaction: false } },
+			{ hooks: { compaction: true } },
+			{},
+		]) {
+			const hooks = await bootRegisteredHooks({ ...overrides });
+			expect(typeof hooks['experimental.session.compacting']).toBe('function');
+		}
+	});
+
+	it('completes with hooks.compaction=false and injects no facts block', async () => {
+		const hooks = await bootRegisteredHooks({ hooks: { compaction: false } });
+		const output = { context: [] as string[] };
+		await hooks['experimental.session.compacting'](
+			{ sessionID: '2533-disabled-session' },
+			output,
+		);
+		expect(factsBlockCount(output)).toBe(0);
+	});
+
+	it('still delegates with the flag true and with it absent: exactly one facts block', async () => {
+		for (const [sessionID, overrides] of [
+			['2533-true-session', { hooks: { compaction: true } }],
+			['2533-absent-session', {}],
+		] as const) {
+			const hooks = await bootRegisteredHooks({ ...overrides });
+			const output = { context: [] as string[] };
+			await hooks['experimental.session.compacting']({ sessionID }, output);
+			expect(factsBlockCount(output)).toBe(1);
+		}
+	});
+
+	it('discards the per-session turn ledger in BOTH flag states (#2107 §4)', async () => {
+		for (const [sessionID, overrides] of [
+			['2533-ledger-disabled-session', { hooks: { compaction: false } }],
+			['2533-ledger-enabled-session', { hooks: { compaction: true } }],
+		] as const) {
+			const hooks = await bootRegisteredHooks({ ...overrides });
+			beginTurnLedger(sessionID, 4096, true);
+			expect(getTurnLedgerSummary(sessionID)).not.toBeNull();
+			await hooks['experimental.session.compacting'](
+				{ sessionID },
+				{ context: [] },
+			);
+			expect(getTurnLedgerSummary(sessionID)).toBeNull();
+		}
+	});
+});

--- a/tests/unit/hooks/compaction-host-hook-2533.test.ts
+++ b/tests/unit/hooks/compaction-host-hook-2533.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import OpenCodeSwarmPlugin from '../../../src/index';
 import {
@@ -32,11 +32,34 @@ const SESSION_IDS = [
 	'2533-ledger-enabled-',
 ] as const;
 
-afterEach(() => {
+const createdDirs: string[] = [];
+
+afterEach(async () => {
 	// Ledger state is module-scoped; clear the sessions this file seeded so a
 	// later co-run test file sees a clean surface.
 	for (const sessionID of SESSION_IDS) {
 		clearTurnLedger(`${sessionID}session`);
+	}
+	// Remove the temp project dirs this file created (repo convention).
+	// Bounded retry: a freshly-booted plugin can hold open handles in the
+	// project dir on Windows (EBUSY). Hygiene never fails the test, but a dir
+	// that stays unreclaimed after the retries is reported, not silently
+	// leaked.
+	for (const dir of createdDirs.splice(0)) {
+		for (let attempt = 0; attempt < 4; attempt += 1) {
+			try {
+				rmSync(dir, { recursive: true, force: true });
+				break;
+			} catch {
+				if (attempt === 3) {
+					console.warn(
+						`[compaction-host-hook-2533] temp dir not reclaimed: ${dir}`,
+					);
+				} else {
+					await Bun.sleep(50);
+				}
+			}
+		}
 	}
 });
 
@@ -44,6 +67,7 @@ async function bootRegisteredHooks(
 	overrides: Record<string, unknown>,
 ): Promise<Record<string, (...args: unknown[]) => Promise<unknown>>> {
 	const directory = canonicalMkdtemp('swarm-2533-');
+	createdDirs.push(directory);
 	const opencodeDir = path.join(directory, '.opencode');
 	mkdirSync(opencodeDir, { recursive: true });
 	writeFileSync(

--- a/tests/unit/hooks/gated-hook-registration-class.test.ts
+++ b/tests/unit/hooks/gated-hook-registration-class.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { rmSync } from 'node:fs';
+import { swarmState } from '../../../src/state';
 import {
 	bootSwarmPluginHost,
 	createPluginHostProject,
@@ -20,8 +22,11 @@ import {
  * (filter(Boolean) compose arrays, no-op-method factories, in-handler flag
  * checks) — this test exists so a future regression of the class fails CI.
  *
- * Note on delegation_tracker: it defaults to false (opt-in), so both its
- * default-off and explicit-on states are exercised.
+ * Surface notes (review PRR-005/PRR-006): agent_activity's registered surface
+ * is tool.execute.before/after (no-op methods when disabled), so a dedicated
+ * boot below fires those keys directly. delegation_tracker is gated
+ * in-handler (delegation-tracker.ts), so its default-off state is covered by
+ * the hooks-absent boot; the explicit-on boot exercises the enabled branch.
  */
 
 const BOOTS = [
@@ -34,7 +39,7 @@ const BOOTS = [
 		overrides: { hooks: { agent_activity: false } },
 	},
 	{
-		label: 'delegation_tracker=true (opt-in)',
+		label: 'delegation_tracker=true (opt-in, in-handler enabled branch)',
 		overrides: { hooks: { delegation_tracker: true } },
 	},
 	{ label: 'hooks absent (all defaults)', overrides: {} },
@@ -50,38 +55,102 @@ const BOOTS = [
 	},
 ] as const;
 
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of createdDirs.splice(0)) {
+		// Bounded retry: a freshly-booted plugin can hold open handles in the
+		// project dir on Windows (EBUSY). Hygiene never fails the test, but a
+		// dir that stays unreclaimed after the retries is reported, not
+		// silently leaked.
+		for (let attempt = 0; attempt < 4; attempt += 1) {
+			try {
+				rmSync(dir, { recursive: true, force: true });
+				break;
+			} catch {
+				if (attempt === 3) {
+					console.warn(
+						`[gated-hook-registration-class] temp dir not reclaimed: ${dir}`,
+					);
+				} else {
+					await Bun.sleep(50);
+				}
+			}
+		}
+	}
+});
+
+async function bootAndTrack(
+	overrides: Record<string, unknown>,
+): Promise<Record<string, (...args: unknown[]) => Promise<unknown>>> {
+	const host = await bootSwarmPluginHost(
+		createPluginHostProject('swarm-2533-class-'),
+		{ ...overrides },
+	);
+	createdDirs.push(host.directory);
+	return host.hooks;
+}
+
 describe('config-gated hook factories never throw through the registered compose chains (#2533 class)', () => {
 	for (const { label, overrides } of BOOTS) {
 		it(`resolves messages.transform and system.transform with ${label}`, async () => {
-			const host = await bootSwarmPluginHost(
-				createPluginHostProject('swarm-2533-class-'),
-				{ ...overrides },
-			);
+			const hooks = await bootAndTrack({ ...overrides });
 			const sessionID = 'class-audit-session';
 			const messagesOutput = { messages: [] as unknown[] };
-			await host.hooks['experimental.chat.messages.transform'](
+			await hooks['experimental.chat.messages.transform'](
 				{ messages: [], sessionID },
 				messagesOutput,
 			);
 			const systemOutput = { system: [] as unknown[] };
-			await host.hooks['experimental.chat.system.transform'](
+			await hooks['experimental.chat.system.transform'](
 				{ sessionID },
 				systemOutput,
 			);
-			expect(true).toBe(true);
+			// Both chains mutate their outputs in place; resolution plus intact
+			// array surfaces is the disabled-state postcondition.
+			expect(Array.isArray(messagesOutput.messages)).toBe(true);
+			expect(Array.isArray(systemOutput.system)).toBe(true);
 		});
 
 		it(`resolves compaction with ${label}`, async () => {
-			const host = await bootSwarmPluginHost(
-				createPluginHostProject('swarm-2533-class-'),
-				{ ...overrides },
-			);
+			const hooks = await bootAndTrack({ ...overrides });
 			const output = { context: [] as string[] };
-			await host.hooks['experimental.session.compacting'](
+			await hooks['experimental.session.compacting'](
 				{ sessionID: 'class-audit-compaction' },
 				output,
 			);
 			expect(Array.isArray(output.context)).toBe(true);
 		});
 	}
+
+	it('proves the agent_activity disabled branch is a no-op through its registered surface', async () => {
+		// Enabled control: toolBefore seeds swarmState.activeToolCalls and
+		// toolAfter consumes the entry (src/hooks/agent-activity.ts).
+		const enabled = await bootAndTrack({
+			hooks: { agent_activity: true },
+		});
+		const enabledInput = {
+			tool: 'class-audit-tool',
+			sessionID: 'class-audit-tool-session',
+			callID: 'class-audit-tool-call-enabled',
+		};
+		await enabled['tool.execute.before'](enabledInput, { args: {} });
+		expect(swarmState.activeToolCalls.has(enabledInput.callID)).toBe(true);
+		await enabled['tool.execute.after'](enabledInput, {});
+		expect(swarmState.activeToolCalls.has(enabledInput.callID)).toBe(false);
+
+		// Disabled: the factory's no-op branch must neither throw nor track.
+		const disabled = await bootAndTrack({
+			hooks: { agent_activity: false },
+		});
+		const disabledInput = {
+			tool: 'class-audit-tool',
+			sessionID: 'class-audit-tool-session',
+			callID: 'class-audit-tool-call-disabled',
+		};
+		await disabled['tool.execute.before'](disabledInput, { args: {} });
+		expect(swarmState.activeToolCalls.has(disabledInput.callID)).toBe(false);
+		await disabled['tool.execute.after'](disabledInput, {});
+		expect(swarmState.activeToolCalls.has(disabledInput.callID)).toBe(false);
+	});
 });

--- a/tests/unit/hooks/gated-hook-registration-class.test.ts
+++ b/tests/unit/hooks/gated-hook-registration-class.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	bootSwarmPluginHost,
+	createPluginHostProject,
+} from '../../helpers/plugin-host';
+
+/**
+ * Defect-class guardrail for issue #2533: a host-hook registration in
+ * src/index.ts that indexes a config-gated hook factory's returned record (or
+ * handler object) and calls it unguarded, while the factory omits that key or
+ * method when its flag is disabled, throws at runtime for every user who sets
+ * the documented opt-out.
+ *
+ * The compaction instance of the class is covered by
+ * compaction-host-hook-2533.test.ts. This file pins the OTHER gated-hook
+ * consumers: for each config flag that can disable a hook factory feeding the
+ * registered compose chains, boot the real plugin with the flag in its
+ * disabled state and fire the registered hooks that factory feeds, asserting
+ * they resolve. The 2026-09-06 census found every such consumer safe
+ * (filter(Boolean) compose arrays, no-op-method factories, in-handler flag
+ * checks) — this test exists so a future regression of the class fails CI.
+ *
+ * Note on delegation_tracker: it defaults to false (opt-in), so both its
+ * default-off and explicit-on states are exercised.
+ */
+
+const BOOTS = [
+	{
+		label: 'system_enhancer=false',
+		overrides: { hooks: { system_enhancer: false } },
+	},
+	{
+		label: 'agent_activity=false',
+		overrides: { hooks: { agent_activity: false } },
+	},
+	{
+		label: 'delegation_tracker=true (opt-in)',
+		overrides: { hooks: { delegation_tracker: true } },
+	},
+	{ label: 'hooks absent (all defaults)', overrides: {} },
+	{
+		label: 'system_enhancer+agent_activity+compaction all off',
+		overrides: {
+			hooks: {
+				system_enhancer: false,
+				agent_activity: false,
+				compaction: false,
+			},
+		},
+	},
+] as const;
+
+describe('config-gated hook factories never throw through the registered compose chains (#2533 class)', () => {
+	for (const { label, overrides } of BOOTS) {
+		it(`resolves messages.transform and system.transform with ${label}`, async () => {
+			const host = await bootSwarmPluginHost(
+				createPluginHostProject('swarm-2533-class-'),
+				{ ...overrides },
+			);
+			const sessionID = 'class-audit-session';
+			const messagesOutput = { messages: [] as unknown[] };
+			await host.hooks['experimental.chat.messages.transform'](
+				{ messages: [], sessionID },
+				messagesOutput,
+			);
+			const systemOutput = { system: [] as unknown[] };
+			await host.hooks['experimental.chat.system.transform'](
+				{ sessionID },
+				systemOutput,
+			);
+			expect(true).toBe(true);
+		});
+
+		it(`resolves compaction with ${label}`, async () => {
+			const host = await bootSwarmPluginHost(
+				createPluginHostProject('swarm-2533-class-'),
+				{ ...overrides },
+			);
+			const output = { context: [] as string[] };
+			await host.hooks['experimental.session.compacting'](
+				{ sessionID: 'class-audit-compaction' },
+				output,
+			);
+			expect(Array.isArray(output.context)).toBe(true);
+		});
+	}
+});


### PR DESCRIPTION
Closes #2533

## Summary

Setting the documented opt-out `hooks.compaction=false` broke every session compaction instead of disabling the plugin's compaction enrichment: the registered `experimental.session.compacting` wrapper in `src/index.ts` awaited a handler that `createCompactionCustomizerHook` omits when the flag is false, so each compaction — including the automatic one at context overflow — rejected with `TypeError: compactionHook["experimental.session.compacting"] is not a function`, which the pinned host (v1.18.3) does not catch (audit HOOKS-1). The wrapper now calls the customizer delegate only when the factory actually provided it (`typeof delegate === 'function'`). The wrapper stays registered in every flag state because it also carries a flag-independent obligation: the #2107 §4 per-turn injection-ledger reset (`advanceTurnGeneration`), which must fire on every host compaction since the host still compacts when the plugin's customization is disabled. Behavior with `hooks.compaction=true` or absent is unchanged: exactly one `<swarm_compaction_facts>` block is still appended.

- `src/index.ts` — guarded the delegate call inside the always-registered wrapper (~line 4020); comment now documents both obligations.
- `tests/unit/hooks/compaction-host-hook-2533.test.ts` (NEW) — regression test through the REAL `server()` boot (never the factory): all three flag states, zero facts blocks when disabled, exactly one when enabled/absent, and the turn ledger discarded in BOTH states.
- `tests/unit/hooks/gated-hook-registration-class.test.ts` (NEW) — defect-class guardrail: boots the real plugin with each config-gated hook flag disabled (incl. all-off) and fires the registered compose chains + compaction hook.
- `tests/helpers/plugin-host.ts` (NEW) — shared real-`server()` boot fixture; consumed by the class test and reserved for #2585's interrupt/restart/compaction scenarios.
- `docs/releases/pending/2533-disabled-compaction-host-hook.md` (NEW) — release fragment.

## Invariant audit

- 1 (plugin init): touched — the change is inside the `server()` hooks object (registration shape unchanged; no new awaits/I/O/subprocesses). Evidence: `node scripts/repro-704.mjs` → "OK T1[500-file tight deadline] — server() resolved in 43.6ms (deadline=400ms)", T2/T3 OK, exit 0.
- 2 (runtime portability): touched — same file as the entry shape. Evidence: `bun run build` exit 0; `node --input-type=module -e "await import('./dist/index.js')"` exit 0; `bun test tests/smoke/packaging.test.ts` 10 pass / 0 fail.
- 3 (subprocesses): not touched — no spawn changes in the diff.
- 4 (.swarm containment): not touched — new tests write only under the OS temp dir via `canonicalMkdtemp` (`scripts/check-test-tmpdir.sh` → "All new/changed test temp roots are external and canonicalized").
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — two new bun:test files (4 + 10 tests, each far under 500 lines; no `mock.module`). Evidence: `bun run check:test-file-cap` → "New-file violations: 0, Ratchet violations: 0"; `scripts/check-mock-cleanup.sh` clean.
- 8 (session state): not touched — `advanceTurnGeneration` call site unchanged in position and semantics.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): touched (in-scope per the issue) — the compaction hook is a host-hook registration but not a chat-transform chain; it mutates neither `output.system` nor `output.messages`. Evidence: `bun test` on `system-splice-ratchet-2526`, `host-message-role-contract-2526`, `chat-transform-rebind-guard` + `index.test.ts` → 28 pass / 0 fail.
- 11 (tool registration): not touched — no tool/metadata/manifest changes; `bun run drift:check -- --enforce` → "No drift detected".
- 12 (release/cache): touched — `docs/releases/pending/2533-disabled-compaction-host-hook.md` shipped; no version/CHANGELOG hand edits.

## Test plan

- Regression: `bun test tests/unit/hooks/compaction-host-hook-2533.test.ts tests/unit/hooks/gated-hook-registration-class.test.ts` → 14 pass / 0 fail.
- Impacted suites: `bun test tests/unit/hooks/compaction-customizer-context.test.ts tests/unit/hooks/hook-composition.test.ts tests/unit/hooks/hook-composition-order.test.ts` → 39 pass / 0 fail; invariant-10 suites + `tests/unit/index.test.ts` → 28 pass / 0 fail.
- Acceptance checks (issue-tracer, frozen pre-fix): 6/6 PASS — C1 disabled-compaction RED→GREEN, C2 enabled/absent GREEN→GREEN (exactly one facts block), C3 turn-ledger RED→GREEN (both flag states), C4 gated-hook class GREEN→GREEN, C5 fixture ERROR→GREEN, C6 fragment ERROR→GREEN; revert/mutation probes M1-M4 demonstrated each discriminates.
- Quality: `bun run typecheck` exit 0; `bunx @biomejs/biome@2.3.14 ci` (changed files) exit 0; `bun run check:events` passed (61 kinds); `bun run check:registry-citations` passed (88 baseline); `tests/unit/utils/atomic-write-ratchet.test.ts` 7 pass; `check:test-tmpdir` / `check:test-clock` / `check:mock-cleanup` 0 new violations; `bun run drift:check -- --enforce` clean; deferred-work scan clean.

## Root Cause

`src/hooks/compaction-customizer.ts:181-185` returns `{}` when `config.hooks?.compaction === false` (factory omits the handler), while the `server()` hooks object registered `'experimental.session.compacting'` unconditionally and awaited `compactionHook['experimental.session.compacting'](input, output)` with no guard — `undefined is not a function` on every compaction for operators who set the documented opt-out (`src/config/schema.ts:246`, default `true`). The plugin's own init log already modeled the key as optional (`compaction: !!compactionHook[...]`), contradicting the unguarded call.

## Recurrence Prevention (defect class)

- Defect class: a host-hook registration in `src/index.ts` that indexes a config-gated hook factory's returned record (or handler object) and calls it unguarded while the factory omits that key/method when its flag is off.
- Sweep result: 37 sites (P1 record-indexing 8 + P2 disabled empty-record shapes 15 + P3 handler-object delegations 14) — exactly one class member (the compaction wrapper); every sibling guarded by construction (filtered compose arrays, unconditional methods, in-handler flag checks, presence condition at `index.ts:4922`).
- Guardrail: permanent CI test `tests/unit/hooks/gated-hook-registration-class.test.ts` (real boots with each gated flag off) + frozen checks C3/C4; demonstrated to bite via mutation probes (guard reverted → C1 RED; `advanceTurnGeneration` removed → C3 RED "session ledger survived").

## Regression Protection

- `tests/unit/hooks/compaction-host-hook-2533.test.ts`: disabled/true/absent legs through the registered callback; facts-block count 0 vs 1; ledger discard in both states.
- `tests/unit/hooks/gated-hook-registration-class.test.ts`: 5 gated-hook boots (incl. `system_enhancer`+`agent_activity`+`compaction` all off) each resolve messages.transform, system.transform, and compacting.
- Test drift review: frozen-check manifest verified (all 6 blobs OK, zero AMEND rows) — no check was weakened to reach green.

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 disabled compaction completes through the registered callback | frozen check C1: base RED (`^C1-DISABLED-COMPACTION-REJECTED` TypeError) → head GREEN (`C1-OK ... context entries: 0`); regression test "completes with hooks.compaction=false and injects no facts block" |
| AC2 true/absent unchanged, exactly one facts block | frozen check C2 GREEN→GREEN (`exactly one <swarm_compaction_facts> block in both legs`); test "still delegates with the flag true and with it absent" |
| AC3 advanceTurnGeneration preserved in both states | frozen check C3 RED→GREEN (`C3-OK ... in both flag states`); test "discards the per-session turn ledger in BOTH flag states (#2107 §4)"; mutation M2 proof |
| AC4 no other gated hook throws disabled | frozen check C4 GREEN→GREEN (5 boots); 37-site census in the trace; guardrail test 10 pass |
| AC5 tests exercise the registered host hook; fixture reusable by #2585 | frozen check C5 GREEN (fixture boots `.server(`, never imports the factory); `tests/helpers/plugin-host.ts` consumed by the class test and documented for #2585 |
| AC6 release fragment + invariant audit | frozen check C6 GREEN (`docs/releases/pending/2533-*.md` present); this PR's Invariant audit section above |

## Risk and Rollback

- Risk level: low — single guarded-call hunk inside the existing registration; enabled path byte-equivalent.
- Rollback: revert the single commit (`f35f7856`); no schema, migration, or dependency changes.
- Residual risk: none identified; one non-blocking coverage note (class guardrail does not fire tool.execute.before/after — recorded in the trace).

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.

PR head: 39040e27c395a2bab2426696e4ea8c749b9dc5d4 (adds the PR-review feedback round: guardrail-test hardening, reviewer- and critic-approved)

## Issue Closure

Closes #2533

---

Published: PR #2620 https://github.com/ZaxbyHub/opencode-swarm/pull/2620 (branch fix/issue-2533-disabled-compaction-host-hook, base main). PR head: 39040e27c395a2bab2426696e4ea8c749b9dc5d4 (adds the PR-review feedback round: guardrail-test hardening, reviewer- and critic-approved) (equals the final-critic reviewed-commit). Body verified live: first line "Closes #2533"; required headings present; check-title and pr-standards PASS at open. Merge status: AWAITING_USER_APPROVAL — the 5.1 merge gate requires a separately recorded, explicit user approval quoted verbatim in 10b-merge-approval.md before any merge.
