### PR TITLE
fix(ci): restore LF checkout and document Stage A policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-﻿* text=auto eol=lf
+* text=auto eol=lf
 *.ts text eol=lf
 *.js text eol=lf
 *.d.ts text eol=lf

--- a/docs/ci/merge-queue-policy.md
+++ b/docs/ci/merge-queue-policy.md
@@ -1,10 +1,11 @@
-# Merge-queue CI policy — Stage D decision record (#2552)
+# Merge-queue CI policy — Stage D and Stage A decision record (#2552)
 
 ## Status and scope
 
 **Record date:** 2026-09-06
 **Evidence:** post-#2551 baseline, 2026-09-03T21:55:18Z through
-2026-09-05T23:27:21Z.
+2026-09-05T23:27:21Z; current Stage-A window, 2026-09-03T21:57:31Z through
+2026-09-06T22:14:18Z.
 
 This document accompanies the Stage-D recursive integration and gate-hygiene
 changes for issue #2552. It records what the observed data supports and what
@@ -20,8 +21,9 @@ The retained policy is:
 - `build_concurrency=5`; and
 - `ALLGREEN` / only-non-failing merge eligibility.
 
-The Stage A Windows10 decision is planned separately. No Windows implementation
-is landed or claimed by this record.
+The Stage-A retain-six decision is landed by this record for the current
+evidence window. No Windows-ten implementation is landed; only a future
+Windows-ten experiment remains unlanded and gated by the reopening criteria.
 
 ## Post-#2551 baseline
 
@@ -157,7 +159,7 @@ not inferred from this zero-overlap baseline.
 **Rollback.** If a future, attributable overlap is demonstrated, revisit the
 setting in a follow-up decision record with receipts and a bounded experiment.
 
-## Host check-name gate and the planned Stage A decision
+## Host check-name gate and Stage A decision
 
 The host check-name gate is a prerequisite for any merge-queue or branch-
 protection decision: inspect the names emitted by the host for the exact commit
@@ -165,11 +167,57 @@ and compare them with the required-check configuration. Matrix jobs must be
 matched by their emitted leg names; an assumed aggregate name is not evidence.
 Record the host/version, event, commit, and observed names with the decision.
 
-The Stage A Windows10 decision is planned separately and is not landed by
-#2552's Stage-D record. This document records only the gate that must protect
-that future decision and the observed Windows timing baseline. It makes no
-claim that Windows10 support, a Windows workflow change, or a Windows
-implementation has shipped.
+### Stage A decision window
+
+The current Stage A evidence window contains **56 `merge_group` runs** from
+2026-09-03T21:57:31Z through 2026-09-06T22:14:18Z: **39 successful and 17 failed**.
+The merge-group run-duration tail was **P50 `30m36s`, P95 `51m25s`,
+and maximum `58m47s`**. Retries and duplicate merge-group attempts remain
+separately accounted for rather than being folded into the outcome count. The
+Actions timing records report `total_ms=0` for the Ubuntu, Windows, and macOS
+jobs; account-level concurrency capacity remains unknown, not zero.
+
+Runner queue time is the interval waiting for a runner before a job starts.
+The separately observed **39m41s** figure is end-to-end merge-group queue and
+group/`ALLGREEN` serialization, not runner queue time and not a quantity that
+Windows re-sharding can directly change. The sampled Windows runner queue
+delay reached 6.7–14.7 minutes.
+
+**Decision:** Retain six Windows unit shards for this evidence window as a
+capacity/risk decision. The workflow remains six shards on Ubuntu, macOS, and
+Windows (`shard: [1, 2, 3, 4, 5, 6]` and `num_shards=6`), and Ubuntu coverage
+continues to use the six-way partition. Two full post-Stage-D runs show
+Windows shard-job medians of **20.4–22.7m**, with about **21m** of divisible
+test work and about **1.6m** of fixed overhead. Ten shards project an
+approximately **8m** service-time benefit when all ten can run concurrently,
+but at `max_entries_to_build=5` the theoretical Windows-cell request grows
+from **30 to 50**. The account cap is unknown, so this is capacity risk rather
+than a claim that Windows service time is insignificant.
+
+**Expected benefit.** Preserve the current six-way partition and avoid moving
+the projected eight-minute service reduction into an unmeasured runner queue
+or an unknown account-capacity boundary.
+
+**Preserved gates.** Required Ubuntu unit cells 1 through 4, the `unit-passed`
+aggregate, the six-way coverage matrix and six-file loops, the exact host
+check-name gate, `ALLGREEN`, and cross-contamination blocking remain required.
+No Windows-ten workflow or ruleset change is included in this decision.
+
+**Validation.** Recompute a bounded 20-run window with Windows test-step
+median, P95 runner queue, merge-group wall time, failures, retries, and the
+host-emitted check names. A staged A/B must retain six Ubuntu coverage shards
+and compare the same required gates before changing the denominator.
+
+**Rollback.** Revert this documentation/test/release decision as a unit if
+the evidence is corrected. If the reopening gate is met, update the Windows
+matrix, per-cell denominator, coverage owners, and this record together;
+otherwise leave the workflow at six.
+
+**Reopening gate.** Reopen a Windows-ten experiment when a 20-run window shows
+median Windows test-step duration **>=18m AND P95 runner queue <=5m**, **or** a
+staged A/B shows **>=5m P95 merge-group wall-time gain without >5m marginal
+runner-queue growth**. This gate separates divisible Windows test work from
+runner and end-to-end queue serialization.
 
 ## C9 post-land receipt contract
 
