### PR TITLE
feat(retrieval): add deterministic quality evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           # platform-path PRs to the ubuntu-only matrix). grep without -q
           # or -m reads its input to EOF before exiting, so git diff always
           # finishes writing normally and no SIGPIPE is possible.
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null | grep -E '^(src/worktree/|src/turbo/|src/sandbox/|src/plan/|src/parallel/|src/knowledge/|src/memory/|src/tools/|scripts/|runners/|\.github/workflows/)' >/dev/null; then
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null | grep -E '^(src/worktree/|src/turbo/|src/sandbox/|src/plan/|src/parallel/|src/knowledge/|src/lang/|src/memory/|src/evaluation/|src/tools/|scripts/|tests/fixtures/memory-recall-heldout/|runners/|\.github/workflows/)' >/dev/null; then
             echo "touches-platform-paths=true" >> "$GITHUB_OUTPUT"
           else
             echo "touches-platform-paths=false" >> "$GITHUB_OUTPUT"
@@ -358,6 +358,9 @@ jobs:
       - name: Memory recall regression gate
         if: needs.detect-release.outputs.is-release != 'true'
         run: bun run check:memory-recall
+      - name: Retrieval quality regression gate
+        if: needs.detect-release.outputs.is-release != 'true'
+        run: bun run check:retrieval-quality
 
   # Two-tier CI: on pull_request, run ubuntu-only with 4 shards for fast feedback
   # UNLESS the diff touches a platform-sensitive path (issue #1737 FR-013,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,13 @@ jobs:
   # is blocking within this workflow (pull_request + merge_group triggers).
   memory-recall-regression:
     needs: [detect-release]
-    runs-on: ubuntu-latest
+    # Issues #2489/#2490 require the bounded graph/retrieval measurements to
+    # exercise the supported host filesystem flavors, not just Ubuntu.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -802,14 +802,6 @@ Run golden Swarm memory recall evaluation fixtures
 
 **Args:** `--json, --fixtures <directory>, --profiles <list>, --manifest <file>`
 
-Optional `--profiles lexical,hybrid,hybrid+rerank` compares the production
-recall stages with identical bounded candidate and token budgets. `--manifest
-<file>` accepts a packaged held-out corpus `manifest.json`; the command rejects
-other filenames because the loader resolves the selected corpus directory's
-`manifest.json`, then loads that corpus (rather than merely displaying the path)
-and verifies canonical containment after symlink resolution. Report manifests are rejected. The legacy provider-by-mode
-report remains the default when `--profiles` is omitted.
-
 #### `/swarm memory audit-verify`
 
 Verify the memory audit-log hash chain (tamper detection)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -800,7 +800,15 @@ Export current Swarm memory to JSONL files
 
 Run golden Swarm memory recall evaluation fixtures
 
-**Args:** `--json, --fixtures <directory>`
+**Args:** `--json, --fixtures <directory>, --profiles <list>, --manifest <file>`
+
+Optional `--profiles lexical,hybrid,hybrid+rerank` compares the production
+recall stages with identical bounded candidate and token budgets. `--manifest
+<file>` accepts a packaged held-out corpus `manifest.json`; the command rejects
+other filenames because the loader resolves the selected corpus directory's
+`manifest.json`, then loads that corpus (rather than merely displaying the path)
+and verifies canonical containment after symlink resolution. Report manifests are rejected. The legacy provider-by-mode
+report remains the default when `--profiles` is omitted.
 
 #### `/swarm memory audit-verify`
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -190,6 +190,10 @@ Memory commands:
 
 `/swarm memory evaluate --json` runs the golden recall fixtures under `tests/fixtures/memory-recall` against both `local-jsonl` and `sqlite`, across manual, injection, and curator recall modes. Pass `--fixtures <directory>` to evaluate a different fixture directory from an interactive CLI run. The JSON report includes `precision@k`, `recall@k`, `injection_count`, `noisy_injection_count`, `same_scope_noise_count`, `cross_scope_leak_count`, and `stale_memory_count`.
 
+For retrieval-quality comparisons, pass `--profiles lexical,hybrid,hybrid+rerank`. These profiles use the production lexical → dense → RRF → rerank path with identical candidate and token resource caps. The offline held-out gate uses a 20-record candidate cap over the shared 20-case corpus; `returned_token_estimate` is an honest text-only measurement, not an assertion that prompt tokens were consumed. `lexical` is always available; `hybrid` and `hybrid+rerank` report `degraded` or `skipped` with an explicit reason when optional dependencies are unavailable. Reports record provenance, latency, caps, and unavailable-cost provenance rather than inventing model measurements. Omit `--profiles` to preserve the legacy schema-v1 provider-by-mode report.
+
+`--manifest <file>` is an additive, containment-checked option for a held-out corpus named `manifest.json` (including the packaged `tests/fixtures/memory-recall-heldout/manifest.json` or an equivalent corpus under the project root). Other filenames are rejected because the loader resolves the selected corpus directory's `manifest.json`. It loads and evaluates that corpus; report manifests are not accepted as inert display inputs. The held-out corpus is content-addressed and records exact symbols, edges, known misses, spurious edges, paraphrases, analyzer identities, profile thresholds, and Linux/macOS/Windows gate IDs. Known limitations are bounded offline evaluation, deterministic injected dense adapters in the regression gate, and no model downloads or network access; missing optional components degrade honestly to lexical retrieval.
+
 Rollback to JSONL provider:
 
 1. Stop using memory tools for the project.
@@ -568,6 +572,15 @@ greater than the baseline tolerance (0.05). CI runs it as the
 `memory-recall-regression` job. Regenerate the baseline with
 `bun run scripts/memory-recall-regression.ts --update` when an intentional
 metric change lands, and justify it in the PR.
+
+`bun run check:retrieval-quality` validates the versioned held-out contract and
+runs two complete production evaluator passes. It compares canonical ranked
+IDs, metrics, statuses, caps, provenance, identities, degradation reasons, and
+thresholds while excluding only timestamps, measured latency, temporary paths,
+and other measurement-only fields. It reports and gates the graph direct-source
+positive-hit count separately from route completion (the current corpus requires
+14 positive paraphrase hits out of 20). Its bounded JSON output is suitable for
+issue #2503 trend aggregation.
 
 ## Inspecting Or Resetting Local Memory
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -194,6 +194,8 @@ For retrieval-quality comparisons, pass `--profiles lexical,hybrid,hybrid+rerank
 
 `--manifest <file>` is an additive, containment-checked option for a held-out corpus named `manifest.json` (including the packaged `tests/fixtures/memory-recall-heldout/manifest.json` or an equivalent corpus under the project root). Other filenames are rejected because the loader resolves the selected corpus directory's `manifest.json`. It loads and evaluates that corpus; report manifests are not accepted as inert display inputs. The held-out corpus is content-addressed and records exact symbols, edges, known misses, spurious edges, paraphrases, analyzer identities, profile thresholds, and Linux/macOS/Windows gate IDs. Known limitations are bounded offline evaluation, deterministic injected dense adapters in the regression gate, and no model downloads or network access; missing optional components degrade honestly to lexical retrieval.
 
+The CLI rejects held-out manifest files larger than 1 MiB before parsing them; each source file and the aggregate source set have separate byte caps in the loader.
+
 Rollback to JSONL provider:
 
 1. Stop using memory tools for the project.

--- a/docs/releases/pending/issue-2489-2490-retrieval-quality.md
+++ b/docs/releases/pending/issue-2489-2490-retrieval-quality.md
@@ -1,0 +1,7 @@
+## Retrieval-quality and graph integrity (#2489, #2490)
+
+- Reuse bounded repository-graph indexes and reject incompatible graph schemas
+  while preserving safe fallback behavior.
+- Add deterministic, content-addressed multilingual retrieval-quality fixtures,
+  production-wired lexical/hybrid/rerank profiles, explicit provenance and
+  resource caps, and a blocking two-run regression gate.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		".opencode/skills/orchestrating-subagents",
 		".opencode/skills/durable-session-state",
 		"tests/fixtures/memory-recall",
+		"tests/fixtures/memory-recall-heldout",
 		"opencode-swarm.schema.json",
 		"README.md",
 		"LICENSE"
@@ -131,7 +132,8 @@
 		"check:error-channel-discard": "bun run scripts/check-error-channel-discard.ts",
 		"check:path-identity": "bun run scripts/check-path-identity.ts",
 		"check:registry-citations": "bun run scripts/check-registry-citations.ts",
-		"check:memory-recall": "bun run scripts/memory-recall-regression.ts"
+		"check:memory-recall": "bun run scripts/memory-recall-regression.ts",
+		"check:retrieval-quality": "bun run scripts/retrieval-quality-regression.ts"
 	},
 	"dependencies": {
 		"@opencode-ai/plugin": "^1.18.3",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -71,6 +71,32 @@ export const REQUIRED_EVALUATION_FIXTURE_IDS = [
 	'boundary-error',
 ];
 
+export const REQUIRED_HELDOUT_RETRIEVAL_FILES = [
+	'tests/fixtures/memory-recall-heldout/manifest.json',
+	...[
+		'bash.sh',
+		'c.c',
+		'cpp.cpp',
+		'csharp.cs',
+		'css.css',
+		'dart.dart',
+		'go.go',
+		'ini.ini',
+		'java.java',
+		'javascript.js',
+		'kotlin.kt',
+		'php.php',
+		'powershell.ps1',
+		'python.py',
+		'regex.regex',
+		'ruby.rb',
+		'rust.rs',
+		'swift.swift',
+		'tsx.tsx',
+		'typescript.ts',
+	].map((name) => `tests/fixtures/memory-recall-heldout/sources/${name}`),
+];
+
 const REQUIRED_PACKAGE_FILES = [
 	'dist/index.js',
 	'dist/index.d.ts',
@@ -85,6 +111,7 @@ const REQUIRED_PACKAGE_FILES = [
 		`evaluation-fixtures/tier1/${id}/environment/defect.ts`,
 		`evaluation-fixtures/tier1/${id}/environment/defect.test.ts`,
 	]),
+	...REQUIRED_HELDOUT_RETRIEVAL_FILES,
 	'README.md',
 	'LICENSE',
 	'package.json',
@@ -407,8 +434,11 @@ async function main() {
 				"const privateCiFix = path.join(projectDir, '.swarm', 'bundled-skills', 'ci-fix-monitor', 'SKILL.md');",
 				"const packageRoot = path.join(process.cwd(), 'node_modules', 'opencode-swarm');",
 				"const packagedPlan = path.join(packageRoot, '.opencode', 'skills', 'swarm-plan', 'SKILL.md');",
+				"const heldoutManifest = path.join(packageRoot, 'tests', 'fixtures', 'memory-recall-heldout', 'manifest.json');",
 				"const evaluationTasks = await loadTier1EvaluationTasks(packageRoot);",
 				"if (evaluationTasks.length !== 12) throw new Error('packed Tier-1 evaluation fixtures did not resolve');",
+				"const heldout = JSON.parse(readFileSync(heldoutManifest, 'utf8'));",
+				"if (heldout.split !== 'heldout' || heldout.cases?.length !== 20) throw new Error('packed held-out retrieval corpus did not resolve');",
 				"const sentinel = '---\\nname: swarm-plan\\naudience: ragappv3\\ndescription: repository-owned sentinel\\n---\\n';",
 				"mkdirSync(path.dirname(nativePlan), { recursive: true });",
 				"writeFileSync(nativePlan, sentinel);",

--- a/scripts/registry-citation-baseline.json
+++ b/scripts/registry-citation-baseline.json
@@ -310,27 +310,6 @@
 			"note": "Pre-existing debt, not approved drift: \"recordEmittedRecommendations\" exists in src/services/recommendation-ledger.ts but not inside src/services/recommendation-ledger.ts:623 (recommendation-ledger.writerCitations[0])."
 		},
 		{
-			"rowId": "repo-graph",
-			"file": "src/tools/repo-graph/storage.ts",
-			"identifier": "loadGraph",
-			"kind": "out-of-range",
-			"note": "Pre-existing debt, not approved drift: \"loadGraph\" exists in src/tools/repo-graph/storage.ts but not inside src/tools/repo-graph/storage.ts:204 (repo-graph.readerCitations[0])."
-		},
-		{
-			"rowId": "repo-graph",
-			"file": "src/tools/repo-graph/storage.ts",
-			"identifier": "loadOrCreateGraph",
-			"kind": "out-of-range",
-			"note": "Pre-existing debt, not approved drift: \"loadOrCreateGraph\" exists in src/tools/repo-graph/storage.ts but not inside :506 (repo-graph.writerCitations[0])."
-		},
-		{
-			"rowId": "repo-graph",
-			"file": "src/tools/repo-graph/storage.ts",
-			"identifier": "saveGraph",
-			"kind": "out-of-range",
-			"note": "Pre-existing debt, not approved drift: \"saveGraph\" exists in src/tools/repo-graph/storage.ts but not inside src/tools/repo-graph/storage.ts:339 (repo-graph.writerCitations[0])."
-		},
-		{
 			"rowId": "session-state-snapshot",
 			"file": "src/services/context-budget-service.ts",
 			"identifier": "writeBudgetState",

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -2508,12 +2508,12 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		canonicalRoot: 'project-swarm',
 		writerModules: ['src/tools/repo-graph/indexed-storage.ts'],
 		writerCitations: [
-			'src/tools/repo-graph/indexed-storage.ts:582 syncIndexFromGraph — full-replace transaction: DELETE FROM edges/files/graph_meta then re-INSERT every node/edge',
-			'src/tools/repo-graph/storage.ts:690 syncIndexFromGraph — invoked from saveGraph only when the indexed-mode save lock was acquired, inside the lock span',
+			'src/tools/repo-graph/indexed-storage.ts:586 syncIndexFromGraph — full-replace transaction: DELETE FROM edges/files/graph_meta then re-INSERT every node/edge',
+			'src/tools/repo-graph/storage.ts:709 syncIndexFromGraph — invoked from saveGraph only when the indexed-mode save lock was acquired, inside the lock span',
 		],
 		readerCitations: [
-			'src/tools/repo-graph/indexed-storage.ts:940 queryNodeByFile — indexed single-row SELECT by path/module_name (resolveTargetRow), sync',
-			'src/tools/repo-graph/indexed-storage.ts:988 loadSubgraphForFiles — bounded-neighbourhood closure via idx_edges_source/idx_edges_target, sync',
+			'src/tools/repo-graph/indexed-storage.ts:952 queryNodeByFile — indexed single-row SELECT by path/module_name (resolveTargetRow), sync',
+			'src/tools/repo-graph/indexed-storage.ts:1000 loadSubgraphForFiles — bounded-neighbourhood closure via idx_edges_source/idx_edges_target, sync',
 		],
 		schemaVersion: 'schema_migrations versioned (6, indexed-storage.ts:91-136)',
 		stateClass: 'derived-rebuildable',
@@ -2768,10 +2768,10 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		canonicalRoot: 'project-swarm',
 		writerModules: ['src/tools/repo-graph/storage.ts'],
 		writerCitations: [
-			'src/tools/repo-graph/storage.ts:339 saveGraph — atomic temp+rename with 5×100 ms Windows retry; :506 loadOrCreateGraph (COPYFILE_EXCL)',
+			'src/tools/repo-graph/storage.ts:480 saveGraph — atomic temp+rename with 5×100 ms Windows retry; :755 loadOrCreateGraph (COPYFILE_EXCL)',
 		],
 		readerCitations: [
-			'src/tools/repo-graph/storage.ts:204 loadGraph / :293 loadGraphSync — FULL-FILE with validation behind a 16-workspace mtime-invalidated cache (cache.ts:13)',
+			'src/tools/repo-graph/storage.ts:277 loadGraph / :375 loadGraphSync — FULL-FILE with validation behind a 16-workspace mtime-invalidated cache (cache.ts:13)',
 			'src/memory/reflection-service.ts:386 loadBoundedGraph — ≤16 MiB',
 		],
 		schemaVersion: 'graph schema with workspaceRoot identity validation (:360-386)',
@@ -4020,6 +4020,7 @@ export const EXEMPT_WRITER_MODULES: Readonly<Record<string, string>> = Object.fr
 	'src/db/sqlite-loader.ts': 'bun:sqlite/node:sqlite loader (issue #1873) — DB rows own the streams',
 	'src/memory/jsonl-migration.ts': 'legacy JSONL→SQLite migration executor — memory-sqlite row owns the destination',
 	'src/retention/jsonl-cap.ts': 'shared retention plumbing (appendCappedJsonl/readTailJsonl, issue #2483 §1) — callers own the streams; their rows carry the cap citations',
+	'src/evaluation/retrieval-quality.ts': 'temporary bounded evaluation artifacts under os.tmpdir — always removed in finally and never durable project state',
 });
 
 /** Sequence window for fix-in-issue dispositions (issue #2036 amendment clause). */

--- a/scripts/retrieval-quality-regression.ts
+++ b/scripts/retrieval-quality-regression.ts
@@ -1,0 +1,522 @@
+import * as path from 'node:path';
+import {
+	evaluateHeldoutGraphRetrievalQuality,
+	type HeldoutGraphQualityReport,
+} from '../src/evaluation';
+import { languageDefinitions } from '../src/lang/registry';
+import { LANGUAGE_REGISTRY } from '../src/lang/profiles';
+import {
+	evaluateMemoryRecallFixtures,
+	validateRecallEvaluationManifest,
+	type RecallEvaluationReport,
+} from '../src/memory/evaluation';
+import {
+	loadHeldoutRecallEvaluationCorpus,
+	type MemoryRecord,
+	type MemoryReranker,
+	type SQLiteRetrievalDependencies,
+} from '../src/memory';
+import type { RerankCandidate } from '../src/memory/embeddings/reranker';
+import type { RecallRequest } from '../src/memory/types';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const CORPUS_ROOT = path.join(
+	ROOT,
+	'tests',
+	'fixtures',
+	'memory-recall-heldout',
+);
+const EVALUATION_FIXTURES = path.join(
+	ROOT,
+	'tests',
+	'fixtures',
+	'memory-recall',
+);
+const PROFILES = ['lexical', 'hybrid', 'hybrid+rerank'] as const;
+const QUALITY_CANDIDATE_COUNT = 20;
+const QUALITY_TOKEN_BUDGET = 256;
+
+type HeldoutCase = {
+	id: string;
+	language: string;
+	source_path: string;
+	content_hash: string;
+	expected_symbols: string[];
+	expected_edges: Array<string | { from: string; to: string }>;
+	known_misses: string[];
+	spurious_edges: Array<string | { from: string; to: string }>;
+	paraphrase: string;
+	analyzer_id: string;
+};
+
+type HeldoutManifest = {
+	corpus_id: string;
+	split: string;
+	version: string;
+	supported_languages: string[];
+	analyzer_extensions: Array<{ language: string; extractor_id: string }>;
+	os_gates: Record<string, unknown>;
+	thresholds: Record<string, number>;
+	cases: HeldoutCase[];
+};
+
+function fail(message: string): never {
+	throw new Error(`retrieval-quality: ${message}`);
+}
+
+function assertNonEmpty(value: unknown, label: string): asserts value is string {
+	if (typeof value !== 'string' || value.trim() === '') fail(`${label} is empty`);
+}
+
+function assertCaseList(value: unknown, label: string): asserts value is string[] {
+	if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.trim() === '')) {
+		fail(`${label} must be a non-empty string list`);
+	}
+}
+
+function assertEdgeList(value: unknown, label: string): void {
+	if (!Array.isArray(value) || value.length === 0) fail(`${label} must be non-empty`);
+	for (const edge of value) {
+		if (typeof edge === 'string') {
+			if (!/\S+\s*(?:->|=>|::)\s*\S+/.test(edge)) fail(`${label} contains an invalid edge`);
+			continue;
+		}
+		if (!edge || typeof edge !== 'object') fail(`${label} contains an invalid edge`);
+		const candidate = edge as Record<string, unknown>;
+		assertNonEmpty(candidate.from ?? candidate.source, `${label}.from`);
+		assertNonEmpty(candidate.to ?? candidate.target, `${label}.to`);
+	}
+}
+
+function isContained(candidate: string, root: string): boolean {
+	const child = path.resolve(candidate);
+	const parent = path.resolve(root);
+	return child === parent || child.startsWith(`${parent}${path.sep}`);
+}
+
+async function loadHeldoutManifest(): Promise<HeldoutManifest> {
+	const manifest = await loadHeldoutRecallEvaluationCorpus(CORPUS_ROOT) as HeldoutManifest;
+	assertNonEmpty(manifest.corpus_id, 'corpus_id');
+	if (manifest.split !== 'heldout') fail('manifest split must be heldout');
+	assertNonEmpty(manifest.version, 'manifest version');
+	if (!Array.isArray(manifest.cases) || manifest.cases.length === 0) fail('manifest cases are empty');
+	const authoritative = languageDefinitions.map((definition) => definition.id).sort();
+	if (JSON.stringify([...manifest.supported_languages].sort()) !== JSON.stringify(authoritative)) {
+		fail('manifest languages do not match the authoritative language registry');
+	}
+	const dispatch = LANGUAGE_REGISTRY.getAll().filter((profile) => !profile.parserOnly).map((profile) => profile.id).sort();
+	const analyzerLanguages = manifest.analyzer_extensions.map((entry) => entry.language).sort();
+	if (JSON.stringify(analyzerLanguages) !== JSON.stringify(dispatch)) fail('analyzer extension languages do not match dispatch registry');
+	for (const platform of ['linux', 'macos', 'windows']) {
+		const gate = manifest.os_gates?.[platform];
+		if (!gate || typeof gate !== 'object' || !Object.values(gate as Record<string, unknown>).some((value) => typeof value === 'string' && value.trim())) {
+			fail(`missing runnable ${platform} gate`);
+		}
+	}
+	for (const [key, value] of Object.entries(manifest.thresholds ?? {})) {
+		if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) fail(`invalid threshold ${key}`);
+	}
+	if (typeof manifest.thresholds.direct_source_positive_hits !== 'number')
+		fail('manifest is missing direct_source_positive_hits threshold');
+	for (const entry of manifest.cases) {
+		assertNonEmpty(entry.id, 'case id');
+		assertNonEmpty(entry.language, `${entry.id}.language`);
+		assertNonEmpty(entry.source_path, `${entry.id}.source_path`);
+		if (!/^[a-f0-9]{64}$/i.test(entry.content_hash)) fail(`${entry.id}.content_hash is not SHA-256`);
+		assertCaseList(entry.expected_symbols, `${entry.id}.expected_symbols`);
+		assertEdgeList(entry.expected_edges, `${entry.id}.expected_edges`);
+		assertCaseList(entry.known_misses, `${entry.id}.known_misses`);
+		assertEdgeList(entry.spurious_edges, `${entry.id}.spurious_edges`);
+		assertNonEmpty(entry.paraphrase, `${entry.id}.paraphrase`);
+		assertNonEmpty(entry.analyzer_id, `${entry.id}.analyzer_id`);
+		const source = path.resolve(CORPUS_ROOT, entry.source_path);
+		if (!isContained(source, CORPUS_ROOT)) fail(`${entry.id}.source_path escapes corpus root`);
+	}
+	return manifest;
+}
+
+function canonicalize(value: unknown, key?: string): unknown {
+	if (
+		key === 'generated_at' ||
+		key === 'latency_ms' ||
+		key === 'latency_ms_delta' ||
+		key === 'fixture_directory'
+	)
+		return undefined;
+	if (Array.isArray(value)) return value.map((item) => canonicalize(item)).filter((item) => item !== undefined);
+	if (value && typeof value === 'object') {
+		const result: Record<string, unknown> = {};
+		for (const [entryKey, entryValue] of Object.entries(value)) {
+			const normalized = canonicalize(entryValue, entryKey);
+			if (normalized !== undefined) result[entryKey] = normalized;
+		}
+		return Object.fromEntries(Object.entries(result).sort(([left], [right]) => left.localeCompare(right)));
+	}
+	return value;
+}
+
+const EMBEDDING_DIMENSION = 64;
+
+function deterministicEmbedding(text: string): Float32Array {
+	const vector = new Float32Array(EMBEDDING_DIMENSION);
+	const normalized = text.toLowerCase().replace(/\s+/g, ' ');
+	for (const width of [2, 3, 4]) {
+		for (let start = 0; start + width <= normalized.length; start++) {
+			let hash = 2166136261;
+			for (let index = start; index < start + width; index++) {
+				hash ^= normalized.charCodeAt(index);
+				hash = Math.imul(hash, 16777619) >>> 0;
+			}
+			vector[hash % EMBEDDING_DIMENSION] += width === 4 ? 0.5 : 1;
+		}
+	}
+	const norm = Math.hypot(...vector);
+	if (norm === 0) return vector;
+	for (let index = 0; index < vector.length; index++) vector[index] /= norm;
+	return vector;
+}
+
+function createDeterministicDependencies(): SQLiteRetrievalDependencies {
+	const embeddingProvider = {
+		modelVersion: 'retrieval-quality-embedding-v1',
+		dimension: EMBEDDING_DIMENSION,
+		available: true,
+		embed: async (text: string) => deterministicEmbedding(text),
+		embedBatch: async (texts: string[]) => texts.map(deterministicEmbedding),
+	};
+	const denseSelector = async (
+		_request: RecallRequest,
+		queryEmbedding: Float32Array,
+		records: readonly MemoryRecord[],
+	): Promise<MemoryRecord[]> =>
+		[...records]
+			.map((record) => ({
+				record,
+				score: cosineSimilarity(queryEmbedding, deterministicEmbedding(record.text)),
+			}))
+			.sort(
+				(left, right) =>
+					right.score - left.score || left.record.id.localeCompare(right.record.id),
+			)
+			.map(({ record }) => record);
+	const reranker: MemoryReranker = {
+		available: true,
+		modelVersion: 'retrieval-quality-reranker-v1',
+		rerank: async <T extends RerankCandidate>(candidates: T[], query?: string) => {
+			// The injected reranker is intentionally conservative: it proves the
+			// production reranker hook is invoked without replacing the dense
+			// ranking with a label-aware oracle. Keeping the received order makes
+			// hybrid+rerank a matched-resource non-regression control.
+			void query;
+			return [...candidates];
+		},
+	};
+	return {
+		embeddingProvider,
+		denseSelector,
+		reranker,
+		now: () => 0,
+	};
+}
+
+function cosineSimilarity(left: Float32Array, right: Float32Array): number {
+	let dot = 0;
+	let leftNorm = 0;
+	let rightNorm = 0;
+	for (let index = 0; index < left.length; index++) {
+		dot += left[index] * right[index];
+		leftNorm += left[index] * left[index];
+		rightNorm += right[index] * right[index];
+	}
+	return leftNorm === 0 || rightNorm === 0
+		? 0
+		: dot / Math.sqrt(leftNorm * rightNorm);
+}
+
+function enforceManifestThresholds(
+	manifest: HeldoutManifest,
+	report: RecallEvaluationReport,
+): void {
+	const precisionThreshold = manifest.thresholds.precision_at_k;
+	const recallThreshold = manifest.thresholds.recall_at_k;
+	const maxKnownMisses = manifest.thresholds.max_known_misses;
+	const maxSpuriousEdges = manifest.thresholds.max_spurious_edges;
+	if (
+		typeof precisionThreshold !== 'number' ||
+		report.summary['precision@k'] < precisionThreshold
+	)
+		fail(
+			`precision@k ${report.summary['precision@k'].toFixed(3)} is below manifest threshold ${precisionThreshold}`,
+		);
+	if (
+		typeof recallThreshold !== 'number' ||
+		report.summary['recall@k'] < recallThreshold
+	)
+		fail(
+			`recall@k ${report.summary['recall@k'].toFixed(3)} is below manifest threshold ${recallThreshold}`,
+		);
+	if (typeof maxKnownMisses !== 'number' || typeof maxSpuriousEdges !== 'number')
+		fail('manifest is missing graph measurement thresholds');
+	for (const entry of manifest.cases) {
+		if (
+			entry.known_misses.length > maxKnownMisses ||
+			entry.spurious_edges.length > maxSpuriousEdges
+		)
+			fail(`case ${entry.id} exceeds manifest graph measurement thresholds`);
+	}
+}
+
+function enforceProfileComparisons(
+	manifest: HeldoutManifest,
+	report: RecallEvaluationReport,
+): void {
+	const expectedComparisonCount = manifest.cases.length * (PROFILES.length - 1);
+	if (report.comparisons.length !== expectedComparisonCount)
+		fail(
+			`expected ${expectedComparisonCount} lexical-to-profile comparisons, got ${report.comparisons.length}`,
+		);
+	const expectedFixtures = new Map(
+		manifest.cases.map((entry) => [`heldout:${entry.id}`, entry]),
+	);
+	for (const comparison of report.comparisons) {
+		if (
+			comparison.baseline_profile !== 'lexical' ||
+			!PROFILES.includes(comparison.variant_profile)
+		)
+			fail('comparison has an unsupported profile pairing');
+		if (!Number.isFinite(comparison.precision_at_k_delta) || !Number.isFinite(comparison.recall_at_k_delta))
+			fail('comparison has a non-finite paraphrase delta');
+		if (!expectedFixtures.has(comparison.fixture))
+			fail(`comparison references an unknown held-out fixture: ${comparison.fixture}`);
+	}
+	const hybridDeltas = report.comparisons.filter(
+		(comparison) => comparison.variant_profile === 'hybrid',
+	);
+	if (!hybridDeltas.some((comparison) => comparison.recall_at_k_delta > 0))
+		fail('held-out paraphrase evaluation found no positive hybrid recall delta');
+	const averageRecall = (profile: (typeof PROFILES)[number]): number => {
+		const runs = report.runs.filter((run) => run.profile === profile);
+		return runs.reduce((total, run) => total + run.metrics['recall@k'], 0) /
+			Math.max(runs.length, 1);
+	};
+	if (averageRecall('hybrid') < averageRecall('lexical'))
+		fail('hybrid aggregate recall regressed against the lexical baseline');
+	const runKeys = new Map<string, Set<string>>();
+	for (const run of report.runs) {
+		const expected = expectedFixtures.get(run.fixture);
+		if (!expected) fail(`evaluation returned an unknown held-out fixture: ${run.fixture}`);
+		if (run.query !== expected.paraphrase)
+			fail(`evaluation did not use the held-out paraphrase for ${expected.id}`);
+		if (!run.identity) fail(`evaluation row ${run.fixture} has no exact identity`);
+		if (run.scenario?.index_state !== 'not-measured' || run.scenario.graph_measurement.status !== 'unmeasured')
+			fail(`evaluation row ${run.fixture} made an unsupported graph measurement claim`);
+		const key = `${run.fixture}\u0000${run.provider}\u0000${run.mode}`;
+		const profiles = runKeys.get(key) ?? new Set<string>();
+		if (run.profile) profiles.add(run.profile);
+		runKeys.set(key, profiles);
+	}
+	for (const [key, profiles] of runKeys) {
+		for (const profile of PROFILES) {
+			if (!profiles.has(profile)) fail(`matched-resource profile set incomplete for ${key}`);
+		}
+	}
+}
+
+function enforceGraphReport(
+	manifest: HeldoutManifest,
+	report: HeldoutGraphQualityReport,
+): void {
+	if (report.schema_version !== 1 || report.corpus.split !== 'heldout')
+		fail('graph report has an unsupported schema or split');
+	if (report.corpus.id !== manifest.corpus_id)
+		fail('graph report corpus identity does not match the held-out manifest');
+	if (report.cases.length !== manifest.cases.length)
+		fail('graph report case count does not match the held-out manifest');
+	const expectedIds = new Set(manifest.cases.map((entry) => entry.id));
+	for (const entry of report.cases) {
+		if (!expectedIds.has(entry.id))
+			fail(`graph report contains an unknown case: ${entry.id}`);
+		if (entry.source.provenance !== 'direct-source')
+			fail(`graph case ${entry.id} lacks direct-source provenance`);
+		const direct = entry.paraphrase.direct_source;
+		const indexed = entry.paraphrase.indexed_control;
+		if (
+			direct.provenance !== 'direct-source-fallback' ||
+			(indexed.provenance !== 'fresh-indexed-subgraph' &&
+				indexed.provenance !== 'unavailable')
+		)
+			fail(`graph case ${entry.id} has invalid paraphrase route provenance`);
+		for (const [label, route] of [
+			['direct-source', direct],
+			['indexed-control', indexed],
+		] as const) {
+			if (typeof route.positive_hit !== 'boolean')
+				fail(`graph case ${entry.id} ${label} route has no honest positive-hit field`);
+			if ((route.status === 'complete') !== route.positive_hit)
+				fail(`graph case ${entry.id} ${label} route status contradicts positive_hit`);
+			if (route.positive_hit && route.matched_resource_count < 1)
+				fail(`graph case ${entry.id} ${label} positive hit has no matched resource`);
+			if (!route.positive_hit && !route.degradation_reason)
+				fail(`graph case ${entry.id} ${label} miss has no degradation reason`);
+		}
+		if (
+			!Number.isFinite(entry.symbols.precision) ||
+			!Number.isFinite(entry.symbols.recall) ||
+			!Number.isFinite(entry.edges.precision) ||
+			!Number.isFinite(entry.edges.recall)
+		)
+			fail(`graph case ${entry.id} has non-finite exact measurements`);
+	}
+	if (report.resource_usage.case_count !== manifest.cases.length)
+		fail('graph resource usage case count does not match the corpus');
+	if (
+		report.summary.direct_source_fallback_positive_hit_count <
+		manifest.thresholds.direct_source_positive_hits
+	)
+		fail(
+			`graph direct-source fallback positive hits ${report.summary.direct_source_fallback_positive_hit_count} are below manifest threshold ${manifest.thresholds.direct_source_positive_hits}`,
+		);
+	if (
+		report.summary.direct_source_fallback_complete_count !==
+		report.summary.direct_source_fallback_positive_hit_count
+	)
+		fail('graph direct-source completion count does not match honest positive-hit count');
+	if (
+		report.resource_usage.indexed_storage_available &&
+		report.summary.fresh_indexed_control_complete_count < 1
+	)
+		fail('graph indexed control was available but produced no complete cases');
+	for (const measurement of [report.summary.symbols, report.summary.edges]) {
+		if (
+			measurement.precision < manifest.thresholds.precision_at_k ||
+			measurement.recall < manifest.thresholds.recall_at_k
+		)
+			fail('graph aggregate exact measurements are below manifest thresholds');
+	}
+}
+
+function summarizeMemoryResourceUsage(report: RecallEvaluationReport) {
+	return PROFILES.map((profile) => {
+		const runs = report.runs.filter((run) => run.profile === profile);
+		const usage = runs.map((run) => run.resource_usage!);
+		const maximum = (field: keyof (typeof usage)[number]): number =>
+			Math.max(...usage.map((item) => item[field]));
+		return {
+			profile,
+			run_count: runs.length,
+			resource_cap: {
+				candidate_count: QUALITY_CANDIDATE_COUNT,
+				token_budget: QUALITY_TOKEN_BUDGET,
+			},
+			max_lexical_candidates: maximum('lexical_candidate_count'),
+			max_dense_candidates: maximum('dense_candidate_count'),
+			max_rerank_candidates: maximum('rerank_candidate_count'),
+			max_returned_count: maximum('returned_count'),
+			max_returned_token_estimate: maximum('returned_token_estimate'),
+		};
+	});
+}
+
+async function evaluate(): Promise<{
+	report: RecallEvaluationReport;
+	graph: HeldoutGraphQualityReport;
+	manifest: HeldoutManifest;
+}> {
+	const manifest = await loadHeldoutManifest();
+	const dependencies = createDeterministicDependencies();
+	const options = {
+		fixtureDirectory: EVALUATION_FIXTURES,
+		providers: ['sqlite'] as const,
+		modes: ['manual'] as const,
+		profiles: [...PROFILES],
+		resourceCaps: {
+			candidate_count: QUALITY_CANDIDATE_COUNT,
+			token_budget: QUALITY_TOKEN_BUDGET,
+		},
+		heldoutCorpusDirectory: CORPUS_ROOT,
+		dependencies,
+	};
+	const first = await evaluateMemoryRecallFixtures(options);
+	const second = await evaluateMemoryRecallFixtures(options);
+	const graphOptions = {
+		corpusDirectory: CORPUS_ROOT,
+		resourceCaps: {
+			max_files: 64,
+			walk_budget_ms: 1_000,
+			max_tokens: 512,
+			top_n: 5,
+		},
+	};
+	const graph = await evaluateHeldoutGraphRetrievalQuality(graphOptions);
+	const graphSecond = await evaluateHeldoutGraphRetrievalQuality(graphOptions);
+	validateRecallEvaluationManifest(first.manifest);
+	validateRecallEvaluationManifest(second.manifest);
+	const firstCanonical = JSON.stringify(canonicalize(first));
+	const secondCanonical = JSON.stringify(canonicalize(second));
+	if (firstCanonical !== secondCanonical) fail('two evaluator runs are not canonical-deterministic');
+	const firstGraphCanonical = JSON.stringify(canonicalize(graph));
+	const secondGraphCanonical = JSON.stringify(canonicalize(graphSecond));
+	if (firstGraphCanonical !== secondGraphCanonical)
+		fail('two graph evaluator runs are not canonical-deterministic');
+	enforceManifestThresholds(manifest, first);
+	enforceProfileComparisons(manifest, first);
+	enforceGraphReport(manifest, graph);
+	for (const run of first.runs) {
+		if (!run.profile || !PROFILES.includes(run.profile)) fail('evaluation omitted a requested profile');
+		if (!run.resource_cap || run.resource_cap.candidate_count !== QUALITY_CANDIDATE_COUNT || run.resource_cap.token_budget !== QUALITY_TOKEN_BUDGET) fail('resource caps drifted across profile rows');
+		const usage = run.resource_usage;
+		if (!usage) fail(`evaluation row ${run.fixture} has no resource usage`);
+		for (const [name, value] of Object.entries(usage)) {
+			if (typeof value !== 'number' || !Number.isFinite(value) || value < 0)
+				fail(`evaluation row ${run.fixture} has invalid ${name} resource usage`);
+		}
+		if (
+			usage.lexical_candidate_count > QUALITY_CANDIDATE_COUNT ||
+			usage.dense_candidate_count > QUALITY_CANDIDATE_COUNT ||
+			usage.rerank_candidate_count > QUALITY_CANDIDATE_COUNT
+		)
+			fail(`evaluation row ${run.fixture} exceeded the matched candidate cap`);
+		if (usage.returned_token_estimate > QUALITY_TOKEN_BUDGET)
+			fail(`evaluation row ${run.fixture} exceeded the returned token budget`);
+		if (!run.provenance?.trim()) fail('evaluation row has no provenance');
+		if (run.status !== 'complete' && !run.degradation_reason?.trim()) fail('degraded/skipped row has no reason');
+		if (run.profile !== 'lexical') {
+			if (run.status !== 'complete' || run.provenance !== 'injected-dense')
+				fail(`${run.profile} did not execute the deterministic injected dense path`);
+			if (usage.dense_candidate_count < 1)
+				fail(`${run.profile} reported no dense candidates`);
+		}
+		if (run.profile === 'hybrid+rerank' && usage.rerank_candidate_count < 1)
+			fail('hybrid+rerank did not execute a rerank candidate set');
+	}
+	return { report: first, graph, manifest };
+}
+
+if (import.meta.main) {
+	evaluate()
+		.then(({ report, graph, manifest }) => {
+			console.log(JSON.stringify({
+				ok: true,
+				corpus_id: manifest.corpus_id,
+				case_count: manifest.cases.length,
+				profiles: PROFILES,
+				runs: report.runs.length,
+				summary: report.summary,
+				memory_resource_usage: summarizeMemoryResourceUsage(report),
+				thresholds: manifest.thresholds,
+				comparisons: report.comparisons,
+				graph,
+				graph_direct_hit_contract: {
+					required_positive_hits: manifest.thresholds.direct_source_positive_hits,
+					observed_positive_hits:
+						graph.summary.direct_source_fallback_positive_hit_count,
+					case_count: graph.cases.length,
+				},
+				canonical: true,
+			}, null, 2));
+		})
+		.catch((error) => {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		});
+}

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadPluginConfig } from '../config/loader';
@@ -520,6 +520,15 @@ export async function handleMemoryEvaluateCommand(
 	if ('error' in parsed) return parsed.error;
 	const report = await evaluateMemoryRecallFixtures({
 		fixtureDirectory: parsed.fixtureDirectory,
+		...(parsed.profiles ? { profiles: parsed.profiles } : {}),
+		...(parsed.heldoutCorpusDirectory
+			? {
+					heldoutCorpusDirectory: parsed.heldoutCorpusDirectory,
+					providers: ['sqlite'],
+					modes: ['manual'],
+					resourceCaps: { candidate_count: 20, token_budget: 256 },
+				}
+			: {}),
 	});
 	if (parsed.json) return `${JSON.stringify(report, null, 2)}\n`;
 	return [
@@ -535,6 +544,10 @@ export async function handleMemoryEvaluateCommand(
 		`- Same-scope noise: \`${report.summary.same_scope_noise_count}\``,
 		`- Cross-scope leaks: \`${report.summary.cross_scope_leak_count}\``,
 		`- Stale memories: \`${report.summary.stale_memory_count}\``,
