### PR TITLE
fix(runtime): bound subprocess output capture

### DIFF
--- a/docs/releases/pending/issue-2530-subprocess-output.md
+++ b/docs/releases/pending/issue-2530-subprocess-output.md
@@ -1,0 +1,9 @@
+# Bounded cross-runtime subprocess output
+
+`bunSpawn` now starts bounded background capture for unclaimed piped stdout and
+stderr. Node-hosted plugins can safely await process exit before reading output,
+without child-process pipe backpressure causing a timeout or truncated result.
+
+Buffered output is capped at 5 MiB per pipe by default. Calls can set a positive
+safe-integer `maxBuffer`; an overflow terminates the child and reports a typed
+`BunCompatOutputLimitError` consistently for both buffered output streams.

--- a/docs/releases/pending/issue-2530-subprocess-output.md
+++ b/docs/releases/pending/issue-2530-subprocess-output.md
@@ -4,6 +4,12 @@
 stderr. Node-hosted plugins can safely await process exit before reading output,
 without child-process pipe backpressure causing a timeout or truncated result.
 
-Buffered output is capped at 5 MiB per pipe by default. Calls can set a positive
-safe-integer `maxBuffer`; an overflow terminates the child and reports a typed
+Worktree Git callers treat bounded-output overflow as an ordinary failed Git
+operation (or fail open for the Windows path-budget advisory), so a noisy
+repository cannot make those safety checks reject unexpectedly.
+
+Asynchronous `bunSpawn` buffered output is capped at 5 MiB per pipe by default.
+Those calls can set a positive safe-integer `maxBuffer`; an overflow terminates the child and reports a typed
 `BunCompatOutputLimitError` consistently for both buffered output streams.
+`bunSpawnSync` remains a direct host-synchronous adapter and does not apply the
+asynchronous stream-capture option.