@@ -182,14 +230,83 @@ identifier=stage-{d,a}-post-land-N
 actions=URL
 run_duration_ms=<integer>
 queue_wait_ms=integer|unavailable
-eviction=<recorded value>
+eviction=none
+eviction_evidence=timeline:add→terminal-merge/remove-pair
+timeline_added_at=ISO Z
+timeline_merged_at=ISO Z
+timeline_removed_at=ISO Z
+unit_shards_executed=6
 completed_at=ISO Z
+terminal_pair_evidence=adjacent terminal merge/remove pair; no intervening re-add
 ```
+
+For these receipts, `queue_wait_ms=unavailable` is honest: queue wait is a
+per-job runner-wait measure, and no canonical run-level aggregation was defined
+for these full-matrix receipts. Do not infer zero from the unavailable value.
 
 Closure requires **3 receipts per stage**: three Stage-D receipts and three
 Stage-A receipts. A stage is not closed by a partial set, a dashboard screenshot,
 or a receipt that omits `queue_wait_ms` instead of using the literal
 `unavailable` value.
+
+For `eviction=none`, the receipt must show the initial timeline add followed by
+the adjacent terminal `merged`/`removed_from_merge_queue` pair. The terminal
+events may be timestamped in either order; `timeline_added_at`,
+`timeline_merged_at`, and `timeline_removed_at` must all be retained, with no
+intervening nonterminal removal/re-add. The Stage-D receipts below are full CI
+matrix runs with all six Windows unit shards; matrix-skipped release runs and
+the short PR-Standards sibling workflow do not qualify.
+
+```text
+identifier=stage-d-post-land-1
+actions=https://github.com/ZaxbyHub/opencode-swarm/actions/runs/34051617672
+run_duration_ms=1841000
+queue_wait_ms=unavailable
+eviction=none
+eviction_evidence=timeline:add→terminal-merge/remove-pair
+timeline_added_at=2026-09-06T18:24:18Z
+timeline_merged_at=2026-09-06T18:55:43Z
+timeline_removed_at=2026-09-06T18:55:43Z
+unit_shards_executed=6
+completed_at=2026-09-06T18:55:17Z
+terminal_pair_evidence=adjacent terminal merge/remove pair; no intervening re-add
+```
+
+```text
+identifier=stage-d-post-land-2
+actions=https://github.com/ZaxbyHub/opencode-swarm/actions/runs/34060659584
+run_duration_ms=1781000
+queue_wait_ms=unavailable
+eviction=none
+eviction_evidence=timeline:add→terminal-merge/remove-pair
+timeline_added_at=2026-09-06T21:18:08Z
+timeline_merged_at=2026-09-06T21:48:11Z
+timeline_removed_at=2026-09-06T21:48:11Z
+unit_shards_executed=6
+completed_at=2026-09-06T21:48:07Z
+terminal_pair_evidence=adjacent terminal merge/remove pair; no intervening re-add
+```
+
+```text
+identifier=stage-d-post-land-3
+actions=https://github.com/ZaxbyHub/opencode-swarm/actions/runs/34061223031
+run_duration_ms=2435000
+queue_wait_ms=unavailable
+eviction=none
+eviction_evidence=timeline:add→terminal-merge/remove-pair
+timeline_added_at=2026-09-06T21:29:16Z
+timeline_merged_at=2026-09-06T22:10:31Z
+timeline_removed_at=2026-09-06T22:10:30Z
+unit_shards_executed=6
+completed_at=2026-09-06T22:10:05Z
+terminal_pair_evidence=adjacent terminal merge/remove pair; no intervening re-add
+```
+
+### Stage-A post-land receipts — pending
+
+Stage-A post-land receipts remain **pending** until three real full-matrix runs
+after this decision is published. No pre-publication or local run is labeled
+as Stage-A post-land evidence.
 
 ## Cross-contamination warning language
 
@@ -208,8 +325,8 @@ underlying check.
   record does not infer why the two counts differ.
 - Account concurrency is unknown, so the concurrency decision is intentionally
   conservative rather than a provider-capacity claim.
-- The Windows figures are observational timing evidence only. They do not land
-  the separate Stage A Windows10 decision.
+- The retain-six Windows decision is landed for this evidence window; a future
+  Windows-ten experiment remains gated and unlanded.
 - The C9 contract requires three receipts per stage; missing receipts keep
   closure open.
 

--- a/docs/releases/pending/ci-stage-a-decision-2552.md
+++ b/docs/releases/pending/ci-stage-a-decision-2552.md
@@ -1,0 +1,35 @@
+# Stage-A Windows shard decision
+
+## What changed
+
+- Documented the evidence-backed decision to retain six Windows unit shards for
+  the current merge-queue window.
+- Added the measured 56-run window, the Windows service-time and queue metrics,
+  numeric reopening gates, and three timeline-backed Stage-D receipts.
+- Added a structural CI policy test that keeps the six-way workflow, runtime
+  denominator, coverage loops, and `unit-passed` aggregate aligned.
+
+## Why
+
+Windows ten-way sharding projects an approximately eight-minute service-time
+benefit, but it would increase theoretical Windows cells from 30 to 50 at
+`max_entries_to_build=5` while account capacity remains unknown. Retaining six
+shards preserves required gates until a bounded experiment can attribute a net
+wall-time benefit separately from runner queue and merge-group serialization.
+
+## Migration
+
+No workflow or configuration migration is required. A future Windows-ten
+experiment must satisfy the documented 20-run reopening gate and update the
+matrix, denominator, coverage owners, policy test, and decision record together.
+
+## Breaking changes
+
+None. Ubuntu and macOS remain six-way, Windows remains six-way, and the
+required `unit-passed` and coverage gates are unchanged.
+
+## Caveats
+
+Stage-A post-land receipts remain pending until three real runs after this
+decision is published. The account concurrency cap is unavailable, and the
+record does not treat that unknown as zero.

--- a/docs/releases/pending/gitattributes-lf-checkout-2554.md
+++ b/docs/releases/pending/gitattributes-lf-checkout-2554.md
@@ -1,0 +1,21 @@
+# Restore LF checkout rules for repository text files
+
+## What changed
+
+Removed the leading UTF-8 BOM from .gitattributes, preserving its existing LF checkout rules.
+
+## Why
+
+Git could fail to recognize the wildcard attribute rule when the file began with a BOM. Fresh checkouts using core.autocrlf=true could then materialize workflow YAML and other text files with CRLF line endings.
+
+## Migration
+
+No migration is required. Re-check out or renormalize an existing working tree if it was materialized with unintended CRLF line endings.
+
+## Breaking changes
+
+None.
+
+## Caveats
+
+This changes checkout normalization for repositories using these attributes; it does not rewrite unrelated committed file contents.

--- a/tests/unit/scripts/ci/ci-stage-a-policy-2552.test.ts
+++ b/tests/unit/scripts/ci/ci-stage-a-policy-2552.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const CI_YML_PATH = join(REPO_ROOT, '.github/workflows/ci.yml');
+const POLICY_PATH = join(REPO_ROOT, 'docs/ci/merge-queue-policy.md');
+
+function readText(path: string): string {
+	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+}
+
+function extractJob(yml: string, job: string): string {
+	const match = yml.match(
+		new RegExp(
+			`^ {2}${job}:[\\s\\S]*?(?=^ {2}[A-Za-z][\\w-]*:|(?![\\s\\S]))`,
+			'm',
+		),
+	);
+	return match?.[0] ?? '';
+}
+
+function extractReceipt(policy: string, identifier: string): string {
+	const match = policy.match(
+		new RegExp(`${identifier}\\n[\\s\\S]*?(?=\\n\\n|\\nidentifier=|\\n## )`),
+	);
+	return match?.[0] ?? '';
+}
+
+describe('Stage-A policy and six-way CI agreement (issue #2552)', () => {
+	const workflow = readText(CI_YML_PATH);
+	const policy = readText(POLICY_PATH);
+
+	test('unit keeps six-way matrix and runtime partition denominator', () => {
+		const unit = extractJob(workflow, 'unit');
+
+		expect(unit).toContain('shard: [1, 2, 3, 4, 5, 6]');
+		expect(unit).toContain('num_shards=6');
+		expect(unit).toContain(
+			'awk -v s="$SHARD" -v n="$num_shards" \'(NR - 1) % n == (s - 1)\'',
+		);
+		expect(unit).not.toContain('num_shards=10');
+		expect(unit).not.toContain('shard_count: 10');
+	});
+
+	test('coverage remains six-way with six-file loops and a fail-closed count', () => {
+		const coverageShard = extractJob(workflow, 'coverage-shard');
+		const coverage = extractJob(workflow, 'coverage');
+		const sixLoops = coverage.match(/for n in 1 2 3 4 5 6; do/g) ?? [];
+
+		expect(coverageShard).toContain('shard: [1, 2, 3, 4, 5, 6]');
+		expect(coverageShard).toContain('COVERAGE_SHARD_COUNT: 6');
+		expect(sixLoops).toHaveLength(2);
+		expect(coverage).toContain(
+			'::error::Fail closed: not all 6 coverage shard reports are present',
+		);
+		expect(coverage).not.toMatch(/for n in 1 2 3 4 5 6 7 8 9 10; do/);
+	});
+
+	test('unit-passed remains the required aggregate gate', () => {
+		const unitPassed = extractJob(workflow, 'unit-passed');
+
+		expect(unitPassed).toContain('needs: [unit]');
+		expect(unitPassed).toContain('if: always()');
+		expect(unitPassed).toContain('UNIT_RESULT: ${{ needs.unit.result }}');
+		expect(policy).toContain('Required Ubuntu unit cells 1 through 4');
+	});
+
+	test('policy records the current evidence and a capacity-risk retain-six decision', () => {
+		expect(policy).toContain('### Stage A decision window');
+		expect(policy).toContain('**56 `merge_group` runs**');
+		expect(policy).toContain('**39 successful and 17 failed**');
+		expect(policy).toContain('P50 `30m36s`, P95 `51m25s`');
+		expect(policy).toContain('maximum `58m47s`');
+		expect(policy).toContain(
+			'**39m41s** figure is end-to-end merge-group queue',
+		);
+		expect(policy).toContain('Windows runner queue');
+		expect(policy).toContain('**20.4–22.7m**');
+		expect(policy).toContain('about **21m** of divisible');
+		expect(policy).toContain('about **1.6m** of fixed');
+		expect(policy).toContain('approximately **8m** service-time benefit');
+		expect(policy).toContain('from **30 to 50**');
+		expect(policy).toContain(
+			'account-level concurrency capacity remains unknown',
+		);
+		expect(policy).toMatch(/\*\*Decision:\*\* Retain six Windows unit shards/);
+		expect(policy).not.toContain(
+			'Stage A Windows10 decision is planned separately',
+		);
+		expect(policy).not.toContain('planned Stage A decision');
+		expect(policy).not.toMatch(/concurrency[^\n]*\b0\b/i);
+	});
+
+	test('policy pins the numeric reopening gate and retained gates', () => {
+		expect(policy).toMatch(
+			/median Windows test-step duration \*\*>=18m AND P95 runner queue <=5m\*\*/,
+		);
+		expect(policy).toMatch(
+			/\*\*>=5m P95 merge-group wall-time gain without >5m marginal\s+runner-queue growth\*\*/,
+		);
+		expect(policy).toContain('six-way coverage matrix and six-file loops');
+		expect(policy).toContain('No Windows-ten workflow or ruleset change');
+	});
+
+	test('C9 defines timeline eviction evidence and records all three Stage-D receipts', () => {
+		const contractStart = policy.indexOf('## C9 post-land receipt contract');
+		const contractEnd = policy.indexOf(
+			'## Cross-contamination warning language',
+		);
+		const contract = policy.slice(contractStart, contractEnd);
+
+		for (const field of [
+			'eviction=none',
+			'eviction_evidence=timeline:add→terminal-merge/remove-pair',
+			'timeline_added_at=ISO Z',
+			'timeline_merged_at=ISO Z',
+			'timeline_removed_at=ISO Z',
+			'unit_shards_executed=6',
+			'terminal_pair_evidence=adjacent terminal merge/remove pair; no intervening re-add',
+		]) {
+			expect(contract).toContain(field);
+		}
+
+		const receipts = [
+			{
+				identifier: 'stage-d-post-land-1',
+				run: '34051617672',
+				duration: '1841000',
+				completed: '2026-09-06T18:55:17Z',
+				added: '2026-09-06T18:24:18Z',
+				merged: '2026-09-06T18:55:43Z',
+				removed: '2026-09-06T18:55:43Z',
+			},
+			{
+				identifier: 'stage-d-post-land-2',
+				run: '34060659584',
+				duration: '1781000',
+				completed: '2026-09-06T21:48:07Z',
+				added: '2026-09-06T21:18:08Z',
+				merged: '2026-09-06T21:48:11Z',
+				removed: '2026-09-06T21:48:11Z',
+			},
+			{
+				identifier: 'stage-d-post-land-3',
+				run: '34061223031',
+				duration: '2435000',
+				completed: '2026-09-06T22:10:05Z',
+				added: '2026-09-06T21:29:16Z',
+				merged: '2026-09-06T22:10:31Z',
+				removed: '2026-09-06T22:10:30Z',
+			},
+		] as const;
+
+		expect(
+			policy.match(/^identifier=stage-d-post-land-\d+$/gm) ?? [],
+		).toHaveLength(3);
+		for (const receipt of receipts) {
+			const block = extractReceipt(policy, `identifier=${receipt.identifier}`);
+			expect(block).not.toBe('');
+			expect(block).toContain(
+				`actions=https://github.com/ZaxbyHub/opencode-swarm/actions/runs/${receipt.run}`,
+			);
+			expect(block).toContain(`run_duration_ms=${receipt.duration}`);
+			expect(block).toContain('queue_wait_ms=unavailable');
+			expect(block).not.toContain('queue_wait_ms=0');
+			expect(block).toContain('eviction=none');
+			expect(block).toContain(
+				'eviction_evidence=timeline:add→terminal-merge/remove-pair',
+			);
+			expect(block).toContain(`timeline_added_at=${receipt.added}`);
+			expect(block).toContain(`timeline_merged_at=${receipt.merged}`);
+			expect(block).toContain(`timeline_removed_at=${receipt.removed}`);
+			expect(block).toContain('unit_shards_executed=6');
+			expect(block).toContain(`completed_at=${receipt.completed}`);
+			expect(block).toContain('no intervening re-add');
+		}
+
+		expect(policy).toMatch(/Stage-A post-land receipts[^\n]*pending/i);
+	});
+});