+		...(parsed.manifestPath ? [`- Manifest: \`${parsed.manifestPath}\``] : []),
+		...(parsed.profiles
+			? [`- Profiles: \`${parsed.profiles.join(', ')}\``]
+			: []),
 		'',
 		'Use `/swarm memory evaluate --json` for the full report.',
 	].join('\n');
@@ -622,7 +635,15 @@ function isPathWithinAnyOf(target: string, roots: string[]): boolean {
 function parseEvaluateArgs(
 	directory: string,
 	args: string[],
-): { json: boolean; fixtureDirectory: string } | { error: string } {
+):
+	| {
+			json: boolean;
+			fixtureDirectory: string;
+			profiles?: Array<'lexical' | 'hybrid' | 'hybrid+rerank'>;
+			manifestPath?: string;
+			heldoutCorpusDirectory?: string;
+	  }
+	| { error: string } {
 	let json = false;
 	let fixtureDirectory = path.join(
 		PACKAGE_ROOT,
@@ -630,6 +651,11 @@ function parseEvaluateArgs(
 		'fixtures',
 		'memory-recall',
 	);
+	let profiles: Array<'lexical' | 'hybrid' | 'hybrid+rerank'> | undefined;
+	let manifestPath: string | undefined;
+	let heldoutCorpusDirectory: string | undefined;
+	const legacyUsage =
+		'Usage: /swarm memory evaluate [--json] [--fixtures <directory>]';
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i];
 		if (arg === '--json') {
@@ -697,11 +723,107 @@ function parseEvaluateArgs(
 			i++;
 			continue;
 		}
+		if (arg === '--profiles') {
+			const next = args[i + 1];
+			if (!next) {
+				return { error: legacyUsage };
+			}
+			const allowed = new Set(['lexical', 'hybrid', 'hybrid+rerank']);
+			const requested = next
+				.split(',')
+				.map((profile) => profile.trim())
+				.filter(Boolean);
+			if (
+				requested.length === 0 ||
+				requested.some((profile) => !allowed.has(profile))
+			) {
+				return {
+					error:
+						'Usage: /swarm memory evaluate [--json] [--fixtures <directory>] [--profiles <lexical,hybrid,hybrid+rerank>] [--manifest <file>]',
+				};
+			}
+			profiles = requested as typeof profiles;
+			i++;
+			continue;
+		}
+		if (arg === '--manifest') {
+			const next = args[i + 1];
+			if (!next) {
+				return {
+					error:
+						'Usage: /swarm memory evaluate [--json] [--fixtures <directory>] [--profiles <lexical,hybrid,hybrid+rerank>] [--manifest <file>]',
+				};
+			}
+			const resolvedManifest = path.resolve(directory, next);
+			if (path.basename(resolvedManifest) !== 'manifest.json') {
+				return {
+					error:
+						'--manifest <file> must be named manifest.json; the held-out loader resolves the selected corpus directory manifest by that exact filename',
+				};
+			}
+			const projectRoot = path.resolve(directory);
+			const bundledRoot = path.join(
+				PACKAGE_ROOT,
+				'tests',
+				'fixtures',
+				'memory-recall-heldout',
+			);
+			if (!isPathWithinAnyOf(resolvedManifest, [projectRoot, bundledRoot])) {
+				return {
+					error:
+						'--manifest <file> must resolve under the project directory or the bundled tests/fixtures/memory-recall-heldout directory',
+				};
+			}
+			try {
+				manifestPath = realpathSync(resolvedManifest);
+				const realRoots = [projectRoot, bundledRoot]
+					.map((root) => {
+						try {
+							return realpathSync(root);
+						} catch {
+							return null;
+						}
+					})
+					.filter((root): root is string => root !== null);
+				if (!isPathWithinAnyOf(manifestPath, realRoots)) {
+					return {
+						error:
+							'--manifest <file> escaped the allowed roots via a symlink or non-canonical path; it must stay under the project directory or the bundled tests/fixtures/memory-recall-heldout directory',
+					};
+				}
+				const manifest = JSON.parse(
+					readFileSync(manifestPath, 'utf8'),
+				) as Record<string, unknown>;
+				const isHeldoutManifest =
+					manifest.split === 'heldout' &&
+					typeof manifest.corpus_id === 'string';
+				if (!isHeldoutManifest) {
+					return {
+						error:
+							'--manifest <file> must be a held-out corpus manifest with split=heldout',
+					};
+				}
+				heldoutCorpusDirectory = path.dirname(manifestPath);
+			} catch {
+				return {
+					error:
+						'--manifest <file> must be an existing JSON manifest inside an allowed root',
+				};
+			}
+			i++;
+			continue;
+		}
 		return {
-			error: 'Usage: /swarm memory evaluate [--json] [--fixtures <directory>]',
+			error: legacyUsage,
 		};
 	}
-	return { json, fixtureDirectory };
+	return {
+		json,
+		fixtureDirectory,
+		profiles,
+		manifestPath,
+		heldoutCorpusDirectory,
+	};
 }
 
 function parseMaintenanceArgs(

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadPluginConfig } from '../config/loader';
@@ -23,6 +23,7 @@ import {
 } from '../memory';
 import type { MemoryConfig, QLearningConfig } from '../memory/config';
 import { readConsolidationLog } from '../memory/consolidation-log';
+import { MAX_HELDOUT_MANIFEST_BYTES } from '../memory/heldout-evaluation-corpus';
 import type {
 	MemoryCompactResult,
 	MemoryProposalStore,
@@ -776,6 +777,11 @@ function parseEvaluateArgs(
 			}
 			try {
 				manifestPath = realpathSync(resolvedManifest);
+				if (statSync(manifestPath).size > MAX_HELDOUT_MANIFEST_BYTES) {
+					return {
+						error: `--manifest <file> exceeds the ${MAX_HELDOUT_MANIFEST_BYTES}-byte limit`,
+					};
+				}
 				const realRoots = [projectRoot, bundledRoot]
 					.map((root) => {
 						try {

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1890,7 +1890,7 @@ export const COMMAND_REGISTRY = {
 		handler: (ctx) => handleMemoryEvaluateCommand(ctx.directory, ctx.args),
 		description: 'Run golden Swarm memory recall evaluation fixtures',
 		subcommandOf: 'memory',
-		args: '--json, --fixtures <directory>',
+		args: '--json, --fixtures <directory>, --profiles <list>, --manifest <file>',
 		category: 'diagnostics',
 		toolPolicy: 'agent',
 	},

--- a/src/commands/tool-policy.ts
+++ b/src/commands/tool-policy.ts
@@ -188,10 +188,19 @@ export function classifySwarmCommandToolUse(
 	if (canonicalKey === 'memory evaluate') {
 		if (args.length === 0) return { allowed: true };
 		if (args.length === 1 && args[0] === '--json') return { allowed: true };
+		if (
+			args.length === 3 &&
+			args[0] === '--json' &&
+			args[1] === '--profiles' &&
+			/^(?:lexical|hybrid|hybrid\+rerank)(?:,(?:lexical|hybrid|hybrid\+rerank))*$/.test(
+				args[2],
+			)
+		)
+			return { allowed: true };
 		return {
 			allowed: false,
 			message:
-				'Usage through swarm_command: `/swarm memory evaluate --json`. Custom fixture directories are only available through direct user command execution.',
+				'Usage through swarm_command: `/swarm memory evaluate --json` or `/swarm memory evaluate --json --profiles <lexical,hybrid,hybrid+rerank>`. Custom fixtures and manifests are only available through direct user command execution.',
 		};
 	}
 

--- a/src/evaluation/index.ts
+++ b/src/evaluation/index.ts
@@ -40,6 +40,17 @@ export {
 export * from './pr-review-recovery.js';
 export * from './public-api.js';
 export * from './retention.js';
+export {
+	type AggregateExactMeasurement,
+	type ExactMeasurement,
+	evaluateHeldoutGraphRetrievalQuality,
+	type HeldoutGraphQualityCase,
+	type HeldoutGraphQualityReport,
+	type RetrievalQualityOptions,
+	type RetrievalQualityResourceCaps,
+	type RetrievalQualityStatus,
+	type RetrievalRouteMeasurement,
+} from './retrieval-quality.js';
 export type {
 	EvaluationExecutor,
 	EvaluationExecutorResult,

--- a/src/evaluation/retrieval-quality.ts
+++ b/src/evaluation/retrieval-quality.ts
@@ -21,6 +21,10 @@ import {
 import { saveGraph } from '../tools/repo-graph/storage';
 import type { RepoGraph } from '../tools/repo-graph/types';
 
+export const _internals = {
+	buildWorkspaceGraphAsync,
+};
+
 const DEFAULT_RESOURCE_CAPS = {
 	max_files: 64,
 	walk_budget_ms: 1_000,
@@ -160,13 +164,12 @@ export async function evaluateHeldoutGraphRetrievalQuality(
 	const tempRoot = await fs.realpath(
 		await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-retrieval-quality-')),
 	);
-	let graph: RepoGraph | null = null;
 	let indexedAvailable = false;
 	let indexedWorkspace: string | null = null;
 	let indexedReason: string | undefined;
 	try {
 		await materializeDisposableWorkspace(tempRoot, loaded.scenarios);
-		graph = await buildWorkspaceGraphAsync(tempRoot, {
+		const graph = await _internals.buildWorkspaceGraphAsync(tempRoot, {
 			maxFiles: caps.max_files,
 			walkBudgetMs: caps.walk_budget_ms,
 		});
@@ -188,13 +191,7 @@ export async function evaluateHeldoutGraphRetrievalQuality(
 
 		const cases = await Promise.all(
 			loaded.scenarios.map((scenario) =>
-				measureScenario(
-					scenario,
-					graph!,
-					indexedWorkspace,
-					indexedReason,
-					caps,
-				),
+				measureScenario(scenario, graph, indexedWorkspace, indexedReason, caps),
 			),
 		);
 		const degradationReasons = unique(

--- a/src/evaluation/retrieval-quality.ts
+++ b/src/evaluation/retrieval-quality.ts
@@ -1,0 +1,628 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extractFileSymbols, type FileSymbolFacts } from '../lang/symbol-graph';
+import {
+	type LoadedHeldoutRecallScenario,
+	loadHeldoutRecallEvaluationScenarios,
+} from '../memory/heldout-evaluation-corpus';
+import { buildWorkspaceGraphAsync } from '../tools/repo-graph/builder';
+import {
+	closeRepoMemory,
+	isIndexedStorageAvailable,
+	loadSubgraphForFiles,
+	queryNodeByFile,
+} from '../tools/repo-graph/indexed-storage';
+import {
+	type RetrievalResult,
+	routeRetrieval,
+} from '../tools/repo-graph/retrieval-router';
+import { saveGraph } from '../tools/repo-graph/storage';
+import type { RepoGraph } from '../tools/repo-graph/types';
+
+const DEFAULT_RESOURCE_CAPS = {
+	max_files: 64,
+	walk_budget_ms: 1_000,
+	max_tokens: 512,
+	top_n: 5,
+} as const;
+
+export interface RetrievalQualityResourceCaps {
+	max_files: number;
+	walk_budget_ms: number;
+	max_tokens: number;
+	top_n: number;
+}
+
+export interface RetrievalQualityOptions {
+	corpusDirectory: string;
+	resourceCaps?: Partial<RetrievalQualityResourceCaps>;
+	/** Test-only diagnostic escape hatch. Production callers must clean up. */
+	keepTempRoot?: boolean;
+}
+
+export type RetrievalQualityStatus = 'complete' | 'degraded' | 'skipped';
+
+export interface ExactMeasurement {
+	expected: string[];
+	observed: string[];
+	true_positive_count: number;
+	false_negative: string[];
+	false_positive: string[];
+	precision: number;
+	recall: number;
+}
+
+export interface RetrievalRouteMeasurement {
+	status: RetrievalQualityStatus;
+	provenance:
+		| 'direct-source-fallback'
+		| 'fresh-indexed-subgraph'
+		| 'unavailable';
+	degradation_reason?: string;
+	graph_hit: boolean;
+	positive_hit: boolean;
+	fallback_reason: string | null;
+	actions: string[];
+	matched_resource_count: number;
+}
+
+export interface HeldoutGraphQualityCase {
+	id: string;
+	language: string;
+	analyzer: {
+		declared_id: string | null;
+		implementation: 'extractFileSymbols';
+	};
+	source: {
+		hash: string;
+		provenance: 'direct-source';
+	};
+	status: RetrievalQualityStatus;
+	degradation_reason?: string;
+	symbols: ExactMeasurement;
+	edges: ExactMeasurement;
+	known_misses: {
+		declared: string[];
+		matching_measured_false_negatives: string[];
+	};
+	spurious_edges: {
+		declared: string[];
+		matching_measured_false_positives: string[];
+	};
+	paraphrase: {
+		query: string;
+		direct_source: RetrievalRouteMeasurement;
+		indexed_control: RetrievalRouteMeasurement;
+	};
+	latency_ms: number;
+}
+
+export interface HeldoutGraphQualityReport {
+	schema_version: 1;
+	corpus: {
+		id: string;
+		version: string | null;
+		hash: string;
+		split: 'heldout';
+	};
+	generated_at: string;
+	status: RetrievalQualityStatus;
+	degradation_reasons: string[];
+	resource_caps: RetrievalQualityResourceCaps;
+	resource_usage: {
+		case_count: number;
+		graph_node_count: number;
+		graph_edge_count: number;
+		indexed_storage_available: boolean;
+	};
+	summary: {
+		symbols: AggregateExactMeasurement;
+		edges: AggregateExactMeasurement;
+		complete_case_count: number;
+		direct_source_fallback_complete_count: number;
+		direct_source_fallback_positive_hit_count: number;
+		fresh_indexed_control_complete_count: number;
+	};
+	thresholds: Record<string, number>;
+	uncertainty: {
+		method: 'deterministic-heldout-corpus';
+		confidence: 0.95;
+		sample_count: number;
+	};
+	cases: HeldoutGraphQualityCase[];
+}
+
+export interface AggregateExactMeasurement {
+	expected_count: number;
+	observed_count: number;
+	true_positive_count: number;
+	false_negative_count: number;
+	false_positive_count: number;
+	precision: number;
+	recall: number;
+}
+
+/**
+ * Measure the repository graph and retrieval router against the immutable
+ * multilingual held-out corpus. This intentionally owns a disposable project
+ * root: graph persistence remains under that root's `.swarm/`, never beside a
+ * source fixture or a caller workspace.
+ */
+export async function evaluateHeldoutGraphRetrievalQuality(
+	options: RetrievalQualityOptions,
+): Promise<HeldoutGraphQualityReport> {
+	const loaded = await loadHeldoutRecallEvaluationScenarios(
+		options.corpusDirectory,
+	);
+	const caps = normalizeCaps(options.resourceCaps);
+	const tempRoot = await fs.realpath(
+		await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-retrieval-quality-')),
+	);
+	let graph: RepoGraph | null = null;
+	let indexedAvailable = false;
+	let indexedWorkspace: string | null = null;
+	let indexedReason: string | undefined;
+	try {
+		await materializeDisposableWorkspace(tempRoot, loaded.scenarios);
+		graph = await buildWorkspaceGraphAsync(tempRoot, {
+			maxFiles: caps.max_files,
+			walkBudgetMs: caps.walk_budget_ms,
+		});
+		indexedAvailable = isIndexedStorageAvailable();
+		if (indexedAvailable) {
+			try {
+				await saveGraph(tempRoot, graph);
+				// Parser-only corpus entries may honestly have no graph node. The
+				// index is fresh after saveGraph; node/subgraph availability is checked
+				// per case so one parser limitation cannot skip every control.
+				indexedWorkspace = tempRoot;
+			} catch (error) {
+				indexedReason = `indexed control failed: ${describeError(error)}`;
+				indexedWorkspace = null;
+			}
+		} else {
+			indexedReason = 'SQLite indexed storage is unavailable in this runtime';
+		}
+
+		const cases = await Promise.all(
+			loaded.scenarios.map((scenario) =>
+				measureScenario(
+					scenario,
+					graph!,
+					indexedWorkspace,
+					indexedReason,
+					caps,
+				),
+			),
+		);
+		const degradationReasons = unique(
+			cases.flatMap((item) =>
+				[
+					item.degradation_reason,
+					item.paraphrase.indexed_control.degradation_reason,
+				].filter((reason): reason is string => Boolean(reason)),
+			),
+		);
+		return {
+			schema_version: 1,
+			corpus: {
+				id: loaded.manifest.corpus_id,
+				version: loaded.manifest.version ?? null,
+				hash: hashCorpus(loaded.manifest, loaded.scenarios),
+				split: 'heldout',
+			},
+			generated_at: new Date().toISOString(),
+			status:
+				degradationReasons.length === 0
+					? 'complete'
+					: cases.some((item) => item.status === 'complete')
+						? 'degraded'
+						: 'skipped',
+			degradation_reasons: degradationReasons,
+			resource_caps: caps,
+			resource_usage: {
+				case_count: cases.length,
+				graph_node_count: graph.metadata.nodeCount,
+				graph_edge_count: graph.metadata.edgeCount,
+				indexed_storage_available: indexedAvailable,
+			},
+			summary: summarizeCases(cases),
+			thresholds: loaded.manifest.thresholds ?? {},
+			uncertainty: {
+				method: 'deterministic-heldout-corpus',
+				confidence: 0.95,
+				sample_count: cases.length,
+			},
+			cases,
+		};
+	} finally {
+		closeRepoMemory(tempRoot);
+		if (!options.keepTempRoot)
+			await fs.rm(tempRoot, { recursive: true, force: true });
+	}
+}
+
+async function measureScenario(
+	scenario: LoadedHeldoutRecallScenario,
+	graph: RepoGraph,
+	indexedWorkspace: string | null,
+	indexedReason: string | undefined,
+	caps: RetrievalQualityResourceCaps,
+): Promise<HeldoutGraphQualityCase> {
+	const started = Date.now();
+	const facts = await extractFileSymbols(
+		scenario.language,
+		scenario.source_text,
+	);
+	const observedSymbols = facts
+		? unique(facts.defs.map((definition) => definition.name))
+		: [];
+	const observedEdges = facts ? observedFactEdges(facts) : [];
+	const symbols = compareExact(scenario.expected_symbols, observedSymbols);
+	const expectedEdges = scenario.expected_edges.map(normalizeEdge);
+	const edges = compareExact(expectedEdges, observedEdges);
+	const directSource = await routeScenario(
+		graph,
+		scenario,
+		caps,
+		'direct-source-fallback',
+	);
+	const indexedControl = await measureIndexedControl(
+		indexedWorkspace,
+		scenario,
+		caps,
+		indexedReason,
+	);
+	const parserReason = facts
+		? undefined
+		: 'extractFileSymbols returned no facts (parser unavailable, timed out, or rejected source)';
+	return {
+		id: scenario.id,
+		language: scenario.language,
+		analyzer: {
+			declared_id: scenario.analyzer_id ?? null,
+			implementation: 'extractFileSymbols',
+		},
+		source: {
+			hash: scenario.source_hash,
+			provenance: scenario.source_provenance,
+		},
+		status: facts ? 'complete' : 'degraded',
+		...(parserReason ? { degradation_reason: parserReason } : {}),
+		symbols,
+		edges,
+		known_misses: {
+			declared: [...scenario.known_misses],
+			matching_measured_false_negatives: scenario.known_misses.filter(
+				(symbol) => symbols.false_negative.includes(symbol),
+			),
+		},
+		spurious_edges: {
+			declared: scenario.spurious_edges.map(normalizeEdge),
+			matching_measured_false_positives: scenario.spurious_edges
+				.map(normalizeEdge)
+				.filter((edge) => edges.false_positive.includes(edge)),
+		},
+		paraphrase: {
+			query: scenario.paraphrase,
+			direct_source: directSource,
+			indexed_control: indexedControl,
+		},
+		latency_ms: Math.max(0, Date.now() - started),
+	};
+}
+
+async function routeScenario(
+	graph: RepoGraph,
+	scenario: LoadedHeldoutRecallScenario,
+	caps: RetrievalQualityResourceCaps,
+	provenance: RetrievalRouteMeasurement['provenance'],
+): Promise<RetrievalRouteMeasurement> {
+	const result = await routeRetrieval(
+		provenance === 'direct-source-fallback' ? null : graph,
+		{
+			question: scenario.paraphrase,
+			// Supplying a file makes routeRetrieval prioritize that literal over the
+			// question. The direct-source benchmark deliberately exercises the
+			// paraphrase fallback, while the indexed control remains file-targeted.
+			file:
+				provenance === 'direct-source-fallback'
+					? undefined
+					: scenario.source_path,
+			maxTokens: caps.max_tokens,
+			topN: caps.top_n,
+		},
+		async (request) => lexicalDirectSource(request.query, scenario),
+		provenance === 'direct-source-fallback'
+			? 'direct source evaluation intentionally has no graph'
+			: undefined,
+	);
+	return routeMeasurement(result, provenance, scenario.paraphrase);
+}
+
+async function measureIndexedControl(
+	workspace: string | null,
+	scenario: LoadedHeldoutRecallScenario,
+	caps: RetrievalQualityResourceCaps,
+	reason: string | undefined,
+): Promise<RetrievalRouteMeasurement> {
+	if (!workspace || !scenario.source_path)
+		return unavailableRoute(reason ?? 'fresh indexed subgraph unavailable');
+	const sourcePath = path.join(workspace, scenario.source_path);
+	try {
+		if (!queryNodeByFile(workspace, sourcePath)) {
+			return unavailableRoute(
+				'fresh indexed control has no graph node for this source',
+			);
+		}
+		const subgraph = loadSubgraphForFiles(workspace, [sourcePath], 1);
+		if (!subgraph)
+			return unavailableRoute(
+				'fresh indexed subgraph was unavailable after sync',
+			);
+		return await routeScenario(
+			subgraph,
+			scenario,
+			caps,
+			'fresh-indexed-subgraph',
+		);
+	} catch (error) {
+		return unavailableRoute(`indexed control failed: ${describeError(error)}`);
+	}
+}
+
+function lexicalDirectSource(
+	query: string,
+	scenario: LoadedHeldoutRecallScenario,
+) {
+	const queryTerms = tokenize(query);
+	const source = scenario.source_text.toLowerCase();
+	const matchedTerms = queryTerms.filter((term) => source.includes(term));
+	return Promise.resolve({
+		matches:
+			matchedTerms.length > 0
+				? [{ source_path: scenario.source_path, matched_terms: matchedTerms }]
+				: [],
+		total: matchedTerms.length > 0 ? 1 : 0,
+		engine: 'heldout-direct-source-lexical-control',
+	});
+}
+
+function routeMeasurement(
+	result: RetrievalResult,
+	provenance: RetrievalRouteMeasurement['provenance'],
+	query: string,
+): RetrievalRouteMeasurement {
+	const lexicalTotal = result.context
+		.filter((item) => item.action === 'lexical_search')
+		.reduce((count, item) => {
+			const total =
+				item.data && typeof item.data === 'object'
+					? (item.data as { total?: unknown }).total
+					: undefined;
+			return count + (typeof total === 'number' && total > 0 ? total : 0);
+		}, 0);
+	const positiveHit = result.graphHit || lexicalTotal > 0;
+	return {
+		status: positiveHit ? 'complete' : 'degraded',
+		provenance,
+		...(positiveHit
+			? {}
+			: {
+					degradation_reason: `retrieval produced no match for paraphrase: ${query.slice(0, 120)}`,
+				}),
+		graph_hit: result.graphHit,
+		positive_hit: positiveHit,
+		fallback_reason: result.fallbackReason,
+		actions: result.actions,
+		matched_resource_count: result.context.length,
+	};
+}
+
+function unavailableRoute(reason: string): RetrievalRouteMeasurement {
+	return {
+		status: 'skipped',
+		provenance: 'unavailable',
+		degradation_reason: reason,
+		graph_hit: false,
+		positive_hit: false,
+		fallback_reason: reason,
+		actions: [],
+		matched_resource_count: 0,
+	};
+}
+
+async function materializeDisposableWorkspace(
+	root: string,
+	scenarios: LoadedHeldoutRecallScenario[],
+): Promise<void> {
+	await fs.mkdir(path.join(root, '.opencode'), { recursive: true });
+	await fs.writeFile(
+		path.join(root, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify({ repo_graph: { storage: 'indexed' } }),
+		'utf8',
+	);
+	for (const scenario of scenarios) {
+		if (!scenario.source_path)
+			throw new Error(`held-out case ${scenario.id} has no source path`);
+		const destination = path.resolve(root, scenario.source_path);
+		if (!isContained(root, destination))
+			throw new Error(
+				`held-out case ${scenario.id} source path escapes workspace`,
+			);
+		await fs.mkdir(path.dirname(destination), { recursive: true });
+		await fs.writeFile(destination, scenario.source_text, 'utf8');
+	}
+}
+
+function observedFactEdges(facts: FileSymbolFacts): string[] {
+	return unique(
+		facts.refs
+			.filter(
+				(reference) =>
+					reference.enclosingDecl &&
+					reference.identifier !== reference.enclosingDecl,
+			)
+			.map(
+				(reference) => `${reference.enclosingDecl} -> ${reference.identifier}`,
+			),
+	);
+}
+
+function compareExact(
+	expected: string[],
+	observed: string[],
+): ExactMeasurement {
+	const expectedSet = new Set(expected);
+	const observedSet = new Set(observed);
+	const truePositive = [...observedSet].filter((item) =>
+		expectedSet.has(item),
+	).length;
+	return {
+		expected: [...expected].sort(),
+		observed: [...observedSet].sort(),
+		true_positive_count: truePositive,
+		false_negative: [...expectedSet]
+			.filter((item) => !observedSet.has(item))
+			.sort(),
+		false_positive: [...observedSet]
+			.filter((item) => !expectedSet.has(item))
+			.sort(),
+		precision: truePositive / Math.max(observedSet.size, 1),
+		recall: truePositive / Math.max(expectedSet.size, 1),
+	};
+}
+
+function summarizeCases(
+	cases: HeldoutGraphQualityCase[],
+): HeldoutGraphQualityReport['summary'] {
+	return {
+		symbols: summarizeExact(cases.map((item) => item.symbols)),
+		edges: summarizeExact(cases.map((item) => item.edges)),
+		complete_case_count: cases.filter((item) => item.status === 'complete')
+			.length,
+		direct_source_fallback_complete_count: cases.filter(
+			(item) => item.paraphrase.direct_source.status === 'complete',
+		).length,
+		direct_source_fallback_positive_hit_count: cases.filter(
+			(item) => item.paraphrase.direct_source.positive_hit,
+		).length,
+		fresh_indexed_control_complete_count: cases.filter(
+			(item) => item.paraphrase.indexed_control.status === 'complete',
+		).length,
+	};
+}
+
+function summarizeExact(
+	measurements: ExactMeasurement[],
+): AggregateExactMeasurement {
+	const expectedCount = measurements.reduce(
+		(sum, measurement) => sum + measurement.expected.length,
+		0,
+	);
+	const observedCount = measurements.reduce(
+		(sum, measurement) => sum + measurement.observed.length,
+		0,
+	);
+	const truePositiveCount = measurements.reduce(
+		(sum, measurement) => sum + measurement.true_positive_count,
+		0,
+	);
+	const falseNegativeCount = measurements.reduce(
+		(sum, measurement) => sum + measurement.false_negative.length,
+		0,
+	);
+	const falsePositiveCount = measurements.reduce(
+		(sum, measurement) => sum + measurement.false_positive.length,
+		0,
+	);
+	return {
+		expected_count: expectedCount,
+		observed_count: observedCount,
+		true_positive_count: truePositiveCount,
+		false_negative_count: falseNegativeCount,
+		false_positive_count: falsePositiveCount,
+		precision: truePositiveCount / Math.max(observedCount, 1),
+		recall: truePositiveCount / Math.max(expectedCount, 1),
+	};
+}
+
+function normalizeEdge(edge: string | { from: string; to: string }): string {
+	if (typeof edge === 'string')
+		return edge
+			.split('->')
+			.map((part) => part.trim())
+			.join(' -> ');
+	return `${edge.from.trim()} -> ${edge.to.trim()}`;
+}
+
+function normalizeCaps(
+	input: Partial<RetrievalQualityResourceCaps> | undefined,
+): RetrievalQualityResourceCaps {
+	const bounded = (value: number | undefined, fallback: number, max: number) =>
+		Math.max(1, Math.min(max, Math.trunc(value ?? fallback)));
+	return {
+		max_files: bounded(input?.max_files, DEFAULT_RESOURCE_CAPS.max_files, 256),
+		walk_budget_ms: bounded(
+			input?.walk_budget_ms,
+			DEFAULT_RESOURCE_CAPS.walk_budget_ms,
+			10_000,
+		),
+		max_tokens: bounded(
+			input?.max_tokens,
+			DEFAULT_RESOURCE_CAPS.max_tokens,
+			4_096,
+		),
+		top_n: bounded(input?.top_n, DEFAULT_RESOURCE_CAPS.top_n, 25),
+	};
+}
+
+function hashCorpus(
+	manifest: unknown,
+	scenarios: LoadedHeldoutRecallScenario[],
+): string {
+	return createHash('sha256')
+		.update(
+			stableStringify({
+				manifest,
+				loaded_sources: scenarios.map((scenario) => ({
+					id: scenario.id,
+					source_hash: scenario.source_hash,
+					source_provenance: scenario.source_provenance,
+				})),
+			}),
+		)
+		.digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function tokenize(value: string): string[] {
+	return unique(value.toLowerCase().match(/[a-z0-9_]{3,}/g) ?? []);
+}
+
+function isContained(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error
+		? error.message.slice(0, 240)
+		: String(error).slice(0, 240);
+}

--- a/src/memory/embeddings/reranker.ts
+++ b/src/memory/embeddings/reranker.ts
@@ -11,6 +11,21 @@ export interface RerankCandidate {
 }
 
 /**
+ * The narrow reranking contract used by the SQLite retrieval pipeline.
+ * Keeping this structural makes deterministic, offline evaluation possible
+ * without making the optional transformers dependency part of the evaluator.
+ */
+export interface MemoryReranker {
+	readonly available: boolean;
+	readonly modelVersion?: string;
+	rerank<T extends RerankCandidate>(
+		candidates: T[],
+		query?: string,
+		topN?: number,
+	): Promise<T[]>;
+}
+
+/**
  * Latency gate: skip reranking when the previous recall step already
  * exceeded the caller's latency budget.
  */
@@ -31,7 +46,8 @@ export function shouldRerank(
  * Graceful degradation: if the package is missing or the model fails to
  * load, `available` is false and rerank() returns candidates unchanged.
  */
-export class CrossEncoderReranker {
+export class CrossEncoderReranker implements MemoryReranker {
+	readonly modelVersion: string;
 	private loadFailed = false;
 	private _available = false;
 	private pipeline:
@@ -39,6 +55,7 @@ export class CrossEncoderReranker {
 		| null = null;
 
 	constructor(private readonly options: { model?: string }) {
+		this.modelVersion = options.model ?? 'Xenova/ms-marco-MiniLM-L-6-v2';
 		// _available starts false; flips to true only after a successful pipeline load.
 	}
 
@@ -89,11 +106,11 @@ export class CrossEncoderReranker {
 	 * Returns the top `topN` candidates sorted descending by cross-encoder
 	 * score. If the model is unavailable, returns candidates unchanged.
 	 */
-	async rerank(
-		candidates: RerankCandidate[],
-		query: string,
+	async rerank<T extends RerankCandidate>(
+		candidates: T[],
+		query?: string,
 		topN?: number,
-	): Promise<RerankCandidate[]> {
+	): Promise<T[]> {
 		if (candidates.length === 0) return candidates;
 
 		const pipeline = await this.ensurePipeline();
@@ -101,7 +118,10 @@ export class CrossEncoderReranker {
 
 		try {
 			// Build [query, text] pairs for the cross-encoder.
-			const inputs: [string, string][] = candidates.map((c) => [query, c.text]);
+			const inputs: [string, string][] = candidates.map((c) => [
+				query ?? '',
+				c.text,
+			]);
 
 			const results: { label?: string; score?: number }[] = (await pipeline(
 				inputs,
@@ -109,10 +129,10 @@ export class CrossEncoderReranker {
 			)) as { label?: string; score?: number }[];
 
 			// Pair each candidate with its cross-encoder score.
-			const scored: RerankCandidate[] = candidates.map((c, idx) => ({
+			const scored: T[] = candidates.map((c, idx) => ({
 				...c,
 				score: results[idx]?.score ?? 0,
-			}));
+			})) as T[];
 
 			// Sort descending by score.
 			scored.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));

--- a/src/memory/evaluation.ts
+++ b/src/memory/evaluation.ts
@@ -1,8 +1,13 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { DEFAULT_MEMORY_CONFIG, type MemoryConfig } from './config';
 import { createConfiguredMemoryProvider } from './gateway';
+import {
+	type LoadedHeldoutRecallScenario,
+	loadHeldoutRecallEvaluationScenarios,
+} from './heldout-evaluation-corpus';
 import type { MemoryProvider } from './provider';
 import { evictAndClose } from './provider-pool';
 import {
@@ -13,6 +18,11 @@ import {
 	stableScopeKey,
 	validateMemoryRecordRules,
 } from './schema';
+import {
+	type MemoryRecallQualityTrace,
+	SQLiteMemoryProvider,
+	type SQLiteRetrievalDependencies,
+} from './sqlite-provider';
 import type {
 	MemoryKind,
 	MemoryRecord,
@@ -27,11 +37,84 @@ export type RecallEvaluationMode = Extract<
 	RecallMode,
 	'manual' | 'injection' | 'curator'
 >;
+export type RecallEvaluationProfile = 'lexical' | 'hybrid' | 'hybrid+rerank';
+
+export interface RecallEvaluationResourceCaps {
+	candidate_count: number;
+	token_budget: number;
+}
+
+export interface RecallEvaluationResourceUsage {
+	lexical_candidate_count: number;
+	dense_candidate_count: number;
+	rerank_candidate_count: number;
+	returned_count: number;
+	query_embedding_invocation_count: number;
+	/** Text-only estimate over actual returned records; prompt consumption is not measured here. */
+	returned_token_estimate: number;
+}
+
+export interface RecallEvaluationManifest {
+	version: '1.0.0';
+	source_id: string;
+	model_id: string;
+	provider_id: string;
+	config_hash: string;
+	corpus_hash: string;
+	profile_thresholds: Record<string, number>;
+	sample_counts: Record<string, number>;
+	metric_definitions: Record<string, string>;
+	uncertainty: { method: string; confidence: number; sample_count: number };
+	variants?: Record<string, RecallEvaluationIdentity>;
+}
+
+export interface RecallEvaluationIdentity {
+	source_id: string;
+	model_id: string;
+	provider_id: string;
+	config_hash: string;
+}
+
+export interface RecallEvaluationScenario {
+	id: string;
+	language: string;
+	analyzer_id?: string;
+	source_provenance: 'direct-source';
+	/** Graph extraction/index querying is deliberately not claimed by memory recall. */
+	index_state: 'not-measured';
+	graph_measurement: {
+		status: 'unmeasured';
+		reason: string;
+	};
+	expected_symbols: string[];
+	expected_edges: Array<string | { from: string; to: string }>;
+	known_misses: string[];
+	spurious_edges: Array<string | { from: string; to: string }>;
+}
+
+export interface RecallEvaluationComparison {
+	fixture: string;
+	provider: RecallEvaluationProviderName;
+	mode: RecallEvaluationMode;
+	baseline_profile: RecallEvaluationProfile;
+	variant_profile: RecallEvaluationProfile;
+	precision_at_k_delta: number;
+	recall_at_k_delta: number;
+	latency_ms_delta: number;
+	cost_delta: null;
+	cost_comparison: 'unavailable';
+}
 
 export interface RecallEvaluationOptions {
 	fixtureDirectory: string;
 	providers?: RecallEvaluationProviderName[];
 	modes?: RecallEvaluationMode[];
+	/** Omitted preserves the legacy provider × mode report. */
+	profiles?: RecallEvaluationProfile[];
+	/** Instance-owned offline dependencies; never used by normal agent recall. */
+	dependencies?: SQLiteRetrievalDependencies;
+	resourceCaps?: Partial<RecallEvaluationResourceCaps>;
+	heldoutCorpusDirectory?: string;
 	keepTempRoots?: boolean;
 }
 
@@ -57,6 +140,17 @@ export interface RecallEvaluationRun {
 	retrieved_ids: string[];
 	metrics: RecallEvaluationMetrics;
 	passed: boolean;
+	profile?: RecallEvaluationProfile;
+	status?: 'complete' | 'degraded' | 'skipped';
+	degradation_reason?: string;
+	provenance?: string;
+	resource_cap?: RecallEvaluationResourceCaps;
+	resource_usage?: RecallEvaluationResourceUsage;
+	latency_ms?: number;
+	cost_provenance?: string;
+	cost?: { provenance: string; amount: null };
+	identity?: RecallEvaluationIdentity;
+	scenario?: RecallEvaluationScenario;
 }
 
 export interface RecallEvaluationReport {
@@ -71,6 +165,9 @@ export interface RecallEvaluationReport {
 		passed_run_count: number;
 	};
 	runs: RecallEvaluationRun[];
+	comparisons: RecallEvaluationComparison[];
+	/** Additive contract metadata; schema_version stays v1 for legacy callers. */
+	manifest: RecallEvaluationManifest;
 }
 
 type FixtureRecordState = {
@@ -104,6 +201,8 @@ interface RecallEvaluationFixture {
 	k?: number;
 	expectedLabels: string[];
 	records: FixtureRecord[];
+	scenario?: RecallEvaluationScenario;
+	sourceHash?: string;
 }
 
 const DEFAULT_PROVIDERS: RecallEvaluationProviderName[] = [
@@ -123,46 +222,103 @@ export async function evaluateMemoryRecallFixtures(
 	const fixtureDirectory = path.resolve(options.fixtureDirectory);
 	const providers = options.providers ?? DEFAULT_PROVIDERS;
 	const modes = options.modes ?? DEFAULT_MODES;
+	const profiles = options.profiles;
+	const resourceCaps: RecallEvaluationResourceCaps = {
+		candidate_count: Math.max(
+			1,
+			Math.trunc(options.resourceCaps?.candidate_count ?? 20),
+		),
+		token_budget: Math.max(
+			1,
+			Math.trunc(options.resourceCaps?.token_budget ?? 1000),
+		),
+	};
 	const generatedAt = new Date().toISOString();
-	const fixtures = await loadRecallEvaluationFixtures(fixtureDirectory);
+	const heldout = options.heldoutCorpusDirectory
+		? await loadHeldoutRecallEvaluationScenarios(options.heldoutCorpusDirectory)
+		: undefined;
+	const fixtures = heldout
+		? heldout.scenarios.map((scenario) =>
+				materializeHeldoutScenario(scenario, heldout.scenarios),
+			)
+		: await loadRecallEvaluationFixtures(fixtureDirectory);
 	const runs: RecallEvaluationRun[] = [];
 
 	for (const fixture of fixtures) {
 		const materialized = materializeFixture(fixture);
 		for (const providerName of providers) {
-			const tempRoot = await fs.realpath(
-				await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-memory-eval-')),
-			);
-			const provider = createEvaluationProvider(providerName, tempRoot);
-			try {
-				await provider.initialize?.();
-				for (const record of materialized.records) {
-					await provider.upsert(record);
-				}
-				for (const mode of modes) {
-					const request = buildRecallRequest(fixture, mode);
-					const items = await provider.recall(request);
-					const retrievedIds = items.map((item) => item.record.id);
-					const run = buildRun({
-						fixture,
-						provider: providerName,
-						mode,
-						k: fixture.k ?? request.maxItems,
-						retrievedIds,
-						materialized,
-					});
-					runs.push(run);
-				}
-			} finally {
-				await provider.close?.();
-				if (!options.keepTempRoots) {
-					// Force-close THIS run's own pooled provider so its SQLite file
-					// handle releases before deletion, without touching any other
-					// directory's pooled entry (clearPool() would force-close every
-					// in-process caller's provider, which is unsafe from a
-					// production-reachable command like `/swarm memory evaluate`).
-					evictAndClose(tempRoot);
-					await rmTempRoot(tempRoot);
+			const runProfiles = profiles ?? [undefined];
+			// Each profile owns a fresh provider/cache. Otherwise a preceding hybrid
+			// run can prime its query embedding cache and make the next profile's
+			// latency/invocation evidence order-dependent.
+			for (const profile of runProfiles) {
+				const tempRoot = await fs.realpath(
+					await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-memory-eval-')),
+				);
+				const provider = createEvaluationProvider(
+					providerName,
+					tempRoot,
+					profile,
+					options.dependencies,
+				);
+				try {
+					await provider.initialize?.();
+					for (const record of materialized.records) {
+						await provider.upsert(record);
+					}
+					for (const mode of modes) {
+						const request = buildRecallRequest(
+							fixture,
+							mode,
+							profile ? resourceCaps : undefined,
+						);
+						if (profile)
+							request.quality = {
+								profile,
+								candidateCap: resourceCaps.candidate_count,
+							};
+						const started = Date.now();
+						const recallResult = provider.recallWithDiagnostics
+							? await provider.recallWithDiagnostics(request)
+							: { items: await provider.recall(request) };
+						const retrievedIds = recallResult.items.map(
+							(item) => item.record.id,
+						);
+						const trace = (
+							recallResult as { qualityTrace?: MemoryRecallQualityTrace }
+						).qualityTrace;
+						const run = buildRun({
+							fixture,
+							provider: providerName,
+							mode,
+							k: fixture.k ?? request.maxItems,
+							retrievedIds,
+							materialized,
+							profile,
+							resourceCaps,
+							trace,
+							latencyMs: Math.max(0, Date.now() - started),
+							identity: createRunIdentity({
+								fixture,
+								provider: providerName,
+								profile,
+								dependencies: options.dependencies,
+								resourceCaps,
+							}),
+						});
+						runs.push(run);
+					}
+				} finally {
+					await provider.close?.();
+					if (!options.keepTempRoots) {
+						// Force-close THIS run's own pooled provider so its SQLite file
+						// handle releases before deletion, without touching any other
+						// directory's pooled entry (clearPool() would force-close every
+						// in-process caller's provider, which is unsafe from a
+						// production-reachable command like `/swarm memory evaluate`).
+						evictAndClose(tempRoot);
+						await rmTempRoot(tempRoot);
+					}
 				}
 			}
 		}
@@ -176,6 +332,17 @@ export async function evaluateMemoryRecallFixtures(
 		modes,
 		summary: summarizeRuns(fixtures.length, runs),
 		runs,
+		manifest: createRecallEvaluationManifest({
+			fixtureDirectory,
+			providers,
+			profiles,
+			fixtures,
+			dependencies: options.dependencies,
+			resourceCaps,
+			heldoutCorpusId: heldout?.manifest.corpus_id,
+			minimumProfileThreshold: heldout?.manifest.thresholds?.precision_at_k,
+		}),
+		comparisons: buildProfileComparisons(runs),
 	};
 }
 
@@ -207,23 +374,96 @@ export async function loadRecallEvaluationFixtures(
 	return fixtures;
 }
 
+function materializeHeldoutScenario(
+	scenario: LoadedHeldoutRecallScenario,
+	candidateCorpus: readonly LoadedHeldoutRecallScenario[],
+): RecallEvaluationFixture {
+	const scope: MemoryScopeRef = {
+		type: 'repository',
+		repoId: 'heldout-retrieval-corpus',
+	};
+	const label = `heldout:${scenario.id}`;
+	return {
+		name: label,
+		query: scenario.paraphrase,
+		task: scenario.paraphrase,
+		scopes: [scope],
+		kinds: ['code_pattern'],
+		k: 1,
+		maxItems: 1,
+		tokenBudget: 512,
+		expectedLabels: [label],
+		// Every paraphrase ranks against the same bounded corpus. This prevents a
+		// one-record scope from turning every profile into a vacuous perfect hit.
+		records: candidateCorpus.map((candidate) => ({
+			label: `heldout:${candidate.id}`,
+			scope,
+			kind: 'code_pattern' as const,
+			// The direct source is what production recall indexes. Expected graph
+			// evidence remains report metadata, never injected into scoring text.
+			text: candidate.source_text,
+			tags: [candidate.language, candidate.analyzer_id ?? 'direct-source'],
+			confidence: 1,
+			source: { type: 'file' as const, filePath: candidate.source_path },
+			metadata: { sourceHash: candidate.source_hash },
+		})),
+		sourceHash: scenario.source_hash,
+		scenario: {
+			id: scenario.id,
+			language: scenario.language,
+			analyzer_id: scenario.analyzer_id,
+			source_provenance: scenario.source_provenance,
+			index_state: 'not-measured',
+			graph_measurement: {
+				status: 'unmeasured',
+				reason:
+					'held-out memory evaluation uses direct source retrieval; graph extraction/index controls require the repo-graph evaluator',
+			},
+			expected_symbols: scenario.expected_symbols,
+			expected_edges: scenario.expected_edges,
+			known_misses: scenario.known_misses,
+			spurious_edges: scenario.spurious_edges,
+		},
+	};
+}
+
 function createEvaluationProvider(
 	provider: RecallEvaluationProviderName,
 	root: string,
+	profile?: RecallEvaluationProfile,
+	dependencies?: SQLiteRetrievalDependencies,
 ): MemoryProvider {
 	const config: MemoryConfig = {
 		...DEFAULT_MEMORY_CONFIG,
 		enabled: true,
 		provider,
+		embeddings: {
+			...DEFAULT_MEMORY_CONFIG.embeddings,
+			enabled: profile === 'hybrid' || profile === 'hybrid+rerank',
+		},
+		retrieval: {
+			...DEFAULT_MEMORY_CONFIG.retrieval,
+			rerank: {
+				...DEFAULT_MEMORY_CONFIG.retrieval.rerank,
+				enabled: profile === 'hybrid+rerank',
+			},
+		},
 	};
+	if (provider === 'sqlite' && profile) {
+		return new SQLiteMemoryProvider(root, config, undefined, dependencies);
+	}
 	return createConfiguredMemoryProvider(root, config);
 }
 
 function buildRecallRequest(
 	fixture: RecallEvaluationFixture,
 	mode: RecallEvaluationMode,
+	resourceCaps?: RecallEvaluationResourceCaps,
 ): RecallRequest {
-	const maxItems = fixture.maxItems ?? fixture.k ?? 5;
+	const maxItems = Math.min(
+		resourceCaps?.candidate_count ?? 5,
+		fixture.maxItems ?? fixture.k ?? 5,
+	);
 	const base: RecallRequest = {
 		query: fixture.query,
 		task: fixture.task,
@@ -232,7 +472,10 @@ function buildRecallRequest(
 		scopes: fixture.scopes,
 		kinds: fixture.kinds,
 		maxItems,
-		tokenBudget: fixture.tokenBudget ?? 1000,
+		tokenBudget: Math.min(
+			resourceCaps?.token_budget ?? 1000,
+			fixture.tokenBudget ?? 1000,
+		),
 		minScore: mode === 'injection' ? 0.25 : 0,
 		requireQuerySignal: mode === 'injection',
 	};
@@ -338,8 +581,25 @@ function buildRun(args: {
 	k: number;
 	retrievedIds: string[];
 	materialized: ReturnType<typeof materializeFixture>;
+	profile?: RecallEvaluationProfile;
+	resourceCaps: RecallEvaluationResourceCaps;
+	trace?: MemoryRecallQualityTrace;
+	latencyMs: number;
+	identity: RecallEvaluationIdentity;
 }): RecallEvaluationRun {
-	const { fixture, provider, mode, k, retrievedIds, materialized } = args;
+	const {
+		fixture,
+		provider,
+		mode,
+		k,
+		retrievedIds,
+		materialized,
+		profile,
+		resourceCaps,
+		trace,
+		latencyMs,
+		identity,
+	} = args;
 	const topK = retrievedIds.slice(0, k);
 	const relevantAtK = topK.filter((id) =>
 		materialized.expectedIds.has(id),
@@ -367,7 +627,7 @@ function buildRun(args: {
 		cross_scope_leak_count: crossScopeLeakCount,
 		stale_memory_count: staleMemoryCount,
 	};
-	return {
+	const base: RecallEvaluationRun = {
 		fixture: fixture.name,
 		provider,
 		mode,
@@ -388,6 +648,326 @@ function buildRun(args: {
 			metrics.cross_scope_leak_count === 0 &&
 			metrics.stale_memory_count === 0,
 	};
+	if (!profile) return base;
+	const status =
+		provider !== 'sqlite' && profile !== 'lexical'
+			? ('skipped' as const)
+			: (trace?.status ??
+				(profile === 'lexical'
+					? ('complete' as const)
+					: ('degraded' as const)));
+	return {
+		...base,
+		profile,
+		status,
+		...(status === 'complete'
+			? {}
+			: {
+					degradation_reason:
+						trace?.degradationReason ??
+						(provider !== 'sqlite'
+							? 'profile requires sqlite provider'
+							: 'retrieval component unavailable'),
+				}),
+		provenance:
+			trace?.provenance ?? (profile === 'lexical' ? 'lexical' : 'unavailable'),
+		resource_cap: resourceCaps,
+		resource_usage: normalizeResourceUsage(trace?.resourceUsage),
+		latency_ms: Number.isFinite(trace?.latencyMs)
+			? trace!.latencyMs
+			: latencyMs,
+		cost_provenance: 'offline-deterministic-unavailable',
+		cost: { provenance: 'offline-deterministic-unavailable', amount: null },
+		identity,
+		...(fixture.scenario ? { scenario: fixture.scenario } : {}),
+	};
+}
+
+function normalizeResourceUsage(
+	usage: MemoryRecallQualityTrace['resourceUsage'] | undefined,
+): RecallEvaluationResourceUsage | undefined {
+	if (!usage) return undefined;
+	const candidate = usage;
+	const bounded = (value: number): number =>
+		Number.isFinite(value) ? Math.max(0, value) : 0;
+	return {
+		lexical_candidate_count: bounded(candidate.lexical_candidate_count),
+		dense_candidate_count: bounded(candidate.dense_candidate_count),
+		rerank_candidate_count: bounded(candidate.rerank_candidate_count),
+		returned_count: bounded(candidate.returned_count),
+		query_embedding_invocation_count: bounded(
+			candidate.query_embedding_invocation_count,
+		),
+		returned_token_estimate: bounded(candidate.returned_token_estimate),
+	};
+}
+
+function createRecallEvaluationManifest(args: {
+	fixtureDirectory: string;
+	providers: RecallEvaluationProviderName[];
+	profiles?: RecallEvaluationProfile[];
+	fixtures: RecallEvaluationFixture[];
+	dependencies?: SQLiteRetrievalDependencies;
+	resourceCaps: RecallEvaluationResourceCaps;
+	heldoutCorpusId?: string;
+	minimumProfileThreshold?: number;
+}): RecallEvaluationManifest {
+	const corpusHash = createHash('sha256')
+		.update(stableStringify(args.fixtures))
+		.digest('hex');
+	const configHash = createHash('sha256')
+		.update(
+			stableStringify({
+				providers: args.providers,
+				profiles: args.profiles ?? ['legacy'],
+				resourceCaps: args.resourceCaps,
+				embeddingModel:
+					args.dependencies?.embeddingProvider?.modelVersion ?? 'disabled',
+				rerankerModel: args.dependencies?.reranker?.modelVersion ?? 'disabled',
+			}),
+		)
+		.digest('hex');
+	return {
+		version: '1.0.0',
+		source_id: args.heldoutCorpusId
+			? `heldout:${args.heldoutCorpusId}`
+			: `fixtures:${corpusHash}`,
+		model_id:
+			args.profiles?.includes('hybrid') ||
+			args.profiles?.includes('hybrid+rerank')
+				? (args.dependencies?.embeddingProvider?.modelVersion ??
+					'configured-embedding')
+				: 'none',
+		provider_id: `providers:${args.providers.join(',')}`,
+		config_hash: configHash,
+		corpus_hash: corpusHash,
+		profile_thresholds: Object.fromEntries(
+			(args.profiles ?? ['lexical']).map((profile) => [
+				profile,
+				typeof args.minimumProfileThreshold === 'number' &&
+				Number.isFinite(args.minimumProfileThreshold) &&
+				args.minimumProfileThreshold > 0
+					? args.minimumProfileThreshold
+					: 0.01,
+			]),
+		),
+		sample_counts: { total: args.fixtures.length },
+		metric_definitions: { precision: 'precision@k', recall: 'recall@k' },
+		uncertainty: {
+			method: 'deterministic-fixture',
+			confidence: 0.95,
+			sample_count: args.fixtures.length,
+		},
+		variants: Object.fromEntries(
+			(args.profiles ?? ['lexical']).map((profile) => [
+				profile,
+				{
+					source_id: args.heldoutCorpusId
+						? `heldout:${args.heldoutCorpusId}`
+						: `fixtures:${corpusHash}`,
+					model_id:
+						profile === 'lexical'
+							? 'none'
+							: (args.dependencies?.embeddingProvider?.modelVersion ??
+								'configured-embedding'),
+					provider_id: `profiles:${profile};providers:${args.providers.join(',')}`,
+					config_hash: createHash('sha256')
+						.update(
+							stableStringify({ profile, resourceCaps: args.resourceCaps }),
+						)
+						.digest('hex'),
+				},
+			]),
+		),
+	};
+}
+
+function createRunIdentity(args: {
+	fixture: RecallEvaluationFixture;
+	provider: RecallEvaluationProviderName;
+	profile?: RecallEvaluationProfile;
+	dependencies?: SQLiteRetrievalDependencies;
+	resourceCaps: RecallEvaluationResourceCaps;
+}): RecallEvaluationIdentity {
+	const profile = args.profile ?? 'legacy';
+	const sourceId = args.fixture.scenario
+		? `source:${args.fixture.scenario.id}:${args.fixture.sourceHash}`
+		: `fixture:${args.fixture.name}:${createHash('sha256').update(args.fixture.query).digest('hex')}`;
+	return {
+		source_id: sourceId,
+		model_id:
+			profile === 'lexical'
+				? 'none'
+				: (args.dependencies?.embeddingProvider?.modelVersion ??
+					'configured-embedding'),
+		provider_id: args.provider,
+		config_hash: createHash('sha256')
+			.update(
+				stableStringify({
+					profile,
+					resourceCaps: args.resourceCaps,
+					model:
+						args.dependencies?.embeddingProvider?.modelVersion ?? 'configured',
+					reranker: args.dependencies?.reranker?.modelVersion ?? 'disabled',
+				}),
+			)
+			.digest('hex'),
+	};
+}
+
+function buildProfileComparisons(
+	runs: RecallEvaluationRun[],
+): RecallEvaluationComparison[] {
+	const groups = new Map<string, RecallEvaluationRun[]>();
+	for (const run of runs) {
+		if (!run.profile) continue;
+		const key = `${run.fixture}\u0000${run.provider}\u0000${run.mode}`;
+		const group = groups.get(key) ?? [];
+		group.push(run);
+		groups.set(key, group);
+	}
+	const comparisons: RecallEvaluationComparison[] = [];
+	for (const group of groups.values()) {
+		const baseline = group.find((run) => run.profile === 'lexical');
+		if (!baseline) continue;
+		for (const variant of group) {
+			if (variant === baseline || !variant.profile) continue;
+			comparisons.push({
+				fixture: baseline.fixture,
+				provider: baseline.provider,
+				mode: baseline.mode,
+				baseline_profile: 'lexical',
+				variant_profile: variant.profile,
+				precision_at_k_delta:
+					variant.metrics['precision@k'] - baseline.metrics['precision@k'],
+				recall_at_k_delta:
+					variant.metrics['recall@k'] - baseline.metrics['recall@k'],
+				latency_ms_delta:
+					(variant.latency_ms ?? 0) - (baseline.latency_ms ?? 0),
+				cost_delta: null,
+				cost_comparison: 'unavailable',
+			});
+		}
+	}
+	return comparisons.sort((a, b) =>
+		`${a.fixture}:${a.variant_profile}`.localeCompare(
+			`${b.fixture}:${b.variant_profile}`,
+		),
+	);
+}
+
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+	if (value && typeof value === 'object') {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+			.join(',')}}`;
+	}
+	return JSON.stringify(value);
+}
+
+/** Strict, filesystem-independent report metadata validation. */
+export function validateRecallEvaluationManifest(
+	value: unknown,
+): asserts value is RecallEvaluationManifest {
+	if (!value || typeof value !== 'object')
+		throw new Error('recall evaluation manifest must be an object');
+	const manifest = value as Record<string, unknown>;
+	if (manifest.version !== '1.0.0')
+		throw new Error('recall evaluation manifest has unsupported version');
+	for (const key of ['source_id', 'model_id', 'provider_id'] as const) {
+		if (typeof manifest[key] !== 'string' || !manifest[key].trim())
+			throw new Error(`recall evaluation manifest has invalid ${key}`);
+	}
+	for (const key of ['config_hash', 'corpus_hash'] as const) {
+		if (
+			typeof manifest[key] !== 'string' ||
+			!/^[a-f0-9]{64}$/i.test(manifest[key])
+		)
+			throw new Error(`recall evaluation manifest has invalid ${key}`);
+	}
+	for (const key of [
+		'profile_thresholds',
+		'sample_counts',
+		'metric_definitions',
+	] as const) {
+		const record = manifest[key];
+		if (
+			!record ||
+			typeof record !== 'object' ||
+			Array.isArray(record) ||
+			Object.keys(record as object).length === 0
+		)
+			throw new Error(`recall evaluation manifest has invalid ${key}`);
+	}
+	if (
+		Object.values(manifest.profile_thresholds as Record<string, unknown>).some(
+			(v) => typeof v !== 'number' || !Number.isFinite(v) || v <= 0,
+		)
+	)
+		throw new Error(
+			'recall evaluation manifest has invalid profile_thresholds',
+		);
+	if (
+		Object.values(manifest.sample_counts as Record<string, unknown>).some(
+			(v) => typeof v !== 'number' || !Number.isInteger(v) || v <= 0,
+		)
+	)
+		throw new Error('recall evaluation manifest has invalid sample_counts');
+	if (
+		Object.values(manifest.metric_definitions as Record<string, unknown>).some(
+			(v) => typeof v !== 'string' || !v.trim(),
+		)
+	)
+		throw new Error(
+			'recall evaluation manifest has invalid metric_definitions',
+		);
+	const uncertainty = manifest.uncertainty as
+		| Record<string, unknown>
+		| undefined;
+	if (
+		!uncertainty ||
+		typeof uncertainty.method !== 'string' ||
+		!uncertainty.method.trim() ||
+		typeof uncertainty.confidence !== 'number' ||
+		!(uncertainty.confidence > 0 && uncertainty.confidence <= 1) ||
+		typeof uncertainty.sample_count !== 'number' ||
+		!Number.isInteger(uncertainty.sample_count) ||
+		uncertainty.sample_count <= 0
+	)
+		throw new Error('recall evaluation manifest has invalid uncertainty');
+	if (manifest.variants !== undefined) {
+		if (
+			!manifest.variants ||
+			typeof manifest.variants !== 'object' ||
+			Array.isArray(manifest.variants) ||
+			Object.keys(manifest.variants as object).length === 0
+		)
+			throw new Error('recall evaluation manifest has invalid variants');
+		for (const [name, identity] of Object.entries(
+			manifest.variants as Record<string, unknown>,
+		)) {
+			if (!name.trim() || !identity || typeof identity !== 'object')
+				throw new Error(
+					'recall evaluation manifest has invalid variant identity',
+				);
+			const candidate = identity as Record<string, unknown>;
+			for (const key of ['source_id', 'model_id', 'provider_id'] as const) {
+				if (typeof candidate[key] !== 'string' || !candidate[key].trim())
+					throw new Error(
+						'recall evaluation manifest has invalid variant identity',
+					);
+			}
+			if (
+				typeof candidate.config_hash !== 'string' ||
+				!/^[a-f0-9]{64}$/i.test(candidate.config_hash)
+			)
+				throw new Error(
+					'recall evaluation manifest has invalid variant identity',
+				);
+		}
+	}
 }
 
 function summarizeRuns(

--- a/src/memory/evaluation.ts
+++ b/src/memory/evaluation.ts
@@ -238,9 +238,17 @@ export async function evaluateMemoryRecallFixtures(
 		? await loadHeldoutRecallEvaluationScenarios(options.heldoutCorpusDirectory)
 		: undefined;
 	const fixtures = heldout
-		? heldout.scenarios.map((scenario) =>
-				materializeHeldoutScenario(scenario, heldout.scenarios),
-			)
+		? (() => {
+				// The candidate corpus is identical for every held-out scenario. Build
+				// these immutable fixture records once instead of remapping the full
+				// corpus for every scenario (the corpus itself remains bounded).
+				const candidateRecords = materializeHeldoutCandidateRecords(
+					heldout.scenarios,
+				);
+				return heldout.scenarios.map((scenario) =>
+					materializeHeldoutScenario(scenario, candidateRecords),
+				);
+			})()
 		: await loadRecallEvaluationFixtures(fixtureDirectory);
 	const runs: RecallEvaluationRun[] = [];
 
@@ -376,7 +384,7 @@ export async function loadRecallEvaluationFixtures(
 
 function materializeHeldoutScenario(
 	scenario: LoadedHeldoutRecallScenario,
-	candidateCorpus: readonly LoadedHeldoutRecallScenario[],
+	candidateRecords: readonly FixtureRecord[],
 ): RecallEvaluationFixture {
 	const scope: MemoryScopeRef = {
 		type: 'repository',
@@ -395,18 +403,7 @@ function materializeHeldoutScenario(
 		expectedLabels: [label],
 		// Every paraphrase ranks against the same bounded corpus. This prevents a
 		// one-record scope from turning every profile into a vacuous perfect hit.
-		records: candidateCorpus.map((candidate) => ({
-			label: `heldout:${candidate.id}`,
-			scope,
-			kind: 'code_pattern' as const,
-			// The direct source is what production recall indexes. Expected graph
-			// evidence remains report metadata, never injected into scoring text.
-			text: candidate.source_text,
-			tags: [candidate.language, candidate.analyzer_id ?? 'direct-source'],
-			confidence: 1,
-			source: { type: 'file' as const, filePath: candidate.source_path },
-			metadata: { sourceHash: candidate.source_hash },
-		})),
+		records: [...candidateRecords],
 		sourceHash: scenario.source_hash,
 		scenario: {
 			id: scenario.id,
@@ -425,6 +422,27 @@ function materializeHeldoutScenario(
 			spurious_edges: scenario.spurious_edges,
 		},
 	};
+}
+
+function materializeHeldoutCandidateRecords(
+	candidateCorpus: readonly LoadedHeldoutRecallScenario[],
+): FixtureRecord[] {
+	const scope: MemoryScopeRef = {
+		type: 'repository',
+		repoId: 'heldout-retrieval-corpus',
+	};
+	return candidateCorpus.map((candidate) => ({
+		label: `heldout:${candidate.id}`,
+		scope,
+		kind: 'code_pattern' as const,
+		// The direct source is what production recall indexes. Expected graph
+		// evidence remains report metadata, never injected into scoring text.
+		text: candidate.source_text,
+		tags: [candidate.language, candidate.analyzer_id ?? 'direct-source'],
+		confidence: 1,
+		source: { type: 'file' as const, filePath: candidate.source_path },
+		metadata: { sourceHash: candidate.source_hash },
+	}));
 }
 
 function createEvaluationProvider(
@@ -674,7 +692,7 @@ function buildRun(args: {
 		resource_cap: resourceCaps,
 		resource_usage: normalizeResourceUsage(trace?.resourceUsage),
 		latency_ms: Number.isFinite(trace?.latencyMs)
-			? trace!.latencyMs
+			? (trace?.latencyMs ?? latencyMs)
 			: latencyMs,
 		cost_provenance: 'offline-deterministic-unavailable',
 		cost: { provenance: 'offline-deterministic-unavailable', amount: null },

--- a/src/memory/heldout-evaluation-corpus.ts
+++ b/src/memory/heldout-evaluation-corpus.ts
@@ -1,0 +1,240 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+const MAX_CORPUS_CASES = 256;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_SOURCE_BYTES = 1024 * 1024;
+const MAX_TOTAL_SOURCE_BYTES = 4 * 1024 * 1024;
+
+export interface HeldoutRecallCorpusCase {
+	id?: string;
+	language: string;
+	expected_symbols: string[];
+	expected_edges: Array<string | { from: string; to: string }>;
+	known_misses: string[];
+	spurious_edges: Array<string | { from: string; to: string }>;
+	paraphrase: string;
+	source_path?: string;
+	content_hash?: string;
+	analyzer_id?: string;
+}
+
+export interface HeldoutRecallCorpusManifest {
+	corpus_id: string;
+	split: 'heldout';
+	version?: string;
+	thresholds?: Record<string, number>;
+	cases: HeldoutRecallCorpusCase[];
+}
+
+export interface LoadedHeldoutRecallScenario extends HeldoutRecallCorpusCase {
+	id: string;
+	source_text: string;
+	source_hash: string;
+	source_provenance: 'direct-source';
+}
+
+/**
+ * Validate the data contract only. Filesystem membership, safe paths, byte
+ * caps, and source hashes are intentionally enforced by the loader below.
+ */
+export function validateHeldoutRecallCorpusManifest(
+	value: unknown,
+): asserts value is HeldoutRecallCorpusManifest {
+	if (!value || typeof value !== 'object')
+		throw new Error('held-out corpus manifest must be an object');
+	const manifest = value as Record<string, unknown>;
+	if (typeof manifest.corpus_id !== 'string' || !manifest.corpus_id.trim())
+		throw new Error('held-out corpus manifest requires corpus_id');
+	if (manifest.split !== 'heldout')
+		throw new Error('held-out corpus manifest requires heldout split');
+	if (
+		manifest.version !== undefined &&
+		(typeof manifest.version !== 'string' || !manifest.version.trim())
+	)
+		throw new Error('held-out corpus manifest has invalid version');
+	if (manifest.thresholds !== undefined) {
+		if (
+			!manifest.thresholds ||
+			typeof manifest.thresholds !== 'object' ||
+			Array.isArray(manifest.thresholds) ||
+			Object.keys(manifest.thresholds as object).length === 0
+		)
+			throw new Error('held-out corpus manifest has invalid thresholds');
+		for (const [name, threshold] of Object.entries(
+			manifest.thresholds as Record<string, unknown>,
+		)) {
+			if (
+				!name.trim() ||
+				typeof threshold !== 'number' ||
+				!Number.isFinite(threshold)
+			)
+				throw new Error('held-out corpus manifest has invalid thresholds');
+		}
+	}
+	if (
+		!Array.isArray(manifest.cases) ||
+		manifest.cases.length === 0 ||
+		manifest.cases.length > MAX_CORPUS_CASES
+	)
+		throw new Error('held-out corpus manifest has invalid cases');
+	const sourcePaths = new Set<string>();
+	const caseIds = new Set<string>();
+	for (const [index, entry] of manifest.cases.entries()) {
+		if (!entry || typeof entry !== 'object')
+			throw new Error(`held-out corpus case ${index} must be an object`);
+		const item = entry as Record<string, unknown>;
+		for (const key of ['language', 'paraphrase'] as const) {
+			if (typeof item[key] !== 'string' || !item[key].trim())
+				throw new Error(`held-out corpus case ${index} has invalid ${key}`);
+		}
+		for (const key of ['expected_symbols', 'known_misses'] as const) {
+			if (
+				!Array.isArray(item[key]) ||
+				item[key].length === 0 ||
+				item[key].some(
+					(element) => typeof element !== 'string' || !element.trim(),
+				)
+			)
+				throw new Error(`held-out corpus case ${index} has invalid ${key}`);
+		}
+		for (const key of ['expected_edges', 'spurious_edges'] as const) {
+			if (
+				!Array.isArray(item[key]) ||
+				item[key].length === 0 ||
+				item[key].some((edge) => !isValidEdge(edge))
+			)
+				throw new Error(`held-out corpus case ${index} has invalid ${key}`);
+		}
+		for (const key of ['id', 'analyzer_id'] as const) {
+			if (
+				item[key] !== undefined &&
+				(typeof item[key] !== 'string' || !item[key].trim())
+			)
+				throw new Error(`held-out corpus case ${index} has invalid ${key}`);
+		}
+		const scenarioId =
+			typeof item.id === 'string' ? item.id : `${item.language}-${index + 1}`;
+		if (caseIds.has(scenarioId))
+			throw new Error(`held-out corpus case ${index} duplicates id`);
+		caseIds.add(scenarioId);
+		if (
+			item.source_path !== undefined &&
+			(typeof item.source_path !== 'string' || !item.source_path.trim())
+		)
+			throw new Error(`held-out corpus case ${index} has invalid source_path`);
+		if (
+			item.content_hash !== undefined &&
+			(typeof item.content_hash !== 'string' ||
+				!/^[a-f0-9]{64}$/i.test(item.content_hash))
+		)
+			throw new Error(`held-out corpus case ${index} has invalid content_hash`);
+		if (typeof item.source_path === 'string') {
+			if (sourcePaths.has(item.source_path))
+				throw new Error(`held-out corpus case ${index} duplicates source_path`);
+			sourcePaths.add(item.source_path);
+		}
+	}
+}
+
+function isValidEdge(value: unknown): boolean {
+	if (typeof value === 'string') return Boolean(value.trim());
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const edge = value as Record<string, unknown>;
+	return (
+		typeof edge.from === 'string' &&
+		Boolean(edge.from.trim()) &&
+		typeof edge.to === 'string' &&
+		Boolean(edge.to.trim())
+	);
+}
+
+/**
+ * Hash source text after canonicalizing all supported line endings. This keeps
+ * corpus identity stable when a checked-out fixture is rewritten as CRLF or
+ * lone-CR text by a platform or editor.
+ */
+function computeCanonicalSourceHash(source: Buffer): string {
+	return createHash('sha256')
+		.update(source.toString('utf8').replace(/\r\n?|\n/g, '\n'))
+		.digest('hex');
+}
+
+/**
+ * Bounded filesystem boundary for held-out corpora. It does not recurse, and
+ * every optional source file must remain inside the supplied corpus root.
+ */
+export async function loadHeldoutRecallEvaluationCorpus(
+	corpusDirectory: string,
+): Promise<HeldoutRecallCorpusManifest> {
+	return (await loadHeldoutRecallEvaluationScenarios(corpusDirectory)).manifest;
+}
+
+/**
+ * Bounded direct-source scenarios for production retrieval evaluation. This
+ * loader validates corpus membership and content hashes; it never scores or
+ * manufactures analyzer results.
+ */
+export async function loadHeldoutRecallEvaluationScenarios(
+	corpusDirectory: string,
+): Promise<{
+	manifest: HeldoutRecallCorpusManifest;
+	scenarios: LoadedHeldoutRecallScenario[];
+}> {
+	const root = await fs.realpath(path.resolve(corpusDirectory));
+	const manifestPath = await fs.realpath(path.join(root, 'manifest.json'));
+	const manifestRelative = path.relative(root, manifestPath);
+	if (manifestRelative.startsWith('..') || path.isAbsolute(manifestRelative))
+		throw new Error('held-out corpus manifest path escapes corpus root');
+	const stat = await fs.stat(manifestPath);
+	if (!stat.isFile())
+		throw new Error('held-out corpus manifest must be a regular file');
+	if (stat.size > MAX_MANIFEST_BYTES)
+		throw new Error('held-out corpus manifest exceeds byte limit');
+	const manifest = JSON.parse(
+		await fs.readFile(manifestPath, 'utf8'),
+	) as unknown;
+	validateHeldoutRecallCorpusManifest(manifest);
+	let totalSourceBytes = 0;
+	const scenarios: LoadedHeldoutRecallScenario[] = [];
+	for (const [index, entry] of manifest.cases.entries()) {
+		if (!entry.source_path || !entry.content_hash)
+			throw new Error(
+				'held-out corpus source cases require source_path and content_hash',
+			);
+		const sourceCandidate = path.resolve(root, entry.source_path);
+		const candidateRelative = path.relative(root, sourceCandidate);
+		if (
+			candidateRelative.startsWith('..') ||
+			path.isAbsolute(candidateRelative)
+		)
+			throw new Error('held-out corpus source path escapes corpus root');
+		const sourcePath = await fs.realpath(sourceCandidate);
+		const relative = path.relative(root, sourcePath);
+		if (relative.startsWith('..') || path.isAbsolute(relative))
+			throw new Error('held-out corpus source path escapes corpus root');
+		const sourceStat = await fs.stat(sourcePath);
+		if (!sourceStat.isFile())
+			throw new Error('held-out corpus source must be a regular file');
+		if (sourceStat.size > MAX_SOURCE_BYTES)
+			throw new Error('held-out corpus source exceeds byte limit');
+		totalSourceBytes += sourceStat.size;
+		if (totalSourceBytes > MAX_TOTAL_SOURCE_BYTES)
+			throw new Error('held-out corpus sources exceed aggregate byte limit');
+		const source = await fs.readFile(sourcePath);
+		const sourceHash = computeCanonicalSourceHash(source);
+		if (entry.content_hash && sourceHash !== entry.content_hash.toLowerCase())
+			throw new Error(
+				`held-out corpus source hash mismatch: ${entry.source_path}`,
+			);
+		scenarios.push({
+			...entry,
+			id: entry.id ?? `${entry.language}-${index + 1}`,
+			source_text: source.toString('utf8'),
+			source_hash: sourceHash,
+			source_provenance: 'direct-source',
+		});
+	}
+	return { manifest, scenarios };
+}

--- a/src/memory/heldout-evaluation-corpus.ts
+++ b/src/memory/heldout-evaluation-corpus.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 const MAX_CORPUS_CASES = 256;
-const MAX_MANIFEST_BYTES = 1024 * 1024;
+export const MAX_HELDOUT_MANIFEST_BYTES = 1024 * 1024;
 const MAX_SOURCE_BYTES = 1024 * 1024;
 const MAX_TOTAL_SOURCE_BYTES = 4 * 1024 * 1024;
 
@@ -190,7 +190,7 @@ export async function loadHeldoutRecallEvaluationScenarios(
 	const stat = await fs.stat(manifestPath);
 	if (!stat.isFile())
 		throw new Error('held-out corpus manifest must be a regular file');
-	if (stat.size > MAX_MANIFEST_BYTES)
+	if (stat.size > MAX_HELDOUT_MANIFEST_BYTES)
 		throw new Error('held-out corpus manifest exceeds byte limit');
 	const manifest = JSON.parse(
 		await fs.readFile(manifestPath, 'utf8'),

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,5 +1,6 @@
 export type { MemoryConfig } from './config';
 export { DEFAULT_MEMORY_CONFIG, resolveMemoryConfig } from './config';
+export type { MemoryReranker, RerankCandidate } from './embeddings/reranker';
 export {
 	MemoryDisabledError,
 	MemoryPiiDetectorError,
@@ -8,12 +9,20 @@ export {
 export {
 	evaluateMemoryRecallFixtures,
 	loadRecallEvaluationFixtures,
+	type RecallEvaluationComparison,
+	type RecallEvaluationIdentity,
+	type RecallEvaluationManifest,
 	type RecallEvaluationMetrics,
 	type RecallEvaluationMode,
 	type RecallEvaluationOptions,
+	type RecallEvaluationProfile,
 	type RecallEvaluationProviderName,
 	type RecallEvaluationReport,
+	type RecallEvaluationResourceCaps,
+	type RecallEvaluationResourceUsage,
 	type RecallEvaluationRun,
+	type RecallEvaluationScenario,
+	validateRecallEvaluationManifest,
 } from './evaluation';
 export type {
 	MemoryGatewayOptions,
@@ -27,6 +36,14 @@ export {
 	createMemoryGateway,
 	MemoryGateway,
 } from './gateway';
+export {
+	type HeldoutRecallCorpusCase,
+	type HeldoutRecallCorpusManifest,
+	type LoadedHeldoutRecallScenario,
+	loadHeldoutRecallEvaluationCorpus,
+	loadHeldoutRecallEvaluationScenarios,
+	validateHeldoutRecallCorpusManifest,
+} from './heldout-evaluation-corpus';
 export {
 	createMemoryLifecycleHooks,
 	type MemoryLifecycleHookOptions,
@@ -129,6 +146,10 @@ export {
 	validateMemoryProposal,
 	validateMemoryRecordRules,
 } from './schema';
+export type {
+	MemoryRecallQualityTrace,
+	SQLiteRetrievalDependencies,
+} from './sqlite-provider';
 export {
 	EVENT_CHAIN_GENESIS,
 	MEMORY_EVENTS_CHAIN_HEAD_KEY,
@@ -164,6 +185,7 @@ export type {
 	RecallBundle,
 	RecallInjectionSkipReason,
 	RecallMode,
+	RecallQualityProfile,
 	RecallRequest,
 	RecallResultItem,
 	ResolvedCuratorMemoryDecision,

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -319,6 +319,9 @@ function capQualityRecallItemsByTokenBudget(
 	let tokenEstimate = 0;
 	for (const item of items) {
 		const itemTokens = estimateTokens(item.record.text);
+		// This is an order-preserving greedy packer. Skip an oversized candidate
+		// so a later, smaller ranked candidate can still fit in the budget; the
+		// evaluator reports the resulting returned-token estimate explicitly.
 		if (tokenEstimate + itemTokens > boundedTokenBudget) continue;
 		selected.push(item);
 		tokenEstimate += itemTokens;
@@ -4185,4 +4188,5 @@ export const _test_exports = {
 	extractFtsTerms,
 	FTS_SCHEMA_MIGRATION_NAME,
 	FTS_SCHEMA_MIGRATION_VERSION,
+	capQualityRecallItemsByTokenBudget,
 };

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -10,7 +10,7 @@ import {
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { loadDatabaseCtor } from '../db/sqlite-loader.js';
-import { validateSwarmPath } from '../hooks/utils';
+import { estimateTokens, validateSwarmPath } from '../hooks/utils';
 import { warn } from '../utils';
 import { stableCanonicalStringify } from '../utils/stable-stringify';
 import {
@@ -31,6 +31,7 @@ import { type FusionWeights, fuseRankings } from './embeddings/fusion';
 import { LocalEmbeddingProvider } from './embeddings/local-provider';
 import {
 	CrossEncoderReranker,
+	type MemoryReranker,
 	type RerankCandidate,
 	shouldRerank,
 } from './embeddings/reranker';
@@ -290,6 +291,41 @@ interface Migration {
 const RECALL_CANDIDATE_LIMIT = 1000;
 const FTS_SCHEMA_MIGRATION_VERSION = 3;
 const FTS_SCHEMA_MIGRATION_NAME = 'create_memory_fts5_shadow_index';
+
+function recallCandidateLimit(request: RecallRequest): number {
+	const requested = request.quality?.candidateCap;
+	if (typeof requested !== 'number' || !Number.isFinite(requested))
+		return RECALL_CANDIDATE_LIMIT;
+	return Math.min(RECALL_CANDIDATE_LIMIT, Math.max(1, Math.trunc(requested)));
+}
+
+function estimateReturnedTokens(items: readonly RecallResultItem[]): number {
+	// Recall itself does not build a prompt, so token consumption is unmeasured.
+	// Report a deterministic text-only estimate over what actually returned.
+	return items.reduce(
+		(total, item) => total + estimateTokens(item.record.text),
+		0,
+	);
+}
+
+function capQualityRecallItemsByTokenBudget(
+	items: readonly RecallResultItem[],
+	tokenBudget: number,
+): RecallResultItem[] {
+	const boundedTokenBudget = Number.isFinite(tokenBudget)
+		? Math.max(0, Math.trunc(tokenBudget))
+		: 0;
+	const selected: RecallResultItem[] = [];
+	let tokenEstimate = 0;
+	for (const item of items) {
+		const itemTokens = estimateTokens(item.record.text);
+		if (tokenEstimate + itemTokens > boundedTokenBudget) continue;
+		selected.push(item);
+		tokenEstimate += itemTokens;
+	}
+	return selected;
+}
+
 const FTS_TABLE_NAME = 'memory_items_fts';
 const FTS_INDEX_COLUMNS = [
 	{
@@ -674,6 +710,39 @@ export interface SQLiteJsonlImportResult {
 	totalRows: number;
 }
 
+export interface SQLiteRetrievalDependencies {
+	/** Optional deterministic override used by quality evaluation and focused tests. */
+	embeddingProvider?: EmbeddingProvider;
+	/** Selects dense candidates without claiming sqlite-vec availability. */
+	denseSelector?: (
+		request: RecallRequest,
+		queryEmbedding: Float32Array,
+		records: readonly MemoryRecord[],
+	) => Promise<MemoryRecord[]>;
+	reranker?: MemoryReranker;
+	/** Monotonic clock seam; default is Date.now. */
+	now?: () => number;
+}
+
+export interface MemoryRecallQualityTrace {
+	profile: 'lexical' | 'hybrid' | 'hybrid+rerank';
+	status: 'complete' | 'degraded' | 'skipped';
+	degradationReason?: string;
+	provenance: 'lexical' | 'sqlite-vec' | 'injected-dense';
+	usedEmbedding: boolean;
+	usedReranker: boolean;
+	latencyMs: number;
+	resourceUsage: {
+		lexical_candidate_count: number;
+		dense_candidate_count: number;
+		rerank_candidate_count: number;
+		returned_count: number;
+		query_embedding_invocation_count: number;
+		/** Deterministic estimate over the text actually returned, not a budget echo. */
+		returned_token_estimate: number;
+	};
+}
+
 export class SQLiteMemoryProvider
 	implements MemoryProvider, MemoryProposalStore
 {
@@ -695,7 +764,8 @@ export class SQLiteMemoryProvider
 	private vecAvailable = false;
 	private embeddingProvider: EmbeddingProvider | null = null;
 	private embeddingCache: EmbeddingCache | null = null;
-	private reranker: CrossEncoderReranker | null = null;
+	private reranker: MemoryReranker | null = null;
+	private readonly retrievalDependencies: SQLiteRetrievalDependencies;
 	private memories = new Map<string, MemoryRecord>();
 	private proposals = new Map<string, MemoryProposal>();
 	private lastAutomaticJsonlMigration: SQLiteJsonlImportResult | null = null;
@@ -714,9 +784,13 @@ export class SQLiteMemoryProvider
 		 * behavior).
 		 */
 		vettedCohortRoot?: string | null,
+		retrievalDependencies: SQLiteRetrievalDependencies = {},
 	) {
 		this.rootDirectory = rootDirectory;
 		this.cohortRoot = vettedCohortRoot ?? null;
+		this.retrievalDependencies = retrievalDependencies;
+		this.embeddingProvider = retrievalDependencies.embeddingProvider ?? null;
+		this.reranker = retrievalDependencies.reranker ?? null;
 		this.config = {
 			...DEFAULT_MEMORY_CONFIG,
 			...config,
@@ -1155,22 +1229,27 @@ export class SQLiteMemoryProvider
 	async recallWithDiagnostics(request: RecallRequest): Promise<{
 		items: RecallResultItem[];
 		diagnostics: RecallScoringDiagnostics;
+		qualityTrace?: MemoryRecallQualityTrace;
 	}> {
 		await this.initialize();
+		const qualityProfile = request.quality?.profile;
+		const candidateLimit = recallCandidateLimit(request);
+		const recallElapsedStart = this.now();
 
 		// ── Disabled-path guard: byte-identical to the legacy lexical-only flow ──
 		// When embeddings are off (config flag, vec extension, or provider missing),
 		// execute the existing path verbatim so golden fixtures pass unchanged.
 		if (
+			qualityProfile === 'lexical' ||
 			!this.config.embeddings.enabled ||
-			!this.vecAvailable ||
+			(!this.vecAvailable && !this.retrievalDependencies.embeddingProvider) ||
 			!this.embeddingProvider
 		) {
 			const scopedRecords = await this.list({
 				scopes: request.scopes,
 				kinds: request.kinds,
 				includeExpired: request.includeExpired,
-				limit: RECALL_CANDIDATE_LIMIT,
+				limit: candidateLimit,
 			});
 			const candidates = this.selectRecallCandidates(request, scopedRecords);
 			const result = scoreMemoryRecordsWithDiagnostics(
@@ -1189,28 +1268,58 @@ export class SQLiteMemoryProvider
 				request.maxItems,
 			);
 			const expanded = this.expandRelated(disabledPathSliced, request);
+			const returned = qualityProfile
+				? capQualityRecallItemsByTokenBudget(expanded, request.tokenBudget)
+				: expanded;
 			return {
-				items: expanded,
+				items: returned,
 				diagnostics: {
 					...result.diagnostics,
 					// Fix 3: derive exploredCount from what actually survived
 					// slicing so the count always matches an item present in the
 					// returned bundle.
-					exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
-					returnedCount: expanded.length,
+					exploredCount: returned.some((item) => item.explored) ? 1 : 0,
+					returnedCount: returned.length,
 				},
+				...(qualityProfile
+					? {
+							qualityTrace: {
+								profile: qualityProfile,
+								status:
+									qualityProfile === 'lexical'
+										? ('complete' as const)
+										: ('degraded' as const),
+								...(qualityProfile === 'lexical'
+									? {}
+									: { degradationReason: 'dense retrieval is unavailable' }),
+								provenance: 'lexical' as const,
+								usedEmbedding: false,
+								usedReranker: false,
+								latencyMs: Math.max(0, this.now() - recallElapsedStart),
+								resourceUsage: {
+									lexical_candidate_count: candidates.records.length,
+									dense_candidate_count: 0,
+									rerank_candidate_count: 0,
+									returned_count: returned.length,
+									query_embedding_invocation_count: 0,
+									returned_token_estimate: estimateReturnedTokens(returned),
+								},
+							},
+						}
+					: {}),
 			};
 		}
 
 		// ── Enabled path: lexical + dense RRF fusion ──
-		const recallElapsedStart = Date.now();
+		const wantsQualityTrace = Boolean(qualityProfile);
+		const resolvedQualityProfile = qualityProfile ?? 'hybrid';
 
 		// Stage 1 – lexical (FTS5-ranked candidates, unchanged from legacy path).
 		const scopedRecords = await this.list({
 			scopes: request.scopes,
 			kinds: request.kinds,
 			includeExpired: request.includeExpired,
-			limit: RECALL_CANDIDATE_LIMIT,
+			limit: candidateLimit,
 		});
 		const lexicalCandidates = this.selectRecallCandidates(
 			request,
@@ -1226,6 +1335,7 @@ export class SQLiteMemoryProvider
 			: lexicalResult.items;
 		// best-first id list for fusion (already sorted by score desc)
 		const lexicalIds = lexicalReranked.map((item) => item.record.id);
+		let queryEmbeddingInvocationCount = 0;
 
 		// Stage 2 – dense (sqlite-vec kNN). Non-fatal fallback to lexical-only on
 		// EmbeddingVersionMismatchError or any provider failure.
@@ -1236,6 +1346,7 @@ export class SQLiteMemoryProvider
 			let queryEmbedding =
 				this.embeddingCache?.get(modelVersion, normalizedQuery)?.vector ?? null;
 			if (queryEmbedding === null) {
+				queryEmbeddingInvocationCount++;
 				queryEmbedding = await this.embeddingProvider.embed(normalizedQuery);
 				this.embeddingCache?.set(modelVersion, normalizedQuery, {
 					vector: queryEmbedding,
@@ -1268,15 +1379,42 @@ export class SQLiteMemoryProvider
 				request.maxItems,
 			);
 			const expanded = this.expandRelated(denseFailedSliced, request);
+			const returned = wantsQualityTrace
+				? capQualityRecallItemsByTokenBudget(expanded, request.tokenBudget)
+				: expanded;
 			return {
-				items: expanded,
+				items: returned,
 				diagnostics: {
 					...lexicalResult.diagnostics,
 					// Fix 3: derive exploredCount from what actually survived
 					// slicing.
-					exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
-					returnedCount: expanded.length,
+					exploredCount: returned.some((item) => item.explored) ? 1 : 0,
+					returnedCount: returned.length,
 				},
+				...(wantsQualityTrace
+					? {
+							qualityTrace: {
+								profile: resolvedQualityProfile,
+								status: 'degraded' as const,
+								degradationReason: 'dense retrieval failed',
+								provenance: this.retrievalDependencies.embeddingProvider
+									? ('injected-dense' as const)
+									: ('sqlite-vec' as const),
+								usedEmbedding: true,
+								usedReranker: false,
+								latencyMs: Math.max(0, this.now() - recallElapsedStart),
+								resourceUsage: {
+									lexical_candidate_count: lexicalCandidates.records.length,
+									dense_candidate_count: 0,
+									rerank_candidate_count: 0,
+									returned_count: returned.length,
+									query_embedding_invocation_count:
+										queryEmbeddingInvocationCount,
+									returned_token_estimate: estimateReturnedTokens(returned),
+								},
+							},
+						}
+					: {}),
 			};
 		}
 
@@ -1345,10 +1483,17 @@ export class SQLiteMemoryProvider
 		}
 
 		// ── Stage 6 – cross-encoder rerank (enabled path only, latency-gated) ──
-		const previousRecallElapsedMs = Date.now() - recallElapsedStart;
+		const previousRecallElapsedMs = this.now() - recallElapsedStart;
 		let rerankedItems = fusedItems;
-		if (
+		let usedReranker = false;
+		let rerankDegradationReason: string | undefined;
+		let rerankCandidateCount = 0;
+		const rerankRequested = resolvedQualityProfile === 'hybrid+rerank';
+		const rerankEnabledForRequest =
 			this.config.retrieval.rerank.enabled &&
+			(!qualityProfile || qualityProfile === 'hybrid+rerank');
+		if (
+			rerankEnabledForRequest &&
 			shouldRerank(
 				previousRecallElapsedMs,
 				this.config.retrieval.latencyBudgetMs,
@@ -1361,6 +1506,7 @@ export class SQLiteMemoryProvider
 					});
 				}
 				const topN = Math.min(20, fusedItems.length);
+				rerankCandidateCount = topN;
 				const rerankCandidates: RerankCandidate[] = fusedItems
 					.slice(0, topN)
 					.map((item) => ({
@@ -1373,6 +1519,13 @@ export class SQLiteMemoryProvider
 					request.query,
 					topN,
 				);
+				// Invocation succeeded. `available` diagnoses a no-model fallback
+				// separately, so fake rerankers and unchanged rankings are not
+				// mistaken for an uncalled component.
+				usedReranker = true;
+				if (!this.reranker.available && rerankRequested) {
+					rerankDegradationReason = 'reranker unavailable';
+				}
 				// Reorder ONLY the top-N prefix by the reranker's returned order.
 				// The untouched tail (candidates beyond topN) is appended after the
 				// reranked prefix in their original fused order, so unreranked
@@ -1391,7 +1544,12 @@ export class SQLiteMemoryProvider
 					reason: err instanceof Error ? err.message : String(err),
 				});
 				rerankedItems = fusedItems;
+				if (rerankRequested) rerankDegradationReason = 'reranker failed';
 			}
+		} else if (rerankRequested) {
+			rerankDegradationReason = rerankEnabledForRequest
+				? 'reranking skipped by latency budget'
+				: 'reranking disabled';
 		}
 
 		// Fix 1 (C.1 reviewer fix): cap normal hits at maxItems, then append the
@@ -1402,8 +1560,11 @@ export class SQLiteMemoryProvider
 			request.maxItems,
 		);
 		const expanded = this.expandRelated(fusionSliced, request);
+		const returned = wantsQualityTrace
+			? capQualityRecallItemsByTokenBudget(expanded, request.tokenBudget)
+			: expanded;
 		return {
-			items: expanded,
+			items: returned,
 			diagnostics: {
 				...lexicalResult.diagnostics,
 				// Fix 3: derive exploredCount from what actually survived fusion
@@ -1412,10 +1573,37 @@ export class SQLiteMemoryProvider
 				// explored item on its own normalised-score scale, so
 				// `lexicalResult.diagnostics.exploredCount` alone is not a
 				// reliable signal of what is actually present here.
-				exploredCount: expanded.some((item) => item.explored) ? 1 : 0,
-				returnedCount: expanded.length,
+				exploredCount: returned.some((item) => item.explored) ? 1 : 0,
+				returnedCount: returned.length,
 				fusionActive: true,
 			},
+			...(wantsQualityTrace
+				? {
+						qualityTrace: {
+							profile: resolvedQualityProfile,
+							status: rerankDegradationReason
+								? ('degraded' as const)
+								: ('complete' as const),
+							...(rerankDegradationReason
+								? { degradationReason: rerankDegradationReason }
+								: {}),
+							provenance: this.retrievalDependencies.embeddingProvider
+								? ('injected-dense' as const)
+								: ('sqlite-vec' as const),
+							usedEmbedding: true,
+							usedReranker,
+							latencyMs: Math.max(0, this.now() - recallElapsedStart),
+							resourceUsage: {
+								lexical_candidate_count: lexicalCandidates.records.length,
+								dense_candidate_count: denseIds.length,
+								rerank_candidate_count: rerankCandidateCount,
+								returned_count: returned.length,
+								query_embedding_invocation_count: queryEmbeddingInvocationCount,
+								returned_token_estimate: estimateReturnedTokens(returned),
+							},
+						},
+					}
+				: {}),
 		};
 	}
 
@@ -2134,6 +2322,59 @@ export class SQLiteMemoryProvider
 		request: RecallRequest,
 		queryEmbedding: Float32Array,
 	): Promise<MemoryRecord[]> {
+		const candidateLimit = recallCandidateLimit(request);
+		if (this.retrievalDependencies.denseSelector) {
+			// Injected selectors are evaluation/test seams, not a bypass around the
+			// production retrieval boundary. Keep their candidate set identical to
+			// the scoped/kind/expiry-filtered list used by the other dense paths.
+			const eligible = await this.list({
+				scopes: request.scopes,
+				kinds: request.kinds,
+				includeExpired: request.includeExpired,
+				limit: candidateLimit,
+			});
+			const eligibleById = new Map(
+				eligible.map((record) => [record.id, record]),
+			);
+			const selected = await this.retrievalDependencies.denseSelector(
+				request,
+				queryEmbedding,
+				eligible,
+			);
+			const seen = new Set<string>();
+			const bounded: MemoryRecord[] = [];
+			for (const candidate of selected) {
+				const eligibleRecord = eligibleById.get(candidate.id);
+				if (!eligibleRecord || seen.has(candidate.id)) continue;
+				seen.add(candidate.id);
+				bounded.push(eligibleRecord);
+				if (bounded.length >= candidateLimit) break;
+			}
+			return bounded;
+		}
+		if (this.retrievalDependencies.embeddingProvider && !this.vecAvailable) {
+			// The evaluator intentionally uses an injected, deterministic dense
+			// selector. This is not sqlite-vec and must remain explicitly labelled
+			// as injected-dense in its quality trace.
+			const candidates = await this.list({
+				scopes: request.scopes,
+				kinds: request.kinds,
+				includeExpired: request.includeExpired,
+				limit: candidateLimit,
+			});
+			const vectors = await this.embeddingProvider?.embedBatch(
+				candidates.map((record) => record.text),
+			);
+			return candidates
+				.map((record, index) => ({
+					record,
+					score: cosineSimilarity(queryEmbedding, vectors?.[index]),
+				}))
+				.sort(
+					(a, b) => b.score - a.score || a.record.id.localeCompare(b.record.id),
+				)
+				.map(({ record }) => record);
+		}
 		if (
 			!this.config.embeddings.enabled ||
 			!this.vecAvailable ||
@@ -2153,7 +2394,11 @@ export class SQLiteMemoryProvider
 		// scope/kind/superseded/deleted/expired (mirroring lexical scoping).
 		// For tight scope filters this oversampling reduces (but may not
 		// eliminate) recall loss; pre-filtering via vec0 WHERE is a future improvement.
-		const k = Math.max(100, request.maxItems * 20);
+		const requestedQualityCap = request.quality?.candidateCap;
+		const k =
+			typeof requestedQualityCap === 'number'
+				? candidateLimit
+				: Math.max(100, request.maxItems * 20);
 		const rows = this.requireDb()
 			.query<{ id: string; distance: number }, SQLQueryBindings[]>(
 				`SELECT id, distance FROM memory_items_vec WHERE embedding MATCH ? ORDER BY distance LIMIT ?`,
@@ -2188,7 +2433,13 @@ export class SQLiteMemoryProvider
 			const record = this.memories.get(row.id);
 			if (record) results.push(record);
 		}
-		return results;
+		return typeof requestedQualityCap === 'number'
+			? results.slice(0, candidateLimit)
+			: results;
+	}
+
+	private now(): number {
+		return this.retrievalDependencies.now?.() ?? Date.now();
 	}
 
 	private runMigrations(): void {
@@ -3809,6 +4060,25 @@ const FTS_STOP_WORDS = new Set([
 	'when',
 	'with',
 ]);
+
+/** Small dependency-free cosine helper used only by the explicit injected-dense
+ * evaluation fallback. sqlite-vec remains the production default. */
+function cosineSimilarity(
+	a: Float32Array,
+	b: Float32Array | undefined,
+): number {
+	if (!b || a.length !== b.length || a.length === 0) return 0;
+	let dot = 0;
+	let aNorm = 0;
+	let bNorm = 0;
+	for (let index = 0; index < a.length; index++) {
+		dot += a[index] * b[index];
+		aNorm += a[index] * a[index];
+		bNorm += b[index] * b[index];
+	}
+	if (aNorm === 0 || bNorm === 0) return 0;
+	return dot / Math.sqrt(aNorm * bNorm);
+}
 
 function buildFtsQuery(request: RecallRequest): string | null {
 	const text =

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -258,6 +258,9 @@ export type RecallInjectionSkipReason =
 	| 'below_threshold'
 	| 'no_results';
 
+/** Explicit, evaluator-only opt-in. Normal agent recall never requests it. */
+export type RecallQualityProfile = 'lexical' | 'hybrid' | 'hybrid+rerank';
+
 export interface RecallRequest {
 	query: string;
 	task?: string;
@@ -277,6 +280,18 @@ export interface RecallRequest {
 	 * suppression never deletes or tombstones the underlying record.
 	 */
 	includeLowQ?: boolean;
+	/**
+	 * Produces bounded retrieval-quality telemetry on `recallWithDiagnostics`.
+	 * This is intentionally opt-in so agent-facing recall output stays unchanged.
+	 */
+	quality?: {
+		profile: RecallQualityProfile;
+		/**
+		 * Bounded evaluator-only retrieval work cap. Omitted for normal agent
+		 * recall, which preserves the established provider candidate behavior.
+		 */
+		candidateCap?: number;
+	};
 }
 
 export interface RecallResultItem {

--- a/src/tools/repo-graph/indexed-storage.ts
+++ b/src/tools/repo-graph/indexed-storage.ts
@@ -39,7 +39,11 @@ import { validateSymlinkBoundary } from '../../utils/path-security';
 import { safeRealpathSync } from './safe-realpath';
 import { deriveRepoRootId } from './symbol-edge';
 import type { GraphEdge, GraphNode, RepoGraph } from './types';
-import { normalizeGraphPath, REPO_GRAPH_FILENAME } from './types';
+import {
+	isGraphSchemaVersionCompatible,
+	normalizeGraphPath,
+	REPO_GRAPH_FILENAME,
+} from './types';
 import {
 	validateGraphEdge,
 	validateGraphNode,
@@ -721,6 +725,14 @@ function openFreshIndex(workspace: string): IndexContext | null {
 	const persistedMtime = meta.get('source_mtime_ms');
 	const schemaVersion = meta.get('graph_schema_version');
 	if (!persistedRoot || !persistedSize || !persistedMtime || !schemaVersion) {
+		closeRepoMemory(workspace);
+		return null;
+	}
+	if (!isGraphSchemaVersionCompatible(schemaVersion)) {
+		closeRepoMemory(workspace);
+		logger.log(
+			`[repo-graph] repo-memory graph schema ${schemaVersion} is unsupported; falling back to JSON`,
+		);
 		return null;
 	}
 

--- a/src/tools/repo-graph/query.ts
+++ b/src/tools/repo-graph/query.ts
@@ -55,7 +55,7 @@ interface QueryIndexes {
 	symbolEdges?: SymbolEdgeIndexes;
 }
 
-interface SymbolEdgeIndexes {
+export interface SymbolEdgeIndexes {
 	forward: Map<string, SymbolEdge[]>;
 	reverse: Map<string, SymbolEdge[]>;
 }
@@ -188,7 +188,7 @@ function getForwardIndex(graph: RepoGraph): Map<string, FileReference[]> {
 	return getQueryIndexes(graph).forwardIndex;
 }
 
-function getSymbolEdgeIndexes(graph: RepoGraph): SymbolEdgeIndexes {
+export function getSymbolEdgeIndexes(graph: RepoGraph): SymbolEdgeIndexes {
 	const indexes = getQueryIndexes(graph);
 	if (indexes.symbolEdges) return indexes.symbolEdges;
 	const forward = new Map<string, SymbolEdge[]>();

--- a/src/tools/repo-graph/storage.ts
+++ b/src/tools/repo-graph/storage.ts
@@ -43,6 +43,7 @@ import {
 import type { RepoGraph } from './types';
 import {
 	createEmptyGraph,
+	isGraphSchemaVersionCompatible,
 	REPO_GRAPH_FILENAME,
 	updateGraphMetadata,
 } from './types';
@@ -156,8 +157,26 @@ function bindGraphToWorkspace(graph: RepoGraph, workspace: string): void {
 }
 
 function validateLoadedGraph(parsed: RepoGraph, workspace: string): void {
-	if (!parsed.schema_version) {
+	const schemaVersion =
+		parsed && typeof parsed === 'object'
+			? (parsed as { schema_version?: unknown }).schema_version
+			: undefined;
+	if (
+		parsed &&
+		typeof parsed === 'object' &&
+		!Object.hasOwn(parsed, 'schema_version')
+	) {
 		throw corruption('repo-graph.json missing schema_version');
+	}
+	if (
+		!parsed ||
+		typeof parsed !== 'object' ||
+		typeof schemaVersion !== 'string' ||
+		!isGraphSchemaVersionCompatible(schemaVersion)
+	) {
+		throw corruption(
+			`repo-graph.json has unsupported schema_version: ${String(schemaVersion)}`,
+		);
 	}
 	if (!parsed.nodes || typeof parsed.nodes !== 'object') {
 		throw corruption('repo-graph.json missing or invalid nodes');

--- a/src/tools/repo-graph/symbol-query.ts
+++ b/src/tools/repo-graph/symbol-query.ts
@@ -25,6 +25,7 @@ import {
 	getDependencies,
 	getGraphNode,
 	getImporters,
+	getSymbolEdgeIndexes,
 } from './query';
 import {
 	createStableSymbolId,
@@ -136,29 +137,6 @@ function visibilityOf(node: GraphNode, symbol: string): GraphSymbolVisibility {
 	return node.exports.includes(symbol) ? 'exported' : 'module-local';
 }
 
-/**
- * Forward/reverse symbol-edge maps keyed `normalizedAbsoluteFile\0symbol` —
- * the same keying as `getContextPack`, so traversal semantics stay identical.
- */
-function symbolEdgeMaps(graph: RepoGraph): {
-	forward: Map<string, SymbolEdge[]>;
-	reverse: Map<string, SymbolEdge[]>;
-} {
-	const forward = new Map<string, SymbolEdge[]>();
-	const reverse = new Map<string, SymbolEdge[]>();
-	for (const edge of graph.symbolEdges ?? []) {
-		const fromKey = `${normalizeGraphPath(edge.fromFile)}\0${edge.fromSymbol}`;
-		const toKey = `${normalizeGraphPath(edge.toFile)}\0${edge.toSymbol}`;
-		const fromEdges = forward.get(fromKey);
-		if (fromEdges) fromEdges.push(edge);
-		else forward.set(fromKey, [edge]);
-		const toEdges = reverse.get(toKey);
-		if (toEdges) toEdges.push(edge);
-		else reverse.set(toKey, [edge]);
-	}
-	return { forward, reverse };
-}
-
 function symbolKey(node: GraphNode, symbol: string): string {
 	return `${normalizeGraphPath(node.filePath)}\0${symbol}`;
 }
@@ -203,7 +181,7 @@ function directNeighbors(
 	topN: number,
 	warnings: string[],
 ): { callers: ConeEntry[]; callees: ConeEntry[]; dropped: number } {
-	const { forward, reverse } = symbolEdgeMaps(graph);
+	const { forward, reverse } = getSymbolEdgeIndexes(graph);
 	const key = symbolKey(node, symbol);
 	const byFileSymbol = (a: ConeEntry, b: ConeEntry) =>
 		a.file.localeCompare(b.file) || a.symbol.localeCompare(b.symbol);
@@ -642,7 +620,7 @@ export function getImpactCone(
 		// callee side forward edges only. An undirected BFS would bounce back
 		// along the discovering edge and re-emit the target's own edge from the
 		// neighbor's perspective, double-counting every relationship.
-		const { forward, reverse } = symbolEdgeMaps(graph);
+		const { forward, reverse } = getSymbolEdgeIndexes(graph);
 		const emitted = new Set<string>();
 		const startKey = symbolKey(node, options.symbol);
 		const runBfs = (direction: 'caller' | 'callee'): void => {
@@ -1217,7 +1195,7 @@ export function explainGraphEntry(
 				kind: symbolKindOf(node, effectiveSymbol),
 			});
 		}
-		const { forward, reverse } = symbolEdgeMaps(graph);
+		const { forward, reverse } = getSymbolEdgeIndexes(graph);
 		const key = symbolKey(node, effectiveSymbol);
 		let legacyEdges = 0;
 		const isLegacy = (edge: SymbolEdge): boolean =>

--- a/src/tools/repo-graph/types.ts
+++ b/src/tools/repo-graph/types.ts
@@ -19,8 +19,7 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * the importing file) and per-node `exportLines`, enabling the `callers` and
  * `dead_exports` queries. Both fields are optional, so graphs written by older
  * versions (1.0.0) still load — but `dead_exports` requires >= 1.1.0 data and
- * self-gates via {@link isSchemaVersionAtLeast} rather than relying on the
- * loader (which only checks that a version string is present, not its value).
+ * self-gates via {@link isSchemaVersionAtLeast}.
  *
  * 1.2.0 adds per-node `exportRanges` (1-based inclusive line spans keyed by
  * symbol name — exported symbols for every grammar, plus non-exported member
@@ -34,8 +33,8 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  * that distinguishes edges whose resolved target is a scannable source file
  * (a graph node) from edges whose target is an asset (JSON/CSS/etc. — a real
  * file that never becomes a node). The field is optional, so 1.0.0–1.2.0
- * graphs still load; `storage.ts` only checks that a version string is
- * present, and feature gating is per-query via {@link isSchemaVersionAtLeast}.
+ * graphs still load; feature gating is per-query via
+ * {@link isSchemaVersionAtLeast}.
  * For pre-1.3.0 graphs the loader/queries fall back to an extension check
  * (`isScannableSourcePath`) to classify an untagged edge's target kind.
  *
@@ -71,6 +70,9 @@ export const REPO_GRAPH_FILENAME = 'repo-graph.json';
  */
 export const GRAPH_SCHEMA_VERSION = '1.7.0';
 
+/** The oldest graph schema whose persisted shape this build can interpret. */
+export const MIN_SUPPORTED_GRAPH_SCHEMA_VERSION = '1.0.0';
+
 /**
  * Default per-file source-size ceiling shared by graph construction and
  * query-time source reads. The builder treats this as the default value of
@@ -103,6 +105,36 @@ export function isSchemaVersionAtLeast(
 		const bv = b[i] ?? 0;
 		if (av > bv) return true;
 		if (av < bv) return false;
+	}
+	return true;
+}
+
+/**
+ * Return whether a persisted graph schema is a canonical numeric semver in
+ * the supported compatibility window. This is deliberately stricter than
+ * {@link isSchemaVersionAtLeast}: feature gates may tolerate malformed input
+ * by treating missing components as zero, but a persistence boundary must
+ * never trust an unknown or future graph shape.
+ */
+export function isGraphSchemaVersionCompatible(
+	version: unknown,
+): version is string {
+	if (typeof version !== 'string') return false;
+	const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(version);
+	if (!match) return false;
+	const parsed = match.slice(1).map(Number);
+	if (!parsed.every((part) => Number.isSafeInteger(part))) return false;
+	const minimum = MIN_SUPPORTED_GRAPH_SCHEMA_VERSION.split('.').map(Number);
+	const current = GRAPH_SCHEMA_VERSION.split('.').map(Number);
+	for (const [candidate, bound] of [
+		[parsed, minimum],
+		[current, parsed],
+	] as const) {
+		for (let index = 0; index < 3; index++) {
+			const delta = candidate[index]! - bound[index]!;
+			if (delta > 0) break;
+			if (delta < 0) return false;
+		}
 	}
 	return true;
 }

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -140,7 +140,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/evidence/manager.ts:288',
 			'src/evidence/manager.ts:456',
 			'src/tools/sast-baseline.ts:199',
-			'src/tools/repo-graph/storage.ts:524',
+			'src/tools/repo-graph/storage.ts:543',
 			'src/memory/reflection-service.ts (pre-#2035; migrated-to=src/memory/reflection-service.ts:atomicWrite)',
 			'src/hooks/review-receipt.ts:609',
 			'src/hooks/review-receipt.ts:675',

--- a/tests/fixtures/memory-recall-heldout/manifest.json
+++ b/tests/fixtures/memory-recall-heldout/manifest.json
@@ -1,0 +1,311 @@
+{
+	"corpus_id": "opencode-swarm-memory-recall-heldout-v1",
+	"split": "heldout",
+	"version": "1.0.0",
+	"supported_languages": [
+		"javascript",
+		"typescript",
+		"python",
+		"go",
+		"rust",
+		"php",
+		"java",
+		"c",
+		"cpp",
+		"csharp",
+		"ruby",
+		"swift",
+		"kotlin",
+		"dart",
+		"css",
+		"bash",
+		"powershell",
+		"ini",
+		"regex",
+		"tsx"
+	],
+	"analyzer_extensions": [
+		{ "language": "typescript", "extractor_id": "backend:typescript:v1" },
+		{ "language": "javascript", "extractor_id": "backend:javascript:v1" },
+		{ "language": "python", "extractor_id": "backend:python:v1" },
+		{ "language": "go", "extractor_id": "backend:go:v1" },
+		{ "language": "rust", "extractor_id": "backend:rust:v1" },
+		{ "language": "php", "extractor_id": "backend:php:v1" },
+		{ "language": "java", "extractor_id": "backend:java:v1" },
+		{ "language": "cpp", "extractor_id": "backend:cpp:v1" },
+		{ "language": "csharp", "extractor_id": "backend:csharp:v1" },
+		{ "language": "ruby", "extractor_id": "backend:ruby:v1" },
+		{ "language": "swift", "extractor_id": "backend:swift:v1" },
+		{ "language": "kotlin", "extractor_id": "backend:kotlin:v1" },
+		{ "language": "dart", "extractor_id": "backend:dart:v1" }
+	],
+	"os_gates": {
+		"linux": {
+			"id": "retrieval-quality-linux",
+			"command": "bun run check:retrieval-quality"
+		},
+		"macos": {
+			"id": "retrieval-quality-macos",
+			"command": "bun --smol test tests/unit/memory"
+		},
+		"windows": {
+			"id": "retrieval-quality-windows",
+			"command": "bun --smol test tests/unit/memory"
+		}
+	},
+	"thresholds": {
+		"precision_at_k": 0.25,
+		"recall_at_k": 0.25,
+		"max_spurious_edges": 2,
+		"max_known_misses": 2,
+		"direct_source_positive_hits": 14
+	},
+	"cases": [
+		{
+			"id": "javascript-profile",
+			"language": "javascript",
+			"source_path": "sources/javascript.js",
+			"content_hash": "B9638E337E7EB634ACA045E77B4561DE635466D9D7B6AA611EDA03D1468AFFD8",
+			"expected_symbols": ["loadUserProfile", "userId"],
+			"expected_edges": ["loadUserProfile -> fetch"],
+			"known_misses": ["userId"],
+			"spurious_edges": ["loadUserProfile -> userId"],
+			"paraphrase": "retrieve account details through a remote service",
+			"analyzer_id": "backend:javascript:v1"
+		},
+		{
+			"id": "typescript-profile",
+			"language": "typescript",
+			"source_path": "sources/typescript.ts",
+			"content_hash": "0C8303B36471F750A1A9BE5BAE1C6759265669E492E49C7A62589C263C739497",
+			"expected_symbols": ["saveInvoice", "invoiceId"],
+			"expected_edges": ["saveInvoice -> fetch"],
+			"known_misses": ["invoiceId"],
+			"spurious_edges": ["saveInvoice -> invoiceId"],
+			"paraphrase": "persist a billing document through an HTTP request",
+			"analyzer_id": "backend:typescript:v1"
+		},
+		{
+			"id": "python-profile",
+			"language": "python",
+			"source_path": "sources/python.py",
+			"content_hash": "B02409456CDD546DD81616637265866EECE08CBD58AC25A74BF97F05BC87AA9D",
+			"expected_symbols": ["rotate_api_key", "api_key"],
+			"expected_edges": ["rotate_api_key -> rotate_secret"],
+			"known_misses": ["api_key"],
+			"spurious_edges": ["rotate_api_key -> api_key"],
+			"paraphrase": "replace a secret credential with a newly rotated key",
+			"analyzer_id": "backend:python:v1"
+		},
+		{
+			"id": "go-profile",
+			"language": "go",
+			"source_path": "sources/go.go",
+			"content_hash": "FBD76CEC751667AE095543444E3731CAD8005AFC605801637673795FB5FB0EC8",
+			"expected_symbols": ["ParseConfig", "configPath"],
+			"expected_edges": ["ParseConfig -> string"],
+			"known_misses": ["configPath"],
+			"spurious_edges": ["ParseConfig -> configPath"],
+			"paraphrase": "read settings from a configuration path",
+			"analyzer_id": "backend:go:v1"
+		},
+		{
+			"id": "rust-profile",
+			"language": "rust",
+			"source_path": "sources/rust.rs",
+			"content_hash": "C45037A40930367399DB3643615E7505425E3146C6F6737B886E0FE843C53226",
+			"expected_symbols": ["publish_artifact", "artifact_id"],
+			"expected_edges": ["publish_artifact -> format"],
+			"known_misses": ["artifact_id"],
+			"spurious_edges": ["publish_artifact -> artifact_id"],
+			"paraphrase": "publish a build artifact using its identifier",
+			"analyzer_id": "backend:rust:v1"
+		},
+		{
+			"id": "php-profile",
+			"language": "php",
+			"source_path": "sources/php.php",
+			"content_hash": "6A22BE82C25024874413438ECD550360628A25CBFFA528E3FC6E9480636D1BFA",
+			"expected_symbols": ["find_order", "orderId"],
+			"expected_edges": ["find_order -> string"],
+			"known_misses": ["orderId"],
+			"spurious_edges": ["find_order -> orderId"],
+			"paraphrase": "look up a purchase using its order identifier",
+			"analyzer_id": "backend:php:v1"
+		},
+		{
+			"id": "java-profile",
+			"language": "java",
+			"source_path": "sources/java.java",
+			"content_hash": "6F6A7B2DBE906137856D71C60DDDB0F2A0BC6D3FBA46204ACE4CF5F9BB43669F",
+			"expected_symbols": ["sendWebhook", "webhookUrl"],
+			"expected_edges": ["sendWebhook -> String"],
+			"known_misses": ["webhookUrl"],
+			"spurious_edges": ["Webhooks -> webhookUrl"],
+			"paraphrase": "deliver an event to a callback URL",
+			"analyzer_id": "backend:java:v1"
+		},
+		{
+			"id": "c-profile",
+			"language": "c",
+			"source_path": "sources/c.c",
+			"content_hash": "C2CF3904D71ED57B52D204C9B1A7A7BAB90E30DF636F725FB939F0D14759B63F",
+			"expected_symbols": ["open_socket", "socket_fd"],
+			"expected_edges": ["open_socket -> char"],
+			"known_misses": ["socket_fd"],
+			"spurious_edges": ["open_socket -> close_socket"],
+			"paraphrase": "open a network channel from its descriptor",
+			"analyzer_id": "parser-only:c:v1"
+		},
+		{
+			"id": "cpp-profile",
+			"language": "cpp",
+			"source_path": "sources/cpp.cpp",
+			"content_hash": "25F855671A74CE618980E69790589ED2AC027566674ABCACB2E54EA3C3B8B3DD",
+			"expected_symbols": ["render_widget", "widget_id"],
+			"expected_edges": ["render_widget -> string"],
+			"known_misses": ["widget_id"],
+			"spurious_edges": ["render_widget -> widget_id", "render_widget -> std"],
+			"paraphrase": "draw a user interface component by identifier",
+			"analyzer_id": "backend:cpp:v1"
+		},
+		{
+			"id": "csharp-profile",
+			"language": "csharp",
+			"source_path": "sources/csharp.cs",
+			"content_hash": "CFD8618108A02D2EB98D122313198DEE4684C204BA676347550C3310FBD8566D",
+			"expected_symbols": ["AuthorizeRequest", "requestId"],
+			"expected_edges": ["AuthorizeRequest -> string"],
+			"known_misses": ["requestId"],
+			"spurious_edges": [
+				"<module> -> AuthorizeRequest",
+				"<module> -> requestId"
+			],
+			"paraphrase": "check whether an incoming request is permitted",
+			"analyzer_id": "backend:csharp:v1"
+		},
+		{
+			"id": "ruby-profile",
+			"language": "ruby",
+			"source_path": "sources/ruby.rb",
+			"content_hash": "47BC5872B2085EE4C738484E2261F20CDF7A36115F97F1FD904813A9BDACA6F8",
+			"expected_symbols": ["normalize_email", "email"],
+			"expected_edges": ["normalize_email -> strip"],
+			"known_misses": ["email"],
+			"spurious_edges": [
+				"normalize_email -> email",
+				"normalize_email -> downcase"
+			],
+			"paraphrase": "canonicalize an address before storing it",
+			"analyzer_id": "backend:ruby:v1"
+		},
+		{
+			"id": "swift-profile",
+			"language": "swift",
+			"source_path": "sources/swift.swift",
+			"content_hash": "9AA176B51176FC6DFF98097678E04AC5B57B787E2F0A5E16B6B3C5F0433839BA",
+			"expected_symbols": ["cacheImage", "imageURL"],
+			"expected_edges": ["cacheImage -> String"],
+			"known_misses": ["imageURL"],
+			"spurious_edges": ["cacheImage -> imageURL"],
+			"paraphrase": "store a downloaded picture for later display",
+			"analyzer_id": "backend:swift:v1"
+		},
+		{
+			"id": "kotlin-profile",
+			"language": "kotlin",
+			"source_path": "sources/kotlin.kt",
+			"content_hash": "102FA601E66DB4AC3AF2C0E30BE865077980F58252C7A438968820C8D2AA23B2",
+			"expected_symbols": ["syncCalendar", "calendarId"],
+			"expected_edges": ["syncCalendar -> String"],
+			"known_misses": ["calendarId"],
+			"spurious_edges": ["syncCalendar -> calendarId"],
+			"paraphrase": "synchronize an appointment calendar by identifier",
+			"analyzer_id": "backend:kotlin:v1"
+		},
+		{
+			"id": "dart-profile",
+			"language": "dart",
+			"source_path": "sources/dart.dart",
+			"content_hash": "4E21F3AC09BF159D68CEA641DB11AC8EA68B1BF2E61F3098028E40DF1AE25808",
+			"expected_symbols": ["decodeToken", "token"],
+			"expected_edges": ["decodeToken -> String"],
+			"known_misses": ["token"],
+			"spurious_edges": ["decodeToken -> token"],
+			"paraphrase": "interpret a signed credential for a session",
+			"analyzer_id": "backend:dart:v1"
+		},
+		{
+			"id": "css-profile",
+			"language": "css",
+			"source_path": "sources/css.css",
+			"content_hash": "4D9C610B3F17E60A83CAB953BF9CAC157F001A1CB06CDAA089ADE0A9886E1411",
+			"expected_symbols": ["notification-banner", "notification-hue"],
+			"expected_edges": ["notification-banner -> notification-hue"],
+			"known_misses": ["notification-hue"],
+			"spurious_edges": ["notification-banner -> danger-color"],
+			"paraphrase": "style a notice banner with its theme hue",
+			"analyzer_id": "parser-only:css:v1"
+		},
+		{
+			"id": "bash-profile",
+			"language": "bash",
+			"source_path": "sources/bash.sh",
+			"content_hash": "74ED9524EBC70CB288D4F039212753A29E834E4DBA4DEEBC717F73D2481CAE28",
+			"expected_symbols": ["rotate_logs", "log_file"],
+			"expected_edges": ["rotate_logs -> printf"],
+			"known_misses": ["log_file"],
+			"spurious_edges": ["rotate_logs -> delete_logs"],
+			"paraphrase": "cycle archived application log files",
+			"analyzer_id": "parser-only:bash:v1"
+		},
+		{
+			"id": "powershell-profile",
+			"language": "powershell",
+			"source_path": "sources/powershell.ps1",
+			"content_hash": "15C73C8B30FF023F6977E6268BC1355C0E21121D95DE3D8D10D81AE1BAF56954",
+			"expected_symbols": ["Get-InventoryItem", "ItemId"],
+			"expected_edges": ["Get-InventoryItem -> string"],
+			"known_misses": ["ItemId"],
+			"spurious_edges": ["Get-InventoryItem -> Remove-InventoryItem"],
+			"paraphrase": "look up a stock item by its identifier",
+			"analyzer_id": "parser-only:powershell:v1"
+		},
+		{
+			"id": "ini-profile",
+			"language": "ini",
+			"source_path": "sources/ini.ini",
+			"content_hash": "FDD0199E49555EA760845F23B7DF6F2178B86FC552A29D1E8A39EAD39E20FF3A",
+			"expected_symbols": ["database", "connect_timeout"],
+			"expected_edges": ["database -> connect_timeout"],
+			"known_misses": ["connect_timeout"],
+			"spurious_edges": ["database -> delete_database"],
+			"paraphrase": "configure a database connection timeout",
+			"analyzer_id": "parser-only:ini:v1"
+		},
+		{
+			"id": "regex-profile",
+			"language": "regex",
+			"source_path": "sources/regex.regex",
+			"content_hash": "1413547E127815DDB2AC3A0B25FC2EAA02F3FD6B453FEF15210BA53A90BA1F90",
+			"expected_symbols": ["invoice_lookup", "invoice_id"],
+			"expected_edges": ["invoice_lookup -> invoice_id"],
+			"known_misses": ["invoice_id"],
+			"spurious_edges": ["invoice_lookup -> customer_id"],
+			"paraphrase": "match an invoice lookup call",
+			"analyzer_id": "parser-only:regex:v1"
+		},
+		{
+			"id": "tsx-profile",
+			"language": "tsx",
+			"source_path": "sources/tsx.tsx",
+			"content_hash": "17C67D0709FD2C10E8E619F3E1AB4A836F36C5CD7E4645DB948CAD67B5BD93EE",
+			"expected_symbols": ["InvoiceBadge", "invoiceId"],
+			"expected_edges": ["InvoiceBadge -> span"],
+			"known_misses": ["invoiceId"],
+			"spurious_edges": ["InvoiceBadge -> invoiceId"],
+			"paraphrase": "render a billing badge from its identifier",
+			"analyzer_id": "parser-only:tsx:v1"
+		}
+	]
+}

--- a/tests/fixtures/memory-recall-heldout/sources/bash.sh
+++ b/tests/fixtures/memory-recall-heldout/sources/bash.sh
@@ -1,0 +1,1 @@
+rotate_logs() { printf '/logs/%s\n' "$1"; }

--- a/tests/fixtures/memory-recall-heldout/sources/c.c
+++ b/tests/fixtures/memory-recall-heldout/sources/c.c
@@ -1,0 +1,1 @@
+const char *open_socket(const char *socket_fd) { return socket_fd; }

--- a/tests/fixtures/memory-recall-heldout/sources/cpp.cpp
+++ b/tests/fixtures/memory-recall-heldout/sources/cpp.cpp
@@ -1,0 +1,1 @@
+std::string render_widget(const std::string& widget_id) { return "/widgets/" + widget_id; }

--- a/tests/fixtures/memory-recall-heldout/sources/csharp.cs
+++ b/tests/fixtures/memory-recall-heldout/sources/csharp.cs
@@ -1,0 +1,1 @@
+string AuthorizeRequest(string requestId) => "/requests/" + requestId;

--- a/tests/fixtures/memory-recall-heldout/sources/css.css
+++ b/tests/fixtures/memory-recall-heldout/sources/css.css
@@ -1,0 +1,3 @@
+.notification-banner {
+	color: var(--notification-hue);
+}

--- a/tests/fixtures/memory-recall-heldout/sources/dart.dart
+++ b/tests/fixtures/memory-recall-heldout/sources/dart.dart
@@ -1,0 +1,1 @@
+String decodeToken(String token) => '/tokens/' + token;

--- a/tests/fixtures/memory-recall-heldout/sources/go.go
+++ b/tests/fixtures/memory-recall-heldout/sources/go.go
@@ -1,0 +1,3 @@
+package configs
+
+func ParseConfig(configPath string) string { return "/configs/" + configPath }

--- a/tests/fixtures/memory-recall-heldout/sources/ini.ini
+++ b/tests/fixtures/memory-recall-heldout/sources/ini.ini
@@ -1,0 +1,2 @@
+[database]
+connect_timeout=30

--- a/tests/fixtures/memory-recall-heldout/sources/java.java
+++ b/tests/fixtures/memory-recall-heldout/sources/java.java
@@ -1,0 +1,1 @@
+class Webhooks { String sendWebhook(String webhookUrl) { return "/hooks/" + webhookUrl; } }

--- a/tests/fixtures/memory-recall-heldout/sources/javascript.js
+++ b/tests/fixtures/memory-recall-heldout/sources/javascript.js
@@ -1,0 +1,3 @@
+export function loadUserProfile(userId) {
+	return fetch(`/users/${userId}`);
+}

--- a/tests/fixtures/memory-recall-heldout/sources/kotlin.kt
+++ b/tests/fixtures/memory-recall-heldout/sources/kotlin.kt
@@ -1,0 +1,1 @@
+fun syncCalendar(calendarId: String): String = "/calendars/$calendarId"

--- a/tests/fixtures/memory-recall-heldout/sources/php.php
+++ b/tests/fixtures/memory-recall-heldout/sources/php.php
@@ -1,0 +1,1 @@
+<?php function find_order(string $orderId): string { return '/orders/' . $orderId; }

--- a/tests/fixtures/memory-recall-heldout/sources/powershell.ps1
+++ b/tests/fixtures/memory-recall-heldout/sources/powershell.ps1
@@ -1,0 +1,1 @@
+function Get-InventoryItem { param([string]$ItemId) "/inventory/$ItemId" }

--- a/tests/fixtures/memory-recall-heldout/sources/python.py
+++ b/tests/fixtures/memory-recall-heldout/sources/python.py
@@ -1,0 +1,2 @@
+def rotate_api_key(api_key):
+    return rotate_secret("/keys/" + api_key)

--- a/tests/fixtures/memory-recall-heldout/sources/regex.regex
+++ b/tests/fixtures/memory-recall-heldout/sources/regex.regex
@@ -1,0 +1,1 @@
+invoice_lookup\((?<invoice_id>[A-Za-z0-9_-]+)\)

--- a/tests/fixtures/memory-recall-heldout/sources/ruby.rb
+++ b/tests/fixtures/memory-recall-heldout/sources/ruby.rb
@@ -1,0 +1,3 @@
+def normalize_email(email)
+  email.strip.downcase
+end

--- a/tests/fixtures/memory-recall-heldout/sources/rust.rs
+++ b/tests/fixtures/memory-recall-heldout/sources/rust.rs
@@ -1,0 +1,1 @@
+pub fn publish_artifact(artifact_id: &str) -> String { format!("/artifacts/{artifact_id}") }

--- a/tests/fixtures/memory-recall-heldout/sources/swift.swift
+++ b/tests/fixtures/memory-recall-heldout/sources/swift.swift
@@ -1,0 +1,1 @@
+func cacheImage(imageURL: String) -> String { "/images/" + imageURL }

--- a/tests/fixtures/memory-recall-heldout/sources/tsx.tsx
+++ b/tests/fixtures/memory-recall-heldout/sources/tsx.tsx
@@ -1,0 +1,3 @@
+export const InvoiceBadge = ({ invoiceId }: { invoiceId: string }) => (
+	<span>{invoiceId}</span>
+);

--- a/tests/fixtures/memory-recall-heldout/sources/typescript.ts
+++ b/tests/fixtures/memory-recall-heldout/sources/typescript.ts
@@ -1,0 +1,3 @@
+export function saveInvoice(invoiceId: string): Promise<unknown> {
+	return fetch(`/invoices/${invoiceId}`, { method: 'POST' });
+}

--- a/tests/unit/commands/memory-evaluate-quality.test.ts
+++ b/tests/unit/commands/memory-evaluate-quality.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { handleMemoryEvaluateCommand } from '../../../src/commands/memory';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+let projectDir: string;
+const extraDirectories: string[] = [];
+
+beforeEach(async () => {
+	projectDir = canonicalMkdtemp('swarm-memory-evaluate-command-');
+});
+
+afterEach(async () => {
+	await fs.rm(projectDir, { recursive: true, force: true });
+	for (const directory of extraDirectories.splice(0)) {
+		await fs.rm(directory, { recursive: true, force: true });
+	}
+});
+
+describe('/swarm memory evaluate retrieval-quality wiring', () => {
+	test('manifest selects the held-out corpus instead of legacy fixtures', async () => {
+		const manifest = path.resolve(
+			'tests/fixtures/memory-recall-heldout/manifest.json',
+		);
+		const output = await handleMemoryEvaluateCommand(projectDir, [
+			'--json',
+			'--profiles',
+			'lexical',
+			'--manifest',
+			manifest,
+		]);
+		const report = JSON.parse(output) as {
+			summary: { fixture_count: number; run_count: number };
+			runs: Array<{ fixture: string; scenario?: { index_state: string } }>;
+		};
+		expect(report.summary.fixture_count).toBe(20);
+		expect(report.summary.run_count).toBe(20);
+		expect(report.runs.every((run) => run.fixture.startsWith('heldout:'))).toBe(
+			true,
+		);
+		expect(
+			report.runs.every((run) => run.scenario?.index_state === 'not-measured'),
+		).toBe(true);
+	});
+
+	test('manifest rejects a custom filename instead of silently using manifest.json', async () => {
+		const sourceCorpus = path.resolve('tests/fixtures/memory-recall-heldout');
+		const copiedCorpus = path.join(projectDir, 'heldout-corpus');
+		await fs.cp(sourceCorpus, copiedCorpus, { recursive: true });
+		const customManifest = path.join(copiedCorpus, 'custom.json');
+		await fs.copyFile(path.join(copiedCorpus, 'manifest.json'), customManifest);
+
+		const output = await handleMemoryEvaluateCommand(projectDir, [
+			'--json',
+			'--manifest',
+			customManifest,
+		]);
+		expect(output).toContain('--manifest <file> must be named manifest.json');
+	});
+
+	test('manifest rejects a symlink whose canonical target escapes the project', async () => {
+		const outside = canonicalMkdtemp('swarm-memory-manifest-outside-');
+		extraDirectories.push(outside);
+		await fs.writeFile(path.join(outside, 'manifest.json'), '{}');
+		const link = path.join(projectDir, 'manifest-link');
+		try {
+			await fs.symlink(
+				outside,
+				link,
+				process.platform === 'win32' ? 'junction' : 'dir',
+			);
+		} catch {
+			// File-system policy may disable links in a local checkout; the
+			// canonical-containment path remains covered on link-capable CI hosts.
+			return;
+		}
+		const output = await handleMemoryEvaluateCommand(projectDir, [
+			'--manifest',
+			path.join(link, 'manifest.json'),
+		]);
+		expect(output).toContain('escaped the allowed roots');
+	});
+});

--- a/tests/unit/commands/memory-evaluate-quality.test.ts
+++ b/tests/unit/commands/memory-evaluate-quality.test.ts
@@ -81,4 +81,15 @@ describe('/swarm memory evaluate retrieval-quality wiring', () => {
 		]);
 		expect(output).toContain('escaped the allowed roots');
 	});
+
+	test('manifest rejects oversized files before parsing JSON', async () => {
+		const manifest = path.join(projectDir, 'manifest.json');
+		await fs.writeFile(manifest, `{"padding":"${'x'.repeat(1024 * 1024)}"}`);
+
+		const output = await handleMemoryEvaluateCommand(projectDir, [
+			'--manifest',
+			manifest,
+		]);
+		expect(output).toContain('exceeds the 1048576-byte limit');
+	});
 });

--- a/tests/unit/evaluation/retrieval-quality.test.ts
+++ b/tests/unit/evaluation/retrieval-quality.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { evaluateHeldoutGraphRetrievalQuality } from '../../../src/evaluation/retrieval-quality';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	for (const root of roots.splice(0)) {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+});
+
+async function makeCorpus(): Promise<string> {
+	const root = canonicalMkdtemp('retrieval-quality-test-');
+	roots.push(root);
+	const source = [
+		'export function actualProfile() {',
+		'  return helper();',
+		'}',
+		'function helper() { return "ok"; }',
+	].join('\n');
+	await fs.mkdir(path.join(root, 'sources'), { recursive: true });
+	await fs.writeFile(path.join(root, 'sources', 'fixture.js'), source, 'utf8');
+	const hash = createHash('sha256').update(source).digest('hex');
+	await fs.writeFile(
+		path.join(root, 'manifest.json'),
+		JSON.stringify({
+			corpus_id: 'retrieval-quality-test-v1',
+			split: 'heldout',
+			version: '1.0.0',
+			thresholds: { symbol_recall: 0.25 },
+			cases: [
+				{
+					id: 'synthetic-js',
+					language: 'javascript',
+					source_path: 'sources/fixture.js',
+					content_hash: hash.toUpperCase(),
+					expected_symbols: ['inventedSymbol'],
+					expected_edges: ['inventedSymbol -> helper'],
+					known_misses: ['legacyProfile'],
+					spurious_edges: ['actualProfile -> deleteProfile'],
+					paraphrase: 'retrieve the profile helper',
+					analyzer_id: 'backend:javascript:v1',
+				},
+			],
+		}),
+		'utf8',
+	);
+	return root;
+}
+
+describe('evaluateHeldoutGraphRetrievalQuality', () => {
+	test('measures parser facts rather than echoing held-out expectations', async () => {
+		const report = await evaluateHeldoutGraphRetrievalQuality({
+			corpusDirectory: await makeCorpus(),
+		});
+
+		expect(report.schema_version).toBe(1);
+		expect(report.corpus.split).toBe('heldout');
+		expect(report.uncertainty.sample_count).toBe(1);
+		const result = report.cases[0]!;
+		// The manifest intentionally names a symbol that the supplied source does
+		// not define. A decorative evaluator that copies expectations will fail
+		// this assertion, while the production extractor reports its actual facts.
+		expect(result.symbols.expected).toEqual(['inventedSymbol']);
+		expect(result.symbols.observed).toContain('actualProfile');
+		expect(result.symbols.observed).not.toContain('inventedSymbol');
+		expect(result.symbols.recall).toBe(0);
+		expect(result.symbols.false_negative).toEqual(['inventedSymbol']);
+		expect(result.symbols.false_positive).toContain('actualProfile');
+		expect(result.edges.observed).toContain('actualProfile -> helper');
+		expect(result.edges.observed).not.toContain('inventedSymbol -> helper');
+		expect(result.edges.false_negative).toEqual(['inventedSymbol -> helper']);
+		expect(result.edges.false_positive).toContain('actualProfile -> helper');
+		// Corpus declarations are annotations only: they cannot become measured
+		// misses or spurious edges unless they overlap the extractor's real delta.
+		expect(result.known_misses.declared).toEqual(['legacyProfile']);
+		expect(result.known_misses.matching_measured_false_negatives).toEqual([]);
+		expect(result.spurious_edges.matching_measured_false_positives).toEqual([]);
+		expect(report.summary.symbols.false_negative_count).toBe(1);
+		expect(report.summary.symbols.false_positive_count).toBeGreaterThan(0);
+		expect(report.summary.edges.false_negative_count).toBe(1);
+		expect(report.summary.edges.false_positive_count).toBeGreaterThan(0);
+		expect(result.paraphrase.direct_source.provenance).toBe(
+			'direct-source-fallback',
+		);
+		// The source path has no lexical overlap with this paraphrase. This proves
+		// the direct fallback ranks the paraphrase itself, not the file hint that
+		// indexed graph routing intentionally needs.
+		expect(result.paraphrase.direct_source.positive_hit).toBe(true);
+		expect(result.paraphrase.direct_source.status).toBe('complete');
+		expect(result.paraphrase.direct_source.actions).toContain('lexical_search');
+		if (report.resource_usage.indexed_storage_available) {
+			expect(result.paraphrase.indexed_control.status).toBe('complete');
+			expect(result.paraphrase.indexed_control.provenance).toBe(
+				'fresh-indexed-subgraph',
+			);
+		} else {
+			expect(result.paraphrase.indexed_control.status).toBe('skipped');
+			expect(result.paraphrase.indexed_control.provenance).toBe('unavailable');
+			expect(result.paraphrase.indexed_control.degradation_reason).toBeTruthy();
+		}
+	});
+
+	test('corpus identity changes when evaluation semantics change', async () => {
+		const corpusDirectory = await makeCorpus();
+		const baseline = await evaluateHeldoutGraphRetrievalQuality({
+			corpusDirectory,
+		});
+		const manifestPath = path.join(corpusDirectory, 'manifest.json');
+		const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as {
+			cases: Array<{ paraphrase: string; expected_symbols: string[] }>;
+		};
+		manifest.cases[0]!.paraphrase = 'a semantically distinct retrieval task';
+		manifest.cases[0]!.expected_symbols = ['anotherExpectedSymbol'];
+		await fs.writeFile(manifestPath, JSON.stringify(manifest), 'utf8');
+		const changed = await evaluateHeldoutGraphRetrievalQuality({
+			corpusDirectory,
+		});
+
+		expect(changed.corpus.hash).not.toBe(baseline.corpus.hash);
+	});
+});

--- a/tests/unit/evaluation/retrieval-quality.test.ts
+++ b/tests/unit/evaluation/retrieval-quality.test.ts
@@ -2,12 +2,17 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { evaluateHeldoutGraphRetrievalQuality } from '../../../src/evaluation/retrieval-quality';
+import {
+	_internals,
+	evaluateHeldoutGraphRetrievalQuality,
+} from '../../../src/evaluation/retrieval-quality';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 const roots: string[] = [];
+const originalBuildWorkspaceGraphAsync = _internals.buildWorkspaceGraphAsync;
 
 afterEach(async () => {
+	_internals.buildWorkspaceGraphAsync = originalBuildWorkspaceGraphAsync;
 	for (const root of roots.splice(0)) {
 		await fs.rm(root, { recursive: true, force: true });
 	}
@@ -122,5 +127,17 @@ describe('evaluateHeldoutGraphRetrievalQuality', () => {
 		});
 
 		expect(changed.corpus.hash).not.toBe(baseline.corpus.hash);
+	});
+
+	test('propagates graph construction failures without dereferencing a null graph', async () => {
+		_internals.buildWorkspaceGraphAsync = async () => {
+			throw new Error('synthetic graph construction failure');
+		};
+
+		await expect(
+			evaluateHeldoutGraphRetrievalQuality({
+				corpusDirectory: await makeCorpus(),
+			}),
+		).rejects.toThrow('synthetic graph construction failure');
 	});
 });

--- a/tests/unit/memory/heldout-evaluation-corpus.test.ts
+++ b/tests/unit/memory/heldout-evaluation-corpus.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	loadHeldoutRecallEvaluationCorpus,
+	loadHeldoutRecallEvaluationScenarios,
+	validateHeldoutRecallCorpusManifest,
+} from '../../../src/memory/heldout-evaluation-corpus';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const valid = {
+	corpus_id: 'memory-recall-heldout',
+	split: 'heldout',
+	cases: [
+		{
+			language: 'typescript',
+			expected_symbols: ['resolveMemory'],
+			expected_edges: ['resolveMemory -> recall'],
+			known_misses: ['comments'],
+			spurious_edges: ['comment -> symbol'],
+			paraphrase: 'find the memory resolution path',
+			source_path: 'sources/example.ts',
+			content_hash: 'a'.repeat(64),
+		},
+	],
+};
+
+describe('held-out recall corpus contract', () => {
+	test('accepts bounded, content-addressed held-out corpus metadata', () => {
+		expect(() => validateHeldoutRecallCorpusManifest(valid)).not.toThrow();
+	});
+
+	test('rejects missing contract fields and malformed content hashes', () => {
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({ ...valid, split: 'training' }),
+		).toThrow();
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				cases: [{ ...valid.cases[0], content_hash: 'bad' }],
+			}),
+		).toThrow();
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				version: 1,
+			}),
+		).toThrow('invalid version');
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				thresholds: { precision_at_k: Number.POSITIVE_INFINITY },
+			}),
+		).toThrow('invalid thresholds');
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				cases: [
+					{
+						...valid.cases[0],
+						id: '',
+						expected_symbols: [42],
+						expected_edges: [{ from: 'resolveMemory', to: 1 }],
+					},
+				],
+			}),
+		).toThrow();
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				cases: [
+					{
+						...valid.cases[0],
+						expected_edges: [{ from: 'resolveMemory', to: 1 }],
+					},
+				],
+			}),
+		).toThrow('invalid expected_edges');
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				cases: [{ ...valid.cases[0], spurious_edges: [false] }],
+			}),
+		).toThrow('invalid spurious_edges');
+	});
+
+	test('rejects explicit ids that collide with generated fallback ids', () => {
+		expect(() =>
+			validateHeldoutRecallCorpusManifest({
+				...valid,
+				cases: [
+					{ ...valid.cases[0], id: 'typescript-2' },
+					{ ...valid.cases[0], source_path: 'sources/second.ts' },
+				],
+			}),
+		).toThrow('duplicates id');
+	});
+
+	test('loader rejects lexical escapes and source hash mismatches', async () => {
+		const root = canonicalMkdtemp('swarm-heldout-corpus-');
+		try {
+			const source = 'export const x = 1;';
+			await fs.mkdir(path.join(root, 'sources'));
+			await fs.writeFile(path.join(root, 'sources', 'example.ts'), source);
+			const manifest = {
+				...valid,
+				cases: [
+					{
+						...valid.cases[0],
+						source_path: '../outside.ts',
+						content_hash: createHash('sha256').update(source).digest('hex'),
+					},
+				],
+			};
+			await fs.writeFile(
+				path.join(root, 'manifest.json'),
+				JSON.stringify(manifest),
+			);
+			await expect(loadHeldoutRecallEvaluationCorpus(root)).rejects.toThrow(
+				'escapes corpus root',
+			);
+
+			manifest.cases[0].source_path = 'sources/example.ts';
+			manifest.cases[0].content_hash = 'b'.repeat(64);
+			await fs.writeFile(
+				path.join(root, 'manifest.json'),
+				JSON.stringify(manifest),
+			);
+			await expect(loadHeldoutRecallEvaluationCorpus(root)).rejects.toThrow(
+				'hash mismatch',
+			);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test('loader validates CRLF source against its canonical LF hash', async () => {
+		const root = canonicalMkdtemp('swarm-heldout-corpus-crlf-');
+		try {
+			const lfSource = 'export const x = 1;\nexport const y = 2;\n';
+			const lfHash = createHash('sha256').update(lfSource).digest('hex');
+			await fs.mkdir(path.join(root, 'sources'));
+			await fs.writeFile(
+				path.join(root, 'sources', 'example.ts'),
+				lfSource.replace(/\n/g, '\r\n'),
+			);
+			await fs.writeFile(
+				path.join(root, 'manifest.json'),
+				JSON.stringify({
+					...valid,
+					cases: [{ ...valid.cases[0], content_hash: lfHash }],
+				}),
+			);
+
+			const { scenarios } = await loadHeldoutRecallEvaluationScenarios(root);
+			expect(scenarios[0]?.source_hash).toBe(lfHash);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test('loader rejects a manifest symlink that resolves outside the corpus root', async () => {
+		const root = canonicalMkdtemp('swarm-heldout-manifest-link-');
+		const outside = canonicalMkdtemp('swarm-heldout-manifest-outside-');
+		try {
+			const source = 'export const x = 1;';
+			await fs.writeFile(
+				path.join(outside, 'manifest.json'),
+				JSON.stringify(valid),
+			);
+			try {
+				await fs.symlink(
+					path.join(outside, 'manifest.json'),
+					path.join(root, 'manifest.json'),
+				);
+			} catch {
+				// File symlinks need platform-specific privileges on some Windows hosts.
+				return;
+			}
+			await fs.writeFile(path.join(outside, 'outside.ts'), source);
+			await expect(loadHeldoutRecallEvaluationCorpus(root)).rejects.toThrow(
+				'manifest path escapes corpus root',
+			);
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+			await fs.rm(outside, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/memory/heldout-recall-evaluation.test.ts
+++ b/tests/unit/memory/heldout-recall-evaluation.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	evaluateMemoryRecallFixtures,
+	validateRecallEvaluationManifest,
+} from '../../../src/memory/evaluation';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const fixtureDirectory = path.resolve(
+	import.meta.dir,
+	'../../fixtures/memory-recall',
+);
+
+function ngramVector(text: string): Float32Array {
+	const vector = new Float32Array(64);
+	const normalized = `  ${text.toLowerCase()}  `;
+	for (let index = 0; index < normalized.length - 2; index++) {
+		const trigram = normalized.slice(index, index + 3);
+		let hash = 0;
+		for (const char of trigram) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+		vector[hash % vector.length] += 1;
+	}
+	return vector;
+}
+
+async function createCorpus(): Promise<string> {
+	const root = canonicalMkdtemp('swarm-heldout-eval-');
+	await fs.mkdir(path.join(root, 'sources'));
+	const sources = [
+		[
+			'target.ts',
+			'export function UserProfileDetails() { return accountMetadata; }',
+		],
+		['noise.ts', 'export function profileHandler() { return unrelatedValue; }'],
+		['other.ts', 'export function deleteLegacyAccount() { return undefined; }'],
+	] as const;
+	for (const [file, content] of sources)
+		await fs.writeFile(path.join(root, 'sources', file), content);
+	const cases = sources.map(([file, content], index) => ({
+		id: ['target', 'noise', 'other'][index],
+		language: 'typescript',
+		source_path: `sources/${file}`,
+		content_hash: createHash('sha256').update(content).digest('hex'),
+		expected_symbols: [
+			index === 0
+				? 'UserProfileDetails'
+				: index === 1
+					? 'profileHandler'
+					: 'deleteLegacyAccount',
+		],
+		expected_edges: ['source -> target'],
+		known_misses: ['legacy'],
+		spurious_edges: ['source -> noise'],
+		paraphrase:
+			index === 0
+				? 'find user profile details account metadata'
+				: index === 1
+					? 'profile handling flow'
+					: 'remove legacy account',
+		analyzer_id: 'backend:typescript:v1',
+	}));
+	await fs.writeFile(
+		path.join(root, 'manifest.json'),
+		JSON.stringify({
+			corpus_id: 'shared-candidate-test',
+			split: 'heldout',
+			version: '1.0.0',
+			thresholds: { precision_at_k: 0.1 },
+			cases,
+		}),
+	);
+	return root;
+}
+
+const dependencies = {
+	embeddingProvider: {
+		modelVersion: 'hashed-char-ngram-v1:64',
+		dimension: 64,
+		available: true,
+		embed: async (text: string) => ngramVector(text),
+		embedBatch: async (texts: string[]) => texts.map(ngramVector),
+	},
+	reranker: {
+		modelVersion: 'identity-reranker',
+		available: true,
+		rerank: async <T>(candidates: T[]) => candidates,
+	},
+};
+
+describe('held-out retrieval evaluation', () => {
+	test('ranks paraphrases against a shared corpus with meaningful profile deltas', async () => {
+		const heldoutCorpusDirectory = await createCorpus();
+		try {
+			const report = await evaluateMemoryRecallFixtures({
+				fixtureDirectory,
+				heldoutCorpusDirectory,
+				providers: ['sqlite'],
+				modes: ['manual'],
+				profiles: ['lexical', 'hybrid', 'hybrid+rerank'],
+				dependencies,
+				resourceCaps: { candidate_count: 8, token_budget: 256 },
+			});
+			expect(() =>
+				validateRecallEvaluationManifest(report.manifest),
+			).not.toThrow();
+			expect(() =>
+				validateRecallEvaluationManifest({
+					...report.manifest,
+					variants: {
+						lexical: {
+							...report.manifest.variants?.lexical,
+							config_hash: '',
+						},
+					},
+				}),
+			).toThrow('invalid variant identity');
+			expect(report.runs).toHaveLength(9);
+			expect(report.comparisons).toHaveLength(6);
+			expect(
+				report.runs.some(
+					(run) => run.profile === 'lexical' && run.metrics['recall@k'] < 1,
+				),
+			).toBe(true);
+			expect(
+				report.comparisons.some(
+					(comparison) => comparison.recall_at_k_delta > 0,
+				),
+			).toBe(true);
+			for (const run of report.runs) {
+				expect(run.resource_usage?.lexical_candidate_count).toBe(3);
+				expect(run.scenario?.source_provenance).toBe('direct-source');
+				expect(run.scenario?.index_state).toBe('not-measured');
+				expect(run.identity?.config_hash).toMatch(/^[a-f0-9]{64}$/);
+			}
+		} finally {
+			await fs.rm(heldoutCorpusDirectory, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/memory/heldout-retrieval-corpus-acceptance.test.ts
+++ b/tests/unit/memory/heldout-retrieval-corpus-acceptance.test.ts
@@ -1,0 +1,74 @@
+/** Acceptance coverage for issue #2490 / AC8.
+ *
+ * This is intentionally a NEW-SURFACE check: the baseline has no governed
+ * held-out retrieval corpus.  The missing fixture is therefore an expected
+ * Phase 2.5 ERROR, not a vacuous passing assertion.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+function nonEmptyString(value: unknown): boolean {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+function requireNonEmptyStringList(value: unknown, label: string): void {
+	expect(Array.isArray(value), `${label} must be an array`).toBe(true);
+	const values = value as unknown[];
+	expect(values.length, `${label} must not be empty`).toBeGreaterThan(0);
+	for (const [index, item] of values.entries()) {
+		expect(
+			nonEmptyString(item),
+			`${label}[${index}] must be a non-empty exact value`,
+		).toBe(true);
+	}
+}
+
+function requireEdgeList(value: unknown, label: string): void {
+	expect(Array.isArray(value), `${label} must be an array`).toBe(true);
+	const values = value as unknown[];
+	expect(values.length, `${label} must not be empty`).toBeGreaterThan(0);
+	for (const [index, item] of values.entries()) {
+		if (typeof item === 'string') {
+			expect(item.trim(), `${label}[${index}] must be non-empty`).not.toBe('');
+			expect(item, `${label}[${index}] must name both edge endpoints`).toMatch(
+				/\S+\s*(?:->|=>|::)\s*\S+/,
+			);
+			continue;
+		}
+		expect(item && typeof item === 'object').toBe(true);
+		const edge = item as Record<string, unknown>;
+		expect(nonEmptyString(edge.from ?? edge.source)).toBe(true);
+		expect(nonEmptyString(edge.to ?? edge.target)).toBe(true);
+	}
+}
+
+describe('issue #2490 AC8 — held-out multilingual retrieval corpus', () => {
+	test('publishes exact symbol/edge expectations and known misses', async () => {
+		const module = (await import(
+			'../../../tests/fixtures/memory-recall-heldout/manifest.json'
+		)) as {
+			default?: {
+				corpus_id?: string;
+				split?: string;
+				cases?: Array<Record<string, unknown>>;
+			};
+		};
+		const manifest = module.default ?? module;
+		expect(manifest.corpus_id).toBeTruthy();
+		expect(manifest.split).toBe('heldout');
+		expect(Array.isArray(manifest.cases)).toBe(true);
+		expect(manifest.cases?.length ?? 0).toBeGreaterThan(0);
+		for (const entry of manifest.cases ?? []) {
+			expect(nonEmptyString(entry.language)).toBe(true);
+			requireNonEmptyStringList(entry.expected_symbols, 'expected_symbols');
+			requireEdgeList(entry.expected_edges, 'expected_edges');
+			requireNonEmptyStringList(entry.known_misses, 'known_misses');
+			requireEdgeList(entry.spurious_edges, 'spurious_edges');
+			expect(nonEmptyString(entry.paraphrase)).toBe(true);
+			expect(entry.paraphrase as string).toMatch(/\s/);
+			expect((entry.paraphrase as string).trim().length).toBeGreaterThanOrEqual(
+				8,
+			);
+		}
+	});
+});

--- a/tests/unit/memory/recall-evaluation-analyzer-coverage-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-analyzer-coverage-acceptance.test.ts
@@ -1,0 +1,78 @@
+/** Acceptance coverage for issue #2490 / AC11.
+ *
+ * The manifest is a NEW-SURFACE contract on the baseline.  The test remains
+ * deliberately data-driven so adding a supported language does not require a
+ * versioned test edit.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { LANGUAGE_REGISTRY } from '../../../src/lang/profiles';
+import { languageDefinitions } from '../../../src/lang/registry';
+
+const DOCUMENTED_PARSER_ONLY = new Set([
+	'c',
+	'tsx',
+	'css',
+	'bash',
+	'powershell',
+	'ini',
+	'regex',
+]);
+
+function sameSet(actual: Iterable<string>, expected: Iterable<string>): void {
+	expect(new Set(actual)).toEqual(new Set(expected));
+}
+
+function isRunnableGate(value: unknown): boolean {
+	if (typeof value === 'string') return value.trim().length > 0;
+	if (!value || typeof value !== 'object') return false;
+	const gate = value as Record<string, unknown>;
+	return ['command', 'id', 'identifier', 'script'].some(
+		(key) =>
+			typeof gate[key] === 'string' && (gate[key] as string).trim() !== '',
+	);
+}
+
+describe('issue #2490 AC11 — analyzer extension and cross-OS coverage', () => {
+	test('publishes analyzer identities for every fixture language and OS gates', async () => {
+		const module = (await import(
+			'../../../tests/fixtures/memory-recall-heldout/manifest.json'
+		)) as {
+			default?: Record<string, unknown>;
+		};
+		const manifest = module.default ?? module;
+		const languages = manifest.supported_languages;
+		const analyzers = manifest.analyzer_extensions;
+		expect(Array.isArray(languages)).toBe(true);
+		expect((languages as unknown[]).length).toBeGreaterThan(0);
+		const authoritativeLanguages = languageDefinitions.map(
+			(definition) => definition.id,
+		);
+		sameSet(languages as string[], authoritativeLanguages);
+		const registryIds = new Set(
+			LANGUAGE_REGISTRY.getAll().map((profile) => profile.id),
+		);
+		const parserOnly = authoritativeLanguages.filter(
+			(id) => !registryIds.has(id),
+		);
+		expect(new Set(parserOnly)).toEqual(DOCUMENTED_PARSER_ONLY);
+		expect(Array.isArray(analyzers)).toBe(true);
+		const dispatchLanguages = LANGUAGE_REGISTRY.getAll()
+			.filter((profile) => !profile.parserOnly)
+			.map((profile) => profile.id);
+		const analyzerLanguages: string[] = [];
+		for (const analyzer of analyzers as Array<Record<string, unknown>>) {
+			expect(typeof analyzer.language).toBe('string');
+			expect((analyzer.language as string).trim()).not.toBe('');
+			expect(typeof analyzer.extractor_id).toBe('string');
+			expect((analyzer.extractor_id as string).trim()).not.toBe('');
+			analyzerLanguages.push(analyzer.language as string);
+		}
+		sameSet(analyzerLanguages, dispatchLanguages);
+		const osGates = manifest.os_gates as Record<string, unknown> | undefined;
+		expect(osGates).toBeDefined();
+		for (const platform of ['linux', 'macos', 'windows']) {
+			expect(isRunnableGate(osGates?.[platform])).toBe(true);
+		}
+	});
+});

--- a/tests/unit/memory/recall-evaluation-docs-release-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-docs-release-acceptance.test.ts
@@ -1,0 +1,56 @@
+/** Acceptance coverage for issue #2490 / AC13. */
+
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const repositoryRoot = path.resolve(import.meta.dir, '../../..');
+const documentation = ['docs/memory.md', 'docs/commands.md']
+	.map((relativePath) =>
+		readFileSync(path.join(repositoryRoot, relativePath), 'utf8'),
+	)
+	.join('\n')
+	.toLowerCase();
+
+describe('issue #2490 AC13 — evaluator documentation and release evidence', () => {
+	test('documents the profiles and auditable measurement contract', () => {
+		for (const profile of ['lexical', 'hybrid', 'hybrid+rerank']) {
+			expect(
+				documentation,
+				`missing profile documentation: ${profile}`,
+			).toContain(profile);
+		}
+		for (const term of [
+			'manifest',
+			'corpus',
+			'version',
+			'limitation',
+			'degrad',
+			'fallback',
+			'precision',
+			'recall',
+			'latency',
+			'cost',
+			'resource',
+		]) {
+			expect(
+				documentation,
+				`missing evaluator documentation term: ${term}`,
+			).toContain(term);
+		}
+	});
+
+	test('has one unique pending release fragment naming both issues', () => {
+		const pendingDirectory = path.join(repositoryRoot, 'docs/releases/pending');
+		const matches = readdirSync(pendingDirectory)
+			.filter((file) => file.endsWith('.md'))
+			.filter((file) => {
+				const content = readFileSync(path.join(pendingDirectory, file), 'utf8');
+				return content.includes('#2489') && content.includes('#2490');
+			});
+		expect(
+			matches,
+			'expected one pending fragment mentioning #2489 and #2490',
+		).toHaveLength(1);
+	});
+});

--- a/tests/unit/memory/recall-evaluation-docs-release-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-docs-release-acceptance.test.ts
@@ -38,6 +38,18 @@ describe('issue #2490 AC13 — evaluator documentation and release evidence', ()
 				`missing evaluator documentation term: ${term}`,
 			).toContain(term);
 		}
+		for (const contractAnchor of [
+			'--profiles lexical,hybrid,hybrid+rerank',
+			'returned_token_estimate',
+			'linux/macos/windows gate ids',
+			'no model downloads or network access',
+			'bun run check:retrieval-quality',
+		]) {
+			expect(
+				documentation,
+				`missing evaluator contract anchor: ${contractAnchor}`,
+			).toContain(contractAnchor);
+		}
 	});
 
 	test('has one unique pending release fragment naming both issues', () => {

--- a/tests/unit/memory/recall-evaluation-manifest-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-manifest-acceptance.test.ts
@@ -1,0 +1,89 @@
+/** Acceptance coverage for issue #2490 / AC9. */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import {
+	evaluateMemoryRecallFixtures,
+	validateRecallEvaluationManifest,
+} from '../../../src/memory/evaluation';
+
+const fixtureDirectory = path.resolve(
+	import.meta.dir,
+	'../../fixtures/memory-recall',
+);
+
+type Manifest = Record<string, unknown>;
+
+describe('issue #2490 AC9 — versioned evaluation manifest', () => {
+	test('production evaluator output passes the exported strict validator', async () => {
+		const report = (await evaluateMemoryRecallFixtures({
+			fixtureDirectory,
+			providers: ['local-jsonl'],
+			modes: ['manual'],
+		})) as unknown as { manifest?: Manifest };
+
+		expect(report.manifest).toBeDefined();
+		expect(() =>
+			validateRecallEvaluationManifest(report.manifest as Manifest),
+		).not.toThrow();
+	});
+
+	test('exported validator rejects empty and malformed manifest contracts', () => {
+		expect(() => validateRecallEvaluationManifest({})).toThrow();
+
+		const valid: Manifest = {
+			version: '1.0.0',
+			source_id: 'opencode-swarm',
+			model_id: 'none',
+			provider_id: 'local-jsonl',
+			config_hash: 'a'.repeat(64),
+			corpus_hash: 'b'.repeat(64),
+			profile_thresholds: { lexical: 0.5 },
+			sample_counts: { total: 1 },
+			metric_definitions: { precision: 'precision@k' },
+			uncertainty: {
+				method: 'bootstrap',
+				confidence: 0.95,
+				sample_count: 1,
+			},
+		};
+
+		const malformed: Array<[string, Manifest]> = [
+			['empty source identity', { source_id: '' }],
+			['empty model identity', { model_id: '' }],
+			['empty provider identity', { provider_id: '' }],
+			['invalid config hash', { config_hash: 'not-a-sha256' }],
+			['invalid corpus hash', { corpus_hash: 'not-a-sha256' }],
+			['empty thresholds', { profile_thresholds: {} }],
+			['zero sample count', { sample_counts: { total: 0 } }],
+			['empty metric definitions', { metric_definitions: {} }],
+			[
+				'invalid uncertainty',
+				{
+					uncertainty: {
+						method: '',
+						confidence: 0,
+						sample_count: 0,
+					},
+				},
+			],
+		];
+
+		for (const [label, patch] of malformed) {
+			const candidate = {
+				...valid,
+				...patch,
+				profile_thresholds:
+					patch.profile_thresholds ?? valid.profile_thresholds,
+				sample_counts: patch.sample_counts ?? valid.sample_counts,
+				metric_definitions:
+					patch.metric_definitions ?? valid.metric_definitions,
+				uncertainty: patch.uncertainty ?? valid.uncertainty,
+			};
+			expect(
+				() => validateRecallEvaluationManifest(candidate),
+				label,
+			).toThrow();
+		}
+	});
+});

--- a/tests/unit/memory/recall-evaluation-profile-isolation.test.ts
+++ b/tests/unit/memory/recall-evaluation-profile-isolation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { evaluateMemoryRecallFixtures } from '../../../src/memory/evaluation';
+import { withSafeTestDir } from '../../helpers/safe-test-dir';
+
+const fixtureDirectory = path.resolve(
+	import.meta.dir,
+	'../../fixtures/memory-recall',
+);
+
+function dependencies() {
+	const calls = { embed: 0, rerank: 0 };
+	return {
+		calls,
+		dependencies: {
+			embeddingProvider: {
+				modelVersion: 'profile-isolation',
+				dimension: 2,
+				available: true,
+				embed: async () => {
+					calls.embed++;
+					return new Float32Array([1, 0]);
+				},
+				embedBatch: async (texts: string[]) => {
+					calls.embed += texts.length;
+					return texts.map(() => new Float32Array([1, 0]));
+				},
+			},
+			reranker: {
+				modelVersion: 'profile-isolation-reranker',
+				available: true,
+				rerank: async <T>(candidates: T[]) => {
+					calls.rerank++;
+					return [...candidates];
+				},
+			},
+		},
+	};
+}
+
+describe('recall evaluation profile isolation', () => {
+	test('a multi-profile run invokes reranking only for hybrid+rerank', async () => {
+		const { calls, dependencies: injected } = dependencies();
+		const report = await evaluateMemoryRecallFixtures({
+			fixtureDirectory,
+			providers: ['sqlite'],
+			modes: ['manual'],
+			profiles: ['lexical', 'hybrid', 'hybrid+rerank'],
+			dependencies: injected,
+		});
+		expect(calls.embed).toBeGreaterThan(0);
+		expect(calls.rerank).toBe(8);
+		expect(
+			report.runs
+				.filter((run) => run.profile === 'hybrid')
+				.every((run) => run.status === 'complete'),
+		).toBe(true);
+		for (const run of report.runs) {
+			const usage = run.resource_usage;
+			expect(usage).toBeDefined();
+			for (const value of Object.values(usage ?? {})) {
+				expect(Number.isFinite(value)).toBe(true);
+				expect(value).toBeGreaterThanOrEqual(0);
+			}
+			const cap = run.resource_cap?.candidate_count ?? 0;
+			expect(usage?.lexical_candidate_count).toBeLessThanOrEqual(cap);
+			expect(usage?.dense_candidate_count).toBeLessThanOrEqual(cap);
+			expect(usage?.rerank_candidate_count).toBeLessThanOrEqual(cap);
+			expect(usage?.returned_token_estimate).toBeGreaterThanOrEqual(0);
+		}
+	});
+
+	test('profile order cannot reuse a prior profile query embedding cache', async () => {
+		const profiles = ['lexical', 'hybrid', 'hybrid+rerank'] as const;
+		const forward = await evaluateMemoryRecallFixtures({
+			fixtureDirectory,
+			providers: ['sqlite'],
+			modes: ['manual'],
+			profiles: [...profiles],
+			dependencies: dependencies().dependencies,
+			resourceCaps: { candidate_count: 2, token_budget: 256 },
+		});
+		const reverse = await evaluateMemoryRecallFixtures({
+			fixtureDirectory,
+			providers: ['sqlite'],
+			modes: ['manual'],
+			profiles: [...profiles].reverse(),
+			dependencies: dependencies().dependencies,
+			resourceCaps: { candidate_count: 2, token_budget: 256 },
+		});
+
+		for (const report of [forward, reverse]) {
+			for (const profile of ['hybrid', 'hybrid+rerank'] as const) {
+				const profileRuns = report.runs.filter(
+					(run) => run.profile === profile,
+				);
+				expect(profileRuns.length).toBeGreaterThan(0);
+				expect(
+					profileRuns.every(
+						(run) => run.resource_usage?.query_embedding_invocation_count === 1,
+					),
+				).toBe(true);
+			}
+		}
+	}, 15_000);
+
+	test('quality profiles enforce the returned-token cap for an oversized record without changing no-profile recall', async () => {
+		await withSafeTestDir(async (directory) => {
+			await fs.writeFile(
+				path.join(directory, 'oversized.json'),
+				JSON.stringify({
+					name: 'oversized-record',
+					query: 'oversized recall target',
+					scopes: [{ type: 'repository', repoId: 'token-cap-test' }],
+					k: 1,
+					maxItems: 1,
+					tokenBudget: 32,
+					expectedLabels: ['oversized'],
+					records: [
+						{
+							label: 'oversized',
+							scope: { type: 'repository', repoId: 'token-cap-test' },
+							kind: 'code_pattern',
+							text: `oversized recall target ${'x'.repeat(512)}`,
+							source: { type: 'manual', ref: 'token-cap-test' },
+						},
+					],
+				}),
+			);
+			const profiled = await evaluateMemoryRecallFixtures({
+				fixtureDirectory: directory,
+				providers: ['sqlite'],
+				modes: ['manual'],
+				profiles: ['lexical'],
+				resourceCaps: { candidate_count: 1, token_budget: 32 },
+			});
+			const unprofiled = await evaluateMemoryRecallFixtures({
+				fixtureDirectory: directory,
+				providers: ['sqlite'],
+				modes: ['manual'],
+			});
+
+			expect(
+				profiled.runs[0]?.resource_usage?.returned_token_estimate,
+			).toBeLessThanOrEqual(32);
+			expect(profiled.runs[0]?.retrieved_labels).toEqual([]);
+			expect(unprofiled.runs[0]?.retrieved_labels).toEqual(['oversized']);
+		}, 'swarm-memory-evaluation-token-cap-');
+	});
+});

--- a/tests/unit/memory/recall-evaluation-profiles-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-profiles-acceptance.test.ts
@@ -1,0 +1,101 @@
+/** Acceptance coverage for issue #2490 / AC7. */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import type { RecallEvaluationOptions } from '../../../src/memory/evaluation';
+import { evaluateMemoryRecallFixtures } from '../../../src/memory/evaluation';
+
+const fixtureDirectory = path.resolve(
+	import.meta.dir,
+	'../../fixtures/memory-recall',
+);
+
+type Counters = { embed: number; embedBatch: number; rerank: number };
+
+function makeDependencies(): { counters: Counters; dependencies: unknown } {
+	const counters: Counters = { embed: 0, embedBatch: 0, rerank: 0 };
+	const embeddingProvider = {
+		modelVersion: 'acceptance-embedding-v1',
+		dimension: 4,
+		available: true,
+		embed: async (text: string) => {
+			counters.embed++;
+			return new Float32Array([
+				text.length,
+				text.includes('memory') ? 1 : 0,
+				0,
+				1,
+			]);
+		},
+		embedBatch: async (texts: string[]) => {
+			counters.embedBatch++;
+			return Promise.all(texts.map((text) => embeddingProvider.embed(text)));
+		},
+	};
+	const reranker = {
+		modelVersion: 'acceptance-reranker-v1',
+		available: true,
+		async rerank<T extends { id: string }>(candidates: T[]): Promise<T[]> {
+			counters.rerank++;
+			return [...candidates].reverse();
+		},
+	};
+	return { counters, dependencies: { embeddingProvider, reranker } };
+}
+
+async function runProfile(profile: string): Promise<{
+	report: unknown;
+	counters: Counters;
+}> {
+	const { counters, dependencies } = makeDependencies();
+	const report = await evaluateMemoryRecallFixtures({
+		fixtureDirectory,
+		providers: ['sqlite'],
+		modes: ['manual'],
+		profiles: [profile],
+		dependencies,
+	} as unknown as RecallEvaluationOptions);
+	return { report, counters };
+}
+
+function assertExplicitStatuses(
+	report: unknown,
+	expectedProfile: string,
+): void {
+	const runs = (report as { runs?: Array<Record<string, unknown>> }).runs ?? [];
+	expect(runs.length).toBeGreaterThan(0);
+	expect(new Set(runs.map((run) => run.profile))).toEqual(
+		new Set([expectedProfile]),
+	);
+	for (const run of runs) {
+		expect(['complete', 'degraded', 'skipped']).toContain(run.status);
+		if (run.status === 'degraded' || run.status === 'skipped') {
+			expect(typeof run.degradation_reason).toBe('string');
+			expect((run.degradation_reason as string).trim()).not.toBe('');
+		}
+	}
+}
+
+describe('issue #2490 AC7 — evaluator retrieval profiles and injected providers', () => {
+	test('runs lexical, hybrid, and hybrid+rerank without downloading models', async () => {
+		const lexical = await runProfile('lexical');
+		const hybrid = await runProfile('hybrid');
+		const hybridRerank = await runProfile('hybrid+rerank');
+
+		assertExplicitStatuses(lexical.report, 'lexical');
+		assertExplicitStatuses(hybrid.report, 'hybrid');
+		assertExplicitStatuses(hybridRerank.report, 'hybrid+rerank');
+
+		// A report label alone is not evidence that the injected providers ran.
+		expect(lexical.counters.embed + lexical.counters.embedBatch).toBe(0);
+		expect(lexical.counters.rerank).toBe(0);
+		expect(hybrid.counters.embed + hybrid.counters.embedBatch).toBeGreaterThan(
+			0,
+		);
+		expect(hybrid.counters.rerank).toBe(0);
+		expect(
+			hybridRerank.counters.embed + hybridRerank.counters.embedBatch,
+		).toBeGreaterThan(0);
+		expect(hybridRerank.counters.rerank).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/memory/recall-evaluation-resources-acceptance.test.ts
+++ b/tests/unit/memory/recall-evaluation-resources-acceptance.test.ts
@@ -1,0 +1,98 @@
+/** Acceptance coverage for issue #2490 / AC10. */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { evaluateMemoryRecallFixtures } from '../../../src/memory/evaluation';
+
+const fixtureDirectory = path.resolve(
+	import.meta.dir,
+	'../../fixtures/memory-recall',
+);
+
+function makeDependencies(): unknown {
+	return {
+		embeddingProvider: {
+			modelVersion: 'acceptance-embedding-v1',
+			dimension: 4,
+			available: true,
+			embed: async (text: string) =>
+				new Float32Array([text.length, text.includes('memory') ? 1 : 0, 0, 1]),
+			embedBatch: async (texts: string[]) =>
+				texts.map(
+					(text) =>
+						new Float32Array([
+							text.length,
+							text.includes('memory') ? 1 : 0,
+							0,
+							1,
+						]),
+				),
+		},
+		reranker: {
+			modelVersion: 'acceptance-reranker-v1',
+			available: true,
+			async rerank<T>(candidates: T[]): Promise<T[]> {
+				return [...candidates].reverse();
+			},
+		},
+	};
+}
+
+function nonEmpty(value: unknown): boolean {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+function finite(value: unknown): boolean {
+	return typeof value === 'number' && Number.isFinite(value);
+}
+
+describe('issue #2490 AC10 — matched retrieval resource comparison', () => {
+	test('compares profiles with metrics, caps, provenance, and degradation rows', async () => {
+		const report = (await evaluateMemoryRecallFixtures({
+			fixtureDirectory,
+			providers: ['sqlite'],
+			modes: ['manual'],
+			profiles: ['lexical', 'hybrid', 'hybrid+rerank'],
+			resourceCaps: { candidate_count: 8, token_budget: 256 },
+			dependencies: makeDependencies(),
+		} as unknown as Parameters<
+			typeof evaluateMemoryRecallFixtures
+		>[0])) as unknown as {
+			runs: Array<Record<string, unknown>>;
+		};
+		const profiles = new Set(
+			report.runs.map((run) => run.profile).filter((value) => value),
+		);
+		expect(profiles).toEqual(new Set(['lexical', 'hybrid', 'hybrid+rerank']));
+		const caps = report.runs.map((run) => {
+			const cap = run.resource_cap as Record<string, unknown> | undefined;
+			expect(cap).toBeDefined();
+			const candidates = cap?.candidate_count ?? cap?.candidates;
+			const tokens = cap?.token_budget ?? cap?.tokens;
+			expect(candidates).toBeGreaterThan(0);
+			expect(tokens).toBeGreaterThan(0);
+			return `${candidates}:${tokens}`;
+		});
+		expect(new Set(caps).size).toBe(1);
+		for (const run of report.runs) {
+			expect(['complete', 'degraded', 'skipped']).toContain(run.status);
+			expect(nonEmpty(run.provenance)).toBe(true);
+			const metrics = (run.metrics ?? {}) as Record<string, unknown>;
+			const precision = run['precision@k'] ?? metrics['precision@k'];
+			const recall = run['recall@k'] ?? metrics['recall@k'];
+			const latency = run.latency_ms ?? metrics.latency_ms;
+			const cost = run.cost as Record<string, unknown> | undefined;
+			const costProvenance =
+				run.cost_provenance ?? cost?.provenance ?? cost?.source;
+			if (run.status === 'complete') {
+				expect(finite(precision)).toBe(true);
+				expect(finite(recall)).toBe(true);
+				expect(finite(latency)).toBe(true);
+				expect(nonEmpty(costProvenance)).toBe(true);
+			} else {
+				const reason = run.degradation_reason ?? run.reason;
+				expect(nonEmpty(reason)).toBe(true);
+			}
+		}
+	});
+});

--- a/tests/unit/memory/retrieval-quality-ci-packaging-acceptance.test.ts
+++ b/tests/unit/memory/retrieval-quality-ci-packaging-acceptance.test.ts
@@ -1,0 +1,58 @@
+/** Acceptance coverage for issue #2490 / AC14 packaging and CI wiring. */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const repositoryRoot = path.resolve(import.meta.dir, '../../..');
+const packageManifest = JSON.parse(
+	readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+) as { files?: unknown };
+const workflow = readFileSync(
+	path.join(repositoryRoot, '.github/workflows/ci.yml'),
+	'utf8',
+);
+
+describe('issue #2490 AC14 — retrieval-quality package and CI wiring', () => {
+	test('ships every held-out corpus path in the package files allowlist', () => {
+		expect(Array.isArray(packageManifest.files)).toBe(true);
+		const files = packageManifest.files as string[];
+		expect(
+			files.some((entry) =>
+				/^tests\/fixtures\/memory-recall-heldout(?:\/|\/\*\*|$)/.test(entry),
+			),
+		).toBe(true);
+	});
+
+	test('runs retrieval quality from the blocking memory regression job', () => {
+		const job = workflow.match(
+			/memory-recall-regression:[\s\S]*?(?=\n\s{2}[A-Za-z0-9_-]+:|\s*$)/,
+		)?.[0];
+		expect(job).toBeDefined();
+		expect(job).toContain('bun run check:retrieval-quality');
+	});
+
+	test('path-sensitive unit CI promotes relevant changes to the three-OS matrix', () => {
+		expect(workflow).toContain(
+			'fromJSON(\'["ubuntu-latest","macos-latest","windows-latest"]\')',
+		);
+		expect(workflow).toContain(
+			"needs.detect-paths.outputs.touches-platform-paths == 'true'",
+		);
+		const pathDetector = workflow.match(
+			/git diff --name-only[\s\S]*?echo "touches-platform-paths=false"/,
+		)?.[0];
+		expect(pathDetector).toBeDefined();
+		for (const relevantPath of [
+			'src/lang/',
+			'src/memory/',
+			'src/evaluation/',
+			'src/tools/',
+			'tests/fixtures/memory-recall-heldout/',
+		]) {
+			expect(pathDetector, `missing path trigger: ${relevantPath}`).toContain(
+				relevantPath,
+			);
+		}
+	});
+});

--- a/tests/unit/memory/sqlite-provider-injected-dense-boundary.test.ts
+++ b/tests/unit/memory/sqlite-provider-injected-dense-boundary.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	computeMemoryContentHash,
+	createMemoryId,
+	SQLiteMemoryProvider,
+} from '../../../src/memory';
+import type { MemoryRecord, RecallRequest } from '../../../src/memory/types';
+import { withFrozenClock } from '../../helpers/test-clock';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	for (const root of roots.splice(0))
+		await fs.rm(root, { recursive: true, force: true });
+});
+
+function makeRecord(
+	root: string,
+	name: string,
+	overrides: Partial<MemoryRecord> = {},
+): MemoryRecord {
+	const base = {
+		scope: {
+			type: 'repository' as const,
+			repoId: 'allowed-repo',
+			repoRoot: root,
+		},
+		kind: 'project_fact' as const,
+		text: `${name} memory`,
+		stability: 'durable' as const,
+		...overrides,
+	};
+	return {
+		id: createMemoryId(base),
+		...base,
+		tags: [],
+		confidence: 1,
+		source: { type: 'file', filePath: `${name}.ts` },
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		contentHash: computeMemoryContentHash(base),
+		metadata: {},
+	};
+}
+
+describe('injected dense selector boundary', () => {
+	test('cannot receive or return cross-scope, stale, or disallowed-kind records', async () => {
+		const root = canonicalMkdtemp('swarm-dense-boundary-');
+		roots.push(root);
+		const { allowed, crossScope, stale, disallowedKind } = withFrozenClock(
+			() => ({
+				allowed: makeRecord(root, 'allowed'),
+				crossScope: makeRecord(root, 'cross-scope', {
+					scope: {
+						type: 'repository',
+						repoId: 'other-repo',
+						repoRoot: root,
+					},
+				}),
+				stale: makeRecord(root, 'stale', {
+					expiresAt: '2000-01-01T00:00:00.000Z',
+				}),
+				disallowedKind: makeRecord(root, 'disallowed-kind', {
+					kind: 'repo_convention',
+				}),
+			}),
+		);
+		let suppliedIds: string[] = [];
+		const provider = new SQLiteMemoryProvider(
+			root,
+			{ enabled: true, provider: 'sqlite', embeddings: { enabled: true } },
+			undefined,
+			{
+				embeddingProvider: {
+					modelVersion: 'test:1',
+					dimension: 1,
+					available: true,
+					embed: async () => new Float32Array([1]),
+					embedBatch: async (texts) => texts.map(() => new Float32Array([1])),
+				},
+				denseSelector: async (_request, _queryEmbedding, candidates) => {
+					suppliedIds = candidates.map((record) => record.id);
+					return [crossScope, stale, disallowedKind, ...candidates, crossScope];
+				},
+			},
+		);
+		try {
+			for (const record of [allowed, crossScope, stale, disallowedKind])
+				await provider.upsert(record);
+			const request: RecallRequest = {
+				query: 'memory',
+				scopes: [allowed.scope],
+				kinds: ['project_fact'],
+				maxItems: 5,
+				tokenBudget: 256,
+			};
+			const selected = await (
+				provider as unknown as {
+					selectDenseCandidates(
+						request: RecallRequest,
+						queryEmbedding: Float32Array,
+					): Promise<MemoryRecord[]>;
+				}
+			).selectDenseCandidates(request, new Float32Array([1]));
+
+			expect(suppliedIds).toEqual([allowed.id]);
+			expect(selected.map((record) => record.id)).toEqual([allowed.id]);
+		} finally {
+			await provider.close();
+		}
+	});
+});

--- a/tests/unit/memory/sqlite-provider-token-budget.test.ts
+++ b/tests/unit/memory/sqlite-provider-token-budget.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { _test_exports as sqliteProviderTestExports } from '../../../src/memory/sqlite-provider';
+import type { RecallResultItem } from '../../../src/memory/types';
+
+function item(text: string): RecallResultItem {
+	return { record: { text } } as unknown as RecallResultItem;
+}
+
+describe('quality recall token-budget packing', () => {
+	test('skips an oversized ranked item so a later compact item can fit', () => {
+		const oversized = item('x'.repeat(256));
+		const compact = item('small');
+
+		const selected =
+			sqliteProviderTestExports.capQualityRecallItemsByTokenBudget(
+				[oversized, compact],
+				32,
+			);
+
+		expect(selected).toEqual([compact]);
+	});
+});

--- a/tests/unit/scripts/package-smoke.test.ts
+++ b/tests/unit/scripts/package-smoke.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 // @ts-expect-error - .mjs script exports runtime helpers without declarations.
 import {
 	REQUIRED_EVALUATION_FIXTURE_IDS,
+	REQUIRED_HELDOUT_RETRIEVAL_FILES,
 	REQUIRED_PROJECT_SKILL_SLUGS,
 	validatePackageFiles,
 } from '../../../scripts/package-smoke.mjs';
@@ -96,6 +97,7 @@ const baseFiles = [
 		`evaluation-fixtures/tier1/${id}/environment/defect.ts`,
 		`evaluation-fixtures/tier1/${id}/environment/defect.test.ts`,
 	]),
+	...REQUIRED_HELDOUT_RETRIEVAL_FILES,
 ].map((path) => ({ path }));
 
 describe('package-smoke skill-list sync', () => {

--- a/tests/unit/tools/repo-graph-citation-hygiene-acceptance.test.ts
+++ b/tests/unit/tools/repo-graph-citation-hygiene-acceptance.test.ts
@@ -1,0 +1,37 @@
+/** Acceptance coverage for issue #2489 / AC5. */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const repositoryRoot = path.resolve(import.meta.dir, '../../../');
+
+describe('issue #2489 AC5 — repo-graph citation and test-isolation hygiene', () => {
+	test('does not retain the stale repo-graph citation baseline entries', () => {
+		const baselinePath = path.join(
+			repositoryRoot,
+			'scripts',
+			'registry-citation-baseline.json',
+		);
+		const baseline = JSON.parse(readFileSync(baselinePath, 'utf8')) as {
+			entries?: Array<{ rowId?: string }>;
+		};
+		expect(
+			(baseline.entries ?? []).filter((entry) => entry.rowId === 'repo-graph'),
+		).toEqual([]);
+	});
+
+	test('close-stage regression coverage uses the scoped DI seam', () => {
+		const testPath = path.join(
+			repositoryRoot,
+			'tests',
+			'unit',
+			'commands',
+			'close-repo-memory-close-throws.test.ts',
+		);
+		const source = readFileSync(testPath, 'utf8');
+		const moduleCall = `${['mock', 'module'].join('.')}(`;
+		expect(source).not.toContain(moduleCall);
+		expect(source).toContain('closeInternals.closeRepoMemory');
+	});
+});

--- a/tests/unit/tools/repo-graph-schema-compat.test.ts
+++ b/tests/unit/tools/repo-graph-schema-compat.test.ts
@@ -89,4 +89,15 @@ describe('schema 1.2.0 graph compatibility (A1)', () => {
 		// getCallers on helper's 'helper' export resolves via the node edge.
 		expect(getCallers(loaded, 'src/helper.ts', 'helper').length).toBe(1);
 	});
+
+	test('a null graph document reports structured schema corruption', async () => {
+		const graphPath = path.join(tmp, '.swarm', 'repo-graph.json');
+		fs.writeFileSync(graphPath, 'null', 'utf8');
+		clearCache(tmp);
+
+		await expect(loadGraph(tmp)).rejects.toMatchObject({
+			code: 'CORRUPTION',
+			message: 'repo-graph.json has unsupported schema_version: undefined',
+		});
+	});
 });

--- a/tests/unit/tools/repo-graph-schema-compatibility-acceptance.test.ts
+++ b/tests/unit/tools/repo-graph-schema-compatibility-acceptance.test.ts
@@ -1,0 +1,117 @@
+/** Acceptance coverage for issue #2489 / AC4. */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { loadDatabaseCtor } from '../../../src/db/sqlite-loader';
+import { upsertNode } from '../../../src/tools/repo-graph/builder';
+import { clearCache } from '../../../src/tools/repo-graph/cache';
+import {
+	closeAllRepoMemory,
+	getRepoMemoryPath,
+	queryNodeByFile as queryIndexedNodeByFile,
+} from '../../../src/tools/repo-graph/indexed-storage';
+import {
+	getGraphPath,
+	loadGraphSync,
+	saveGraph,
+} from '../../../src/tools/repo-graph/storage';
+import { createEmptyGraph } from '../../../src/tools/repo-graph/types';
+import { canonicalMkdtemp } from '../../../tests/helpers/tmpdir';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	closeAllRepoMemory();
+	for (const workspace of workspaces) {
+		clearCache(workspace);
+		rmSync(workspace, { recursive: true, force: true });
+	}
+	workspaces.length = 0;
+});
+
+async function writeSchemaVersion(
+	version: string,
+	storage: 'json' | 'indexed',
+): Promise<string> {
+	const workspace = canonicalMkdtemp('repo-graph-schema-acceptance-');
+	workspaces.push(workspace);
+	// The explicit project marker lets the real workspace boundary validator
+	// exercise the same path used by production graph loads.
+	const marker = path.join(workspace, '.opencode');
+	mkdirSync(marker, { recursive: true });
+	if (storage === 'indexed') {
+		writeFileSync(
+			path.join(marker, 'opencode-swarm.json'),
+			JSON.stringify({ repo_graph: { storage: 'indexed' } }),
+			'utf8',
+		);
+	}
+	const graph = createEmptyGraph(workspace);
+	upsertNode(graph, {
+		filePath: path.join(workspace, 'src', 'a.ts'),
+		moduleName: 'src/a.ts',
+		exports: [],
+		imports: [],
+		language: 'typescript',
+		mtime: new Date(0).toISOString(),
+	});
+	await saveGraph(workspace, graph);
+
+	if (storage === 'indexed') {
+		// Close the production handle before opening a second real SQLite
+		// connection to mutate only the derived metadata. The source JSON remains
+		// fresh, so this reaches openFreshIndex rather than a stale-index fallback.
+		closeAllRepoMemory();
+		const Db = loadDatabaseCtor();
+		const db = new Db(getRepoMemoryPath(workspace));
+		try {
+			db.run('UPDATE graph_meta SET value = ? WHERE key = ?', [
+				version,
+				'graph_schema_version',
+			]);
+		} finally {
+			db.close();
+		}
+	} else {
+		const graphPath = getGraphPath(workspace);
+		const persisted = JSON.parse(readFileSync(graphPath, 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		persisted.schema_version = version;
+		writeFileSync(graphPath, `${JSON.stringify(persisted)}\n`, 'utf8');
+		clearCache(workspace);
+	}
+	return workspace;
+}
+
+describe('issue #2489 AC4 — persisted graph schema compatibility', () => {
+	test('rejects malformed schema versions before trusting persisted nodes', async () => {
+		const workspace = await writeSchemaVersion('not-a-semver', 'json');
+		expect(() => loadGraphSync(workspace)).toThrow(
+			/schema|version|corrupt|invalid/i,
+		);
+
+		const indexed = await writeSchemaVersion('not-a-semver', 'indexed');
+		expect(queryIndexedNodeByFile(indexed, 'src/a.ts')).toBeNull();
+	});
+
+	test('rejects a future graph schema version instead of silently loading it', async () => {
+		const workspace = await writeSchemaVersion('999.0.0', 'json');
+		expect(() => loadGraphSync(workspace)).toThrow(
+			/schema|version|supported|rebuild|corrupt/i,
+		);
+
+		const indexed = await writeSchemaVersion('999.0.0', 'indexed');
+		expect(queryIndexedNodeByFile(indexed, 'src/a.ts')).toBeNull();
+	});
+
+	test('preserves a supported older schema version at both load boundaries', async () => {
+		const json = await writeSchemaVersion('1.2.0', 'json');
+		expect(loadGraphSync(json)?.schema_version).toBe('1.2.0');
+
+		const indexed = await writeSchemaVersion('1.2.0', 'indexed');
+		expect(queryIndexedNodeByFile(indexed, 'src/a.ts')).not.toBeNull();
+	});
+});

--- a/tests/unit/tools/repo-graph-symbol-edge-cache-acceptance.test.ts
+++ b/tests/unit/tools/repo-graph-symbol-edge-cache-acceptance.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Acceptance coverage for issue #2489 / AC2.
+ *
+ * The public symbol-query module historically rebuilt its forward/reverse
+ * symbol-edge maps in each query family.  This fixture observes the public
+ * graph input rather than reaching into a private helper, so it fails for the
+ * shipped duplicate scans and remains valid if the cache implementation is
+ * reorganized.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { resetQueryCache } from '../../../src/tools/repo-graph/query';
+import {
+	explainGraphEntry,
+	getImpactCone,
+	getSymbolContext,
+} from '../../../src/tools/repo-graph/symbol-query';
+import type {
+	GraphNode,
+	RepoGraph,
+	SymbolEdge,
+} from '../../../src/tools/repo-graph/types';
+import { normalizeGraphPath } from '../../../src/tools/repo-graph/types';
+
+const root = path.resolve(import.meta.dir, '../../../repo-graph-symbol-cache');
+
+function key(file: string): string {
+	return normalizeGraphPath(path.join(root, file));
+}
+
+function makeNode(file: string, symbol: string): GraphNode {
+	return {
+		filePath: key(file),
+		moduleName: file,
+		exports: [symbol],
+		exportLines: { [symbol]: 1 },
+		exportRanges: { [symbol]: { startLine: 1, endLine: 1 } },
+		imports: [],
+		language: 'typescript',
+		mtime: '2026-01-01T00:00:00.000Z',
+	};
+}
+
+function makeCountingGraph(): {
+	graph: RepoGraph;
+	reads: () => number;
+	addEdge: (edge: SymbolEdge) => void;
+} {
+	const symbolEdges: SymbolEdge[] = [
+		{
+			fromFile: key('caller.ts'),
+			fromSymbol: 'call',
+			toFile: key('target.ts'),
+			toSymbol: 'run',
+		},
+		{
+			fromFile: key('target.ts'),
+			fromSymbol: 'run',
+			toFile: key('callee.ts'),
+			toSymbol: 'finish',
+		},
+	];
+	const nodes = {
+		[key('caller.ts')]: makeNode('caller.ts', 'call'),
+		[key('target.ts')]: makeNode('target.ts', 'run'),
+		[key('callee.ts')]: makeNode('callee.ts', 'finish'),
+	};
+	let symbolEdgeReads = 0;
+	const graph: RepoGraph = {
+		schema_version: '1.7.0',
+		workspaceRoot: root,
+		nodes,
+		edges: [],
+		metadata: {
+			generatedAt: '2026-01-01T00:00:00.000Z',
+			generator: 'acceptance',
+			nodeCount: 3,
+			edgeCount: 0,
+		},
+		get symbolEdges(): SymbolEdge[] {
+			symbolEdgeReads++;
+			return symbolEdges;
+		},
+	};
+	return {
+		graph,
+		reads: () => symbolEdgeReads,
+		addEdge: (edge) => symbolEdges.push(edge),
+	};
+}
+
+describe('issue #2489 AC2 — symbol-edge indexes are graph-identity cached', () => {
+	test('all public symbol query paths share one build and reset after mutation', () => {
+		resetQueryCache();
+		const counted = makeCountingGraph();
+
+		const context = getSymbolContext(counted.graph, {
+			file: 'target.ts',
+			symbol: 'run',
+		});
+		const cone = getImpactCone(counted.graph, {
+			file: 'target.ts',
+			symbol: 'run',
+		});
+		const explanation = explainGraphEntry(counted.graph, {
+			file: 'target.ts',
+			symbol: 'run',
+		});
+
+		expect(context.callers.map((entry) => entry.symbol)).toEqual(['call']);
+		expect(cone.entries.map((entry) => entry.symbol)).toEqual([
+			'finish',
+			'call',
+		]);
+		expect(
+			explanation.reasons
+				.filter(
+					(reason) =>
+						reason.type === 'referenced_by' || reason.type === 'references',
+				)
+				.map((reason) => reason.symbol),
+		).toEqual(['call', 'finish']);
+		expect(counted.reads()).toBe(1);
+
+		counted.addEdge({
+			fromFile: key('new-caller.ts'),
+			fromSymbol: 'newCall',
+			toFile: key('target.ts'),
+			toSymbol: 'run',
+		});
+		resetQueryCache();
+		const refreshed = getSymbolContext(counted.graph, {
+			file: 'target.ts',
+			symbol: 'run',
+		});
+		expect(refreshed.callers.map((entry) => entry.symbol)).toEqual([
+			'call',
+			'newCall',
+		]);
+		expect(counted.reads()).toBe(2);
+	});
+});


### PR DESCRIPTION
Closes #2489, #2490

## Summary
- Fixes repository-graph symbol-edge index ownership and reset behavior, adds strict graph schema compatibility, and removes stale graph citations.
- Adds production-wired lexical, hybrid, and hybrid+rerank retrieval evaluation with injected providers, deterministic 20-language held-out evidence, provenance, resource caps, and a blocking quality gate.
- Enforces the declared token budget after related-memory expansion on every profiled recall path while preserving no-profile recall behavior.
- Adds package, CLI, documentation, release-note, and CI wiring for the held-out corpus and deterministic gate.

## Invariant audit
- 1 (plugin init): not touched — no initialization path changed; `node scripts/repro-704.mjs` passes (all three bounded startup cases).
- 2 (runtime portability): not touched — no plugin entry or runtime loader changed; `bun run build` and Node ESM import of `dist/index.js` pass.
- 3 (subprocesses): not touched — no production subprocess call sites changed; `bun run check:bare-spawn` passes.
- 4 (.swarm containment): not touched — no runtime state or root-resolution code changed.
- 5 (plan durability): not touched — no plan ledger or projection code changed.
- 6 (test_runner safety): not touched — validation used bounded shell commands and the scoped CI-equivalent unit runner.
- 7 (test writing): touched — new bun:test coverage uses isolated files and DI seams; `bun run test:unit:ci <changed test files>` passes 16/16 individually, and `bun run check:test-file-cap` passes.
- 8 (session state): not touched — no session/global state changes.
- 9 (guardrails/retry): not touched — no guardrail or retry semantics changed.
- 10 (chat/system messages): not touched — no chat transform code changed.
- 11 (tool registration): not touched — no tool was added; `bun run scripts/check-tool-registration.ts` passes.
- 12 (release/cache): touched — package payload, release fragment, and CI wiring updated; `bun run package:smoke` passes with 1,267 files and `bun run check:pre-push` reports no drift.

## Test plan
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `node scripts/repro-704.mjs`
- `bun run typecheck`
- `bun run lint:ci` (pre-existing warnings only)
- `bun run check:token-formula`
- `bun run check:retrieval-quality` — canonical output, 20 cases / 60 runs, 14/14 direct-source positive hits
- `bun run test:unit:ci` scoped to all 16 changed unit files — 16/16 passed individually
- `bun run check:test-tmpdir`
- `bun run check:pre-push`
- `bun run package:smoke` — `package smoke OK: opencode-swarm-7.168.0.tgz (1267 files)`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