--- a/src/utils/bun-compat.ts
+++ b/src/utils/bun-compat.ts
@@ -288,6 +288,12 @@ export interface BunCompatSpawnOptions {
 	stdout?: 'inherit' | 'ignore' | 'pipe';
 	stderr?: 'inherit' | 'ignore' | 'pipe';
 	timeout?: number;
+	/**
+	 * Maximum bytes retained for each buffered stdout/stderr stream. Invalid
+	 * values fall back to `DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES` so `bunSpawn`
+	 * keeps its no-throw compatibility contract.
+	 */
+	maxBuffer?: number;
 	/** Preserve the caller's exact Windows argv quoting (required for cmd.exe /c). */
 	windowsVerbatimArguments?: boolean;
 	/**
@@ -300,6 +306,29 @@ export interface BunCompatSpawnOptions {
 	 * short-lived `bunSpawn` callers (git, lint, version checks).
 	 */
 	killProcessTree?: boolean;
+}
+
+/**
+ * Default bounded capture for unclaimed subprocess pipes. Five MiB matches
+ * the established Git subprocess limit while remaining finite by default.
+ */
+export const DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+
+/** Raised when either buffered pipe exceeds its configured output limit. */
+export class BunCompatOutputLimitError extends Error {
+	readonly limit: number;
+	readonly captured: number;
+	readonly total: number;
+
+	constructor(limit: number, captured: number, total: number) {
+		super(
+			`Subprocess output exceeded the ${limit}-byte buffer limit after capturing ${captured} bytes (${total} bytes observed)`,
+		);
+		this.name = 'BunCompatOutputLimitError';
+		this.limit = limit;
+		this.captured = captured;
+		this.total = total;
+	}
 }
 
 export interface BunCompatStream {
@@ -617,32 +646,113 @@ function wrapSpawnFailure(
 	return describeSpawnCwdFailure(cwd, executable, err) ?? err;
 }
 
+function normalizedMaxBuffer(value: unknown): number {
+	return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+		? value
+		: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES;
+}
+
+interface OutputOverflowController {
+	readonly error: BunCompatOutputLimitError | undefined;
+	readonly completed: Promise<void>;
+	overflow(captured: number, total: number): void;
+	complete(): void;
+}
+
+/**
+ * stdout and stderr are one subprocess outcome: once either exceeds its
+ * limit, both buffered views must report the same error after terminal events
+ * drain. The auto-drain callers deliberately swallow their own rejection so a
+ * pipe configured but never read cannot create an unhandled rejection.
+ */
+function createOutputOverflowController(
+	limit: number,
+	requestKill: () => void,
+): OutputOverflowController {
+	let error: BunCompatOutputLimitError | undefined;
+	let killRequested = false;
+	let resolveCompleted!: () => void;
+	const completed = new Promise<void>((resolve) => {
+		resolveCompleted = resolve;
+	});
+	return {
+		get error() {
+			return error;
+		},
+		completed,
+		overflow(captured, total) {
+			if (error) return;
+			error = new BunCompatOutputLimitError(limit, captured, total);
+			if (killRequested) return;
+			killRequested = true;
+			try {
+				requestKill();
+			} catch {
+				// The process may already have exited naturally.
+			}
+		},
+		complete() {
+			resolveCompleted();
+		},
+	};
+}
+
 function streamFromNode(
 	pipe: NodeJS.ReadableStream | null | undefined,
+	limit?: number,
+	controller?: OutputOverflowController,
 ): BunCompatStream {
-	// Expose either full buffered output (`text()`/`bytes()`) or a Web reader for
-	// incremental bounded consumption. Claim exactly one mode lazily: Node
-	// streams start paused, so a bounded reader must not run beside an eager,
-	// unbounded chunk collector.
+	if (!pipe) return staticStream('');
+	// A same-stack reader has exclusive ownership. A deferred auto-claim then
+	// drains every still-unclaimed pipe before an exit-first consumer can block
+	// a child on OS pipe backpressure.
+	let mode: 'buffered' | 'reader' | undefined;
 	let collected: Promise<Buffer> | undefined;
-	let readerClaimed = false;
 	const collect = (): Promise<Buffer> => {
-		if (readerClaimed) {
+		if (mode === 'reader') {
 			return Promise.reject(
 				new TypeError('Subprocess output is already consumed by a reader'),
 			);
 		}
-		collected ??= new Promise((resolve) => {
+		mode = 'buffered';
+		if (collected) return collected;
+		collected = new Promise<Buffer>((resolve) => {
 			if (!pipe) {
 				resolve(Buffer.alloc(0));
 				return;
 			}
 			const chunks: Buffer[] = [];
+			let captured = 0;
+			let total = 0;
+			let finished = false;
+			const finish = () => {
+				if (finished) return;
+				finished = true;
+				resolve(Buffer.concat(chunks));
+			};
 			pipe.on('data', (chunk: Buffer | string) => {
-				chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+				const bytes = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+				total += bytes.byteLength;
+				if (controller?.error || limit === undefined) return;
+				const remaining = limit - captured;
+				if (remaining > 0) {
+					// Copy the retained prefix: a subarray would keep an oversized
+					// source chunk's whole backing buffer alive past the limit.
+					const retained = Buffer.from(bytes.subarray(0, remaining));
+					chunks.push(retained);
+					captured += retained.byteLength;
+				}
+				if (bytes.byteLength > remaining) {
+					controller?.overflow(captured, total);
+				}
 			});
-			pipe.on('end', () => resolve(Buffer.concat(chunks)));
-			pipe.on('error', () => resolve(Buffer.concat(chunks)));
+			pipe.on('end', finish);
+			pipe.on('close', finish);
+			pipe.on('error', finish);
+		}).then(async (bytes): Promise<Buffer> => {
+			await controller?.completed;
+			if (controller?.error) throw controller.error;
+			return bytes;
 		});
 		return collected;
 	};
@@ -692,7 +802,7 @@ function streamFromNode(
 		});
 	};
 
-	return {
+	const result: BunCompatStream = {
 		async text(): Promise<string> {
 			return (await collect()).toString('utf-8');
 		},
@@ -701,13 +811,19 @@ function streamFromNode(
 			return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
 		},
 		getReader(): ReadableStreamDefaultReader<Uint8Array> {
-			if (readerClaimed || collected) {
+			if (mode !== undefined) {
 				throw new TypeError('Subprocess output is already consumed');
 			}
-			readerClaimed = true;
+			mode = 'reader';
 			return toWebReadable().getReader();
 		},
 	};
+	if (pipe && controller && limit !== undefined) {
+		queueMicrotask(() => {
+			if (mode === undefined) void collect().catch(() => undefined);
+		});
+	}
+	return result;
 }
 
 function mapStdio(
@@ -716,12 +832,13 @@ function mapStdio(
 	return v ?? 'pipe';
 }
 
-function streamFromBun(stream: unknown): BunCompatStream {
-	// Bun's subprocess `stdout`/`stderr` is a `ReadableStream` (Web Streams).
-	// Wrap it to expose the `text()`/`bytes()`/`getReader()` shape the rest
-	// of the codebase expects from the shim. We tee the stream when both
-	// shapes are needed in the same call site, but in practice each caller
-	// uses only one path.
+function streamFromBun(
+	stream: unknown,
+	limit?: number,
+	controller?: OutputOverflowController,
+): BunCompatStream {
+	// Bun's subprocess stdout/stderr are Web Streams. Give them the same
+	// ownership, deferred-drain, and finite-buffer contract as Node streams.
 	if (!stream || typeof stream !== 'object') {
 		const empty: BunCompatStream = {
 			async text() {
@@ -741,51 +858,84 @@ function streamFromBun(stream: unknown): BunCompatStream {
 		return empty;
 	}
 	const candidate = stream as {
-		text?: () => Promise<string>;
-		bytes?: () => Promise<Uint8Array>;
 		getReader?: () => ReadableStreamDefaultReader<Uint8Array>;
 	};
-	const collect = async (): Promise<Uint8Array> => {
-		if (typeof candidate.getReader !== 'function') {
-			return new Uint8Array(0);
+	let mode: 'buffered' | 'reader' | undefined;
+	let collected: Promise<Uint8Array> | undefined;
+	const collect = (): Promise<Uint8Array> => {
+		if (mode === 'reader') {
+			return Promise.reject(
+				new TypeError('Subprocess output is already consumed by a reader'),
+			);
 		}
-		const reader = candidate.getReader();
-		const chunks: Uint8Array[] = [];
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			if (value) chunks.push(value);
-		}
-		const total = chunks.reduce((acc, c) => acc + c.byteLength, 0);
-		const out = new Uint8Array(total);
-		let off = 0;
-		for (const c of chunks) {
-			out.set(c, off);
-			off += c.byteLength;
-		}
-		return out;
+		mode = 'buffered';
+		collected ??= (async () => {
+			if (typeof candidate.getReader !== 'function') return new Uint8Array(0);
+			const reader = candidate.getReader();
+			const chunks: Uint8Array[] = [];
+			let captured = 0;
+			let total = 0;
+			try {
+				for (;;) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					if (!value) continue;
+					total += value.byteLength;
+					if (controller?.error || limit === undefined) continue;
+					const remaining = limit - captured;
+					if (remaining > 0) {
+						const retained = value.slice(0, remaining);
+						chunks.push(retained);
+						captured += retained.byteLength;
+					}
+					if (value.byteLength > remaining) {
+						controller?.overflow(captured, total);
+					}
+				}
+			} finally {
+				reader.releaseLock();
+			}
+			await controller?.completed;
+			if (controller?.error) throw controller.error;
+			const out = new Uint8Array(captured);
+			let offset = 0;
+			for (const chunk of chunks) {
+				out.set(chunk, offset);
+				offset += chunk.byteLength;
+			}
+			return out;
+		})();
+		return collected;
 	};
-	const text =
-		typeof candidate.text === 'function'
-			? () => (candidate.text as () => Promise<string>)()
-			: async () => new TextDecoder().decode(await collect());
-	const bytes =
-		typeof candidate.bytes === 'function'
-			? () => (candidate.bytes as () => Promise<Uint8Array>)()
-			: collect;
-	const getReader =
-		typeof candidate.getReader === 'function'
-			? () =>
-					(
-						candidate.getReader as () => ReadableStreamDefaultReader<Uint8Array>
-					)()
-			: () =>
-					new ReadableStream<Uint8Array>({
-						start(controller) {
-							controller.close();
+	const result: BunCompatStream = {
+		async text() {
+			return new TextDecoder().decode(await collect());
+		},
+		bytes: collect,
+		getReader() {
+			if (mode !== undefined) {
+				throw new TypeError('Subprocess output is already consumed');
+			}
+			mode = 'reader';
+			return typeof candidate.getReader === 'function'
+				? candidate.getReader()
+				: new ReadableStream<Uint8Array>({
+						start(streamController) {
+							streamController.close();
 						},
 					}).getReader();
-	return { text, bytes, getReader };
+		},
+	};
+	if (
+		typeof candidate.getReader === 'function' &&
+		controller &&
+		limit !== undefined
+	) {
+		queueMicrotask(() => {
+			if (mode === undefined) void collect().catch(() => undefined);
+		});
+	}
+	return result;
 }
 
 /**
@@ -907,6 +1057,7 @@ export function bunSpawn(
 	cmd: string[],
 	options?: BunCompatSpawnOptions,
 ): BunCompatSubprocess {
+	const maxBuffer = normalizedMaxBuffer(options?.maxBuffer);
 	// #2236 chokepoint: a `cwd` taken from durable or reconstructed state can
 	// point at a directory that has since been torn down. The spawn is still
 	// attempted; every failure path below runs the caught error through
@@ -923,6 +1074,7 @@ export function bunSpawn(
 		// Always build a fresh options object so we never mutate the caller's.
 		const spawnOpts: Record<string, unknown> = { ...options };
 		delete spawnOpts.killProcessTree;
+		delete spawnOpts.maxBuffer;
 		if (mergedEnv !== undefined) spawnOpts.env = mergedEnv;
 		// Security (SC-003.4): a child that traps SIGTERM must still be killed
 		// when the timeout fires. Bun's default kill signal on timeout is
@@ -975,6 +1127,9 @@ export function bunSpawn(
 			options?.killProcessTree
 				? killBunTree(sig)
 				: Promise.resolve(proc.kill(sig));
+		const outputController = createOutputOverflowController(maxBuffer, () => {
+			void killBunProcess('SIGKILL').catch(() => undefined);
+		});
 		let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 		if (
 			options?.killProcessTree === true &&
@@ -992,10 +1147,11 @@ export function bunSpawn(
 		}
 		const exited = proc.exited.finally(() => {
 			if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+			outputController.complete();
 		});
 		return {
-			stdout: streamFromBun(proc.stdout),
-			stderr: streamFromBun(proc.stderr),
+			stdout: streamFromBun(proc.stdout, maxBuffer, outputController),
+			stderr: streamFromBun(proc.stderr, maxBuffer, outputController),
 			exited,
 			get exitCode() {
 				return proc.exitCode;
@@ -1044,6 +1200,9 @@ export function bunSpawn(
 		proc.kill(signal as NodeJS.Signals);
 		return Promise.resolve();
 	};
+	const outputController = createOutputOverflowController(maxBuffer, () => {
+		void killChild('SIGKILL').catch(() => undefined);
+	});
 
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 	let observedSignal: NodeJS.Signals | null = null;
@@ -1076,11 +1235,12 @@ export function bunSpawn(
 		}
 	}).finally(() => {
 		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		outputController.complete();
 	});
 
 	return {
-		stdout: streamFromNode(proc.stdout),
-		stderr: streamFromNode(proc.stderr),
+		stdout: streamFromNode(proc.stdout, maxBuffer, outputController),
+		stderr: streamFromNode(proc.stderr, maxBuffer, outputController),
 		exited,
 		get exitCode(): number | null {
 			// Windows may expose the libuv spawn error (for example -4058 for
@@ -1159,8 +1319,10 @@ export function bunSpawnSync(
 		| undefined;
 	if (bun?.spawnSync) {
 		const mergedEnv = mergeEnvForChild(options?.env, options?.envOverrides);
-		const spawnOpts =
-			mergedEnv !== undefined ? { ...options, env: mergedEnv } : options;
+		const spawnOpts: Record<string, unknown> = { ...options };
+		// `maxBuffer` is an async compatibility-layer option, not a Bun API.
+		delete spawnOpts.maxBuffer;
+		if (mergedEnv !== undefined) spawnOpts.env = mergedEnv;
 		try {
 			return bun.spawnSync(cmd, spawnOpts);
 		} catch (error) {

--- a/src/utils/bun-compat.ts
+++ b/src/utils/bun-compat.ts
@@ -290,8 +290,10 @@ export interface BunCompatSpawnOptions {
 	timeout?: number;
 	/**
 	 * Maximum bytes retained for each buffered stdout/stderr stream. Invalid
-	 * values fall back to `DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES` so `bunSpawn`
-	 * keeps its no-throw compatibility contract.
+	 * values fall back to `DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES` so asynchronous
+	 * `bunSpawn` keeps its no-throw compatibility contract. Synchronous
+	 * `bunSpawnSync` delegates to the host synchronous API and does not apply
+	 * this asynchronous stream-capture option.
 	 */
 	maxBuffer?: number;
 	/** Preserve the caller's exact Windows argv quoting (required for cmd.exe /c). */

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -322,6 +322,12 @@ async function runGit(
 		const stdout = await proc.stdout.text();
 		const stderr = await proc.stderr.text();
 		return { exitCode, stdout, stderr };
+	} catch {
+		return {
+			exitCode: GIT_SPAWN_FAILURE_EXIT_CODE,
+			stdout: '',
+			stderr: `git ${args[0] ?? 'command'} output could not be read in ${cwd}`,
+		};
 	} finally {
 		try {
 			proc.kill();
@@ -440,6 +446,9 @@ export async function checkPathBudget(
 			};
 		}
 
+		return { ok: true };
+	} catch {
+		// The path budget is advisory: unreadable bounded output must not block a lane.
 		return { ok: true };
 	} finally {
 		try {

--- a/tests/unit/utils/bun-compat-exit-first-2530.test.ts
+++ b/tests/unit/utils/bun-compat-exit-first-2530.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync as nodeSpawnSync } from 'node:child_process';
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as bunCompat from '../../../src/utils/bun-compat';
+
+const PROBE_TIMEOUT_MS = 5_000;
+const LARGE_OUTPUT_BYTES = 128 * 1024;
+const OUTPUT_LIMIT_BYTES = 64 * 1024;
+const CAPTURE_BUFFER_BYTES = 512 * 1024;
+
+type SpawnWithOutputLimit = Parameters<typeof bunCompat.bunSpawn>[1] & {
+	maxBuffer?: number;
+};
+
+const nativeSpawn = bunCompat.bunSpawn as unknown as (
+	command: string[],
+	options?: SpawnWithOutputLimit,
+) => bunCompat.BunCompatSubprocess;
+
+function runNodeProbe(
+	makeProbe: (moduleUrl: string) => string,
+	sourcePath = path.resolve('src/utils/bun-compat.ts'),
+) {
+	const tempDir = realpathSync(
+		mkdtempSync(path.join(realpathSync(os.tmpdir()), 'bun-compat-2530-')),
+	);
+	const bundlePath = path.join(tempDir, 'bun-compat.mjs');
+	try {
+		const build = nodeSpawnSync(
+			process.execPath,
+			[
+				'build',
+				sourcePath,
+				'--target',
+				'node',
+				'--format',
+				'esm',
+				'--outfile',
+				bundlePath,
+			],
+			{
+				cwd: process.cwd(),
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: PROBE_TIMEOUT_MS,
+				maxBuffer: 1024 * 1024,
+			},
+		);
+		expect(build.status).toBe(0);
+		return nodeSpawnSync(
+			'node',
+			[
+				'--input-type=module',
+				'--eval',
+				makeProbe(pathToFileURL(bundlePath).href),
+			],
+			{
+				cwd: process.cwd(),
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: PROBE_TIMEOUT_MS,
+				maxBuffer: 1024 * 1024,
+			},
+		);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+const MATRIX_CASES = [
+	{
+		name: 'empty',
+		script: 'process.exit(0)',
+		expectedCode: 0,
+		expectedStdout: '',
+		expectedStderr: '',
+	},
+	{
+		name: 'small',
+		script:
+			"process.stdout.write('small-out'); process.stderr.write('small-err')",
+		expectedCode: 0,
+		expectedStdout: 'small-out',
+		expectedStderr: 'small-err',
+	},
+	{
+		name: 'large-dual',
+		script: `const p = 'L'.repeat(${LARGE_OUTPUT_BYTES}); process.stdout.write(p); process.stderr.write(p)`,
+		expectedCode: 0,
+		expectedStdout: 'L'.repeat(LARGE_OUTPUT_BYTES),
+		expectedStderr: 'L'.repeat(LARGE_OUTPUT_BYTES),
+	},
+	{
+		name: 'nonzero-dual',
+		script: `const p = 'N'.repeat(${LARGE_OUTPUT_BYTES}); process.stdout.write(p); process.stderr.write(p); process.exitCode = 7`,
+		expectedCode: 7,
+		expectedStdout: 'N'.repeat(LARGE_OUTPUT_BYTES),
+		expectedStderr: 'N'.repeat(LARGE_OUTPUT_BYTES),
+	},
+] as const;
+
+function assertOutputMatrix(receipt: unknown) {
+	expect(receipt).toEqual(
+		MATRIX_CASES.map((item) => ({
+			name: item.name,
+			exitCode: item.expectedCode,
+			stdoutLength: item.expectedStdout.length,
+			stderrLength: item.expectedStderr.length,
+			stdoutMatches: true,
+			stderrMatches: true,
+		})),
+	);
+}
+
+async function runNativeMatrix() {
+	const results = [];
+	for (const item of MATRIX_CASES) {
+		const proc = nativeSpawn([process.execPath, '--eval', item.script], {
+			cwd: process.cwd(),
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			timeout: 3_000,
+			maxBuffer: CAPTURE_BUFFER_BYTES,
+		});
+		const exitCode = await proc.exited;
+		const [stdout, stderr] = await Promise.all([
+			proc.stdout.text(),
+			proc.stderr.text(),
+		]);
+		results.push({
+			name: item.name,
+			exitCode,
+			stdoutLength: stdout.length,
+			stderrLength: stderr.length,
+			stdoutMatches: stdout === item.expectedStdout,
+			stderrMatches: stderr === item.expectedStderr,
+		});
+	}
+	return results;
+}
+
+async function readNativeReader(proc: bunCompat.BunCompatSubprocess) {
+	const reader = proc.stdout.getReader();
+	const chunks: Uint8Array[] = [];
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		if (value) chunks.push(value);
+	}
+	const bytes = new Uint8Array(
+		chunks.reduce((size, chunk) => size + chunk.byteLength, 0),
+	);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return new TextDecoder().decode(bytes);
+}
+
+async function nativeOutputLimitProbe() {
+	const outputLimitError = (
+		bunCompat as typeof bunCompat & {
+			BunCompatOutputLimitError?: typeof Error;
+		}
+	).BunCompatOutputLimitError;
+	const describeError = (error: unknown) => ({
+		ok: false as const,
+		name: error instanceof Error ? error.name : typeof error,
+		instanceOf:
+			typeof outputLimitError === 'function' &&
+			error instanceof outputLimitError,
+		limit: (error as { limit?: number }).limit,
+		captured: (error as { captured?: number }).captured,
+		total: (error as { total?: number }).total,
+	});
+	const proc = nativeSpawn(
+		[
+			process.execPath,
+			'--eval',
+			`const p = 'O'.repeat(${LARGE_OUTPUT_BYTES * 2}); process.stdout.write(p); process.stderr.write(p)`,
+		],
+		{
+			cwd: process.cwd(),
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			timeout: 3_000,
+			maxBuffer: OUTPUT_LIMIT_BYTES,
+		},
+	);
+	const stdout = proc.stdout
+		.text()
+		.then(
+			(value) => ({ ok: true as const, length: value.length }),
+			describeError,
+		);
+	const stderr = proc.stderr
+		.text()
+		.then(
+			(value) => ({ ok: true as const, length: value.length }),
+			describeError,
+		);
+	const exitCode = await proc.exited;
+	return {
+		outputLimitErrorExported: typeof outputLimitError === 'function',
+		exitCode,
+		signalCode: proc.signalCode ?? null,
+		stdout: await stdout,
+		stderr: await stderr,
+	};
+}
+
+async function nativeTimeoutProbe() {
+	const proc = nativeSpawn(
+		[
+			process.execPath,
+			'--eval',
+			"process.stdout.write('partial-out'); process.stderr.write('partial-err'); setInterval(() => {}, 1000)",
+		],
+		{
+			cwd: process.cwd(),
+			stdin: 'ignore',
+			stdout: 'pipe',
+			stderr: 'pipe',
+			timeout: 250,
+			maxBuffer: CAPTURE_BUFFER_BYTES,
+		},
+	);
+	const exitCode = await proc.exited;
+	const [stdout, stderr] = await Promise.all([
+		proc.stdout.text(),
+		proc.stderr.text(),
+	]);
+	return {
+		exitCode,
+		signalCode: proc.signalCode ?? null,
+		stdoutLength: stdout.length,
+		stderrLength: stderr.length,
+	};
+}
+
+function assertTimeoutReceipt(receipt: unknown) {
+	const result = receipt as {
+		exitCode: number;
+		signalCode: string | null;
+		stdoutLength: number;
+		stderrLength: number;
+	};
+	expect(result.stdoutLength).toBeGreaterThan(0);
+	expect(result.stderrLength).toBeGreaterThan(0);
+	expect(result.exitCode !== 0 || result.signalCode !== null).toBe(true);
+}
+
+function runPublicCleanProbe() {
+	const repo = realpathSync(
+		mkdtempSync(path.join(realpathSync(os.tmpdir()), 'is-clean-2530-')),
+	);
+	const entryDir = realpathSync(
+		mkdtempSync(path.join(realpathSync(os.tmpdir()), 'is-clean-entry-2530-')),
+	);
+	const entryPath = path.join(entryDir, 'entry.ts');
+	try {
+		const gitOptions = {
+			cwd: repo,
+			encoding: 'utf8' as const,
+			stdio: ['ignore', 'pipe', 'pipe'] as const,
+			timeout: PROBE_TIMEOUT_MS,
+			maxBuffer: CAPTURE_BUFFER_BYTES,
+		};
+		for (const args of [
+			['init', '-b', 'main'],
+			['config', 'user.email', 'test@example.com'],
+			['config', 'user.name', 'Test User'],
+			['commit', '--allow-empty', '-m', 'init'],
+		]) {
+			expect(nodeSpawnSync('git', args, gitOptions).status).toBe(0);
+		}
+		writeFileSync(
+			entryPath,
+			`export { isCleanWorktree } from ${JSON.stringify(path.resolve('src/worktree/core.ts'))};`,
+		);
+		return runNodeProbe(
+			(moduleUrl) => `
+				const { isCleanWorktree } = await import(${JSON.stringify(moduleUrl)});
+				console.log(JSON.stringify({ clean: await isCleanWorktree(${JSON.stringify(repo)}) }));
+			`,
+			entryPath,
+		);
+	} finally {
+		rmSync(entryDir, { recursive: true, force: true });
+		rmSync(repo, { recursive: true, force: true });
+	}
+}
+
+describe('bunSpawn Node fallback exit-first output consumption (#2530)', () => {
+	test('Node fallback preserves empty, small, large, and nonzero dual-stream outcomes', () => {
+		const result = runNodeProbe(
+			(moduleUrl) => `
+			const { bunSpawn } = await import(${JSON.stringify(moduleUrl)});
+			const cases = ${JSON.stringify(
+				MATRIX_CASES.map(({ name, script, expectedCode }) => ({
+					name,
+					script,
+					expectedCode,
+				})),
+			)};
+			const receipts = [];
+			const read = (stream) => Promise.race([
+				stream.text(),
+				new Promise((resolve) => setTimeout(() => resolve(null), 500)),
+			]);
+			for (const item of cases) {
+				const proc = bunSpawn([process.execPath, '--eval', item.script], {
+					cwd: process.cwd(), stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: 3000, maxBuffer: ${CAPTURE_BUFFER_BYTES},
+				});
+				const exitCode = await proc.exited;
+				const [stdout, stderr] = await Promise.all([read(proc.stdout), read(proc.stderr)]);
+				receipts.push({
+					name: item.name,
+					exitCode,
+					stdoutLength: typeof stdout === 'string' ? stdout.length : -1,
+					stderrLength: typeof stderr === 'string' ? stderr.length : -1,
+					stdoutMatches: item.name === 'empty'
+						? stdout === ''
+						: item.name === 'small'
+							? stdout === 'small-out'
+							: stdout === (item.name === 'large-dual' ? 'L' : 'N').repeat(${LARGE_OUTPUT_BYTES}),
+					stderrMatches: item.name === 'empty'
+						? stderr === ''
+						: item.name === 'small'
+							? stderr === 'small-err'
+							: stderr === (item.name === 'large-dual' ? 'L' : 'N').repeat(${LARGE_OUTPUT_BYTES}),
+				});
+			}
+			console.log(JSON.stringify(receipts));
+		`,
+		);
+		expect(result.status).toBe(0);
+		const receipt = JSON.parse(result.stdout.trim()) as Array<{
+			name: string;
+			exitCode: number;
+			stdoutLength: number;
+			stderrLength: number;
+			stdoutMatches: boolean | string;
+		}>;
+		expect(receipt[0]).toMatchObject({
+			name: 'empty',
+			exitCode: 0,
+			stdoutLength: 0,
+		});
+		expect(receipt[1]).toMatchObject({
+			name: 'small',
+			exitCode: 0,
+			stdoutLength: 9,
+		});
+		assertOutputMatrix(receipt);
+	});
+
+	test('native Bun preserves empty, small, large, and nonzero dual-stream outcomes', async () => {
+		expect(await runNativeMatrix()).toEqual(
+			MATRIX_CASES.map((item) => ({
+				name: item.name,
+				exitCode: item.expectedCode,
+				stdoutLength: item.expectedStdout.length,
+				stderrLength: item.expectedStderr.length,
+				stdoutMatches: true,
+				stderrMatches: true,
+			})),
+		);
+	});
+
+	test('native Bun immediate getReader retains stdout ownership', async () => {
+		const proc = nativeSpawn(
+			[process.execPath, '--eval', "process.stdout.write('reader-ready')"],
+			{
+				cwd: process.cwd(),
+				stdin: 'ignore',
+				stdout: 'pipe',
+				stderr: 'pipe',
+				timeout: 3000,
+			},
+		);
+		const text = await readNativeReader(proc);
+		const exitCode = await proc.exited;
+		expect({ exitCode, text }).toEqual({ exitCode: 0, text: 'reader-ready' });
+	});
+
+	test('Node fallback reports bounded output overflow and terminates the child', () => {
+		const result = runNodeProbe(
+			(moduleUrl) => `
+			const { bunSpawn, BunCompatOutputLimitError } = await import(${JSON.stringify(moduleUrl)});
+			const proc = bunSpawn([process.execPath, '--eval',
+				"const p = 'O'.repeat(${LARGE_OUTPUT_BYTES * 2}); process.stdout.write(p); process.stderr.write(p)"
+			], { cwd: process.cwd(), stdin: 'ignore', stdout: 'pipe', stderr: 'pipe', timeout: 3000, maxBuffer: ${OUTPUT_LIMIT_BYTES} });
+			const describe = (promise) => Promise.race([
+				promise.then(
+					(value) => ({ ok: true, length: value.length }),
+					(error) => ({ ok: false, name: error?.name, instanceOf: error instanceof BunCompatOutputLimitError,
+						limit: error?.limit, captured: error?.captured, total: error?.total }),
+				),
+				new Promise((resolve) => setTimeout(() => resolve({ ok: false, name: 'ReadTimeout' }), 500)),
+			]);
+			const exitCode = await proc.exited;
+			console.log(JSON.stringify({ exported: typeof BunCompatOutputLimitError === 'function', exitCode,
+				signalCode: proc.signalCode ?? null, stdout: await describe(proc.stdout.text()), stderr: await describe(proc.stderr.text()) }));
+		`,
+		);
+		expect(result.status).toBe(0);
+		const receipt = JSON.parse(result.stdout.trim()) as {
+			exported: boolean;
+			exitCode: number;
+			signalCode: string | null;
+			stdout: {
+				ok: boolean;
+				name?: string;
+				instanceOf?: boolean;
+				limit?: number;
+				captured?: number;
+				total?: number;
+			};
+			stderr: {
+				ok: boolean;
+				name?: string;
+				instanceOf?: boolean;
+				limit?: number;
+				captured?: number;
+				total?: number;
+			};
+		};
+		expect(receipt.exported).toBe(true);
+		expect(receipt.exitCode !== 0 || receipt.signalCode !== null).toBe(true);
+		const errors = [receipt.stdout, receipt.stderr].filter((item) => !item.ok);
+		expect(errors.length).toBeGreaterThan(0);
+		for (const error of errors) {
+			expect(error).toMatchObject({
+				name: 'BunCompatOutputLimitError',
+				instanceOf: true,
+				limit: OUTPUT_LIMIT_BYTES,
+			});
+			expect(error.captured).toBeLessThanOrEqual(OUTPUT_LIMIT_BYTES);
+			expect(error.total).toBeGreaterThan(OUTPUT_LIMIT_BYTES);
+		}
+	});
+
+	test('native Bun reports bounded output overflow and terminates the child', async () => {
+		const receipt = await nativeOutputLimitProbe();
+		expect(receipt.outputLimitErrorExported).toBe(true);
+		expect(receipt.exitCode !== 0 || receipt.signalCode !== null).toBe(true);
+		const errors = [receipt.stdout, receipt.stderr].filter((item) => !item.ok);
+		expect(errors.length).toBeGreaterThan(0);
+		for (const error of errors) {
+			expect(error).toMatchObject({
+				name: 'BunCompatOutputLimitError',
+				instanceOf: true,
+				limit: OUTPUT_LIMIT_BYTES,
+			});
+			expect(error.captured).toBeLessThanOrEqual(OUTPUT_LIMIT_BYTES);
+			expect(error.total).toBeGreaterThan(OUTPUT_LIMIT_BYTES);
+		}
+	});
+
+	test('Node fallback timeout preserves partial output and termination outcome', () => {
+		const result = runNodeProbe(
+			(moduleUrl) => `
+			const { bunSpawn } = await import(${JSON.stringify(moduleUrl)});
+			const proc = bunSpawn([process.execPath, '--eval',
+				"process.stdout.write('partial-out'); process.stderr.write('partial-err'); setInterval(() => {}, 1000)"
+			], { cwd: process.cwd(), stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+				timeout: 250, maxBuffer: ${CAPTURE_BUFFER_BYTES} });
+			const exitCode = await proc.exited;
+			const read = (stream) => Promise.race([
+				stream.text(),
+				new Promise((resolve) => setTimeout(() => resolve(''), 500)),
+			]);
+			const [stdout, stderr] = await Promise.all([read(proc.stdout), read(proc.stderr)]);
+			console.log(JSON.stringify({ exitCode, signalCode: proc.signalCode ?? null,
+				stdoutLength: stdout.length, stderrLength: stderr.length }));
+		`,
+		);
+		expect(result.status).toBe(0);
+		assertTimeoutReceipt(JSON.parse(result.stdout.trim()));
+	});
+
+	test('native Bun timeout preserves partial output and termination outcome', async () => {
+		assertTimeoutReceipt(await nativeTimeoutProbe());
+	});
+
+	test('plain-Node built public isCleanWorktree path handles a clean Git repo', () => {
+		const result = runPublicCleanProbe();
+		expect(result.status).toBe(0);
+		expect(JSON.parse(result.stdout.trim())).toEqual({ clean: true });
+	});
+});

--- a/tests/unit/utils/bun-compat-exit-first-2530.test.ts
+++ b/tests/unit/utils/bun-compat-exit-first-2530.test.ts
@@ -239,23 +239,22 @@ async function nativeTimeoutProbe() {
 	return {
 		exitCode,
 		signalCode: proc.signalCode ?? null,
-		stdoutLength: stdout.length,
-		stderrLength: stderr.length,
+		stdout,
+		stderr,
+		terminationObserved: exitCode !== 0 || proc.signalCode !== null,
 	};
 }
-
 function assertTimeoutReceipt(receipt: unknown) {
 	const result = receipt as {
-		exitCode: number;
-		signalCode: string | null;
-		stdoutLength: number;
-		stderrLength: number;
+		stdout: string;
+		stderr: string;
+		terminationObserved: boolean;
 	};
-	expect(result.stdoutLength).toBeGreaterThan(0);
-	expect(result.stderrLength).toBeGreaterThan(0);
-	expect(result.exitCode !== 0 || result.signalCode !== null).toBe(true);
+	expect(result.stdout).toBe('partial-out');
+	expect(result.stderr).toBe('partial-err');
+	// A timeout must terminate the interval-owning child, not merely return partial output.
+	expect(result.terminationObserved).toBe(true);
 }
-
 function runPublicCleanProbe() {
 	const repo = realpathSync(
 		mkdtempSync(path.join(realpathSync(os.tmpdir()), 'is-clean-2530-')),
@@ -480,7 +479,8 @@ describe('bunSpawn Node fallback exit-first output consumption (#2530)', () => {
 			]);
 			const [stdout, stderr] = await Promise.all([read(proc.stdout), read(proc.stderr)]);
 			console.log(JSON.stringify({ exitCode, signalCode: proc.signalCode ?? null,
-				stdoutLength: stdout.length, stderrLength: stderr.length }));
+				stdout, stderr,
+				terminationObserved: exitCode !== 0 || proc.signalCode !== null }));
 		`,
 		);
 		expect(result.status).toBe(0);

--- a/tests/unit/utils/bun-compat-output-coherence-2530.test.ts
+++ b/tests/unit/utils/bun-compat-output-coherence-2530.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync as nodeSpawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+	BunCompatOutputLimitError,
+	type BunCompatSubprocess,
+	bunSpawn,
+	DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+} from '../../../src/utils/bun-compat';
+
+const TEST_CWD = path.resolve(import.meta.dir, '../../..');
+const TIMEOUT_MS = 5_000;
+const PROBE_OUTPUT_LIMIT_BYTES = 1024 * 1024;
+
+function resolveNodeExecutable(): string {
+	const names = process.platform === 'win32' ? ['node.exe', 'node'] : ['node'];
+	for (const directory of (process.env.PATH ?? '').split(path.delimiter)) {
+		if (!directory) continue;
+		for (const name of names) {
+			const candidate = path.resolve(directory, name);
+			if (existsSync(candidate)) return candidate;
+		}
+	}
+	throw new Error('node executable not found on PATH');
+}
+
+const BUILD_EXECUTABLE = process.execPath;
+const CHILD_EXECUTABLE = resolveNodeExecutable();
+
+function runNodeProbe(makeProbe: (moduleUrl: string) => string) {
+	const tempDir = realpathSync(
+		mkdtempSync(
+			path.join(realpathSync(os.tmpdir()), 'bun-compat-output-2530-'),
+		),
+	);
+	const bundlePath = path.join(tempDir, 'bun-compat.mjs');
+	try {
+		const build = nodeSpawnSync(
+			BUILD_EXECUTABLE,
+			[
+				'build',
+				path.resolve(TEST_CWD, 'src/utils/bun-compat.ts'),
+				'--target',
+				'node',
+				'--format',
+				'esm',
+				'--outfile',
+				bundlePath,
+			],
+			{
+				cwd: TEST_CWD,
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: TIMEOUT_MS,
+				maxBuffer: PROBE_OUTPUT_LIMIT_BYTES,
+			},
+		);
+		expect(build.status).toBe(0);
+		return nodeSpawnSync(
+			CHILD_EXECUTABLE,
+			[
+				'--input-type=module',
+				'--eval',
+				makeProbe(pathToFileURL(bundlePath).href),
+			],
+			{
+				cwd: TEST_CWD,
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: TIMEOUT_MS,
+				maxBuffer: PROBE_OUTPUT_LIMIT_BYTES,
+			},
+		);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function spawnNativeChild(
+	script: string,
+	maxBuffer?: number,
+): BunCompatSubprocess {
+	return bunSpawn([CHILD_EXECUTABLE, '--eval', script], {
+		cwd: TEST_CWD,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		timeout: TIMEOUT_MS,
+		...(maxBuffer === undefined ? {} : { maxBuffer }),
+	});
+}
+
+describe('native bunSpawn buffered output coherence (#2530)', () => {
+	test('shares one output-limit error across an overflowing pipe and its sibling', async () => {
+		const limit = 64 * 1024;
+		const overflowingBytes = limit + 1;
+		const proc = spawnNativeChild(
+			`process.stderr.write('below-limit'); process.stdout.write('O'.repeat(${overflowingBytes}))`,
+			limit,
+		);
+
+		const stdout = proc.stdout.text();
+		const stderr = proc.stderr.text();
+		await proc.exited;
+		const [stdoutResult, stderrResult] = await Promise.allSettled([
+			stdout,
+			stderr,
+		]);
+
+		expect(stdoutResult.status).toBe('rejected');
+		expect(stderrResult.status).toBe('rejected');
+		if (
+			stdoutResult.status !== 'rejected' ||
+			stderrResult.status !== 'rejected'
+		) {
+			throw new Error(
+				'both buffered pipes must reject after one pipe overflows',
+			);
+		}
+		expect(stderrResult.reason).toBe(stdoutResult.reason);
+		expect(stdoutResult.reason).toBeInstanceOf(BunCompatOutputLimitError);
+		expect(stdoutResult.reason).toMatchObject({
+			limit,
+			captured: limit,
+			total: overflowingBytes,
+		});
+	});
+
+	test('omitting maxBuffer uses the exact 5 MiB default for native Bun overflow', async () => {
+		expect(DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES).toBe(5 * 1024 * 1024);
+		const overflowingBytes = DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES + 1;
+		const proc = spawnNativeChild(
+			`process.stdout.write('O'.repeat(${overflowingBytes}))`,
+		);
+		const reads = await Promise.allSettled([
+			proc.stdout.text(),
+			proc.stderr.text(),
+		]);
+		const exitCode = await proc.exited;
+
+		expect(exitCode).not.toBe(0);
+		expect(reads[0]?.status).toBe('rejected');
+		expect(reads[1]?.status).toBe('rejected');
+		if (reads[0]?.status !== 'rejected' || reads[1]?.status !== 'rejected') {
+			throw new Error('both buffered pipes must reject after default overflow');
+		}
+		expect(reads[1].reason).toBe(reads[0].reason);
+		expect(reads[0].reason).toBeInstanceOf(BunCompatOutputLimitError);
+		expect(reads[0].reason).toMatchObject({
+			limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+			captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+			total: overflowingBytes,
+		});
+	});
+
+	test('plain Node preserves synchronous getReader ownership and exact output', () => {
+		const expected = 'node reader ownership';
+		const childScript = `process.stdout.write(${JSON.stringify(expected)})`;
+		const result = runNodeProbe(
+			(moduleUrl) => `
+				const { bunSpawn } = await import(${JSON.stringify(moduleUrl)});
+				const proc = bunSpawn([process.execPath, '--eval', ${JSON.stringify(childScript)}], {
+					cwd: ${JSON.stringify(TEST_CWD)}, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: ${TIMEOUT_MS}, maxBuffer: ${DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES},
+				});
+				const reader = proc.stdout.getReader();
+				const chunks = [];
+				for (;;) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					if (value) chunks.push(value);
+				}
+				const output = new TextDecoder().decode(
+					Uint8Array.from(chunks.flatMap((chunk) => [...chunk])),
+				);
+				console.log(JSON.stringify({ exitCode: await proc.exited, output }));
+			`,
+		);
+		expect(result.status).toBe(0);
+		expect(JSON.parse(result.stdout.trim())).toEqual({
+			exitCode: 0,
+			output: expected,
+		});
+	});
+
+	test('plain Node shares overflow identity and exact byte accounting across pipes', () => {
+		const limit = 32 * 1024;
+		const overflowingBytes = limit + 1;
+		const safeStderr = 'below-limit';
+		const childScript = `process.stderr.write(${JSON.stringify(safeStderr)}); process.stdout.write("O".repeat(${overflowingBytes}))`;
+		const result = runNodeProbe(
+			(moduleUrl) => `
+				const { bunSpawn, BunCompatOutputLimitError } = await import(${JSON.stringify(moduleUrl)});
+				const proc = bunSpawn([process.execPath, '--eval', ${JSON.stringify(childScript)}], {
+					cwd: ${JSON.stringify(TEST_CWD)}, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: ${TIMEOUT_MS}, maxBuffer: ${limit},
+				});
+				const reads = await Promise.allSettled([proc.stdout.text(), proc.stderr.text()]);
+				const stdoutError = reads[0].status === 'rejected' ? reads[0].reason : null;
+				const stderrError = reads[1].status === 'rejected' ? reads[1].reason : null;
+				const describe = (error) => error instanceof BunCompatOutputLimitError
+					? { name: error.name, limit: error.limit, captured: error.captured, total: error.total }
+					: { name: error?.name ?? null };
+				console.log(JSON.stringify({
+					exitCode: await proc.exited,
+					safeStderrBytes: Buffer.byteLength(${JSON.stringify(safeStderr)}),
+					sameIdentity: stdoutError === stderrError,
+					stdout: describe(stdoutError), stderr: describe(stderrError),
+				}));
+			`,
+		);
+		expect(result.status).toBe(0);
+		const receipt = JSON.parse(result.stdout.trim()) as {
+			safeStderrBytes: number;
+		};
+		expect(receipt.safeStderrBytes).toBeLessThan(limit);
+		expect(receipt).toEqual({
+			exitCode: expect.any(Number),
+			safeStderrBytes: Buffer.byteLength(safeStderr),
+			sameIdentity: true,
+			stdout: {
+				name: 'BunCompatOutputLimitError',
+				limit,
+				captured: limit,
+				total: overflowingBytes,
+			},
+			stderr: {
+				name: 'BunCompatOutputLimitError',
+				limit,
+				captured: limit,
+				total: overflowingBytes,
+			},
+		});
+	});
+
+	test('plain Node applies the exact 5 MiB default when maxBuffer is omitted', () => {
+		const overflowingBytes = DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES + 1;
+		const childScript = `process.stdout.write("O".repeat(${overflowingBytes}))`;
+		const result = runNodeProbe(
+			(moduleUrl) => `
+				const { bunSpawn, BunCompatOutputLimitError } = await import(${JSON.stringify(moduleUrl)});
+				const proc = bunSpawn([process.execPath, '--eval', ${JSON.stringify(childScript)}], {
+					cwd: ${JSON.stringify(TEST_CWD)}, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: ${TIMEOUT_MS},
+				});
+				const reads = await Promise.allSettled([proc.stdout.text(), proc.stderr.text()]);
+				const describe = (read) => read.status === 'rejected'
+					? { name: read.reason?.name, limit: read.reason?.limit,
+						captured: read.reason?.captured, total: read.reason?.total,
+						instanceOf: read.reason instanceof BunCompatOutputLimitError }
+					: { status: 'fulfilled', value: read.value };
+				console.log(JSON.stringify({ exitCode: await proc.exited,
+					sameErrorIdentity: reads[0].status === 'rejected' && reads[1].status === 'rejected'
+						&& reads[0].reason === reads[1].reason,
+					reads: reads.map(describe) }));
+			`,
+		);
+		expect(result.status).toBe(0);
+		expect(JSON.parse(result.stdout.trim())).toEqual({
+			exitCode: expect.any(Number),
+			sameErrorIdentity: true,
+			reads: [
+				{
+					name: 'BunCompatOutputLimitError',
+					limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+				{
+					name: 'BunCompatOutputLimitError',
+					limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+			],
+		});
+	});
+
+	test('plain Node normalizes invalid maxBuffer before exact default overflow', () => {
+		expect(DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES).toBe(5 * 1024 * 1024);
+		const overflowingBytes = DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES + 1;
+		const childScript = `process.stdout.write("O".repeat(${overflowingBytes}))`;
+		const result = runNodeProbe(
+			(moduleUrl) => `
+				const { bunSpawn, BunCompatOutputLimitError } = await import(${JSON.stringify(moduleUrl)});
+				const proc = bunSpawn([process.execPath, '--eval', ${JSON.stringify(childScript)}], {
+					cwd: ${JSON.stringify(TEST_CWD)}, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: ${TIMEOUT_MS}, maxBuffer: 0,
+				});
+				const reads = await Promise.allSettled([proc.stdout.text(), proc.stderr.text()]);
+				const describe = (read) => read.status === 'rejected'
+					? { name: read.reason?.name, limit: read.reason?.limit,
+						captured: read.reason?.captured, total: read.reason?.total,
+						instanceOf: read.reason instanceof BunCompatOutputLimitError }
+					: { status: 'fulfilled', value: read.value };
+				console.log(JSON.stringify({ exitCode: await proc.exited,
+					sameErrorIdentity: reads[0].status === 'rejected' && reads[1].status === 'rejected'
+						&& reads[0].reason === reads[1].reason,
+					reads: reads.map(describe) }));
+			`,
+		);
+		expect(result.status).toBe(0);
+		const receipt = JSON.parse(result.stdout.trim()) as {
+			exitCode: number;
+			sameErrorIdentity: boolean;
+		};
+		expect(receipt.exitCode).not.toBe(0);
+		expect(receipt).toMatchObject({
+			sameErrorIdentity: true,
+			reads: [
+				{
+					name: 'BunCompatOutputLimitError',
+					limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+				{
+					name: 'BunCompatOutputLimitError',
+					limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+			],
+		});
+	});
+
+	test('normalizes invalid maxBuffer values to the default without losing small output', async () => {
+		const invalidMaxBuffers = [0, 1.5, Infinity];
+		const expected = {
+			stdout: 'exact stdout',
+			stderr: 'exact stderr',
+		};
+		expect(DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES).toBeGreaterThan(
+			new TextEncoder().encode(expected.stdout).byteLength,
+		);
+
+		for (const maxBuffer of invalidMaxBuffers) {
+			let proc!: BunCompatSubprocess;
+			expect(() => {
+				proc = spawnNativeChild(
+					`process.stdout.write(${JSON.stringify(expected.stdout)}); process.stderr.write(${JSON.stringify(expected.stderr)})`,
+					maxBuffer,
+				);
+			}).not.toThrow();
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				proc.stdout.text(),
+				proc.stderr.text(),
+			]);
+			expect({ exitCode, stdout, stderr }).toEqual({
+				exitCode: 0,
+				...expected,
+			});
+		}
+	});
+
+	test('normalizes an invalid maxBuffer to the exact default before overflow', async () => {
+		const overflowingBytes = DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES + 1;
+		const proc = spawnNativeChild(
+			`process.stdout.write('O'.repeat(${overflowingBytes}))`,
+			0,
+		);
+		const read = await Promise.allSettled([proc.stdout.text()]);
+		const exitCode = await proc.exited;
+
+		expect(exitCode).not.toBe(0);
+		expect(read[0]?.status).toBe('rejected');
+		if (read[0]?.status !== 'rejected') {
+			throw new Error('invalid maxBuffer must still reject overflow');
+		}
+		expect(read[0].reason).toBeInstanceOf(BunCompatOutputLimitError);
+		expect(read[0].reason).toMatchObject({
+			limit: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+			captured: DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+			total: overflowingBytes,
+		});
+	});
+
+	test('repeated text and bytes calls reuse the settled buffered result', async () => {
+		const proc = spawnNativeChild(
+			"process.stdout.write('repeatable output'); process.stderr.write('')",
+			DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+		);
+		const firstText = proc.stdout.text();
+		const secondText = proc.stdout.text();
+		const firstBytes = proc.stdout.bytes();
+		const secondBytes = proc.stdout.bytes();
+		const stderr = proc.stderr.text();
+		const [exitCode, textA, textB, bytesA, bytesB, stderrText] =
+			await Promise.all([
+				proc.exited,
+				firstText,
+				secondText,
+				firstBytes,
+				secondBytes,
+				stderr,
+			]);
+
+		expect({ exitCode, textA, textB, stderr: stderrText }).toEqual({
+			exitCode: 0,
+			textA: 'repeatable output',
+			textB: 'repeatable output',
+			stderr: '',
+		});
+		expect(bytesA).toEqual(new TextEncoder().encode('repeatable output'));
+		expect(bytesB).toEqual(bytesA);
+	});
+});

--- a/tests/unit/utils/bun-compat-output-coherence-2530.test.ts
+++ b/tests/unit/utils/bun-compat-output-coherence-2530.test.ts
@@ -156,6 +156,34 @@ describe('native bunSpawn buffered output coherence (#2530)', () => {
 		});
 	});
 
+	test('shares the overflow error when stderr alone exceeds the configured limit (FB-002)', async () => {
+		const limit = 64 * 1024;
+		const overflowingBytes = limit + 1;
+		const proc = spawnNativeChild(
+			`process.stdout.write('below-limit'); process.stderr.write('E'.repeat(${overflowingBytes}))`,
+			limit,
+		);
+		const [stdout, stderr] = await Promise.allSettled([
+			proc.stdout.text(),
+			proc.stderr.text(),
+		]);
+		await proc.exited;
+
+		// Before this regression was added, only stdout-triggered overflow was pinned.
+		expect(stdout.status).toBe('rejected');
+		expect(stderr.status).toBe('rejected');
+		if (stdout.status !== 'rejected' || stderr.status !== 'rejected') {
+			throw new Error('both buffered pipes must reject after stderr overflow');
+		}
+		expect(stderr.reason).toBe(stdout.reason);
+		expect(stderr.reason).toBeInstanceOf(BunCompatOutputLimitError);
+		expect(stderr.reason).toMatchObject({
+			limit,
+			captured: limit,
+			total: overflowingBytes,
+		});
+	});
+
 	test('plain Node preserves synchronous getReader ownership and exact output', () => {
 		const expected = 'node reader ownership';
 		const childScript = `process.stdout.write(${JSON.stringify(expected)})`;
@@ -233,6 +261,51 @@ describe('native bunSpawn buffered output coherence (#2530)', () => {
 				captured: limit,
 				total: overflowingBytes,
 			},
+		});
+	});
+
+	test('plain Node shares the overflow error when stderr alone exceeds the configured limit (FB-002)', () => {
+		const limit = 32 * 1024;
+		const overflowingBytes = limit + 1;
+		const childScript = `process.stdout.write('below-limit'); process.stderr.write('E'.repeat(${overflowingBytes}))`;
+		const result = runNodeProbe(
+			(moduleUrl) => `
+				const { bunSpawn, BunCompatOutputLimitError } = await import(${JSON.stringify(moduleUrl)});
+				const proc = bunSpawn([process.execPath, '--eval', ${JSON.stringify(childScript)}], {
+					cwd: ${JSON.stringify(TEST_CWD)}, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe',
+					timeout: ${TIMEOUT_MS}, maxBuffer: ${limit},
+				});
+				const reads = await Promise.allSettled([proc.stdout.text(), proc.stderr.text()]);
+				const describe = (read) => read.status === 'rejected'
+					? { name: read.reason?.name, limit: read.reason?.limit, captured: read.reason?.captured,
+						total: read.reason?.total, instanceOf: read.reason instanceof BunCompatOutputLimitError }
+					: { status: 'fulfilled', value: read.value };
+				console.log(JSON.stringify({ exitCode: await proc.exited,
+					sameErrorIdentity: reads[0].status === 'rejected' && reads[1].status === 'rejected'
+						&& reads[0].reason === reads[1].reason,
+					reads: reads.map(describe) }));
+			`,
+		);
+		expect(result.status).toBe(0);
+		expect(JSON.parse(result.stdout.trim())).toEqual({
+			exitCode: expect.any(Number),
+			sameErrorIdentity: true,
+			reads: [
+				{
+					name: 'BunCompatOutputLimitError',
+					limit,
+					captured: limit,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+				{
+					name: 'BunCompatOutputLimitError',
+					limit,
+					captured: limit,
+					total: overflowingBytes,
+					instanceOf: true,
+				},
+			],
 		});
 	});
 

--- a/tests/unit/worktree/core-git-resolution-containment.test.ts
+++ b/tests/unit/worktree/core-git-resolution-containment.test.ts
@@ -29,7 +29,11 @@
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
-import type { BunCompatSubprocess } from '../../../src/utils/bun-compat';
+import {
+	BunCompatOutputLimitError,
+	type BunCompatSubprocess,
+	DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+} from '../../../src/utils/bun-compat';
 import { GitBinaryMissingError } from '../../../src/utils/git-binary-missing-error';
 import {
 	_internals,
@@ -58,6 +62,23 @@ function mockProc(
 		exitCode,
 		stdout: { text: () => Promise.resolve(stdout) },
 		stderr: { text: () => Promise.resolve('') },
+		kill: () => onKill?.(),
+	} as unknown as BunCompatSubprocess;
+}
+
+function mockDefaultLimitOverflowProc(
+	onKill?: () => void,
+): BunCompatSubprocess {
+	const error = new BunCompatOutputLimitError(
+		DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+		DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES,
+		DEFAULT_BUN_SPAWN_MAX_BUFFER_BYTES + 1,
+	);
+	return {
+		exited: Promise.resolve(1),
+		exitCode: 1,
+		stdout: { text: () => Promise.reject(error) },
+		stderr: { text: () => Promise.reject(error) },
 		kill: () => onKill?.(),
 	} as unknown as BunCompatSubprocess;
 }
@@ -186,5 +207,40 @@ describe('checkPathBudget stays fail-open on a git-resolution failure (#2236)', 
 		const result = await checkPathBudget('C:\\'.padEnd(60, 'w'), directory);
 
 		expect(result.ok).toBe(false);
+	});
+});
+
+describe('worktree callers contain default output-limit overflow (#2530)', () => {
+	test('isCleanWorktree treats an overflowing git result as dirty and cleans up both subprocesses (FB-006)', async () => {
+		const directory = tempRoot('clean-overflow');
+		let spawns = 0;
+		let kills = 0;
+		_internals.bunSpawn = (() => {
+			spawns++;
+			return mockDefaultLimitOverflowProc(() => {
+				kills++;
+			});
+		}) as typeof _internals.bunSpawn;
+
+		// Before the output-limit containment fix, pipe.text() rejected through runGit.
+		await expect(isCleanWorktree(directory)).resolves.toBe(false);
+		expect(spawns).toBe(2);
+		expect(kills).toBe(2);
+	});
+
+	test('checkPathBudget remains fail-open after a default-limit overflow', async () => {
+		const directory = tempRoot('budget-overflow');
+		let kills = 0;
+		_internals.platform = 'win32';
+		_internals.getCoreLongPaths = async () => undefined;
+		_internals.bunSpawn = (() =>
+			mockDefaultLimitOverflowProc(() => {
+				kills++;
+			})) as typeof _internals.bunSpawn;
+
+		await expect(
+			checkPathBudget('C:\\worktrees\\lane-1', directory),
+		).resolves.toEqual({ ok: true });
+		expect(kills).toBe(1);
 	});
 });


### PR DESCRIPTION
Closes #2530

## Summary

- replace lazy subprocess pipe attachment with a deferred, bounded auto-drain shared by the Node and Bun compatibility paths
- preserve synchronous `getReader()` ownership while making exit-first and unread pipes terminate safely
- enforce a 5 MiB per-pipe default, process-coherent typed overflow, single best-effort termination, and settled cross-stream errors
- contain bounded-output read failures in worktree Git callers so noisy repositories fail safely instead of rejecting safety checks
- add native-Bun and compiled plain-Node regression coverage for stdout/stderr overflow, timeout bytes, cleanup, and caller contracts

## Invariant audit

- 1 (plugin init): not touched — `repro-704` passed all cases; tight 500-file case resolved in under 400 ms.
- 2 (runtime portability): touched — Node-targeted builds, plain-Node public-path tests, bundle portability/plugin-shape tests, build, and direct Node ESM import passed.
- 3 (subprocesses): touched — shared adapters retain explicit cwd/stdin/timeout/bounds, request best-effort termination, settle terminal events, and pass Node/Bun overflow/timeout/reader tests; worktree Git output-read failures are contained.
- 4 (.swarm containment): not touched — no runtime storage or working-directory resolution changes.
- 5 (plan durability): not touched — no plan schema, ledger, projection, checkpoint, or export changes.
- 6 (test_runner safety): not touched — validation used isolated shell runners; no broad `test_runner` invocation.
- 7 (test writing): touched — bun:test real-runtime coverage, no `mock.module`, canonical external temp dirs, and all changed test files remain under 500 lines.
- 8 (session state): not touched — no module-global or session-keyed state changed.
- 9 (guardrails/retry): not touched — no policy, retry, fallback, circuit, or scope-authorization path changed.
- 10 (chat/system msg): not touched — no message transform or guidance-carrier changes.
- 11 (tool registration): not touched — no tools, manifests, metadata, agent maps, commands, or help surfaces changed.
- 12 (release/cache): touched — updated `docs/releases/pending/issue-2530-subprocess-output.md`; package smoke passed and no release-owned version/changelog file was edited.

## Test plan

- `bun run test:unit:ci` for the three changed test files — 28 passed
- `bun run typecheck`; `bun run lint:ci`; `bun run build`; plain-Node `dist/index.js` import — passed
- bundle portability/plugin-shape and all required quality gates — passed
- `node scripts/repro-704.mjs` — all three cases passed
- `bun run package:smoke` — passed for `opencode-swarm-7.168.0.tgz` (1244 files)
- `bun test tests/security --timeout 120000` — 168 passed, 4 expected skips
- `bun test tests/adversarial --timeout 120000` — 846 passed
- `bun test tests/smoke --timeout 120000` — 10 passed
- `bun test ./test --timeout 120000` — 137 passed
- `bun run check:pre-push`; 21 quality gates; memory and swarm-model checks — passed
- `check:test-file-cap` passes; changed test files are 499, 488, and 246 lines

## Feedback closure

- FB-001: clarified `maxBuffer` as asynchronous `bunSpawn` scope; `bunSpawnSync` remains an intentional host-synchronous adapter.
- FB-002: added stderr-only overflow coverage for native Bun and compiled Node fallback with shared typed-error identity and exact accounting.
- FB-003: timeout probes now assert exact partial bytes and interval-child termination; caller tests assert cleanup kills.
- FB-004/FB-005: `checkPathBudget` now fails open and `runGit` returns a bounded nonzero result when exit/output reads reject; both retain `finally` cleanup.
- FB-006: added caller-level default-limit overflow tests through the worktree DI seam.
- FB-007 through FB-010: independently verified as no actionable defect (synchronous reader ownership, safe-integer validation, exported type, and informational Copilot note).
- CI-001: superseded historical status-rollup failures; current-head checks and local gates are green.
- CONFLICT-001: base remains an ancestor and GitHub reports a clean merge surface.
- Broad integration validation reproduced unrelated pre-existing failures in curator-schema-retry, dark-matter-wiring, and cross-process-port-binding; those paths are untouched by this PR and current PR checks were green before this patch.

## Rollback

Revert commit `a7f6bc21fa34311ccb90bc091ce7185ec024eca8`. No migration or persisted-state cleanup is required.