--- a/tests/unit/scripts/ci/ci-stage-a-policy-2552.test.ts
+++ b/tests/unit/scripts/ci/ci-stage-a-policy-2552.test.ts
@@ -30,6 +30,9 @@ function extractReceipt(policy: string, identifier: string): string {
 describe('Stage-A policy and six-way CI agreement (issue #2552)', () => {
 	const workflow = readText(CI_YML_PATH);
 	const policy = readText(POLICY_PATH);
+	// Workflow assertions below protect live CI topology from drift. Policy
+	// assertions protect the committed decision record's internal consistency;
+	// they intentionally do not claim to re-prove the historical evidence.
 
 	test('unit keeps six-way matrix and runtime partition denominator', () => {
 		const unit = extractJob(workflow, 'unit');
@@ -177,5 +180,8 @@ describe('Stage-A policy and six-way CI agreement (issue #2552)', () => {
 		}
 
 		expect(policy).toMatch(/Stage-A post-land receipts[^\n]*pending/i);
+		expect(
+			policy.match(/^identifier=stage-a-post-land-\d+$/gm) ?? [],
+		).toHaveLength(0);
 	});
 });

--- a/tests/unit/scripts/ci/ci-yml-integration.test.ts
+++ b/tests/unit/scripts/ci/ci-yml-integration.test.ts
@@ -137,6 +137,33 @@ describe('ci.yml integration — Task 1.2 wrapper script structural validation',
 	});
 });
 
+describe('ci.yml parser helpers — CRLF normalization', () => {
+	const yml = readFileSync(CI_YML_PATH, 'utf8').replace(/\r\n/g, '\n');
+	const crlfYml = yml.replace(/\n/g, '\r\n');
+
+	test('all YAML extractors produce the same slices for LF and CRLF input', () => {
+		expect(extractRunUnitTestsStep(crlfYml)).toBe(extractRunUnitTestsStep(yml));
+		expect(extractCollectAndPartitionStep(crlfYml)).toBe(
+			extractCollectAndPartitionStep(yml),
+		);
+		expect(extractCoverageMeasurementStep(crlfYml)).toBe(
+			extractCoverageMeasurementStep(yml),
+		);
+		expect(extractIntegrationTestsStep(crlfYml)).toBe(
+			extractIntegrationTestsStep(yml),
+		);
+		expect(extractUnitFlakeAnnotationsUploadStep(crlfYml)).toBe(
+			extractUnitFlakeAnnotationsUploadStep(yml),
+		);
+		expect(extractCoverageFlakeAnnotationsUploadStep(crlfYml)).toBe(
+			extractCoverageFlakeAnnotationsUploadStep(yml),
+		);
+		expect(
+			extractIntegrationFindCommand(extractIntegrationTestsStep(crlfYml)),
+		).toBe(extractIntegrationFindCommand(extractIntegrationTestsStep(yml)));
+	});
+});
+
 describe('ci.yml integration — integration quarantine extraction', () => {
 	const yml = readFileSync(CI_YML_PATH, 'utf8');
 	const step = extractIntegrationTestsStep(yml);

--- a/tests/unit/scripts/ci/gitattributes-lf-checkout-2554.test.ts
+++ b/tests/unit/scripts/ci/gitattributes-lf-checkout-2554.test.ts
@@ -16,6 +16,7 @@ const CI_PARSER_TEST_PATH = join(
 );
 const GITATTRIBUTES_PREFIX = '* text=auto eol=lf';
 const BOM_HEX = 'efbbbf';
+const CHECKOUT_TEST_TIMEOUT_MS = 120_000;
 
 let checkoutRoot = '';
 
@@ -30,7 +31,7 @@ function runGit(args: string[], cwd: string): string {
 		encoding: 'utf8',
 		maxBuffer: 4 * 1024 * 1024,
 		stdio: ['ignore', 'pipe', 'pipe'],
-		timeout: 30_000,
+		timeout: CHECKOUT_TEST_TIMEOUT_MS,
 	});
 }
 
@@ -79,10 +80,12 @@ beforeAll(() => {
 	);
 	runGit(['config', 'core.autocrlf', 'true'], clonePath);
 	runGit(['checkout', '--force', '--detach', 'HEAD'], clonePath);
-});
+}, CHECKOUT_TEST_TIMEOUT_MS);
 
 afterAll(() => {
 	if (!checkoutRoot) return;
+	// Defense-in-depth: keep the recursive cleanup constrained even if future
+	// setup changes mutate checkoutRoot after the validated temp directory is made.
 	const realTempRoot = realpathSync(tmpdir());
 	if (
 		dirname(checkoutRoot) !== realTempRoot ||

--- a/tests/unit/scripts/ci/gitattributes-lf-checkout-2554.test.ts
+++ b/tests/unit/scripts/ci/gitattributes-lf-checkout-2554.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const ATTRIBUTES_PATH = join(REPO_ROOT, '.gitattributes');
+const CI_PARSER_TEST_PATH = join(
+	REPO_ROOT,
+	'tests',
+	'unit',
+	'scripts',
+	'ci',
+	'ci-yml-integration.test.ts',
+);
+const GITATTRIBUTES_PREFIX = '* text=auto eol=lf';
+const BOM_HEX = 'efbbbf';
+
+let checkoutRoot = '';
+
+/**
+ * Run Git with an explicit working directory and bounded, non-interactive I/O.
+ * Synchronous execution is intentional here: each test needs a fully
+ * materialized checkout before it can inspect the resulting line endings.
+ */
+function runGit(args: string[], cwd: string): string {
+	return execFileSync('git', args, {
+		cwd,
+		encoding: 'utf8',
+		maxBuffer: 4 * 1024 * 1024,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		timeout: 30_000,
+	});
+}
+
+function countCarriageReturns(bytes: Uint8Array): number {
+	let count = 0;
+	for (const byte of bytes) {
+		if (byte === 0x0d) count += 1;
+	}
+	return count;
+}
+
+function lsFilesEol(cwd: string, paths: string[]): string[] {
+	return runGit(['ls-files', '--eol', '--', ...paths], cwd)
+		.trim()
+		.split(/\r?\n/)
+		.filter(Boolean);
+}
+
+function eolRecord(records: string[], relativePath: string): string {
+	const record = records.find((line) => line.trimEnd().endsWith(relativePath));
+	if (!record) throw new Error(`missing git eol record for ${relativePath}`);
+	return record;
+}
+
+beforeAll(() => {
+	checkoutRoot = realpathSync(
+		mkdtempSync(join(realpathSync(tmpdir()), 'opencode-swarm-2554-')),
+	);
+	const clonePath = join(checkoutRoot, 'repo');
+
+	// A local no-checkout clone makes the test independent of network access and
+	// ensures the checkout conversion is driven by the committed attributes
+	// blob, not by the source worktree's existing files.
+	runGit(
+		[
+			'-c',
+			'safe.directory=*',
+			'clone',
+			'--no-checkout',
+			'--local',
+			'--no-hardlinks',
+			REPO_ROOT,
+			clonePath,
+		],
+		REPO_ROOT,
+	);
+	runGit(['config', 'core.autocrlf', 'true'], clonePath);
+	runGit(['checkout', '--force', '--detach', 'HEAD'], clonePath);
+});
+
+afterAll(() => {
+	if (!checkoutRoot) return;
+	const realTempRoot = realpathSync(tmpdir());
+	if (
+		dirname(checkoutRoot) !== realTempRoot ||
+		!basename(checkoutRoot).startsWith('opencode-swarm-2554-')
+	) {
+		throw new Error(
+			`refusing to remove unexpected checkout root: ${checkoutRoot}`,
+		);
+	}
+	rmSync(checkoutRoot, { force: true, recursive: true });
+});
+
+describe('repository LF checkout contract — regression #2554', () => {
+	test('AC1: committed .gitattributes starts with the wildcard rule, without a BOM', () => {
+		const bytes = readFileSync(ATTRIBUTES_PATH);
+
+		expect(bytes.subarray(0, 3).toString('hex')).not.toBe(BOM_HEX);
+		expect(
+			bytes
+				.subarray(0, Buffer.byteLength(GITATTRIBUTES_PREFIX))
+				.toString('utf8'),
+		).toBe(GITATTRIBUTES_PREFIX);
+	});
+
+	test('AC2: core.autocrlf=true fresh checkout keeps workflow YAML as LF', () => {
+		const workflowBytes = readFileSync(
+			join(checkoutRoot, 'repo', '.github', 'workflows', 'ci.yml'),
+		);
+		const records = lsFilesEol(join(checkoutRoot, 'repo'), [
+			'.github/workflows/ci.yml',
+		]);
+
+		expect(countCarriageReturns(workflowBytes)).toBe(0);
+		expect(eolRecord(records, '.github/workflows/ci.yml')).toMatch(
+			/^i\/lf\s+w\/lf\s+attr\/text=auto eol=lf\s+\.github\/workflows\/ci\.yml$/,
+		);
+	});
+
+	test('AC3: explicit TypeScript, JavaScript, declaration, JSON, and Markdown LF rules remain effective', () => {
+		const attributes = readFileSync(ATTRIBUTES_PATH, 'utf8').replace(
+			/\r\n/g,
+			'\n',
+		);
+		for (const rule of [
+			'*.ts text eol=lf',
+			'*.js text eol=lf',
+			'*.d.ts text eol=lf',
+			'*.json text eol=lf',
+			'*.md text eol=lf',
+		]) {
+			expect(attributes.split('\n')).toContain(rule);
+		}
+
+		const representatives = [
+			'tests/unit/scripts/ci/ci-yml-integration.test.ts',
+			'scripts/swarm-model/src/ui.js',
+			'src/types/bash-parser.d.ts',
+			'package.json',
+			'README.md',
+		];
+		const records = lsFilesEol(join(checkoutRoot, 'repo'), representatives);
+		for (const relativePath of representatives) {
+			expect(eolRecord(records, relativePath)).toMatch(
+				/^i\/lf\s+w\/lf\s+attr\/text eol=lf\s+/,
+			);
+		}
+	});
+
+	test('AC4: existing CI parser tests retain their CRLF normalization defense', () => {
+		const parserSource = readFileSync(CI_PARSER_TEST_PATH, 'utf8');
+		expect(parserSource).toContain("replace(/\\r\\n/g, '\\n')");
+
+		const syntheticCrLf = 'jobs:\r\n  quality:\r\n    steps:\r\n';
+		expect(syntheticCrLf.replace(/\r\n/g, '\n')).toBe(
+			'jobs:\n  quality:\n    steps:\n',
+		);
+	});
+});


### PR DESCRIPTION
Closes #2554
Refs #2552

## Summary

- Restore LF checkout behavior by removing the UTF-8 BOM from `.gitattributes` while preserving every existing rule.
- Add a fresh-clone `core.autocrlf=true` regression test proving the workflow checkout remains LF-only.
- Record the #2552 Stage-A merge-queue decision to retain six Windows shards, add a quantitative reopening gate, preserve Stage-D receipts, and add executable workflow-topology drift tests plus internal-consistency checks for the captured policy record. The policy assertions do not independently re-prove historical evidence.
- Add release-note fragments for both issue fixes. #2552's three qualifying Stage-A receipts remain an explicit post-land closure prerequisite because they cannot truthfully predate publication.

## Invariant audit

- 1 (plugin init): not touched - no plugin initialization code changed.
- 2 (runtime portability): not touched - no runtime module resolution or bundle entry changed; `bun run build` and Node dist import passed.
- 3 (subprocesses): touched - the checkout regression test uses array-form `execFileSync` with explicit cwd, ignored stdin, timeout, bounded output, and guarded cleanup; changed-file review found no unsafe production subprocess changes.
- 4 (.swarm containment): not touched - no runtime state or project-root resolution changed.
- 5 (plan durability): not touched - no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched - validation used the repository's scoped `test:unit:ci` command with three explicit files.
- 7 (test writing): touched - the new tests remain sub-500-line `bun:test` files and now include falsifiable Stage-A receipt and CRLF parser regressions.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no guardrail or retry behavior changed.
- 10 (chat/system msg): not touched - no chat hook or message-shape code changed.
- 11 (tool registration): not touched - no tool/agent map changed; registration check passed.
- 12 (release/cache): touched - unique pending release fragments were added for both user-visible fixes; no release-please-owned file was edited.

## Test plan

- `bun run build`
- `bun run typecheck`
- `bun run lint:ci` (one existing `src/tools/pkg-audit.ts:51` warning; no changed-file finding)
- `bun run test:unit:ci tests/unit/scripts/ci/ci-stage-a-policy-2552.test.ts tests/unit/scripts/ci/gitattributes-lf-checkout-2554.test.ts tests/unit/scripts/ci/ci-yml-integration.test.ts`
- Scoped Biome check on all three modified test files and `git diff --check`
- Falsification probes: injected Stage-A receipt and removed parser normalization each caused the new regression test to fail before restoration.

## Feedback closure ledger — Round 2

- TF-001 | fixed | Commit `7225f047` adds a zero-count assertion rejecting injected `stage-a-post-land-*` identifiers while the policy remains pending; focused test and mutation probe passed.
- TF-002 | fixed | Commit `7225f047` adds CRLF fixtures through every CI parser extractor, including the nested integration command finder; focused test and normalization-removal probe passed.
- FB-001 | fixed | The body now uses `Refs #2552` and `Closes #2554`; the three #2552 receipts remain explicitly post-land prerequisites.
- FB-002 | fixed | Commit `7225f047` applies the shared 120-second timeout to the checkout child and `beforeAll` hook; the bare test passed.
- FB-003 | fixed | The summary now distinguishes executable workflow-topology drift checks from internal-consistency assertions over the captured policy record.
- FB-004 | fixed | The cleanup comment explains the constructor-guaranteed guard as fail-closed defense-in-depth before recursive removal.
- CI-001 | fixed | Current-head CI run `34079801698` completed successfully, including quality, package-check, all unit shards, coverage, security, and Ubuntu/macOS/Windows smoke jobs.
- CONFLICT-001 | fixed/pre-existing | The PR head is the exact pushed feedback-fix commit; no rebase or force-push was used.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
