### PR TITLE
feat(ci): ship advisory headless CI with a host-decoupled runtime (#2497)

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -79,6 +79,7 @@ These are invoked as `/swarm <subcommand>`, NOT as bare `/subcommand`. The list 
 - `/swarm dark-matter` — detect hidden file couplings via co-change NPMI analysis
 - `/swarm simulate` — dry-run hidden coupling analysis with configurable thresholds
 - `/swarm ci-simulate` — create a temporary merge-result worktree and run CI pre-merge
+- `/swarm ci` — advisory headless CI: read-only gate/evidence evaluation with machine exit codes (0 = all gates pass; Markdown + [SWARM_CI_JSON] report; `bunx opencode-swarm ci` outside OpenCode)
 - `/swarm qa-gates` — view or modify QA gate profile for the current plan
 - `/swarm report` — query the SQLite observability sink (filters: --task/--session/--trace/--run/--since, --json)
 - `/swarm acknowledge-spec-drift` — acknowledge spec drift and suppress further warnings

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ Control how tool outputs are summarized for LLM context.
 | `/swarm pr-review <pr-url\|owner/repo#N\|N> [--council] [instructions...]` | Structured deep PR review with parallel lanes, reviewer confirmation, and critic challenge |
 | `/swarm pr-feedback [<pr-url\|owner/repo#N\|N>] [instructions...]` | Ingest and close known PR feedback (review comments, CI failures, conflicts) without a fresh review |
 | `/swarm ci-monitor <pr-url\|owner/repo#N\|N>` | Drive an already-reviewed, approved PR to green and merged (monitor CI, fix, merge; max 5 fix cycles) |
+| `/swarm ci` `[--timeout-ms <n>] [--json]` | Advisory headless CI: read-only gate/evidence evaluation with machine exit codes (also `bunx opencode-swarm ci`; see docs/ci.md) |
 | `/swarm pr subscribe <pr-url\|owner/repo#N\|N>` | Subscribe current session to PR monitoring (session-scoped); requires `pr_monitor.enabled: true` |
 | `/swarm pr unsubscribe <pr-url\|owner/repo#N\|N>` | Remove session's subscription to a PR |
 | `/swarm pr status` | List active PR subscriptions for current session with relative timestamps (the `bunx opencode-swarm run pr status` CLI has no session context, so it lists subscriptions across all sessions) |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,92 @@
+# Advisory headless CI (`swarm ci`)
+
+`swarm ci` runs the gated swarm pipeline's **advisory evaluation** in a clean,
+noninteractive environment — a CI runner with no TTY, no OpenCode host, and no
+plugin boot. It reads the checked-out repo's `.swarm/` durable state through
+the same authoritative readers the live gates use, reports what it found, and
+exits with a machine-readable status. It never runs agents, never dispatches
+LLMs, and never writes to the repo.
+
+```bash
+bunx opencode-swarm ci                 # Markdown report + [SWARM_CI_JSON] block
+bunx opencode-swarm ci --json          # machine block only
+bunx opencode-swarm ci --timeout-ms 600000
+# equivalent inside OpenCode: /swarm ci ... ; registry form: bunx opencode-swarm run ci ...
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | every evaluated gate passed (and at least one gate was evaluated) |
+| 1 | any gate violation, a required check with **no data**, corrupt evidence, or nothing to evaluate (missing/unparseable/empty plan) |
+| 2 | cancelled (SIGINT/SIGTERM) |
+| 3 | deadline exceeded or internal error |
+
+"No data" is never a pass: a task with no recorded gate evidence, or a quality
+threshold with no evidence corpus, is reported `no_data` and fails the run —
+this is the honest-disposition fix for the vacuous-pass behavior the in-process
+`benchmark --ci-gate` exhibits when its live session-state inputs are empty.
+
+## What is evaluated
+
+Composed from the existing authoritative readers (no reimplementation):
+
+- **Plan** — `.swarm/plan.json` projection must exist, parse, and contain tasks
+  (`plan_missing` / `plan_corrupt` / `no_tasks` are distinct exit reasons).
+- **Plan critic** (`critic_pre_plan`) — the `plan_critic_gate` APPROVED snapshot
+  matching the current plan structure.
+- **Per-task gates** — for every plan task: the reader-derived required gates
+  versus recorded gate evidence, with the workflow state guard (a task counts
+  as satisfied only when all required gates are satisfied AND its workflow
+  snapshot is terminal-success: `complete` or `closed`). Evidence is tri-state:
+  `valid` / `missing` / `corrupt` are reported distinctly (#2470 semantics).
+- **Evidence-quality thresholds** — review pass rate (≥70%), test pass rate
+  (≥80%), quality-budget deltas (complexity ≤5, public API ≤10, duplication
+  ≤5%, test-to-code ≥30%), each `pass` / `fail` / `no_data`. This computation
+  is shared with `/swarm benchmark --ci-gate` (one implementation, two callers).
+
+Enabled profile gates that have no durable whole-plan reader (drift check, SME,
+councils, mutation) are listed in the report as **not evaluated** — reported,
+never silently passed. Live session-state checks (agent error rate, hard-limit
+hits) are listed as **not evaluable headless**.
+
+## Machine output
+
+The `[SWARM_CI_JSON]` … `[/SWARM_CI_JSON]` block wraps the pretty-printed
+report: `verdict`, `exit_reason`, `gates[]` (name + `pass|fail|no_data|corrupt|error`),
+`tasks[]` (task_id, evidence_state, required_gates, missing_gates, workflow_state),
+`environment` (`{mode:"advisory", tty, host:"none"}`), `gate_profile`
+(`default` when no QA profile is persisted), `effective_gates`, `not_evaluated`,
+`not_evaluable`, and per-status `counts`. Consume it from stdout:
+
+```bash
+output=$(bunx opencode-swarm ci --json 2>/dev/null); rc=$?
+report=$(printf '%s\n' "$output" | sed -n '/^\[SWARM_CI_JSON\]$/,/^\[\/SWARM_CI_JSON\]$/p' | sed '1d;$d')
+```
+
+## Read-only guarantees
+
+- The evaluated repo is never modified: file-backed reads are pure, and
+  DB-mediated reads (gate profile, plan-critic snapshots — which open the
+  SQLite store and would create WAL sidecars) run against a bounded, discarded
+  temp **shadow copy** of `.swarm/`. If the shadow exceeds 512 MiB, those rows
+  are reported as errors instead of copying unbounded data.
+- No gate can be satisfied or bypassed from this path — it only reads and
+  reports. The live enforcement points (delegation gate, reviewer/test gates at
+  task completion) are unchanged.
+- The evaluation spawns no subprocess and needs no `opencode` binary, no
+  config, and no TTY (`env -i` clean environments are supported).
+
+## Bounds
+
+Startup and evaluation run under an overall deadline (`--timeout-ms`, default
+300000). SIGINT/SIGTERM abort the run (exit 2) and run registered cleanup
+exactly once; the run journal is capped at 200 events.
+
+## Related
+
+- `/swarm benchmark --ci-gate` — the in-process CI threshold gate (plugin
+  context; shares the evidence-quality computation with `swarm ci`).
+- `/swarm ci-simulate` — pre-merge merge-result worktree simulation.
+- `/swarm ci-monitor` — drive an approved PR to green and merged.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -82,7 +82,10 @@ report=$(printf '%s\n' "$output" | sed -n '/^\[SWARM_CI_JSON\]$/,/^\[\/SWARM_CI_
 
 Startup and evaluation run under an overall deadline (`--timeout-ms`, default
 300000). SIGINT/SIGTERM abort the run (exit 2) and run registered cleanup
-exactly once; the run journal is capped at 200 events.
+exactly once; the run journal is capped at 200 events. Note that POSIX-style
+self-signalling is unreliable on Windows (Git Bash in particular), so treat
+signal-driven exit 2 there as best-effort; the `--timeout-ms` deadline is the
+portable bound.
 
 ## Related
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -391,6 +391,14 @@ Dry-run hidden coupling analysis with configurable thresholds
 
 **Args:** `--threshold <number>, --min-commits <number>`
 
+### `/swarm ci`
+
+Advisory headless CI: evaluate the repo gate/evidence state read-only with machine exit codes [--timeout-ms <n>] [--json]
+
+**Args:** `--timeout-ms <n>, --json`
+
+Host-decoupled, read-only evaluation of the checked-out repo (#2497): per-task required gates (tri-state evidence), plan-critic approval, and evidence-quality thresholds, composed from the authoritative readers. Exits 0 only when every evaluated gate passes; 1 on any violation, no-data, corrupt evidence, or a missing plan; 2 on cancellation (SIGINT/SIGTERM); 3 on deadline/internal error. Emits a Markdown report plus a [SWARM_CI_JSON] machine block. Never writes to .swarm and cannot satisfy or bypass any gate; runs with no TTY and no OpenCode host.
+
 ## Utility
 
 ### `/swarm blueprint validate`

--- a/docs/releases/pending/2497-advisory-headless-ci.md
+++ b/docs/releases/pending/2497-advisory-headless-ci.md
@@ -21,7 +21,17 @@
   bounded, discarded shadow copy of `.swarm/` so the evaluated repo is never
   modified; advisory evaluation is strictly read-only and cannot satisfy or
   bypass any gate. Enabled profile gates without a durable whole-plan reader
-  are reported as `not_evaluated` instead of being silently skipped.
+  are reported as `not_evaluated` instead of being silently skipped. The
+  shared evidence-quality reader is a guaranteed pure read (`migrate: false`)
+  so a legacy flat-retrospective bundle is never rewritten in place.
+- The `[SWARM_CI_JSON]` block carries one stable `version: 1` shape on every
+  exit path: cancelled / deadline / error runs emit the full report schema
+  (`plan`, `gate_profile`, `effective_gates`, `not_evaluated`,
+  `not_evaluable`, `counts` present with neutral values) instead of a
+  reduced diagnostic object, so machine consumers parse identically across
+  exit codes 0–3. Markdown table cells and bullets flatten embedded newlines
+  and escape pipes, so repo-controlled plan strings cannot break the report
+  layout.
 - `/swarm benchmark --ci-gate` now computes its evidence-derived quality
   signals through the same shared service as `swarm ci`
   (`src/ci/quality-checks.ts`) — one implementation, byte-compatible

--- a/docs/releases/pending/2497-advisory-headless-ci.md
+++ b/docs/releases/pending/2497-advisory-headless-ci.md
@@ -1,0 +1,47 @@
+### Advisory headless CI: `swarm ci` evaluates gates read-only with machine exit codes
+
+**What changed**
+
+- New `swarm ci` command (also `bunx opencode-swarm ci` and `/swarm ci`) runs
+  the gated pipeline's advisory evaluation in a clean noninteractive
+  environment — no TTY, no OpenCode host, no plugin boot. Exit codes: 0 all
+  evaluated gates pass; 1 any violation / no-data / corrupt evidence /
+  nothing to evaluate; 2 cancelled (SIGINT/SIGTERM); 3 deadline or internal
+  error. Output is a Markdown report plus a machine-readable
+  `[SWARM_CI_JSON]` block (`--json` for the block only). See `docs/ci.md`.
+- New host-decoupled runtime under `src/ci/`: a bounded harness (overall
+  deadline via `--timeout-ms`, signal-driven cancellation with exactly-once
+  cleanup, capped 200-event run journal) around an evaluation that composes
+  the existing authoritative readers — per-task required gates with #2470
+  tri-state evidence (valid / missing / corrupt are distinct), a
+  terminal-workflow guard (`rework_required` and other non-terminal states
+  are never a vacuous pass), plan-critic approval, and the evidence-quality
+  thresholds. "No data" is never a pass.
+- DB-mediated reads (QA gate profile, plan-critic snapshots) run against a
+  bounded, discarded shadow copy of `.swarm/` so the evaluated repo is never
+  modified; advisory evaluation is strictly read-only and cannot satisfy or
+  bypass any gate. Enabled profile gates without a durable whole-plan reader
+  are reported as `not_evaluated` instead of being silently skipped.
+- `/swarm benchmark --ci-gate` now computes its evidence-derived quality
+  signals through the same shared service as `swarm ci`
+  (`src/ci/quality-checks.ts`) — one implementation, byte-compatible
+  benchmark output, plus the in-repo guardrails
+  (`tests/unit/ci/host-decoupling-ratchet.test.ts` bans host-state tokens and
+  durable-writer imports in `src/ci/**`; `tests/unit/ci/wiring-ratchet.test.ts`
+  requires every `src/ci` export be reachable from the production entry or a
+  test seam).
+
+**Why**
+
+Issue #2497 (Workstream F PR 05, from #1224 phase 1): the plugin's
+verification/gate services only executed inside the OpenCode host, and the
+closest existing headless surface (`benchmark --ci-gate`) passes checks
+vacuously when its live session-state inputs are empty. Teams get "did every
+gate pass, with evidence" as a machine check on any CI runner.
+
+**Notes**
+
+- Publishing the composite GitHub Action is deliberately out of scope
+  (tracking slot #2498); this command is the surface that Action will wrap.
+- The full LLM headless pipeline (`opencode serve`-backed architect loop)
+  remains #1224 phase 2; `swarm ci` is advisory-only and spawns no processes.

--- a/src/ci/evaluate.ts
+++ b/src/ci/evaluate.ts
@@ -82,12 +82,18 @@ export interface AdvisoryCiTaskEntry {
 export interface AdvisoryCiReport {
 	version: 1;
 	verdict: 'pass' | 'fail';
+	/** Evaluation exits come from the runtime; `cancelled`/`deadline`/`error`
+	 * are emitted by the command layer when evaluation never completed, so
+	 * every `version: 1` payload shares one shape regardless of exit code. */
 	exit_reason:
 		| 'all_gates_passed'
 		| 'plan_missing'
 		| 'plan_corrupt'
 		| 'no_tasks'
-		| 'gate_violations';
+		| 'gate_violations'
+		| 'cancelled'
+		| 'deadline'
+		| 'error';
 	gates: AdvisoryCiGateRow[];
 	tasks: AdvisoryCiTaskEntry[];
 	plan: {

--- a/src/ci/evaluate.ts
+++ b/src/ci/evaluate.ts
@@ -1,0 +1,553 @@
+/**
+ * Host-decoupled advisory gate evaluation (issue #2497).
+ *
+ * Composes the EXISTING authoritative readers — never a reimplementation —
+ * to answer "did this checked-out repo's swarm work satisfy its gates?" with
+ * honest per-check dispositions (pass / fail / no_data / corrupt / error per
+ * the #2470 tri-state evidence semantics; "no data" is NEVER a pass).
+ *
+ * Read classes (empirically verified against the repo's readers):
+ *  - Direct file reads on the evaluated directory: `loadPlanJsonOnly`
+ *    (pure parse), `readTaskEvidenceState` / `deriveRequiredGates` /
+ *    `hasPassedAllGates` (pure `.swarm/evidence` reads), `loadEvidence` /
+ *    `listEvidenceTaskIds` (pure bundle reads), and the shared
+ *    evidence-quality computation in `src/ci/quality-checks.ts`.
+ *  - Shadow-copy reads: `isPlanCriticApproved` and
+ *    `getProfileLookupForIdentity` are mediated by the ledger/profile SQLite
+ *    store; opening it creates WAL sidecars (and may run the legacy-jsonl
+ *    import), which would MUTATE the evaluated repo. They therefore run
+ *    against a discarded temp copy of `.swarm/` so the advisory run is
+ *    strictly read-only for the repo (frozen check C7). The copy is bounded
+ *    and removed in cleanup.
+ *
+ * Host-decoupling contract: no host client handle, no live plugin session
+ * state, no subprocess, no config load — a scrubbed CI environment
+ * (env -i, no TTY, no opencode binary) is the supported operating mode.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	DEFAULT_QA_GATES,
+	getEffectiveGates,
+	getProfileLookupForIdentity,
+	type QaGates,
+} from '../db/qa-gate-profile.js';
+import {
+	deriveRequiredGates,
+	readTaskEvidenceState,
+} from '../gate-evidence.js';
+import { isPlanCriticApproved } from '../hooks/delegation-gate.js';
+import { loadPlanJsonOnly } from '../plan/manager.js';
+import {
+	CI_QUALITY_THRESHOLDS,
+	computeEvidenceQualitySummary,
+} from './quality-checks.js';
+
+/** Workflow snapshot states that count as terminal success for a task.
+ * Derived from WORKFLOW_STATE_RANK in src/gate-evidence.ts, where
+ * 'complete' (8) and 'closed' (7) are the only terminal-success ranks; any
+ * other state (rework_required, reviewer_run, coder_delegated, ...) means
+ * the task is not demonstrably finished and must not pass vacuously. */
+export const TERMINAL_SUCCESS_STATES = ['complete', 'closed'] as const;
+
+/** Upper bound for the `.swarm/` shadow copy. A repo whose durable state is
+ * larger than this skips the DB-mediated reads (reported as not_evaluable)
+ * rather than copying unbounded data into a temp dir. */
+export const MAX_SHADOW_COPY_BYTES = 512 * 1024 * 1024;
+
+export type AdvisoryCiGateStatus =
+	| 'pass'
+	| 'fail'
+	| 'no_data'
+	| 'corrupt'
+	| 'error';
+
+export interface AdvisoryCiGateRow {
+	name: string;
+	status: AdvisoryCiGateStatus;
+	detail?: string;
+}
+
+export interface AdvisoryCiTaskEntry {
+	task_id: string;
+	evidence_state: 'valid' | 'missing' | 'corrupt' | 'error';
+	required_gates: string[];
+	missing_gates: string[];
+	workflow_state?: string;
+	satisfied: boolean;
+}
+
+export interface AdvisoryCiReport {
+	version: 1;
+	verdict: 'pass' | 'fail';
+	exit_reason:
+		| 'all_gates_passed'
+		| 'plan_missing'
+		| 'plan_corrupt'
+		| 'no_tasks'
+		| 'gate_violations';
+	gates: AdvisoryCiGateRow[];
+	tasks: AdvisoryCiTaskEntry[];
+	plan: {
+		present: boolean;
+		title?: string;
+		swarm?: string;
+		task_count: number;
+	};
+	environment: {
+		mode: 'advisory';
+		tty: boolean;
+		host: 'none';
+	};
+	gate_profile: 'default' | 'profile';
+	effective_gates: QaGates;
+	/** Enabled gates that have no durable whole-plan reader are listed here
+	 * rather than silently omitted or vacuously passed. */
+	not_evaluated: Array<{ name: string; reason: string }>;
+	/** Checks that cannot be evaluated headless (live plugin state). */
+	not_evaluable: Array<{ name: string; reason: string }>;
+	counts: {
+		pass: number;
+		fail: number;
+		no_data: number;
+		corrupt: number;
+		error: number;
+	};
+}
+
+export interface EvaluateAdvisoryCiOptions {
+	directory: string;
+	/** Captured once before any output; the report channel is stdout. */
+	tty: boolean;
+	journal?: (type: string, detail?: string) => void;
+	registerCleanup?: (fn: () => void) => void;
+}
+
+interface PlanLike {
+	title?: string;
+	swarm?: string;
+	phases?: Array<{
+		tasks?: Array<{
+			id: string;
+			status?: string;
+		}>;
+	}>;
+}
+
+function countStatuses(rows: AdvisoryCiGateRow[]): AdvisoryCiReport['counts'] {
+	const counts = { pass: 0, fail: 0, no_data: 0, corrupt: 0, error: 0 };
+	for (const row of rows) counts[row.status]++;
+	return counts;
+}
+
+/** Copy `.swarm/` into a fresh temp dir for DB-mediated reads. Returns null
+ * when `.swarm` is absent or exceeds the copy budget. */
+function createShadowCopy(directory: string): string | null {
+	const swarmDir = path.join(directory, '.swarm');
+	if (!fs.existsSync(swarmDir)) return null;
+	let total = 0;
+	const files: Array<{ src: string; dest: string }> = [];
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const src = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(src);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			const size = fs.statSync(src).size;
+			total += size;
+			if (total > MAX_SHADOW_COPY_BYTES) return;
+			files.push({
+				src,
+				dest: path.join(path.dirname(src), path.basename(src)),
+			});
+		}
+	};
+	walk(swarmDir);
+	if (total > MAX_SHADOW_COPY_BYTES) return null;
+	const shadowRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-ci-shadow-'));
+	const shadowSwarm = path.join(shadowRoot, '.swarm');
+	fs.mkdirSync(shadowSwarm, { recursive: true });
+	for (const { src } of files) {
+		const rel = path.relative(directory, src);
+		const dest = path.join(shadowRoot, rel);
+		fs.mkdirSync(path.dirname(dest), { recursive: true });
+		fs.copyFileSync(src, dest);
+	}
+	return shadowRoot;
+}
+
+/** Gates whose only durable record lives in live plugin state; advisory CI
+ * reports them instead of fabricating a pass. */
+const NOT_EVALUABLE: Array<{ name: string; reason: string }> = [
+	{
+		name: 'agent_error_rate',
+		reason:
+			'requires the plugin live in-process tool-aggregate state; not reconstructible headless',
+	},
+	{
+		name: 'hard_limit_hits',
+		reason:
+			'requires the plugin live in-process agent-session state; not reconstructible headless',
+	},
+];
+
+/** Gate-profile flags that have no durable whole-plan reader the advisory
+ * evaluator could call; they are reported, never silently passed. */
+const NOT_EVALUATED_REASONS: Record<string, string> = {
+	drift_check:
+		'enforced inline by the write-drift-evidence flow; no standalone durable whole-plan reader',
+	sast_enabled:
+		'recorded per-task in evidence bundles; not a whole-plan gate row',
+	sme_enabled: 'advisory SME pass has no durable whole-plan verdict artifact',
+	council_mode:
+		'council gating is per-task through checkCouncilGate at completion time',
+	mutation_test:
+		'mutation gate runs in the evolution harness, not the advisory path',
+	phase_council:
+		'phase councils run interactively; no durable whole-plan verdict',
+	final_council:
+		'final council runs interactively; no durable whole-plan verdict',
+	hallucination_guard:
+		'stream-time guard; no durable whole-plan verdict artifact',
+};
+
+export async function evaluateAdvisoryCi(
+	options: EvaluateAdvisoryCiOptions,
+): Promise<AdvisoryCiReport> {
+	const { directory, tty } = options;
+	const journal = options.journal ?? (() => {});
+	const registerCleanup = options.registerCleanup ?? (() => {});
+	const gates: AdvisoryCiGateRow[] = [];
+	const tasks: AdvisoryCiReport['tasks'] = [];
+
+	const planPath = path.join(directory, '.swarm', 'plan.json');
+	const planExists = fs.existsSync(planPath);
+	const plan = planExists ? await loadPlanJsonOnly(directory) : null;
+
+	if (planExists && !plan) {
+		gates.push({
+			name: 'plan',
+			status: 'corrupt',
+			detail: '.swarm/plan.json exists but failed schema validation',
+		});
+		return finishReport({
+			gates,
+			tasks,
+			planMeta: { present: true, task_count: 0 },
+			tty,
+			exit_reason: 'plan_corrupt',
+			effectiveGates: { ...DEFAULT_QA_GATES },
+			gateProfile: 'default',
+		});
+	}
+	if (!plan) {
+		gates.push({
+			name: 'plan',
+			status: 'no_data',
+			detail: '.swarm/plan.json is missing — nothing to evaluate is not a pass',
+		});
+		return finishReport({
+			gates,
+			tasks,
+			planMeta: { present: false, task_count: 0 },
+			tty,
+			exit_reason: 'plan_missing',
+			effectiveGates: { ...DEFAULT_QA_GATES },
+			gateProfile: 'default',
+		});
+	}
+
+	const planLike = plan as unknown as PlanLike;
+	const planTasks: Array<{ id: string; status?: string }> = [];
+	for (const phase of planLike.phases ?? []) {
+		for (const task of phase.tasks ?? []) planTasks.push(task);
+	}
+	journal('plan_loaded', `${planTasks.length} tasks`);
+
+	if (planTasks.length === 0) {
+		gates.push({ name: 'plan', status: 'pass' });
+		gates.push({
+			name: 'plan tasks',
+			status: 'no_data',
+			detail: 'plan contains no tasks — nothing demonstrably gated',
+		});
+		return finishReport({
+			gates,
+			tasks,
+			planMeta: {
+				present: true,
+				title: planLike.title,
+				swarm: planLike.swarm,
+				task_count: 0,
+			},
+			tty,
+			exit_reason: 'no_tasks',
+			effectiveGates: { ...DEFAULT_QA_GATES },
+			gateProfile: 'default',
+		});
+	}
+
+	// --- shadow copy for DB-mediated reads (gate profile + plan critic) ----
+	let shadowDir: string | null = null;
+	try {
+		shadowDir = createShadowCopy(directory);
+	} catch {
+		shadowDir = null;
+	}
+	if (shadowDir) {
+		registerCleanup(() => {
+			try {
+				fs.rmSync(shadowDir as string, { recursive: true, force: true });
+			} catch {
+				// Best-effort temp cleanup; the OS reclaims tmpdirs.
+			}
+		});
+	}
+
+	// --- effective gate set (R2: default fallback, honest reporting) -------
+	const identity = {
+		swarm: planLike.swarm ?? 'local',
+		title: planLike.title ?? '',
+	};
+	let effectiveGates: QaGates = { ...DEFAULT_QA_GATES };
+	let gateProfile: 'default' | 'profile' = 'default';
+	if (shadowDir) {
+		const lookup = getProfileLookupForIdentity(shadowDir, identity);
+		if (lookup && 'profile' in lookup && lookup.profile) {
+			effectiveGates = getEffectiveGates(lookup.profile, {});
+			gateProfile = 'profile';
+		}
+	}
+	journal('gate_profile', gateProfile);
+
+	gates.push({ name: 'plan', status: 'pass' });
+
+	// --- plan-critic gate (critic_pre_plan) --------------------------------
+	if (effectiveGates.critic_pre_plan) {
+		if (shadowDir) {
+			const approved = await isPlanCriticApproved(shadowDir);
+			gates.push({
+				name: 'plan_critic',
+				status: approved ? 'pass' : 'fail',
+				detail: approved
+					? 'plan-critic APPROVED snapshot matches the current plan structure'
+					: 'no plan_critic_gate APPROVED snapshot matching the current plan (critic_pre_plan is enabled)',
+			});
+		} else {
+			gates.push({
+				name: 'plan_critic',
+				status: 'error',
+				detail:
+					'ledger snapshot read unavailable: durable state exceeds the shadow-copy budget',
+			});
+		}
+	}
+
+	// --- per-task gates (tri-state evidence, terminal workflow) ------------
+	for (const task of planTasks) {
+		try {
+			const state = await readTaskEvidenceState(directory, task.id);
+			if (state.kind === 'ok') {
+				const evidence = state.evidence;
+				const required = [...evidence.required_gates];
+				const satisfiedKeys = Object.keys(evidence.gates ?? {});
+				const missing = required.filter((g) => !satisfiedKeys.includes(g));
+				const workflowState = evidence.workflow?.state;
+				const terminal = TERMINAL_SUCCESS_STATES.includes(
+					workflowState as (typeof TERMINAL_SUCCESS_STATES)[number],
+				);
+				const satisfied = missing.length === 0 && terminal;
+				tasks.push({
+					task_id: task.id,
+					evidence_state: 'valid',
+					required_gates: required,
+					missing_gates: missing,
+					workflow_state: workflowState,
+					satisfied,
+				});
+				gates.push({
+					name: `task ${task.id} gates`,
+					status: satisfied ? 'pass' : 'fail',
+					detail: satisfied
+						? `all required gates satisfied; workflow ${workflowState}`
+						: missing.length > 0
+							? `missing gate evidence: ${missing.join(', ')}${terminal ? '' : `; workflow state ${workflowState} is not terminal`}`
+							: `workflow state ${workflowState} is not a terminal-success state`,
+				});
+			} else if (state.kind === 'missing') {
+				const required = deriveRequiredGates('coder');
+				tasks.push({
+					task_id: task.id,
+					evidence_state: 'missing',
+					required_gates: required,
+					missing_gates: [...required],
+					satisfied: false,
+				});
+				gates.push({
+					name: `task ${task.id} gates`,
+					status: 'no_data',
+					detail: 'no durable task-gate evidence recorded',
+				});
+			} else if (state.kind === 'unparseable') {
+				const required = deriveRequiredGates('coder');
+				tasks.push({
+					task_id: task.id,
+					evidence_state: 'corrupt',
+					required_gates: required,
+					missing_gates: [...required],
+					satisfied: false,
+				});
+				gates.push({
+					name: `task ${task.id} gates`,
+					status: 'corrupt',
+					detail:
+						'task-gate evidence exists but cannot be parsed (#2470 tri-state)',
+				});
+			} else {
+				tasks.push({
+					task_id: task.id,
+					evidence_state: 'error',
+					required_gates: deriveRequiredGates('coder'),
+					missing_gates: deriveRequiredGates('coder'),
+					satisfied: false,
+				});
+				gates.push({
+					name: `task ${task.id} gates`,
+					status: 'error',
+					detail: `evidence reader returned unexpected state ${JSON.stringify((state as { kind?: string }).kind)}`,
+				});
+			}
+		} catch (error) {
+			tasks.push({
+				task_id: task.id,
+				evidence_state: 'error',
+				required_gates: deriveRequiredGates('coder'),
+				missing_gates: deriveRequiredGates('coder'),
+				satisfied: false,
+			});
+			gates.push({
+				name: `task ${task.id} gates`,
+				status: 'error',
+				detail: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	// --- evidence-quality thresholds (shared with benchmark) ---------------
+	const summary = await computeEvidenceQualitySummary(directory);
+	const q = summary.qualityMetrics;
+	const qualityRows: Array<[string, boolean | null, number | null, string]> = [
+		[
+			'review_pass_rate',
+			summary.reviewPassRate === null
+				? null
+				: summary.reviewPassRate >= CI_QUALITY_THRESHOLDS.review_pass_rate,
+			summary.reviewPassRate,
+			`>= ${CI_QUALITY_THRESHOLDS.review_pass_rate}% over ${summary.totalReviews} reviews`,
+		],
+		[
+			'test_pass_rate',
+			summary.testPassRate === null
+				? null
+				: summary.testPassRate >= CI_QUALITY_THRESHOLDS.test_pass_rate,
+			summary.testPassRate,
+			`>= ${CI_QUALITY_THRESHOLDS.test_pass_rate}% over ${summary.testsPassed + summary.testsFailed} tests`,
+		],
+		[
+			'quality_budget.complexity_delta',
+			q.hasEvidence
+				? q.complexityDelta <= CI_QUALITY_THRESHOLDS.max_complexity_delta
+				: null,
+			q.hasEvidence ? q.complexityDelta : null,
+			`<= ${CI_QUALITY_THRESHOLDS.max_complexity_delta}`,
+		],
+		[
+			'quality_budget.public_api_delta',
+			q.hasEvidence
+				? q.publicApiDelta <= CI_QUALITY_THRESHOLDS.max_public_api_delta
+				: null,
+			q.hasEvidence ? q.publicApiDelta : null,
+			`<= ${CI_QUALITY_THRESHOLDS.max_public_api_delta}`,
+		],
+		[
+			'quality_budget.duplication_ratio',
+			q.hasEvidence
+				? q.duplicationRatio <= CI_QUALITY_THRESHOLDS.max_duplication_ratio
+				: null,
+			q.hasEvidence ? q.duplicationRatio : null,
+			`<= ${CI_QUALITY_THRESHOLDS.max_duplication_ratio}%`,
+		],
+		[
+			'quality_budget.test_to_code_ratio',
+			q.hasEvidence
+				? q.testToCodeRatio >= CI_QUALITY_THRESHOLDS.min_test_to_code_ratio
+				: null,
+			q.hasEvidence ? q.testToCodeRatio : null,
+			`>= ${CI_QUALITY_THRESHOLDS.min_test_to_code_ratio}%`,
+		],
+	];
+	for (const [name, passed, value, threshold] of qualityRows) {
+		gates.push({
+			name,
+			status: passed === null ? 'no_data' : passed ? 'pass' : 'fail',
+			detail:
+				passed === null
+					? `no evidence data (${threshold}); not a pass`
+					: `value ${value} ${threshold}`,
+		});
+	}
+
+	return finishReport({
+		gates,
+		tasks,
+		planMeta: {
+			present: true,
+			title: planLike.title,
+			swarm: planLike.swarm,
+			task_count: planTasks.length,
+		},
+		tty,
+		exit_reason: 'gate_violations',
+		effectiveGates,
+		gateProfile,
+	});
+}
+
+function finishReport(args: {
+	gates: AdvisoryCiGateRow[];
+	tasks: AdvisoryCiTaskEntry[];
+	planMeta: AdvisoryCiReport['plan'];
+	tty: boolean;
+	exit_reason: AdvisoryCiReport['exit_reason'];
+	effectiveGates: QaGates;
+	gateProfile: 'default' | 'profile';
+}): AdvisoryCiReport {
+	const counts = countStatuses(args.gates);
+	const allPassed = args.gates.length > 0 && counts.pass === args.gates.length;
+	const verdict: AdvisoryCiReport['verdict'] = allPassed ? 'pass' : 'fail';
+	const exit_reason = allPassed ? 'all_gates_passed' : args.exit_reason;
+	const not_evaluated: AdvisoryCiReport['not_evaluated'] = [];
+	for (const [flag, reason] of Object.entries(NOT_EVALUATED_REASONS)) {
+		if ((args.effectiveGates as unknown as Record<string, boolean>)[flag]) {
+			not_evaluated.push({ name: flag, reason });
+		}
+	}
+	return {
+		version: 1,
+		verdict,
+		exit_reason,
+		gates: args.gates,
+		tasks: args.tasks,
+		plan: args.planMeta,
+		environment: { mode: 'advisory', tty: args.tty, host: 'none' },
+		gate_profile: args.gateProfile,
+		effective_gates: args.effectiveGates,
+		not_evaluated,
+		not_evaluable: [...NOT_EVALUABLE],
+		counts,
+	};
+}

--- a/src/ci/index.ts
+++ b/src/ci/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Public surface of the host-decoupled advisory CI runtime (issue #2497).
+ *
+ * Single import point for downstream consumers — the composite GitHub
+ * Action (#2498) and the read-only MCP verification surface (#2499) — and
+ * for the `swarm ci` command handler (src/commands/ci.ts). Everything the
+ * runtime exposes is re-exported here; nothing under src/ci/ is meant to be
+ * imported by path from outside this directory.
+ */
+
+export {
+	type AdvisoryCiGateRow,
+	type AdvisoryCiGateStatus,
+	type AdvisoryCiReport,
+	type AdvisoryCiTaskEntry,
+	type EvaluateAdvisoryCiOptions,
+	evaluateAdvisoryCi,
+	MAX_SHADOW_COPY_BYTES,
+	TERMINAL_SUCCESS_STATES,
+} from './evaluate.js';
+export {
+	CI_QUALITY_THRESHOLDS,
+	computeEvidenceQualitySummary,
+	type EvidenceQualitySummary,
+} from './quality-checks.js';
+export {
+	renderFullReport,
+	renderJsonBlock,
+	renderMarkdownReport,
+	SWARM_CI_JSON_CLOSE,
+	SWARM_CI_JSON_OPEN,
+} from './report.js';
+export {
+	type CiEvaluateContext,
+	type CiRunEvent,
+	type CiRunOutcome,
+	type CiRunResult,
+	type CiRuntimeOptions,
+	MAX_CI_JOURNAL_EVENTS,
+	runAdvisoryCiRuntime,
+} from './runtime.js';

--- a/src/ci/quality-checks.ts
+++ b/src/ci/quality-checks.ts
@@ -85,7 +85,13 @@ export async function computeEvidenceQualitySummary(
 	for (const tid of await listEvidenceTaskIds(directory)) {
 		let result: Awaited<ReturnType<typeof loadEvidence>>;
 		try {
-			result = await loadEvidence(directory, tid);
+			// `{ migrate: false }` keeps this a pure read: the default load
+			// path would otherwise take the evidence-loader lock and rename a
+			// temp file over a legacy flat-retrospective bundle in place,
+			// mutating the evaluated repo during read-only advisory CI
+			// evaluation (`swarm ci`). The returned bundle is identical either
+			// way, so benchmark output is unchanged.
+			result = await loadEvidence(directory, tid, { migrate: false });
 		} catch (_evidenceErr) {
 			warn('benchmark: skipping corrupt or unreadable evidence for task', tid);
 			continue;

--- a/src/ci/quality-checks.ts
+++ b/src/ci/quality-checks.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared evidence-quality computation (issue #2497, plan D2).
+ *
+ * Extracted verbatim from `src/commands/benchmark.ts` (the cumulative
+ * evidence aggregation loop) so the plugin surface
+ * (`/swarm benchmark --ci-gate`) and the host-decoupled advisory surface
+ * (`swarm ci`) evaluate evidence-derived quality signals through ONE
+ * implementation. `benchmark.ts` consumes `computeEvidenceQualitySummary`
+ * directly; the advisory evaluator additionally maps "no evidence data" to
+ * an honest `no_data` disposition instead of benchmark's
+ * pass-on-no-evidence semantics (which are preserved here byte-for-byte for
+ * the benchmark path).
+ *
+ * Host-decoupling contract: filesystem-only reads (evidence bundles under
+ * `.swarm/evidence/`); no host client, no session state.
+ */
+
+import type { QualityBudgetEvidence } from '../config/evidence-schema.js';
+import {
+	isValidEvidenceType,
+	listEvidenceTaskIds,
+	loadEvidence,
+} from '../evidence/manager.js';
+import { warn } from '../utils/index.js';
+
+/** CI threshold constants (unchanged values, moved from benchmark.ts so both
+ * consumers share one definition). */
+export const CI_QUALITY_THRESHOLDS = {
+	review_pass_rate: 70,
+	test_pass_rate: 80,
+	max_agent_error_rate: 20,
+	max_hard_limit_hits: 1,
+	// Quality budget thresholds
+	max_complexity_delta: 5,
+	max_public_api_delta: 10,
+	max_duplication_ratio: 5, // percentage (5%)
+	min_test_to_code_ratio: 30, // percentage (30%)
+} as const;
+
+export interface EvidenceQualitySummary {
+	reviewPassRate: number | null;
+	testPassRate: number | null;
+	totalReviews: number;
+	testsPassed: number;
+	testsFailed: number;
+	additions: number;
+	deletions: number;
+	qualityMetrics: {
+		complexityDelta: number;
+		publicApiDelta: number;
+		duplicationRatio: number;
+		testToCodeRatio: number;
+		thresholds: {
+			maxComplexityDelta: number;
+			maxPublicApiDelta: number;
+			maxDuplicationRatio: number;
+			minTestToCodeRatio: number;
+		};
+		hasEvidence: boolean;
+	};
+}
+
+/**
+ * Aggregate review/test/diff/quality-budget signals across every evidence
+ * bundle under `.swarm/evidence/`. Behavior-identical to the loop that used
+ * to live inline in `handleBenchmarkCommand` (same rounding, same warn()
+ * side effects on corrupt/unknown entries) so benchmark output stays
+ * byte-compatible after the extraction.
+ */
+export async function computeEvidenceQualitySummary(
+	directory: string,
+): Promise<EvidenceQualitySummary> {
+	let reviewPasses = 0,
+		reviewFails = 0,
+		testPasses = 0,
+		testFails = 0,
+		additions = 0,
+		deletions = 0;
+	// Quality metrics accumulation
+	let totalComplexityDelta = 0;
+	let totalPublicApiDelta = 0;
+	let totalDuplicationRatio = 0;
+	let totalTestToCodeRatio = 0;
+	let qualityEvidenceCount = 0;
+	for (const tid of await listEvidenceTaskIds(directory)) {
+		let result: Awaited<ReturnType<typeof loadEvidence>>;
+		try {
+			result = await loadEvidence(directory, tid);
+		} catch (_evidenceErr) {
+			warn('benchmark: skipping corrupt or unreadable evidence for task', tid);
+			continue;
+		}
+		if (result.status !== 'found') continue;
+		for (const e of result.bundle.entries) {
+			// Skip unknown evidence types gracefully with warning
+			if (!isValidEvidenceType(e.type)) {
+				warn(`Unknown evidence type '${e.type}' in task ${tid}, skipping`);
+				continue;
+			}
+
+			if (e.type === 'review') {
+				if (e.verdict === 'approved') reviewPasses++;
+				else if (e.verdict === 'rejected') reviewFails++;
+			} else if (e.type === 'test') {
+				testPasses += e.tests_passed;
+				testFails += e.tests_failed;
+			} else if (e.type === 'diff') {
+				additions += e.additions;
+				deletions += e.deletions;
+			} else if (e.type === 'quality_budget') {
+				const qe = e as QualityBudgetEvidence;
+				totalComplexityDelta += qe.metrics.complexity_delta;
+				totalPublicApiDelta += qe.metrics.public_api_delta;
+				totalDuplicationRatio += qe.metrics.duplication_ratio * 100; // Convert to percentage
+				totalTestToCodeRatio += qe.metrics.test_to_code_ratio * 100; // Convert to percentage
+				qualityEvidenceCount++;
+			}
+		}
+	}
+	const totalReviews = reviewPasses + reviewFails;
+	const totalTests = testPasses + testFails;
+	const quality = {
+		reviewPassRate: totalReviews
+			? Math.round((reviewPasses / totalReviews) * 1000) / 10
+			: null,
+		testPassRate: totalTests
+			? Math.round((testPasses / totalTests) * 1000) / 10
+			: null,
+		totalReviews,
+		testsPassed: testPasses,
+		testsFailed: testFails,
+		additions,
+		deletions,
+	};
+	// Calculate average quality metrics
+	if (qualityEvidenceCount > 0) {
+		return {
+			...quality,
+			qualityMetrics: {
+				complexityDelta:
+					Math.round((totalComplexityDelta / qualityEvidenceCount) * 10) / 10,
+				publicApiDelta:
+					Math.round((totalPublicApiDelta / qualityEvidenceCount) * 10) / 10,
+				duplicationRatio:
+					Math.round((totalDuplicationRatio / qualityEvidenceCount) * 10) / 10,
+				testToCodeRatio:
+					Math.round((totalTestToCodeRatio / qualityEvidenceCount) * 10) / 10,
+				thresholds: {
+					maxComplexityDelta: CI_QUALITY_THRESHOLDS.max_complexity_delta,
+					maxPublicApiDelta: CI_QUALITY_THRESHOLDS.max_public_api_delta,
+					maxDuplicationRatio: CI_QUALITY_THRESHOLDS.max_duplication_ratio,
+					minTestToCodeRatio: CI_QUALITY_THRESHOLDS.min_test_to_code_ratio,
+				},
+				hasEvidence: true,
+			},
+		};
+	}
+	return {
+		...quality,
+		qualityMetrics: {
+			complexityDelta: 0,
+			publicApiDelta: 0,
+			duplicationRatio: 0,
+			testToCodeRatio: 0,
+			thresholds: {
+				maxComplexityDelta: CI_QUALITY_THRESHOLDS.max_complexity_delta,
+				maxPublicApiDelta: CI_QUALITY_THRESHOLDS.max_public_api_delta,
+				maxDuplicationRatio: CI_QUALITY_THRESHOLDS.max_duplication_ratio,
+				minTestToCodeRatio: CI_QUALITY_THRESHOLDS.min_test_to_code_ratio,
+			},
+			hasEvidence: false,
+		},
+	};
+}

--- a/src/ci/report.ts
+++ b/src/ci/report.ts
@@ -26,6 +26,16 @@ const STATUS_ICONS: Record<string, string> = {
 	error: '💥',
 };
 
+/**
+ * Make plan-controlled strings safe inside a Markdown table cell or bullet:
+ * newlines would break out of the row/list structure (gate names, task ids,
+ * and reasons originate from repo-controlled plan.json content), and pipes
+ * would split the cell.
+ */
+function mdCell(text: string): string {
+	return text.replace(/[\r\n]+/g, ' ').replace(/\|/g, '\\|');
+}
+
 export function renderJsonBlock(report: AdvisoryCiReport): string {
 	return [
 		SWARM_CI_JSON_OPEN,
@@ -48,8 +58,8 @@ export function renderMarkdownReport(report: AdvisoryCiReport): string {
 	];
 	for (const gate of report.gates) {
 		const icon = STATUS_ICONS[gate.status] ?? '';
-		const detail = (gate.detail ?? '').replace(/\|/g, '\\|');
-		lines.push(`| ${gate.name} | ${icon} ${gate.status} | ${detail} |`);
+		const detail = mdCell(gate.detail ?? '');
+		lines.push(`| ${mdCell(gate.name)} | ${icon} ${gate.status} | ${detail} |`);
 	}
 
 	if (report.tasks.length > 0) {
@@ -60,7 +70,7 @@ export function renderMarkdownReport(report: AdvisoryCiReport): string {
 		);
 		for (const task of report.tasks) {
 			lines.push(
-				`| ${task.task_id} | ${task.evidence_state} | ${task.required_gates.join(', ') || '-'} | ${task.missing_gates.join(', ') || '-'} | ${task.workflow_state ?? '-'} | ${task.satisfied ? '✅' : '❌'} |`,
+				`| ${mdCell(task.task_id)} | ${task.evidence_state} | ${task.required_gates.map(mdCell).join(', ') || '-'} | ${task.missing_gates.map(mdCell).join(', ') || '-'} | ${task.workflow_state ? mdCell(task.workflow_state) : '-'} | ${task.satisfied ? '✅' : '❌'} |`,
 			);
 		}
 	}
@@ -72,13 +82,13 @@ export function renderMarkdownReport(report: AdvisoryCiReport): string {
 			'',
 		);
 		for (const item of report.not_evaluated) {
-			lines.push(`- ${item.name}: ${item.reason}`);
+			lines.push(`- ${mdCell(item.name)}: ${mdCell(item.reason)}`);
 		}
 	}
 	if (report.not_evaluable.length > 0) {
 		lines.push('', '### Not evaluable headless', '');
 		for (const item of report.not_evaluable) {
-			lines.push(`- ${item.name}: ${item.reason}`);
+			lines.push(`- ${mdCell(item.name)}: ${mdCell(item.reason)}`);
 		}
 	}
 

--- a/src/ci/report.ts
+++ b/src/ci/report.ts
@@ -1,0 +1,97 @@
+/**
+ * Markdown + JSON rendering for `swarm ci` (issue #2497).
+ *
+ * Output contract (frozen checks C2/C4):
+ *  - default output: a Markdown report with per-gate/per-task tables plus a
+ *    fenced machine block — `[SWARM_CI_JSON]` … `[/SWARM_CI_JSON]` — holding
+ *    the pretty-printed report JSON (mirrors the `[BENCHMARK_JSON]`
+ *    precedent);
+ *  - `--json`: the machine block only.
+ *
+ * Diagnostics embed bounded, lossy-safe excerpts: evidence paths are ASCII,
+ * and any corrupt-evidence excerpt passes through Node's UTF-8 replacement
+ * decoding, so unparseable bytes degrade to U+FFFD rather than throwing.
+ */
+
+import type { AdvisoryCiReport } from './evaluate.js';
+
+export const SWARM_CI_JSON_OPEN = '[SWARM_CI_JSON]';
+export const SWARM_CI_JSON_CLOSE = '[/SWARM_CI_JSON]';
+
+const STATUS_ICONS: Record<string, string> = {
+	pass: '✅',
+	fail: '❌',
+	no_data: '⚪',
+	corrupt: '🧨',
+	error: '💥',
+};
+
+export function renderJsonBlock(report: AdvisoryCiReport): string {
+	return [
+		SWARM_CI_JSON_OPEN,
+		JSON.stringify(report, null, 2),
+		SWARM_CI_JSON_CLOSE,
+	].join('\n');
+}
+
+export function renderMarkdownReport(report: AdvisoryCiReport): string {
+	const lines: string[] = [
+		'## Swarm CI Advisory Report',
+		'',
+		`Verdict: ${report.verdict === 'pass' ? '✅ PASS' : '❌ FAIL'} (exit_reason: ${report.exit_reason})`,
+		`Environment: mode=${report.environment.mode} tty=${report.environment.tty} host=${report.environment.host} gate_profile=${report.gate_profile}`,
+		'',
+		'### Gates',
+		'',
+		'| Gate | Status | Detail |',
+		'|------|--------|--------|',
+	];
+	for (const gate of report.gates) {
+		const icon = STATUS_ICONS[gate.status] ?? '';
+		const detail = (gate.detail ?? '').replace(/\|/g, '\\|');
+		lines.push(`| ${gate.name} | ${icon} ${gate.status} | ${detail} |`);
+	}
+
+	if (report.tasks.length > 0) {
+		lines.push('', '### Tasks', '');
+		lines.push(
+			'| Task | Evidence state | Required gates | Missing gates | Workflow | Satisfied |',
+			'|------|----------------|----------------|---------------|----------|-----------|',
+		);
+		for (const task of report.tasks) {
+			lines.push(
+				`| ${task.task_id} | ${task.evidence_state} | ${task.required_gates.join(', ') || '-'} | ${task.missing_gates.join(', ') || '-'} | ${task.workflow_state ?? '-'} | ${task.satisfied ? '✅' : '❌'} |`,
+			);
+		}
+	}
+
+	if (report.not_evaluated.length > 0) {
+		lines.push(
+			'',
+			'### Enabled gates not evaluated (reported, never passed)',
+			'',
+		);
+		for (const item of report.not_evaluated) {
+			lines.push(`- ${item.name}: ${item.reason}`);
+		}
+	}
+	if (report.not_evaluable.length > 0) {
+		lines.push('', '### Not evaluable headless', '');
+		for (const item of report.not_evaluable) {
+			lines.push(`- ${item.name}: ${item.reason}`);
+		}
+	}
+
+	lines.push(
+		'',
+		`Counts: ${report.counts.pass} pass, ${report.counts.fail} fail, ${report.counts.no_data} no_data, ${report.counts.corrupt} corrupt, ${report.counts.error} error`,
+		'',
+		'Advisory read-only evaluation: this run cannot satisfy, bypass, or modify any gate.',
+	);
+	return lines.join('\n');
+}
+
+/** Full default output: Markdown report + machine block. */
+export function renderFullReport(report: AdvisoryCiReport): string {
+	return `${renderMarkdownReport(report)}\n${renderJsonBlock(report)}`;
+}

--- a/src/ci/runtime.ts
+++ b/src/ci/runtime.ts
@@ -1,0 +1,274 @@
+/**
+ * Host-decoupled bounded advisory-CI runtime (issue #2497).
+ *
+ * This module is the execution harness for `swarm ci`: it owns the five
+ * bounded-execution obligations the issue names — bounded startup, bounded
+ * evaluation ("health wait" for the run's own progress), cancellation,
+ * bounded event streaming, and cleanup — while the evaluation itself lives
+ * in `src/ci/evaluate.ts` and only ever composes the existing authoritative
+ * readers.
+ *
+ * Host-decoupling contract (frozen check C1 / ratchet
+ * tests/unit/ci/host-decoupling-ratchet.test.ts): this module and its
+ * siblings under `src/ci/` must never read the OpenCode host
+ * client handle or the plugin's live in-process session state.
+ * Advisory evaluation spawns no subprocess and opens no host connection;
+ * if a later phase needs one, `runExternalTool`
+ * (src/utils/external-tool-runner.ts) is the designated bounded supervisor —
+ * do not add supervisor code here without a production caller.
+ *
+ * SQLite note (AGENTS.md invariant 2 / #1873): this runtime must not open
+ * `.swarm/swarm.db` itself. DB-mediated reads (gate profiles, plan-critic
+ * snapshots) route through the existing readers in `src/db/qa-gate-profile.ts`
+ * and `src/hooks/delegation-gate.ts`, executed against a discarded shadow
+ * copy of `.swarm/` managed by `src/ci/evaluate.ts` so the evaluated repo is
+ * never mutated (frozen check C7).
+ */
+
+import type { AdvisoryCiReport } from './evaluate.js';
+
+/** Bounded run-journal cap. One event per stage/task/check — not per log
+ * line — so 200 covers large plans while still bounding memory. Mirrors the
+ * named-cap pattern of MAX_PENDING_ADVISORIES (src/utils/advisory-queue.ts). */
+export const MAX_CI_JOURNAL_EVENTS = 200;
+
+/** Terminal outcome vocabulary for an advisory CI run. */
+export type CiRunOutcome =
+	| 'pass'
+	| 'violations'
+	| 'cancelled'
+	| 'deadline'
+	| 'error';
+
+export interface CiRunEvent {
+	seq: number;
+	type: string;
+	detail?: string;
+}
+
+/** Context handed to the evaluation callback. */
+export interface CiEvaluateContext {
+	/** Append a bounded journal event. */
+	journal: (type: string, detail?: string) => void;
+	/** Register a cleanup callback; all callbacks run exactly once in the
+	 * runtime's finally block (even on cancel/deadline/error). */
+	registerCleanup: (fn: () => void) => void;
+	/** Trips when the caller aborts (SIGINT/SIGTERM at the CLI layer). */
+	signal: AbortSignal;
+	/** Milliseconds remaining until the overall deadline (monotonic-ish;
+	 * recomputed per stage). */
+	remainingMs: () => number;
+}
+
+export interface CiRuntimeOptions {
+	directory: string;
+	/** Overall deadline for the whole run. Default 300s; clamps to >=1ms. */
+	deadlineMs?: number;
+	/** Caller-owned abort source (CLI wires SIGINT/SIGTERM). */
+	signal?: AbortSignal;
+	/** The evaluation to run under the harness. */
+	evaluate: (ctx: CiEvaluateContext) => Promise<AdvisoryCiReport>;
+}
+
+export interface CiRunResult {
+	outcome: CiRunOutcome;
+	/** Present for 'pass' and 'violations'; absent for cancel/deadline/error. */
+	report?: AdvisoryCiReport;
+	journal: CiRunEvent[];
+	/** Events dropped because the journal cap was exceeded. */
+	journalTruncated: number;
+	/** True when every registered cleanup callback has run. */
+	cleanupRan: boolean;
+	/** Error detail for 'error'/'deadline'/'cancelled' outcomes. */
+	detail?: string;
+}
+
+/** Deadline/cancel sentinel carried out of the stage race. */
+class RunAborted extends Error {
+	constructor(
+		public reason: 'deadline' | 'cancelled',
+		message: string,
+	) {
+		super(message);
+		this.name = 'RunAborted';
+	}
+}
+
+type Settled<T> = { ok: true; value: T } | { ok: false; error: Error };
+
+/** Race a stage against cancellation without leaving floating rejections:
+ * the wrapped promise settles into a result object, so a losing stage that
+ * later rejects can never surface as an unhandled rejection (the bare-race
+ * hazard documented against withTimeout). */
+async function settle<T>(promise: Promise<T>): Promise<Settled<T>> {
+	return promise.then(
+		(value: T): Settled<T> => ({ ok: true, value }),
+		(error: unknown): Settled<T> => ({
+			ok: false,
+			error: error instanceof Error ? error : new Error(String(error)),
+		}),
+	);
+}
+
+/**
+ * Run one advisory evaluation under bounded-execution semantics.
+ *
+ * Bounds: every stage is raced against both the caller's abort signal and
+ * the overall deadline; the journal is capped; cleanup callbacks run exactly
+ * once in `finally`. The evaluation callback receives the context above and
+ * must not outlive the runtime (cleanup disposes its resources).
+ */
+export async function runAdvisoryCiRuntime(
+	options: CiRuntimeOptions,
+): Promise<CiRunResult> {
+	const deadlineMs = Math.max(1, options.deadlineMs ?? 300_000);
+	const startedAt = Date.now();
+	const events: CiRunEvent[] = [];
+	let journalTruncated = 0;
+	let seq = 0;
+	const cleanups: Array<() => void> = [];
+	let cleanupsRan = false;
+
+	const journal = (type: string, detail?: string) => {
+		seq++;
+		if (events.length >= MAX_CI_JOURNAL_EVENTS) {
+			// Keep the newest events (advisory-queue precedent); count the drops.
+			events.shift();
+			journalTruncated++;
+		}
+		events.push({ seq, type, ...(detail !== undefined ? { detail } : {}) });
+	};
+
+	const registerCleanup = (fn: () => void) => {
+		cleanups.push(fn);
+	};
+
+	const runCleanups = () => {
+		if (cleanupsRan) return;
+		cleanupsRan = true;
+		for (const fn of cleanups) {
+			try {
+				fn();
+			} catch {
+				// Cleanup is best-effort; a failing callback must not block the
+				// remaining ones or the outcome.
+			}
+		}
+	};
+
+	const remainingMs = () => Math.max(0, deadlineMs - (Date.now() - startedAt));
+
+	const abort = options.signal ?? new AbortController().signal;
+	let abortReason: 'cancelled' | null = null;
+	const onAbort = () => {
+		abortReason = 'cancelled';
+	};
+	if (abort.aborted) abortReason = 'cancelled';
+	else abort.addEventListener('abort', onAbort, { once: true });
+
+	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+	let deadlinePromise: Promise<never> | undefined;
+	let cancelPromise: Promise<never> | undefined;
+
+	try {
+		journal('run_started', options.directory);
+
+		// One stage: the whole evaluation. A finer-grained stage split adds
+		// racing overhead without changing the outcome vocabulary; per-stage
+		// bounds are the remaining-deadline budget by construction.
+		deadlinePromise = new Promise<never>((_, reject) => {
+			// The deadline timer is deliberately NOT unref'd: it must remain
+			// able to wake an otherwise-idle loop, because when a hung
+			// evaluation is the only pending work this timer is the sole thing
+			// that can still produce the deadline outcome (an unref'd timer
+			// would let the process exit with no verdict at all). It is always
+			// cleared below once the race is decided.
+			deadlineTimer = setTimeout(() => {
+				reject(new RunAborted('deadline', 'advisory CI run deadline exceeded'));
+			}, deadlineMs);
+		});
+		cancelPromise = new Promise<never>((_, reject) => {
+			if (abortReason === 'cancelled') {
+				reject(new RunAborted('cancelled', 'advisory CI run cancelled'));
+				return;
+			}
+			const listener = () => {
+				reject(new RunAborted('cancelled', 'advisory CI run cancelled'));
+			};
+			abort.addEventListener('abort', listener, { once: true });
+			registerCleanup(() => abort.removeEventListener('abort', listener));
+		});
+
+		const wrapped = settle(
+			Promise.race([
+				options.evaluate({
+					journal,
+					registerCleanup,
+					signal: abort,
+					remainingMs,
+				}),
+				deadlinePromise as Promise<never>,
+				cancelPromise as Promise<never>,
+			]),
+		);
+		// Losing racers must never surface as unhandled rejections after the
+		// winner settles (the bare-race hazard documented against withTimeout):
+		// the deadline timer is cleared below once the race is decided, and the
+		// no-op catches below swallow any rejection that still slips through
+		// (e.g. a late abort after a successful evaluation).
+		const raced = await wrapped;
+		if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+		deadlinePromise.catch(() => {});
+		cancelPromise.catch(() => {});
+
+		if (!raced.ok) {
+			const err = raced.error as Error;
+			if (err instanceof RunAborted) {
+				if (err.reason === 'cancelled') {
+					journal('run_cancelled');
+					return {
+						outcome: 'cancelled',
+						journal: [...events],
+						journalTruncated,
+						cleanupRan: true,
+						detail: err.message,
+					};
+				}
+				journal('run_deadline');
+				return {
+					outcome: 'deadline',
+					journal: [...events],
+					journalTruncated,
+					cleanupRan: true,
+					detail: err.message,
+				};
+			}
+			journal('run_error', err.message);
+			return {
+				outcome: 'error',
+				journal: [...events],
+				journalTruncated,
+				cleanupRan: true,
+				detail: err.message,
+			};
+		}
+
+		const report = raced.value;
+		const outcome: CiRunOutcome =
+			report.verdict === 'pass' ? 'pass' : 'violations';
+		journal('run_finished', outcome);
+		return {
+			outcome,
+			report,
+			journal: [...events],
+			journalTruncated,
+			cleanupRan: true,
+		};
+	} finally {
+		if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+		deadlinePromise?.catch(() => {});
+		cancelPromise?.catch(() => {});
+		if (abortReason === null) abort.removeEventListener('abort', onAbort);
+		runCleanups();
+	}
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -889,6 +889,7 @@ Commands:
   update      Refresh OpenCode's plugin cache so the next start fetches latest from npm
   uninstall   Remove the plugin from OpenCode config
   run         Run a plugin command directly (for use outside OpenCode)
+  ci          Advisory headless CI: evaluate gate/evidence state read-only (exit 0 only if all gates pass)
 
 Options:
   --clean     Also remove config files and custom prompts (with uninstall)
@@ -915,6 +916,7 @@ Examples:
   bunx opencode-swarm uninstall
   bunx opencode-swarm uninstall --clean
   bunx opencode-swarm --help
+  bunx opencode-swarm ci                 # advisory headless CI (exit 0 = all gates pass)
   bunx opencode-swarm run status
   bunx opencode-swarm run sync-plan
   bunx opencode-swarm run knowledge migrate
@@ -951,6 +953,12 @@ async function main(): Promise<void> {
 		process.exit(exitCode);
 	} else if (command === 'run') {
 		const exitCode = await run(args.slice(1));
+		process.exit(exitCode);
+	} else if (command === 'ci') {
+		// Top-level entry for advisory headless CI (#2497): delegates to the
+		// shared registry dispatcher so both surfaces get identical parity
+		// behaviors (did-you-mean, deprecation warnings, policy gates).
+		const exitCode = await run(['ci', ...args.slice(1)]);
 		process.exit(exitCode);
 	} else {
 		console.error(`Unknown command: ${command}`);

--- a/src/commands/benchmark.ts
+++ b/src/commands/benchmark.ts
@@ -1,29 +1,19 @@
-import type { QualityBudgetEvidence } from '../config/evidence-schema';
+import {
+	CI_QUALITY_THRESHOLDS,
+	computeEvidenceQualitySummary,
+} from '../ci/quality-checks.js';
 import {
 	computeGateStatistics,
 	type GateStatisticsReport,
 } from '../evaluation/gate-stats.js';
 import { readGateAuditResult } from '../evaluation/store.js';
-import {
-	isValidEvidenceType,
-	listEvidenceTaskIds,
-	loadEvidence,
-} from '../evidence/manager';
 import { summarizeTelemetryCosts } from '../services/cost-accounting.js';
 import { swarmState } from '../state';
-import { warn } from '../utils';
 
-const CI = {
-	review_pass_rate: 70,
-	test_pass_rate: 80,
-	max_agent_error_rate: 20,
-	max_hard_limit_hits: 1,
-	// Quality budget thresholds
-	max_complexity_delta: 5,
-	max_public_api_delta: 10,
-	max_duplication_ratio: 5, // percentage (5%)
-	min_test_to_code_ratio: 30, // percentage (30%)
-};
+// Shared with the host-decoupled advisory CI evaluator (`swarm ci`, #2497):
+// one definition of the evidence-quality thresholds and computation for both
+// the plugin surface and the headless surface.
+const CI = CI_QUALITY_THRESHOLDS;
 
 const GATE_AUDIT_MIN_SAMPLES = 6;
 
@@ -177,105 +167,22 @@ export async function handleBenchmarkCommand(
 		  }
 		| undefined;
 	if (cumulative) {
-		let reviewPasses = 0,
-			reviewFails = 0,
-			testPasses = 0,
-			testFails = 0,
-			additions = 0,
-			deletions = 0;
-		// Quality metrics accumulation
-		let totalComplexityDelta = 0;
-		let totalPublicApiDelta = 0;
-		let totalDuplicationRatio = 0;
-		let totalTestToCodeRatio = 0;
-		let qualityEvidenceCount = 0;
-		for (const tid of await listEvidenceTaskIds(directory)) {
-			let result: Awaited<ReturnType<typeof loadEvidence>>;
-			try {
-				result = await loadEvidence(directory, tid);
-			} catch (_evidenceErr) {
-				warn(
-					'benchmark: skipping corrupt or unreadable evidence for task',
-					tid,
-				);
-				continue;
-			}
-			if (result.status !== 'found') continue;
-			for (const e of result.bundle.entries) {
-				// Skip unknown evidence types gracefully with warning
-				if (!isValidEvidenceType(e.type)) {
-					warn(`Unknown evidence type '${e.type}' in task ${tid}, skipping`);
-					continue;
-				}
-
-				if (e.type === 'review') {
-					if (e.verdict === 'approved') reviewPasses++;
-					else if (e.verdict === 'rejected') reviewFails++;
-				} else if (e.type === 'test') {
-					testPasses += e.tests_passed;
-					testFails += e.tests_failed;
-				} else if (e.type === 'diff') {
-					additions += e.additions;
-					deletions += e.deletions;
-				} else if (e.type === 'quality_budget') {
-					const qe = e as QualityBudgetEvidence;
-					totalComplexityDelta += qe.metrics.complexity_delta;
-					totalPublicApiDelta += qe.metrics.public_api_delta;
-					totalDuplicationRatio += qe.metrics.duplication_ratio * 100; // Convert to percentage
-					totalTestToCodeRatio += qe.metrics.test_to_code_ratio * 100; // Convert to percentage
-					qualityEvidenceCount++;
-				}
-			}
-		}
-		const totalReviews = reviewPasses + reviewFails,
-			totalTests = testPasses + testFails;
+		// Evidence-derived quality signals come from the shared service
+		// (src/ci/quality-checks.ts) so `/swarm benchmark --ci-gate` and the
+		// host-decoupled `swarm ci` evaluator use ONE implementation (#2497).
+		// Behavior-identical to the loop that used to live inline here
+		// (same rounding, same warn() side effects on corrupt/unknown entries).
+		const summary = await computeEvidenceQualitySummary(directory);
 		quality = {
-			reviewPassRate: totalReviews
-				? Math.round((reviewPasses / totalReviews) * 1000) / 10
-				: null,
-			testPassRate: totalTests
-				? Math.round((testPasses / totalTests) * 1000) / 10
-				: null,
-			totalReviews,
-			testsPassed: testPasses,
-			testsFailed: testFails,
-			additions,
-			deletions,
+			reviewPassRate: summary.reviewPassRate,
+			testPassRate: summary.testPassRate,
+			totalReviews: summary.totalReviews,
+			testsPassed: summary.testsPassed,
+			testsFailed: summary.testsFailed,
+			additions: summary.additions,
+			deletions: summary.deletions,
 		};
-		// Calculate average quality metrics
-		if (qualityEvidenceCount > 0) {
-			qualityMetrics = {
-				complexityDelta:
-					Math.round((totalComplexityDelta / qualityEvidenceCount) * 10) / 10,
-				publicApiDelta:
-					Math.round((totalPublicApiDelta / qualityEvidenceCount) * 10) / 10,
-				duplicationRatio:
-					Math.round((totalDuplicationRatio / qualityEvidenceCount) * 10) / 10,
-				testToCodeRatio:
-					Math.round((totalTestToCodeRatio / qualityEvidenceCount) * 10) / 10,
-				thresholds: {
-					maxComplexityDelta: CI.max_complexity_delta,
-					maxPublicApiDelta: CI.max_public_api_delta,
-					maxDuplicationRatio: CI.max_duplication_ratio,
-					minTestToCodeRatio: CI.min_test_to_code_ratio,
-				},
-				hasEvidence: true,
-			};
-		} else {
-			qualityMetrics = {
-				complexityDelta: 0,
-				publicApiDelta: 0,
-				duplicationRatio: 0,
-				testToCodeRatio: 0,
-				thresholds: {
-					maxComplexityDelta: CI.max_complexity_delta,
-					maxPublicApiDelta: CI.max_public_api_delta,
-					maxDuplicationRatio: CI.max_duplication_ratio,
-					minTestToCodeRatio: CI.min_test_to_code_ratio,
-				},
-				hasEvidence: false,
-			};
-		}
+		qualityMetrics = summary.qualityMetrics;
 	}
 
 	// CI gate

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -1,0 +1,167 @@
+/**
+ * `swarm ci` command handler (issue #2497).
+ *
+ * Advisory headless CI: evaluates a checked-out repo's authoritative gates
+ * read-only (see src/ci/evaluate.ts), renders Markdown + [SWARM_CI_JSON],
+ * and maps the run outcome to a machine exit status:
+ *   0 = every evaluated gate passed (and at least one was evaluated)
+ *   1 = gate violation / no-data / corrupt evidence / nothing to evaluate
+ *   2 = cancelled (SIGINT/SIGTERM)
+ *   3 = deadline or internal error
+ *
+ * The command must run without a TTY and without the OpenCode host
+ * (scrubbed CI environments), so it carries NO toolPolicy (neither
+ * human-only nor agent-gated). It uses `ctx.directory` — never
+ * process.cwd() — per AGENTS.md invariant 4, spawns no subprocess, and
+ * consumes no stdin.
+ */
+
+import {
+	evaluateAdvisoryCi,
+	renderFullReport,
+	renderJsonBlock,
+	runAdvisoryCiRuntime,
+} from '../ci/index.js';
+import type { CommandContext, CommandFailure } from './registry.js';
+
+export const DEFAULT_CI_DEADLINE_MS = 300_000;
+
+export interface CiSignalCancellation {
+	/** The handler invoked on SIGINT/SIGTERM; exported for unit testing the
+	 * wiring without relying on platform signal delivery. */
+	handler: () => void;
+	install: () => void;
+	dispose: () => void;
+}
+
+/** Wire SIGINT/SIGTERM to the run's AbortController. Kept as a seam so the
+ * cancellation contract is unit-testable on platforms where self-signalling
+ * a native process is unreliable (Windows Git Bash; see frozen check C5's
+ * notes). */
+export function createSignalCancellation(
+	controller: AbortController,
+	onCancelled: () => void = () => {},
+): CiSignalCancellation {
+	const handler = () => {
+		if (!controller.signal.aborted) {
+			controller.abort();
+			onCancelled();
+		}
+	};
+	let installed = false;
+	return {
+		handler,
+		install: () => {
+			if (installed) return;
+			installed = true;
+			process.once('SIGINT', handler);
+			process.once('SIGTERM', handler);
+		},
+		dispose: () => {
+			if (!installed) return;
+			installed = false;
+			process.removeListener('SIGINT', handler);
+			process.removeListener('SIGTERM', handler);
+		},
+	};
+}
+
+function parseTimeoutMs(args: string[]): number {
+	const index = args.indexOf('--timeout-ms');
+	if (index === -1) return DEFAULT_CI_DEADLINE_MS;
+	const raw = args[index + 1];
+	if (raw === undefined || raw.startsWith('--')) {
+		throw new Error(
+			'Invalid --timeout-ms value: expected a positive number of milliseconds.',
+		);
+	}
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(
+			'Invalid --timeout-ms value: expected a positive number of milliseconds.',
+		);
+	}
+	return parsed;
+}
+
+function validateNoUnknownFlags(args: string[]): void {
+	const allowed = new Set(['--timeout-ms', '--json']);
+	for (const arg of args) {
+		if (!arg.startsWith('--')) continue;
+		if (!allowed.has(arg)) {
+			throw new Error(`Unknown flag: ${arg}`);
+		}
+	}
+}
+
+export async function handleCiCommand(
+	ctx: CommandContext,
+): Promise<string | CommandFailure> {
+	validateNoUnknownFlags(ctx.args);
+	const deadlineMs = parseTimeoutMs(ctx.args);
+	const jsonOnly = ctx.args.includes('--json');
+	// Captured once, before any output: the report channel is stdout.
+	const tty = Boolean(process.stdout?.isTTY);
+
+	const controller = new AbortController();
+	const signals = createSignalCancellation(controller);
+	signals.install();
+
+	try {
+		const result = await runAdvisoryCiRuntime({
+			directory: ctx.directory,
+			deadlineMs,
+			signal: controller.signal,
+			evaluate: (runCtx) =>
+				evaluateAdvisoryCi({
+					directory: ctx.directory,
+					tty,
+					journal: runCtx.journal,
+					registerCleanup: runCtx.registerCleanup,
+				}),
+		});
+
+		if (result.outcome === 'pass' && result.report) {
+			return jsonOnly
+				? renderJsonBlock(result.report)
+				: renderFullReport(result.report);
+		}
+		if (result.outcome === 'violations' && result.report) {
+			return {
+				text: jsonOnly
+					? renderJsonBlock(result.report)
+					: renderFullReport(result.report),
+				ok: false as const,
+				exitCode: 1,
+			};
+		}
+		// cancelled / deadline / error — the report may be absent; emit a
+		// bounded diagnostic plus the journal tail.
+		const tail = result.journal
+			.slice(-5)
+			.map((e) => `${e.type}${e.detail ? `: ${e.detail}` : ''}`)
+			.join('; ');
+		const detail = result.detail ?? result.outcome;
+		return {
+			text:
+				`swarm ci ${result.outcome}: ${detail}\n` +
+				`journal tail: ${tail || '(empty)'}\n` +
+				`[SWARM_CI_JSON]\n${JSON.stringify(
+					{
+						version: 1,
+						verdict: 'fail',
+						exit_reason: result.outcome,
+						gates: [],
+						tasks: [],
+						environment: { mode: 'advisory', tty, host: 'none' },
+					},
+					null,
+					2,
+				)}\n[/SWARM_CI_JSON]`,
+			ok: false as const,
+			exitCode: result.outcome === 'cancelled' ? 2 : 3,
+		};
+	} finally {
+		signals.dispose();
+	}
+}

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -17,11 +17,13 @@
  */
 
 import {
+	type AdvisoryCiReport,
 	evaluateAdvisoryCi,
 	renderFullReport,
 	renderJsonBlock,
 	runAdvisoryCiRuntime,
 } from '../ci/index.js';
+import { DEFAULT_QA_GATES } from '../db/qa-gate-profile.js';
 import type { CommandContext, CommandFailure } from './registry.js';
 
 export const DEFAULT_CI_DEADLINE_MS = 300_000;
@@ -108,7 +110,7 @@ export async function handleCiCommand(
 	signals.install();
 
 	try {
-		const result = await runAdvisoryCiRuntime({
+		const result = await _internals.runAdvisoryCiRuntime({
 			directory: ctx.directory,
 			deadlineMs,
 			signal: controller.signal,
@@ -135,29 +137,43 @@ export async function handleCiCommand(
 				exitCode: 1,
 			};
 		}
-		// cancelled / deadline / error — the report may be absent; emit a
-		// bounded diagnostic plus the journal tail.
+		// cancelled / deadline / error — evaluation never completed, so the
+		// machine block carries the full report shape with neutral evaluation
+		// fields. One `version: 1` schema for every exit code keeps the
+		// #2498 consumer contract branch-independent.
 		const tail = result.journal
 			.slice(-5)
 			.map((e) => `${e.type}${e.detail ? `: ${e.detail}` : ''}`)
 			.join('; ');
 		const detail = result.detail ?? result.outcome;
+		// 'pass'/'violations' returned above, so only the abort outcomes reach
+		// this diagnostic branch.
+		const diagnosticReason =
+			result.outcome === 'cancelled' ||
+			result.outcome === 'deadline' ||
+			result.outcome === 'error'
+				? result.outcome
+				: 'error';
+		const diagnosticReport: AdvisoryCiReport = {
+			version: 1,
+			verdict: 'fail',
+			exit_reason: diagnosticReason,
+			gates: [],
+			tasks: [],
+			plan: { present: false, task_count: 0 },
+			environment: { mode: 'advisory', tty, host: 'none' },
+			gate_profile: 'default',
+			effective_gates: { ...DEFAULT_QA_GATES },
+			not_evaluated: [],
+			not_evaluable: [],
+			counts: { pass: 0, fail: 0, no_data: 0, corrupt: 0, error: 0 },
+		};
 		return {
-			text:
-				`swarm ci ${result.outcome}: ${detail}\n` +
-				`journal tail: ${tail || '(empty)'}\n` +
-				`[SWARM_CI_JSON]\n${JSON.stringify(
-					{
-						version: 1,
-						verdict: 'fail',
-						exit_reason: result.outcome,
-						gates: [],
-						tasks: [],
-						environment: { mode: 'advisory', tty, host: 'none' },
-					},
-					null,
-					2,
-				)}\n[/SWARM_CI_JSON]`,
+			text: jsonOnly
+				? renderJsonBlock(diagnosticReport)
+				: `swarm ci ${result.outcome}: ${detail}\n` +
+					`journal tail: ${tail || '(empty)'}\n` +
+					renderJsonBlock(diagnosticReport),
 			ok: false as const,
 			exitCode: result.outcome === 'cancelled' ? 2 : 3,
 		};
@@ -165,3 +181,9 @@ export async function handleCiCommand(
 		signals.dispose();
 	}
 }
+
+/** Test seam: dependency injection over the runtime entry so handler-level
+ * diagnostic-branch tests can drive cancelled/deadline outcomes without
+ * timing or signal-delivery dependence (repo convention: DI over mock.module;
+ * restore in afterEach). */
+export const _internals = { runAdvisoryCiRuntime };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -38,6 +38,11 @@ export { handleAutoProceedCommand } from './auto-proceed';
 export { handleBenchmarkCommand } from './benchmark';
 export { handleBrainstormCommand } from './brainstorm';
 export { handleCheckpointCommand } from './checkpoint';
+export {
+	createSignalCancellation,
+	DEFAULT_CI_DEADLINE_MS,
+	handleCiCommand,
+} from './ci';
 export { handleCiSimulateCommand } from './ci-simulate';
 export { handleClarifyCommand } from './clarify';
 export { handleCloseCommand } from './close';

--- a/src/commands/registry.none-tool-policy.test.ts
+++ b/src/commands/registry.none-tool-policy.test.ts
@@ -11,6 +11,7 @@ describe('toolPolicy none classification snapshot', () => {
 			'codebase-review',
 			'concurrency',
 			'council',
+			'ci',
 			'ci-monitor',
 			'coupling',
 			'curate',

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -26,6 +26,7 @@ import { handleAutoProceedCommand } from './auto-proceed.js';
 import { handleBenchmarkCommand } from './benchmark.js';
 import { handleBrainstormCommand } from './brainstorm.js';
 import { handleCheckpointCommand } from './checkpoint.js';
+import { handleCiCommand } from './ci.js';
 import { handleCiMonitorCommand } from './ci-monitor.js';
 import { handleCiSimulateCommand } from './ci-simulate.js';
 import { handleClarifyCommand } from './clarify.js';
@@ -1412,6 +1413,16 @@ export const COMMAND_REGISTRY = {
 		details:
 			'Triggers MODE: PR_FEEDBACK — ingests existing pull-request feedback (review threads, requested changes, CI/check failures, merge conflicts, stale branch state, pasted notes), verifies every claim against source, clusters related problems, fixes confirmed items, validates the branch, and reports closure status for every ledger item. Distinct from /swarm pr-review, which discovers new findings. The PR reference is optional: with none, the architect builds the ledger from the current PR/branch; text after the reference is forwarded as extra instructions. Supports full GitHub URL, owner/repo#N shorthand, or bare PR number (resolved against origin).',
 		category: 'agent',
+		toolPolicy: 'none',
+	},
+	ci: {
+		handler: (ctx) => handleCiCommand(ctx),
+		description:
+			'Advisory headless CI: evaluate the repo gate/evidence state read-only with machine exit codes [--timeout-ms <n>] [--json]',
+		args: '--timeout-ms <n>, --json',
+		details:
+			'Host-decoupled, read-only evaluation of the checked-out repo (#2497): per-task required gates (tri-state evidence), plan-critic approval, and evidence-quality thresholds, composed from the authoritative readers. Exits 0 only when every evaluated gate passes; 1 on any violation, no-data, corrupt evidence, or a missing plan; 2 on cancellation (SIGINT/SIGTERM); 3 on deadline/internal error. Emits a Markdown report plus a [SWARM_CI_JSON] machine block. Never writes to .swarm and cannot satisfy or bypass any gate; runs with no TTY and no OpenCode host.',
+		category: 'diagnostics',
 		toolPolicy: 'none',
 	},
 	'ci-monitor': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3665,6 +3665,10 @@ async function initializeOpenCodeSwarm(
 					template: '/swarm ci-simulate $ARGUMENTS',
 					description: shortcutDescription('ci-simulate'),
 				},
+				'swarm-ci': {
+					template: '/swarm ci $ARGUMENTS',
+					description: shortcutDescription('ci'),
+				},
 				'swarm-learning': {
 					template: '/swarm learning',
 					description: shortcutDescription('learning'),

--- a/tests/helpers/swarm-write-cache-scan.ts
+++ b/tests/helpers/swarm-write-cache-scan.ts
@@ -3353,4 +3353,18 @@ export const EVIDENCE_WRITE_BLIND_SPOTS: readonly EvidenceWriteBlindSpot[] = [
 			'plan.json.rebuild.<time>.<rand> temp file that is renamed onto ' +
 			'plan.json, and that rename IS governed by RULE R.',
 	},
+	{
+		file: 'src/ci/evaluate.ts',
+		rule: 'C',
+		target: 'dest',
+		status: 'not-an-evidence-artifact',
+		reason:
+			'Issue #2497: createShadowCopy() copies .swarm state files into an OS ' +
+			'temporary directory created with fs.mkdtempSync(path.join(os.tmpdir(), ' +
+			"'swarm-ci-shadow-')) so the advisory CI run can evaluate a snapshot " +
+			'without touching the evaluated repo. The `dest` operand is ' +
+			'path.join(shadowRoot, rel), and shadowRoot comes from mkdtempSync, so ' +
+			'the path folds to null — but the target is always OUTSIDE the project ' +
+			'.swarm/evidence/ tree (same shape as cost-accounting.ts|C|snap).',
+	},
 ];

--- a/tests/unit/ci/_fixtures.ts
+++ b/tests/unit/ci/_fixtures.ts
@@ -1,0 +1,215 @@
+/**
+ * Shared fixtures for the advisory-CI tests (issue #2497).
+ *
+ * Builds minimal `.swarm` fixture repos in temp dirs. Satisfying fixtures
+ * are constructed with the repo's own writers (initLedger,
+ * forceRecordPlanCriticApproval) and pre-validated with the repo's own
+ * readers, mirroring the frozen acceptance-check builders so the shapes can
+ * never drift from the real schemas.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readTaskEvidenceState } from '../../../src/gate-evidence.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+import { forceRecordPlanCriticApprovedForTests } from './_plan-critic-approval.js';
+
+export const TS = '2026-01-01T00:00:00.000Z';
+
+export interface FixtureTask {
+	id: string;
+	status: string;
+}
+
+function writeJson(file: string, data: unknown) {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+export function writePlan(dir: string, tasks: FixtureTask[]) {
+	writeJson(path.join(dir, '.swarm', 'plan.json'), {
+		schema_version: '1.0.0',
+		title: 'CI Advisory Fixture',
+		swarm: 'local',
+		current_phase: 1,
+		phases: [
+			{
+				id: 1,
+				name: 'Implementation',
+				status: 'pending',
+				tasks: tasks.map((t) => ({
+					id: t.id,
+					phase: 1,
+					status: t.status,
+					size: 'small',
+					description: `Fixture task ${t.id}`,
+					depends: [],
+					files_touched: ['src/thing.ts'],
+				})),
+			},
+		],
+	});
+}
+
+const gateEv = (agent: string) => ({
+	sessionId: 'sess-ci-2497-tests',
+	timestamp: TS,
+	agent,
+});
+
+export interface TaskEvidenceSpec {
+	taskId: string;
+	/** Required gate keys; defaults to deriveRequiredGates('coder'). */
+	requiredGates?: string[];
+	/** Satisfied gate keys. */
+	satisfied: string[];
+	/** Workflow state; defaults to 'complete' when all gates satisfied. */
+	workflowState: string;
+}
+
+export function writeTaskEvidence(dir: string, spec: TaskEvidenceSpec) {
+	const required = spec.requiredGates ?? ['reviewer', 'test_engineer'];
+	const gates: Record<string, unknown> = {};
+	for (const gate of spec.satisfied) gates[gate] = gateEv(gate);
+	writeJson(path.join(dir, '.swarm', 'evidence', `${spec.taskId}.json`), {
+		taskId: spec.taskId,
+		required_gates: required,
+		gates,
+		requirements_state: 'known',
+		workflow: {
+			schema: 'exact-task-v1',
+			generation: 1,
+			state: spec.workflowState,
+			retryCount: 0,
+			retryHistory: [],
+			retryEpoch: 0,
+			lastOutcome: 'task_completed',
+			lastTransitionId: null,
+			updatedAt: TS,
+		},
+	});
+}
+
+export function writeCorruptTaskEvidence(dir: string, taskId: string) {
+	const file = path.join(dir, '.swarm', 'evidence', `${taskId}.json`);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, '{ this is not valid json !!!');
+}
+
+export interface BundleSpec {
+	taskId: string;
+	review?: 'approved' | 'rejected';
+	tests?: { passed: number; failed: number };
+	qualityBudget?: {
+		complexityDelta: number;
+		publicApiDelta: number;
+		duplicationRatio: number;
+		testToCodeRatio: number;
+	};
+}
+
+export function writeEvidenceBundle(dir: string, spec: BundleSpec) {
+	const entries: Array<Record<string, unknown>> = [];
+	if (spec.review) {
+		entries.push({
+			type: 'review',
+			task_id: spec.taskId,
+			timestamp: TS,
+			agent: 'reviewer',
+			verdict: spec.review,
+			summary: 'Fixture review',
+			risk: 'low',
+			issues: [],
+		});
+	}
+	if (spec.tests) {
+		entries.push({
+			type: 'test',
+			task_id: spec.taskId,
+			timestamp: TS,
+			agent: 'test_engineer',
+			verdict: 'pass',
+			summary: 'Fixture tests',
+			tests_passed: spec.tests.passed,
+			tests_failed: spec.tests.failed,
+			failures: [],
+		});
+	}
+	if (spec.qualityBudget) {
+		entries.push({
+			type: 'quality_budget',
+			task_id: spec.taskId,
+			timestamp: TS,
+			agent: 'quality_budget',
+			verdict: 'pass',
+			summary: 'Fixture quality budget',
+			metrics: {
+				complexity_delta: spec.qualityBudget.complexityDelta,
+				public_api_delta: spec.qualityBudget.publicApiDelta,
+				duplication_ratio: spec.qualityBudget.duplicationRatio,
+				test_to_code_ratio: spec.qualityBudget.testToCodeRatio,
+				base_resolved: false,
+			},
+			thresholds: {
+				max_complexity_delta: 5,
+				max_public_api_delta: 10,
+				max_duplication_ratio: 0.05,
+				min_test_to_code_ratio: 0.3,
+			},
+			violations: [],
+			files_analyzed: ['src/thing.ts'],
+		});
+	}
+	writeJson(
+		path.join(dir, '.swarm', 'evidence', spec.taskId, 'evidence.json'),
+		{
+			schema_version: '1.0.0',
+			task_id: spec.taskId,
+			entries,
+			created_at: TS,
+			updated_at: TS,
+		},
+	);
+}
+
+export function writeCorruptEvidenceBundle(dir: string, taskId: string) {
+	const file = path.join(dir, '.swarm', 'evidence', taskId, 'evidence.json');
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, '{ also not valid json');
+}
+
+/**
+ * Build the fully-satisfying fixture: one completed task with complete gate
+ * evidence, a full evidence bundle, and a recorded plan-critic approval
+ * (written through the repo's own writers so the ledger/DB state is real).
+ */
+export async function buildSatisfiedFixture(): Promise<string> {
+	const dir = canonicalMkdtemp('swarm-ci-tests-satisfied-');
+	writePlan(dir, [{ id: '1.1', status: 'completed' }]);
+	writeTaskEvidence(dir, {
+		taskId: '1.1',
+		satisfied: ['reviewer', 'test_engineer'],
+		workflowState: 'complete',
+	});
+	writeEvidenceBundle(dir, {
+		taskId: '1.1',
+		review: 'approved',
+		tests: { passed: 10, failed: 0 },
+		qualityBudget: {
+			complexityDelta: 1,
+			publicApiDelta: 1,
+			duplicationRatio: 0.01,
+			testToCodeRatio: 0.9,
+		},
+	});
+	const state = await readTaskEvidenceState(dir, '1.1');
+	if (state.kind !== 'ok') {
+		throw new Error(`fixture regression: 1.1 evidence kind=${state.kind}`);
+	}
+	await forceRecordPlanCriticApprovedForTests(dir);
+	return dir;
+}
+
+export function makeFixtureDir(prefix: string): string {
+	return canonicalMkdtemp(prefix);
+}

--- a/tests/unit/ci/_plan-critic-approval.ts
+++ b/tests/unit/ci/_plan-critic-approval.ts
@@ -1,0 +1,34 @@
+/**
+ * Plan-critic approval helper for advisory-CI tests (issue #2497).
+ *
+ * Records a plan-critic approval through the repo's own writers
+ * (initLedger + forceRecordPlanCriticApproval) so the satisfying fixture's
+ * ledger/DB state is produced by production code paths, not hand-written
+ * files.
+ */
+
+import {
+	forceRecordPlanCriticApproval,
+	isPlanCriticApproved,
+} from '../../../src/hooks/delegation-gate.js';
+import { initLedger } from '../../../src/plan/ledger.js';
+import { loadPlanJsonOnly } from '../../../src/plan/manager.js';
+import { derivePlanId } from '../../../src/plan/utils.js';
+import { ensureAgentSession } from '../../../src/state.js';
+
+export async function forceRecordPlanCriticApprovedForTests(
+	dir: string,
+): Promise<void> {
+	const plan = await loadPlanJsonOnly(dir);
+	if (!plan) throw new Error('fixture regression: plan.json unreadable');
+	await initLedger(dir, derivePlanId(plan));
+	ensureAgentSession('fixture-architect-2497-tests', 'architect');
+	await forceRecordPlanCriticApproval(dir, 'fixture-architect-2497-tests', {
+		reason: 'ci2497 test fixture pre-approval',
+		userConfirmed: true,
+	});
+	const approved = await isPlanCriticApproved(dir);
+	if (!approved) {
+		throw new Error('fixture regression: plan-critic approval not recorded');
+	}
+}

--- a/tests/unit/ci/evaluate.test.ts
+++ b/tests/unit/ci/evaluate.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Advisory CI evaluation tests (issue #2497).
+ *
+ * Pins the honest-disposition contract: per-task required gates with
+ * #2470 tri-state evidence (valid / missing / corrupt are DISTINCT), the
+ * rework_required workflow guard (no vacuous pass on non-terminal states),
+ * plan-critic evaluation, quality-threshold no-data semantics, and the
+ * plan_missing / plan_corrupt / no_tasks exit reasons.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	evaluateAdvisoryCi,
+	MAX_SHADOW_COPY_BYTES,
+	TERMINAL_SUCCESS_STATES,
+} from '../../../src/ci/evaluate.js';
+import {
+	buildSatisfiedFixture,
+	makeFixtureDir,
+	writeCorruptEvidenceBundle,
+	writeCorruptTaskEvidence,
+	writeEvidenceBundle,
+	writePlan,
+	writeTaskEvidence,
+} from './_fixtures.js';
+
+describe('advisory evaluation constants', () => {
+	test('TERMINAL_SUCCESS_STATES pins the terminal-success workflow vocabulary', () => {
+		// Mirrors WORKFLOW_STATE_RANK's top two ranks ('complete': 8,
+		// 'closed': 7) in src/gate-evidence.ts; any other workflow state is
+		// reported and never a vacuous pass.
+		expect([...TERMINAL_SUCCESS_STATES]).toEqual(['complete', 'closed']);
+	});
+
+	test('MAX_SHADOW_COPY_BYTES bounds the DB-mediated shadow read', () => {
+		expect(MAX_SHADOW_COPY_BYTES).toBe(512 * 1024 * 1024);
+	});
+});
+
+describe('evaluateAdvisoryCi', () => {
+	test('satisfied fixture: every gate row passes, verdict pass', async () => {
+		const dir = await buildSatisfiedFixture();
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.verdict).toBe('pass');
+		expect(report.exit_reason).toBe('all_gates_passed');
+		expect(report.gates.length).toBeGreaterThan(0);
+		for (const row of report.gates) {
+			expect(row.status, `gate ${row.name} should pass`).toBe('pass');
+		}
+		const task = report.tasks.find((t) => t.task_id === '1.1');
+		expect(task?.evidence_state).toBe('valid');
+		expect(task?.missing_gates).toEqual([]);
+		expect(task?.satisfied).toBe(true);
+		expect(report.environment).toEqual({
+			mode: 'advisory',
+			tty: false,
+			host: 'none',
+		});
+	});
+
+	test('missing gate evidence (violation): fail row naming the missing gate, exit 1 semantics', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-violation-');
+		writePlan(dir, [{ id: '1.1', status: 'in_progress' }]);
+		writeTaskEvidence(dir, {
+			taskId: '1.1',
+			satisfied: ['reviewer'],
+			workflowState: 'reviewer_run',
+		});
+		writeEvidenceBundle(dir, {
+			taskId: '1.1',
+			review: 'approved',
+			tests: { passed: 10, failed: 0 },
+		});
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.verdict).toBe('fail');
+		expect(report.exit_reason).toBe('gate_violations');
+		const row = report.gates.find((g) => g.name === 'task 1.1 gates');
+		expect(row?.status).toBe('fail');
+		expect(row?.detail).toContain('test_engineer');
+		const task = report.tasks.find((t) => t.task_id === '1.1');
+		expect(task?.missing_gates).toEqual(['test_engineer']);
+		expect(task?.satisfied).toBe(false);
+	});
+
+	test('rework_required workflow state is never a vacuous pass', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-rework-');
+		writePlan(dir, [{ id: '1.1', status: 'in_progress' }]);
+		// All required gates satisfied BUT the workflow says re-do.
+		writeTaskEvidence(dir, {
+			taskId: '1.1',
+			satisfied: ['reviewer', 'test_engineer'],
+			workflowState: 'rework_required',
+		});
+		writeEvidenceBundle(dir, {
+			taskId: '1.1',
+			review: 'approved',
+			tests: { passed: 5, failed: 0 },
+		});
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		const row = report.gates.find((g) => g.name === 'task 1.1 gates');
+		expect(row?.status).toBe('fail');
+		expect(row?.detail).toContain('rework_required');
+		const task = report.tasks.find((t) => t.task_id === '1.1');
+		expect(task?.missing_gates).toEqual([]);
+		expect(task?.satisfied).toBe(false);
+		expect(report.verdict).toBe('fail');
+	});
+
+	test('no-data task: no_data row, not a pass', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-nodata-');
+		writePlan(dir, [{ id: '2.1', status: 'pending' }]);
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.verdict).toBe('fail');
+		const row = report.gates.find((g) => g.name === 'task 2.1 gates');
+		expect(row?.status).toBe('no_data');
+		const task = report.tasks.find((t) => t.task_id === '2.1');
+		expect(task?.evidence_state).toBe('missing');
+		// Required-gate vocabulary still comes from the authoritative default
+		// derivation even when evidence is absent.
+		expect(task?.required_gates).toEqual(['reviewer', 'test_engineer']);
+	});
+
+	test('corrupt evidence: corrupt row, distinct from missing', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-corrupt-');
+		writePlan(dir, [{ id: '3.1', status: 'pending' }]);
+		writeCorruptTaskEvidence(dir, '3.1');
+		writeCorruptEvidenceBundle(dir, '3.1');
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		const row = report.gates.find((g) => g.name === 'task 3.1 gates');
+		expect(row?.status).toBe('corrupt');
+		const task = report.tasks.find((t) => t.task_id === '3.1');
+		expect(task?.evidence_state).toBe('corrupt');
+	});
+
+	test('bundle corrupt while task evidence valid: corrupt surfaces from the bundle side', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-bundle-corrupt-');
+		writePlan(dir, [{ id: '1.1', status: 'completed' }]);
+		writeTaskEvidence(dir, {
+			taskId: '1.1',
+			satisfied: ['reviewer', 'test_engineer'],
+			workflowState: 'complete',
+		});
+		writeCorruptEvidenceBundle(dir, '1.1');
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		const taskRow = report.gates.find((g) => g.name === 'task 1.1 gates');
+		expect(taskRow?.status).toBe('pass');
+		// The evidence-corpus quality checks see no data through loadEvidence
+		// (invalid_schema bundles are not 'found'), so review/test rate rows
+		// must be no_data — never pass.
+		const review = report.gates.find((g) => g.name === 'review_pass_rate');
+		expect(review?.status).toBe('no_data');
+		const test = report.gates.find((g) => g.name === 'test_pass_rate');
+		expect(test?.status).toBe('no_data');
+		expect(report.verdict).toBe('fail');
+	});
+
+	test('missing plan: exit_reason plan_missing with plan diagnostic', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-noplan-');
+		fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.verdict).toBe('fail');
+		expect(report.exit_reason).toBe('plan_missing');
+		const planRow = report.gates.find((g) => g.name === 'plan');
+		expect(planRow?.status).toBe('no_data');
+		expect(planRow?.detail).toContain('plan');
+	});
+
+	test('corrupt plan: exit_reason plan_corrupt', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-plan-corrupt-');
+		fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
+		fs.writeFileSync(path.join(dir, '.swarm', 'plan.json'), '{ nope');
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.exit_reason).toBe('plan_corrupt');
+		const planRow = report.gates.find((g) => g.name === 'plan');
+		expect(planRow?.status).toBe('corrupt');
+	});
+
+	test('zero-task plan: exit_reason no_tasks', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-notasks-');
+		writePlan(dir, []);
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.exit_reason).toBe('no_tasks');
+		expect(report.verdict).toBe('fail');
+		const tasksRow = report.gates.find((g) => g.name === 'plan tasks');
+		expect(tasksRow?.status).toBe('no_data');
+	});
+
+	test('plan-critic gate fails when no approval is recorded (critic_pre_plan default)', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-nocritic-');
+		writePlan(dir, [{ id: '1.1', status: 'completed' }]);
+		writeTaskEvidence(dir, {
+			taskId: '1.1',
+			satisfied: ['reviewer', 'test_engineer'],
+			workflowState: 'complete',
+		});
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		const row = report.gates.find((g) => g.name === 'plan_critic');
+		expect(row?.status).toBe('fail');
+		expect(report.verdict).toBe('fail');
+	});
+
+	test('not_evaluable lists the live-state checks; counts match the rows', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-noteval-');
+		writePlan(dir, [{ id: '2.1', status: 'pending' }]);
+		const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+		expect(report.not_evaluable.map((n) => n.name).sort()).toEqual([
+			'agent_error_rate',
+			'hard_limit_hits',
+		]);
+		const total = Object.values(report.counts).reduce((a, b) => a + b, 0);
+		expect(total).toBe(report.gates.length);
+	});
+
+	test('evaluation does not mutate the evaluated .swarm directory', async () => {
+		const dir = makeFixtureDir('swarm-ci-tests-readonly-');
+		writePlan(dir, [{ id: '1.1', status: 'completed' }]);
+		writeTaskEvidence(dir, {
+			taskId: '1.1',
+			satisfied: ['reviewer', 'test_engineer'],
+			workflowState: 'complete',
+		});
+		writeEvidenceBundle(dir, {
+			taskId: '1.1',
+			review: 'approved',
+			tests: { passed: 3, failed: 0 },
+		});
+		const before = snapshotTree(dir);
+		await evaluateAdvisoryCi({ directory: dir, tty: false });
+		const after = snapshotTree(dir);
+		expect(after).toEqual(before);
+	});
+});
+
+function snapshotTree(root: string): Array<[string, string]> {
+	const out: Array<[string, string]> = [];
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(full);
+			else if (entry.isFile()) {
+				out.push([
+					path.relative(root, full),
+					String(fs.statSync(full).size) +
+						':' +
+						crypto
+							.createHash('sha256')
+							.update(fs.readFileSync(full))
+							.digest('hex')
+							.slice(0, 12),
+				]);
+			}
+		}
+	};
+	const swarm = path.join(root, '.swarm');
+	if (fs.existsSync(swarm)) walk(swarm);
+	return out.sort((a, b) => a[0].localeCompare(b[0]));
+}

--- a/tests/unit/ci/host-decoupling-ratchet.test.ts
+++ b/tests/unit/ci/host-decoupling-ratchet.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Host-decoupling ratchet for src/ci/** (issue #2497; plan-critic R1/R4,
+ * Phase 4.2 guardrail).
+ *
+ * Source-scan ratchet: the advisory-CI runtime must never read the OpenCode
+ * host client (`opencodeClient`), the plugin's live session state
+ * (`swarmState`), or import any durable-state WRITER (the evaluation is
+ * read-only; DB-mediated reads go through the shadow copy). This is the
+ * stronger in-repo rung above the frozen C1 static check — it runs in CI on
+ * every PR and bites on any future file added under src/ci/.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const CI_DIR = path.resolve(process.cwd(), 'src', 'ci');
+const HANDLER = path.resolve(process.cwd(), 'src', 'commands', 'ci.ts');
+
+const FORBIDDEN_TOKENS = ['opencodeClient', 'swarmState'] as const;
+
+const FORBIDDEN_WRITER_IMPORTS = [
+	'initLedger',
+	'recordGateEvidence',
+	'saveEvidence',
+	'setGates',
+	'transitionTaskWorkflowEvidence',
+	'appendLedgerEvent',
+] as const;
+
+/** Recursive *.ts listing: a forbidden file hidden in a nested subdirectory
+ * (e.g. src/ci/sub/leak.ts) must not evade the scan — the ratchet covers
+ * ALL of src/ci/**, at any depth (reviewer Probe C, #2497 4.5 round 1). */
+function listCiModules(): string[] {
+	const out: string[] = [];
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(full);
+			else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+		}
+	};
+	walk(CI_DIR);
+	return out;
+}
+
+describe('src/ci host-decoupling ratchet', () => {
+	test('src/ci modules exist', () => {
+		const modules = listCiModules();
+		expect(modules.length).toBeGreaterThan(0);
+	});
+
+	test('no host-state tokens in any src/ci module or the ci command handler', () => {
+		const files = [...listCiModules(), HANDLER];
+		for (const file of files) {
+			const source = fs.readFileSync(file, 'utf-8');
+			for (const token of FORBIDDEN_TOKENS) {
+				expect(
+					source.includes(token),
+					`${path.relative(process.cwd(), file)} must not reference ${token}`,
+				).toBe(false);
+			}
+		}
+	});
+
+	test('no durable-state writer imports in any src/ci module or the handler', () => {
+		const files = [...listCiModules(), HANDLER];
+		for (const file of files) {
+			const source = fs.readFileSync(file, 'utf-8');
+			for (const writer of FORBIDDEN_WRITER_IMPORTS) {
+				expect(
+					source.includes(writer),
+					`${path.relative(process.cwd(), file)} must not import writer ${writer} (advisory evaluation is read-only)`,
+				).toBe(false);
+			}
+		}
+	});
+});

--- a/tests/unit/ci/quality-checks.test.ts
+++ b/tests/unit/ci/quality-checks.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared evidence-quality service tests (issue #2497, plan D2/R5).
+ *
+ * Pins parity with the benchmark `--ci-gate` computation over fixed
+ * evidence inputs: the same rounding, the same pass-on-no-evidence
+ * semantics for the benchmark surface (the ADVISORY surface re-maps
+ * no-evidence to no_data in evaluate.ts), and the no-data dispositions the
+ * advisory evaluator relies on.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	CI_QUALITY_THRESHOLDS,
+	computeEvidenceQualitySummary,
+} from '../../../src/ci/quality-checks.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+import { TS, writeEvidenceBundle } from './_fixtures.js';
+
+describe('computeEvidenceQualitySummary', () => {
+	test('aggregates review/test/quality-budget evidence with benchmark rounding', async () => {
+		const dir = canonicalMkdtemp('swarm-ci-quality-');
+		writeEvidenceBundle(dir, {
+			taskId: '1.1',
+			review: 'approved',
+			tests: { passed: 9, failed: 1 },
+			qualityBudget: {
+				complexityDelta: 2,
+				publicApiDelta: 3,
+				duplicationRatio: 0.02,
+				testToCodeRatio: 0.55,
+			},
+		});
+		writeEvidenceBundle(dir, {
+			taskId: '2.1',
+			review: 'rejected',
+			tests: { passed: 6, failed: 2 },
+			qualityBudget: {
+				complexityDelta: 4,
+				publicApiDelta: 5,
+				duplicationRatio: 0.04,
+				testToCodeRatio: 0.65,
+			},
+		});
+		const summary = await computeEvidenceQualitySummary(dir);
+		// 1/2 approved reviews = 50%; 15/17 tests = 88.2% (benchmark rounding:
+		// one decimal place).
+		expect(summary.totalReviews).toBe(2);
+		expect(summary.reviewPassRate).toBe(50);
+		expect(summary.testsPassed).toBe(15);
+		expect(summary.testsFailed).toBe(3);
+		expect(summary.testPassRate).toBe(83.3);
+		// Averages over two quality_budget entries, converted to percentages.
+		expect(summary.qualityMetrics.hasEvidence).toBe(true);
+		expect(summary.qualityMetrics.complexityDelta).toBe(3);
+		expect(summary.qualityMetrics.publicApiDelta).toBe(4);
+		expect(summary.qualityMetrics.duplicationRatio).toBe(3);
+		expect(summary.qualityMetrics.testToCodeRatio).toBe(60);
+		// Thresholds mirror the shared constants.
+		expect(summary.qualityMetrics.thresholds).toEqual({
+			maxComplexityDelta: CI_QUALITY_THRESHOLDS.max_complexity_delta,
+			maxPublicApiDelta: CI_QUALITY_THRESHOLDS.max_public_api_delta,
+			maxDuplicationRatio: CI_QUALITY_THRESHOLDS.max_duplication_ratio,
+			minTestToCodeRatio: CI_QUALITY_THRESHOLDS.min_test_to_code_ratio,
+		});
+	});
+
+	test('no evidence corpus: null rates and hasEvidence false (benchmark semantics preserved)', async () => {
+		const dir = canonicalMkdtemp('swarm-ci-quality-empty-');
+		fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
+		const summary = await computeEvidenceQualitySummary(dir);
+		expect(summary.reviewPassRate).toBeNull();
+		expect(summary.testPassRate).toBeNull();
+		expect(summary.totalReviews).toBe(0);
+		expect(summary.qualityMetrics.hasEvidence).toBe(false);
+		expect(summary.qualityMetrics.complexityDelta).toBe(0);
+	});
+
+	test('corrupt bundle is skipped without throwing (warn-side-effect parity)', async () => {
+		const dir = canonicalMkdtemp('swarm-ci-quality-corrupt-');
+		const bundleDir = path.join(dir, '.swarm', 'evidence', '9.9');
+		fs.mkdirSync(bundleDir, { recursive: true });
+		fs.writeFileSync(path.join(bundleDir, 'evidence.json'), '{ not valid json');
+		const summary = await computeEvidenceQualitySummary(dir);
+		expect(summary.reviewPassRate).toBeNull();
+	});
+
+	test('unknown evidence types fail bundle validation and are skipped whole', async () => {
+		const dir = canonicalMkdtemp('swarm-ci-quality-unknown-');
+		writeEvidenceBundle(dir, { taskId: '1.1', review: 'approved' });
+		// A bundle containing an entry with an unknown type fails loadEvidence
+		// schema validation (invalid_schema), so the WHOLE bundle is skipped —
+		// the loop's per-entry isValidEvidenceType guard is defensive parity
+		// with the historical benchmark loop, not a reachable path for
+		// schema-validated bundles.
+		const bundlePath = path.join(
+			dir,
+			'.swarm',
+			'evidence',
+			'2.2',
+			'evidence.json',
+		);
+		fs.mkdirSync(path.dirname(bundlePath), { recursive: true });
+		fs.writeFileSync(
+			bundlePath,
+			JSON.stringify({
+				schema_version: '1.0.0',
+				task_id: '2.2',
+				entries: [
+					{
+						type: 'review',
+						task_id: '2.2',
+						timestamp: TS,
+						agent: 'reviewer',
+						verdict: 'rejected',
+						summary: 'fixture',
+						risk: 'low',
+						issues: [],
+					},
+					{
+						type: 'definitely-not-a-real-type',
+						task_id: '2.2',
+						timestamp: TS,
+					},
+				],
+				created_at: TS,
+				updated_at: TS,
+			}),
+		);
+		const summary = await computeEvidenceQualitySummary(dir);
+		expect(summary.totalReviews).toBe(1);
+		expect(summary.reviewPassRate).toBe(100);
+	});
+});

--- a/tests/unit/ci/quality-checks.test.ts
+++ b/tests/unit/ci/quality-checks.test.ts
@@ -132,4 +132,50 @@ describe('computeEvidenceQualitySummary', () => {
 		expect(summary.totalReviews).toBe(1);
 		expect(summary.reviewPassRate).toBe(100);
 	});
+
+	test('legacy flat-retrospective bundle: pure read, no in-place write-back (PR #2629 Copilot finding)', async () => {
+		// The `.git` marker matters: without a project root, the evidence-lock
+		// path throws before writing and the test would pass vacuously even if
+		// the migration were re-enabled. With it, the default loadEvidence
+		// path takes the lock and renames a temp file over the bundle.
+		const dir = canonicalMkdtemp('swarm-ci-quality-flatretro-');
+		fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+		const bundlePath = path.join(
+			dir,
+			'.swarm',
+			'evidence',
+			'4.2',
+			'evidence.json',
+		);
+		fs.mkdirSync(path.dirname(bundlePath), { recursive: true });
+		// Flat-retrospective shape (type 'retrospective', no schema_version)
+		// that wraps to a schema-valid bundle — the exact input that triggers
+		// the in-place migration write-back.
+		const legacy = JSON.stringify({
+			type: 'retrospective',
+			task_id: '4.2',
+			timestamp: TS,
+			agent: 'architect',
+			verdict: 'info',
+			summary: 'legacy flat retro',
+			phase_number: 1,
+			total_tool_calls: 10,
+			coder_revisions: 0,
+			reviewer_rejections: 0,
+			test_failures: 0,
+			security_findings: 0,
+			integration_issues: 0,
+			task_count: 1,
+			task_complexity: 'simple',
+		});
+		fs.writeFileSync(bundlePath, legacy);
+		const summary = await computeEvidenceQualitySummary(dir);
+		// The bundle is still readable and counted (the wrapped form is
+		// equivalent for aggregation).
+		expect(summary.totalReviews).toBe(0);
+		// Byte-identity: the read must not rewrite the bundle in place and
+		// must not leave an evidence-loader lock sentinel behind.
+		expect(fs.readFileSync(bundlePath, 'utf8')).toBe(legacy);
+		expect(fs.existsSync(path.join(dir, '.swarm', 'locks'))).toBe(false);
+	});
 });

--- a/tests/unit/ci/report.test.ts
+++ b/tests/unit/ci/report.test.ts
@@ -153,4 +153,25 @@ describe('swarm ci report rendering', () => {
 		expect(md).toContain('a \\| b \\| c');
 		expect(md).not.toContain('a | b | c');
 	});
+
+	test('newlines in plan-controlled cells cannot break the table structure (PRR-009)', () => {
+		// Gate names, task ids, and reasons originate from repo-controlled
+		// plan.json strings; a raw newline would forge extra table rows when
+		// the report is posted as a PR comment.
+		const report = sampleReport();
+		report.gates[0].name = 'evil\ngate | injected';
+		report.gates[2].detail = 'ok\n| forged | row |';
+		report.tasks[0].task_id = '1.1\n| hack |';
+		report.not_evaluated[0].reason = 'reason\n- forged bullet';
+		const md = renderMarkdownReport(report);
+		// Every table row is a single line: the injected newlines are gone.
+		expect(md).not.toContain('evil\ngate');
+		expect(md).not.toContain('ok\n| forged');
+		expect(md).not.toContain('1.1\n| hack');
+		expect(md).not.toContain('reason\n- forged');
+		// The cell content survives, flattened and pipe-escaped.
+		expect(md).toContain('evil gate \\| injected');
+		expect(md).toContain('ok \\| forged \\| row \\|');
+		expect(md).toContain('1.1 \\| hack \\|');
+	});
 });

--- a/tests/unit/ci/report.test.ts
+++ b/tests/unit/ci/report.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Advisory-CI report rendering tests (issue #2497).
+ *
+ * Pins the output contract: [SWARM_CI_JSON] marker pair, parseable
+ * pretty-printed JSON, Markdown per-gate/per-task tables, the exact
+ * environment block, and the --json (block-only) shape.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AdvisoryCiReport } from '../../../src/ci/evaluate.js';
+import {
+	renderFullReport,
+	renderJsonBlock,
+	renderMarkdownReport,
+	SWARM_CI_JSON_CLOSE,
+	SWARM_CI_JSON_OPEN,
+} from '../../../src/ci/report.js';
+
+function sampleReport(): AdvisoryCiReport {
+	return {
+		version: 1,
+		verdict: 'fail',
+		exit_reason: 'gate_violations',
+		gates: [
+			{ name: 'plan', status: 'pass' },
+			{ name: 'plan_critic', status: 'pass' },
+			{
+				name: 'task 1.1 gates',
+				status: 'pass',
+				detail: 'all required gates satisfied',
+			},
+			{
+				name: 'task 2.1 gates',
+				status: 'no_data',
+				detail: 'no durable task-gate evidence recorded',
+			},
+			{
+				name: 'task 3.1 gates',
+				status: 'corrupt',
+				detail: 'unparseable evidence',
+			},
+			{ name: 'review_pass_rate', status: 'pass', detail: 'value 100 >= 70%' },
+		],
+		tasks: [
+			{
+				task_id: '1.1',
+				evidence_state: 'valid',
+				required_gates: ['reviewer', 'test_engineer'],
+				missing_gates: [],
+				workflow_state: 'complete',
+				satisfied: true,
+			},
+			{
+				task_id: '2.1',
+				evidence_state: 'missing',
+				required_gates: ['reviewer', 'test_engineer'],
+				missing_gates: ['reviewer', 'test_engineer'],
+				satisfied: false,
+			},
+			{
+				task_id: '3.1',
+				evidence_state: 'corrupt',
+				required_gates: ['reviewer', 'test_engineer'],
+				missing_gates: ['reviewer', 'test_engineer'],
+				satisfied: false,
+			},
+		],
+		plan: {
+			present: true,
+			title: 'CI Advisory Fixture',
+			swarm: 'local',
+			task_count: 3,
+		},
+		environment: { mode: 'advisory', tty: false, host: 'none' },
+		gate_profile: 'default',
+		effective_gates: {
+			reviewer: true,
+			test_engineer: true,
+			council_mode: false,
+			sme_enabled: true,
+			critic_pre_plan: true,
+			hallucination_guard: false,
+			sast_enabled: true,
+			mutation_test: false,
+			phase_council: false,
+			drift_check: true,
+			final_council: false,
+		},
+		not_evaluated: [
+			{
+				name: 'drift_check',
+				reason: 'enforced inline by the write-drift-evidence flow',
+			},
+		],
+		not_evaluable: [
+			{ name: 'agent_error_rate', reason: 'requires live plugin state' },
+		],
+		counts: { pass: 3, fail: 0, no_data: 1, corrupt: 1, error: 0 },
+	};
+}
+
+describe('swarm ci report rendering', () => {
+	test('JSON block uses the exact marker pair and parses back to the report', () => {
+		const block = renderJsonBlock(sampleReport());
+		expect(block.startsWith(SWARM_CI_JSON_OPEN)).toBe(true);
+		expect(block.endsWith(SWARM_CI_JSON_CLOSE)).toBe(true);
+		const lines = block.split('\n');
+		expect(lines[0]).toBe('[SWARM_CI_JSON]');
+		expect(lines[lines.length - 1]).toBe('[/SWARM_CI_JSON]');
+		const jsonText = lines.slice(1, -1).join('\n');
+		const parsed = JSON.parse(jsonText) as AdvisoryCiReport;
+		expect(parsed.verdict).toBe('fail');
+		expect(parsed.exit_reason).toBe('gate_violations');
+		expect(parsed.gates.length).toBe(6);
+		// Pretty-printed (2-space indent) like the [BENCHMARK_JSON] precedent.
+		expect(jsonText).toContain('\n  "version": 1,');
+	});
+
+	test('Markdown report has per-gate and per-task tables and the environment line', () => {
+		const md = renderMarkdownReport(sampleReport());
+		expect(md).toContain('## Swarm CI Advisory Report');
+		expect(md).toContain('| Gate | Status | Detail |');
+		expect(md).toContain(
+			'| Task | Evidence state | Required gates | Missing gates | Workflow | Satisfied |',
+		);
+		expect(md).toContain('| plan | ✅ pass |');
+		expect(md).toContain('| task 2.1 gates | ⚪ no_data |');
+		expect(md).toContain('| 1.1 | valid |');
+		expect(md).toContain('mode=advisory tty=false host=none');
+		expect(md).toContain('Advisory read-only evaluation');
+		// Not-evaluable / not-evaluated surfaces are reported, never hidden.
+		expect(md).toContain('agent_error_rate');
+		expect(md).toContain('drift_check');
+	});
+
+	test('full report = markdown + machine block, with the block last', () => {
+		const full = renderFullReport(sampleReport());
+		const open = full.indexOf(SWARM_CI_JSON_OPEN);
+		const close = full.indexOf(SWARM_CI_JSON_CLOSE);
+		expect(open).toBeGreaterThan(0);
+		expect(close).toBeGreaterThan(open);
+		expect(full.slice(0, open)).toContain('## Swarm CI Advisory Report');
+	});
+
+	test('gate detail pipes are escaped in the Markdown table', () => {
+		const report = sampleReport();
+		report.gates.push({
+			name: 'weird',
+			status: 'fail',
+			detail: 'a | b | c',
+		});
+		const md = renderMarkdownReport(report);
+		expect(md).toContain('a \\| b \\| c');
+		expect(md).not.toContain('a | b | c');
+	});
+});

--- a/tests/unit/ci/runtime-bounds.test.ts
+++ b/tests/unit/ci/runtime-bounds.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Bounded advisory-CI runtime tests (issue #2497; frozen check C5's pinned
+ * test file).
+ *
+ * Pins the three bounded-execution obligations:
+ *  (a) a hung evaluation stage is cut by the deadline and the run reports a
+ *      deadline outcome;
+ *  (b) abort/cancellation mid-run produces a cancelled outcome AND runs the
+ *      registered cleanup callbacks exactly once (the SIGINT/SIGTERM →
+ *      exit-2 contract; self-signalling native processes is unreliable on
+ *      Windows Git Bash, so the seam is tested in-process here);
+ *  (c) the run journal is bounded (capped event count, drops counted).
+ *
+ * Timing notes: the hung stage is TIMER-BACKED (setTimeout), so the
+ * per-test budget can always preempt it; the deadline uses short
+ * millisecond budgets and the assertions are outcome-based, not
+ * wall-clock-based, to stay deterministic across CI platforms (Windows
+ * timer tick ~15.6ms — deadlines here are >= 50ms).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+	type AdvisoryCiReport,
+	MAX_CI_JOURNAL_EVENTS,
+	runAdvisoryCiRuntime,
+} from '../../../src/ci/runtime.js';
+
+function minimalReport(verdict: 'pass' | 'fail'): AdvisoryCiReport {
+	return {
+		version: 1,
+		verdict,
+		exit_reason: verdict === 'pass' ? 'all_gates_passed' : 'gate_violations',
+		gates: [
+			{
+				name: 'plan',
+				status: verdict === 'pass' ? 'pass' : 'fail',
+			},
+		],
+		tasks: [],
+		plan: { present: true, task_count: 0 },
+		environment: { mode: 'advisory', tty: false, host: 'none' },
+		gate_profile: 'default',
+		effective_gates: {
+			reviewer: true,
+			test_engineer: true,
+			council_mode: false,
+			sme_enabled: true,
+			critic_pre_plan: true,
+			hallucination_guard: false,
+			sast_enabled: true,
+			mutation_test: false,
+			phase_council: false,
+			drift_check: true,
+			final_council: false,
+		},
+		not_evaluated: [],
+		not_evaluable: [],
+		counts:
+			verdict === 'pass'
+				? { pass: 1, fail: 0, no_data: 0, corrupt: 0, error: 0 }
+				: { pass: 0, fail: 1, no_data: 0, corrupt: 0, error: 0 },
+	};
+}
+
+describe('runAdvisoryCiRuntime bounds', () => {
+	test('deadline cuts a hung evaluation stage and reports the deadline outcome', async () => {
+		const result = await runAdvisoryCiRuntime({
+			directory: 'C:\\definitely\\not\\used',
+			deadlineMs: 60,
+			evaluate: () =>
+				// Timer-backed hang: the runtime deadline must win the race.
+				new Promise<AdvisoryCiReport>(() => {}),
+		});
+		expect(result.outcome).toBe('deadline');
+		expect(result.report).toBeUndefined();
+		expect(result.journal.some((e) => e.type === 'run_deadline')).toBe(true);
+		expect(result.cleanupRan).toBe(true);
+	}, 5000);
+
+	test('abort mid-run produces a cancelled outcome and runs cleanup exactly once', async () => {
+		const controller = new AbortController();
+		let cleanups = 0;
+		const result = await runAdvisoryCiRuntime({
+			directory: 'C:\\definitely\\not\\used',
+			deadlineMs: 5000,
+			signal: controller.signal,
+			evaluate: async (ctx) => {
+				ctx.registerCleanup(() => {
+					cleanups++;
+				});
+				// Cancel while the stage is in flight, then hang on a timer so
+				// only the cancellation can resolve the run.
+				controller.abort();
+				await new Promise(() => {});
+			},
+		});
+		expect(result.outcome).toBe('cancelled');
+		expect(result.cleanupRan).toBe(true);
+		expect(cleanups).toBe(1);
+	}, 5000);
+
+	test('pre-aborted signal resolves immediately as cancelled with cleanup', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const result = await runAdvisoryCiRuntime({
+			directory: 'C:\\definitely\\not\\used',
+			deadlineMs: 5000,
+			signal: controller.signal,
+			evaluate: () => new Promise<AdvisoryCiReport>(() => {}),
+		});
+		expect(result.outcome).toBe('cancelled');
+		expect(result.cleanupRan).toBe(true);
+	}, 5000);
+
+	test('a failing evaluation surfaces as the error outcome, not a crash', async () => {
+		const result = await runAdvisoryCiRuntime({
+			directory: 'C:\\definitely\\not\\used',
+			deadlineMs: 5000,
+			evaluate: async () => {
+				throw new Error('boom');
+			},
+		});
+		expect(result.outcome).toBe('error');
+		expect(result.detail).toContain('boom');
+		expect(result.cleanupRan).toBe(true);
+	}, 5000);
+
+	test('verdict mapping: pass and violations outcomes carry the report', async () => {
+		const pass = await runAdvisoryCiRuntime({
+			directory: '.',
+			deadlineMs: 5000,
+			evaluate: async () => minimalReport('pass'),
+		});
+		expect(pass.outcome).toBe('pass');
+		expect(pass.report?.verdict).toBe('pass');
+
+		const fail = await runAdvisoryCiRuntime({
+			directory: '.',
+			deadlineMs: 5000,
+			evaluate: async () => minimalReport('fail'),
+		});
+		expect(fail.outcome).toBe('violations');
+		expect(fail.report?.verdict).toBe('fail');
+	}, 5000);
+
+	test('run journal is bounded: cap enforced, drops counted, newest kept', async () => {
+		let emitted = 0;
+		const result = await runAdvisoryCiRuntime({
+			directory: '.',
+			deadlineMs: 5000,
+			evaluate: async (ctx) => {
+				for (let i = 0; i < MAX_CI_JOURNAL_EVENTS + 150; i++) {
+					ctx.journal('tick', String(i));
+					emitted++;
+				}
+				return minimalReport('pass');
+			},
+		});
+		expect(emitted).toBe(MAX_CI_JOURNAL_EVENTS + 150);
+		expect(result.journal.length).toBe(MAX_CI_JOURNAL_EVENTS);
+		// Total events = run_started + ticks + run_finished; drops = total - cap.
+		expect(result.journalTruncated).toBe(emitted + 2 - MAX_CI_JOURNAL_EVENTS);
+		// Newest events survive the cap: the final tick and the run_finished
+		// event appended after the evaluation returned.
+		const last = result.journal[result.journal.length - 1];
+		const secondLast = result.journal[result.journal.length - 2];
+		expect(last.type).toBe('run_finished');
+		expect(secondLast.type).toBe('tick');
+		expect(secondLast.detail).toBe(String(emitted - 1));
+		// The run_finished event lands after the ticks (it also fits because
+		// the cap keeps shifting).
+		expect(result.journal.some((e) => e.type === 'run_finished')).toBe(true);
+	}, 5000);
+
+	test('cleanup callbacks run even when the evaluation succeeds', async () => {
+		let cleanups = 0;
+		const result = await runAdvisoryCiRuntime({
+			directory: '.',
+			deadlineMs: 5000,
+			evaluate: async (ctx) => {
+				ctx.registerCleanup(() => {
+					cleanups++;
+				});
+				ctx.registerCleanup(() => {
+					throw new Error('cleanup failure must not block the others');
+				});
+				ctx.registerCleanup(() => {
+					cleanups++;
+				});
+				return minimalReport('pass');
+			},
+		});
+		expect(result.outcome).toBe('pass');
+		expect(result.cleanupRan).toBe(true);
+		// A failing callback is skipped; the remaining ones still run.
+		expect(cleanups).toBe(2);
+	}, 5000);
+});

--- a/tests/unit/ci/wiring-ratchet.test.ts
+++ b/tests/unit/ci/wiring-ratchet.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Wiring ratchet for src/ci exports (issue #2497; plan-critic R3).
+ *
+ * Every export under src/ci/*.ts must be reachable from the production
+ * entry (`src/commands/ci.ts`) by walking ACTUAL import statements
+ * transitively — no internal-only orphan exports, no unwired surfaces.
+ * This is the in-repo strengthening above the frozen C9 coarse scan.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const REPO = process.cwd();
+const CI_DIR = path.join(REPO, 'src', 'ci');
+const ENTRY = path.join(REPO, 'src', 'commands', 'ci.ts');
+
+// Matches both `import ... from '...'` and re-export edges
+// (`export { x } from '...'` / `export type { x } from '...'`), which are
+// real edges of the module graph (the src/ci barrel is built from them).
+const IMPORT_RE =
+	/(?:import|export)\s+(?:type\s+)?(?:\{[^}]*\}|[\w$]+|\*\s+as\s+[\w$]+)?\s*(?:from\s+)?['"]([^'"]+)['"]/g;
+
+function resolveSpec(fromFile: string, spec: string): string | null {
+	if (!spec.startsWith('.')) return null; // external package
+	const resolved = path.resolve(path.dirname(fromFile), spec);
+	// Source imports use the .js ESM specifier convention for .ts files.
+	const base = resolved.endsWith('.js') ? resolved.slice(0, -3) : resolved;
+	for (const candidate of [`${base}.ts`, base, path.join(base, 'index.ts')]) {
+		if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+			return candidate;
+		}
+	}
+	return null;
+}
+
+function importsOf(file: string): Array<{ target: string; file: string }> {
+	const source = fs.readFileSync(file, 'utf-8');
+	const out: Array<{ target: string; file: string }> = [];
+	let match: RegExpExecArray | null;
+	IMPORT_RE.lastIndex = 0;
+	while ((match = IMPORT_RE.exec(source)) !== null) {
+		const target = resolveSpec(file, match[1]);
+		if (target) out.push({ target, file });
+	}
+	return out;
+}
+
+function exportedNames(file: string): string[] {
+	const source = fs.readFileSync(file, 'utf-8');
+	const names: string[] = [];
+	// export const/function/class/let X — single declarator form only.
+	for (const m of source.matchAll(
+		/export\s+(?:const|let|function|class)\s+([A-Za-z_$][\w$]*)/g,
+	)) {
+		names.push(m[1]);
+	}
+	// export { a, b as c } from '...' / export { a, b };
+	for (const m of source.matchAll(/export\s*\{([^}]+)\}/g)) {
+		for (const part of m[1].split(',')) {
+			const entry = part.trim();
+			// Inline `type X` entries re-export X from the ORIGIN module,
+			// whose declaration site this scan already checks — skip them so
+			// a barrel's type re-exports are not double-counted as the
+			// barrel's own declarations.
+			if (entry.startsWith('type ')) continue;
+			const name = entry
+				.split(/\s+as\s+/)
+				.pop()
+				?.trim();
+			if (name) names.push(name);
+		}
+	}
+	return [...new Set(names)];
+}
+
+/** Recursive *.ts listing: orphan exports in nested subdirectories must be
+ * scanned too (reviewer Probe C, #2497 4.5 round 1). */
+function listCiModules(): string[] {
+	const out: string[] = [];
+	const walk = (dir: string) => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(full);
+			else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+		}
+	};
+	walk(CI_DIR);
+	return out;
+}
+
+describe('src/ci wiring ratchet', () => {
+	test('every src/ci module is reachable from src/commands/ci.ts via real imports', () => {
+		const ciModules = listCiModules();
+		const reachable = new Set<string>();
+		const queue = [ENTRY];
+		while (queue.length > 0) {
+			const file = queue.pop() as string;
+			if (reachable.has(file)) continue;
+			reachable.add(file);
+			for (const { target } of importsOf(file)) queue.push(target);
+		}
+		const orphans = ciModules.filter((m) => !reachable.has(m));
+		expect(
+			orphans.map((m) => path.relative(REPO, m)),
+			'src/ci modules not imported (transitively) by the production entry src/commands/ci.ts',
+		).toEqual([]);
+	});
+
+	test('every export in src/ci modules is referenced by the production graph or a test seam', () => {
+		const ciModules = listCiModules();
+		const reachable = new Set<string>();
+		const queue = [ENTRY];
+		while (queue.length > 0) {
+			const file = queue.pop() as string;
+			if (reachable.has(file)) continue;
+			reachable.add(file);
+			for (const { target } of importsOf(file)) queue.push(target);
+		}
+		// Reference consumers: the reachable production graph plus this
+		// feature's test files — the repo sanctions test-only _internals-style
+		// seams (AGENTS.md invariant 7), so an export consumed by tests is
+		// wired; an export consumed by NEITHER is dead.
+		for (const f of fs.readdirSync(path.join(REPO, 'tests/unit/ci'))) {
+			// Every test/helper under tests/unit/ci is this feature's test seam.
+			reachable.add(path.join(REPO, 'tests/unit/ci', f));
+		}
+		reachable.add(path.join(REPO, 'tests/unit/commands/ci.test.ts'));
+		const graphSources = new Map<string, string>();
+		for (const file of reachable) {
+			try {
+				graphSources.set(file, fs.readFileSync(file, 'utf-8'));
+			} catch {
+				// Non-file or unreadable node: skip.
+			}
+		}
+		const orphans: string[] = [];
+		for (const module of ciModules) {
+			const rel = path.relative(REPO, module);
+			for (const name of exportedNames(module)) {
+				let referenced = false;
+				for (const [file, source] of graphSources) {
+					if (file === module) continue;
+					// Match the bare identifier anywhere (import, usage, or — accepted
+					// limitation — a comment mention; a text scan, not a symbol-graph
+					// walk, keeps this deterministic under bun test).
+					if (new RegExp(`\\b${name}\\b`).test(source)) {
+						referenced = true;
+						break;
+					}
+				}
+				if (!referenced) orphans.push(`${rel}: ${name}`);
+			}
+		}
+		expect(
+			orphans,
+			'src/ci exports referenced by neither the production graph nor a test seam',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/commands/ci.test.ts
+++ b/tests/unit/commands/ci.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `swarm ci` command-handler tests (issue #2497; plan D3/R1/R4).
+ *
+ * Pins: registry presence + toolPolicy 'none' (runnable without a TTY and
+ * NOT agent-callable as a chat tool), argument validation (typed
+ * diagnostics for --timeout-ms abuse and unknown flags; the runtime is
+ * never entered on invalid input), the outcome→exit-code mapping, and the
+ * signal-cancellation seam (SIGINT/SIGTERM → abort; exit 2).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	createSignalCancellation,
+	handleCiCommand,
+} from '../../../src/commands/ci.js';
+import {
+	COMMAND_REGISTRY,
+	type CommandContext,
+	isCommandFailure,
+} from '../../../src/commands/registry.js';
+import { buildSatisfiedFixture, makeFixtureDir } from '../ci/_fixtures.js';
+
+function ctx(directory: string, args: string[] = []): CommandContext {
+	return {
+		directory,
+		args,
+		sessionID: '',
+		agents: {},
+		source: 'cli',
+	};
+}
+
+describe('swarm ci registry entry', () => {
+	test("COMMAND_REGISTRY registers 'ci' with toolPolicy 'none'", () => {
+		const entry = COMMAND_REGISTRY['ci' as keyof typeof COMMAND_REGISTRY] as
+			| { toolPolicy?: string; handler?: unknown; description?: string }
+			| undefined;
+		expect(entry).toBeDefined();
+		expect(entry?.handler).toBeTypeOf('function');
+		// 'none': not agent-callable (no chat-tool bypass surface), not
+		// human-only/restricted (CI runners have no TTY).
+		expect(entry?.toolPolicy).toBe('none');
+		expect(entry?.description).toContain('Advisory headless CI');
+	});
+});
+
+describe('swarm ci argument validation', () => {
+	test('missing --timeout-ms value throws a typed error', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-novalue-');
+		await expect(handleCiCommand(ctx(dir, ['--timeout-ms']))).rejects.toThrow(
+			/--timeout-ms/,
+		);
+	});
+
+	test('non-numeric --timeout-ms value throws', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-nan-');
+		await expect(
+			handleCiCommand(ctx(dir, ['--timeout-ms', 'banana'])),
+		).rejects.toThrow(/--timeout-ms/);
+	});
+
+	test('negative --timeout-ms value throws', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-neg-');
+		await expect(
+			handleCiCommand(ctx(dir, ['--timeout-ms', '-5'])),
+		).rejects.toThrow(/--timeout-ms/);
+	});
+
+	test('zero --timeout-ms value throws', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-zero-');
+		await expect(
+			handleCiCommand(ctx(dir, ['--timeout-ms', '0'])),
+		).rejects.toThrow(/--timeout-ms/);
+	});
+
+	test('unknown flag throws before the runtime is entered', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-unknown-');
+		await expect(handleCiCommand(ctx(dir, ['--turbo']))).rejects.toThrow(
+			/Unknown flag/,
+		);
+	});
+});
+
+describe('swarm ci outcome mapping', () => {
+	test('satisfied fixture: exit-0 path returns the full report string', async () => {
+		const dir = await buildSatisfiedFixture();
+		const result = await handleCiCommand(ctx(dir));
+		expect(typeof result).toBe('string');
+		const text = result as string;
+		expect(text).toContain('[SWARM_CI_JSON]');
+		expect(text).toContain('[/SWARM_CI_JSON]');
+		expect(text).toContain('## Swarm CI Advisory Report');
+	}, 15000);
+
+	test('gate violation: structured failure with exit code 1', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-violation-');
+		fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
+		// No plan.json → plan_missing is a violation (exit 1), and the
+		// diagnostic mentions the plan.
+		const result = await handleCiCommand(ctx(dir));
+		expect(isCommandFailure(result)).toBe(true);
+		if (isCommandFailure(result)) {
+			expect(result.exitCode).toBe(1);
+			expect(result.text).toContain('plan');
+		}
+	}, 15000);
+
+	test('--json emits the machine block only (no Markdown headings)', async () => {
+		const dir = await buildSatisfiedFixture();
+		const result = await handleCiCommand(ctx(dir, ['--json']));
+		expect(typeof result).toBe('string');
+		const text = result as string;
+		expect(text.startsWith('[SWARM_CI_JSON]')).toBe(true);
+		expect(text).not.toContain('## Swarm CI Advisory Report');
+	}, 15000);
+});
+
+describe('signal cancellation seam', () => {
+	test('handler aborts the controller exactly once and notifies', () => {
+		const controller = new AbortController();
+		let notified = 0;
+		const seam = createSignalCancellation(controller, () => {
+			notified++;
+		});
+		seam.install();
+		try {
+			expect(process.listenerCount('SIGINT')).toBeGreaterThan(0);
+			seam.handler();
+			seam.handler();
+			expect(controller.signal.aborted).toBe(true);
+			expect(notified).toBe(1);
+		} finally {
+			seam.dispose();
+		}
+	});
+
+	test('install/dispose manages listeners idempotently', () => {
+		const controller = new AbortController();
+		const seam = createSignalCancellation(controller);
+		const before = process.listenerCount('SIGINT');
+		seam.install();
+		seam.install(); // second install is a no-op
+		expect(process.listenerCount('SIGINT')).toBe(before + 1);
+		seam.dispose();
+		expect(process.listenerCount('SIGINT')).toBe(before);
+		seam.dispose(); // second dispose is a no-op
+		expect(process.listenerCount('SIGINT')).toBe(before);
+	});
+});

--- a/tests/unit/commands/ci.test.ts
+++ b/tests/unit/commands/ci.test.ts
@@ -8,10 +8,11 @@
  * signal-cancellation seam (SIGINT/SIGTERM → abort; exit 2).
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+	_internals,
 	createSignalCancellation,
 	handleCiCommand,
 } from '../../../src/commands/ci.js';
@@ -148,4 +149,90 @@ describe('signal cancellation seam', () => {
 		seam.dispose(); // second dispose is a no-op
 		expect(process.listenerCount('SIGINT')).toBe(before);
 	});
+});
+
+describe('swarm ci diagnostic branch (exit 2/3)', () => {
+	const realRuntime = _internals.runAdvisoryCiRuntime;
+
+	afterEach(() => {
+		_internals.runAdvisoryCiRuntime = realRuntime;
+	});
+
+	function stubOutcome(
+		outcome: 'cancelled' | 'deadline' | 'error',
+		detail: string,
+	) {
+		_internals.runAdvisoryCiRuntime = async () => ({
+			outcome,
+			journal: [
+				{ seq: 1, type: 'run_started', detail: 'evaluating' },
+				{ seq: 2, type: `run_${outcome}` },
+			],
+			journalTruncated: 0,
+			cleanupRan: true,
+			detail,
+		});
+	}
+
+	function parseDiagnosticBlock(text: string): Record<string, unknown> {
+		const start = text.indexOf('[SWARM_CI_JSON]');
+		const end = text.indexOf('[/SWARM_CI_JSON]');
+		expect(start).toBeGreaterThan(-1);
+		expect(end).toBeGreaterThan(start);
+		return JSON.parse(
+			text.slice(start + '[SWARM_CI_JSON]'.length, end),
+		) as Record<string, unknown>;
+	}
+
+	test('deadline path (exit 3) emits the full version-1 report shape', async () => {
+		stubOutcome('deadline', 'advisory CI run deadline exceeded');
+		const dir = makeFixtureDir('swarm-ci-cmd-deadline-');
+		const result = await handleCiCommand(ctx(dir));
+		expect(isCommandFailure(result)).toBe(true);
+		if (!isCommandFailure(result)) return;
+		expect(result.exitCode).toBe(3);
+		// Human diagnostic + journal tail around the machine block.
+		expect(result.text).toContain('swarm ci deadline:');
+		expect(result.text).toContain('journal tail: run_started');
+		const parsed = parseDiagnosticBlock(result.text);
+		expect(parsed.version).toBe(1);
+		expect(parsed.verdict).toBe('fail');
+		expect(parsed.exit_reason).toBe('deadline');
+		// One schema for every exit code: the fields the reduced diagnostic
+		// used to drop are present (neutral values) on this branch too.
+		for (const key of [
+			'gates',
+			'tasks',
+			'plan',
+			'environment',
+			'gate_profile',
+			'effective_gates',
+			'not_evaluated',
+			'not_evaluable',
+			'counts',
+		]) {
+			expect(parsed).toHaveProperty(key);
+		}
+		expect(parsed.counts).toEqual({
+			pass: 0,
+			fail: 0,
+			no_data: 0,
+			corrupt: 0,
+			error: 0,
+		});
+	}, 15000);
+
+	test('cancelled path with --json emits the machine block only (exit 2)', async () => {
+		stubOutcome('cancelled', 'advisory CI run cancelled');
+		const dir = makeFixtureDir('swarm-ci-cmd-cancel-');
+		const result = await handleCiCommand(ctx(dir, ['--json']));
+		expect(isCommandFailure(result)).toBe(true);
+		if (!isCommandFailure(result)) return;
+		expect(result.exitCode).toBe(2);
+		// --json means the machine block only, on every exit path.
+		expect(result.text.startsWith('[SWARM_CI_JSON]')).toBe(true);
+		expect(result.text).not.toContain('journal tail');
+		const parsed = parseDiagnosticBlock(result.text);
+		expect(parsed.exit_reason).toBe('cancelled');
+	}, 15000);
 });

--- a/tests/unit/commands/swarm-subcommand-parity.test.ts
+++ b/tests/unit/commands/swarm-subcommand-parity.test.ts
@@ -367,7 +367,9 @@ describe('swarm-subcommand-parity', () => {
 		// for issue #1825, documented in .claude/skills/swarm/SKILL.md.
 		// 114 → 115: /swarm report added (#2482), documented in
 		// .claude/skills/swarm/SKILL.md.
-		expect(expectedCommands.size).toBe(115);
+		// 115 → 116: /swarm ci added — advisory headless CI (#2497), documented
+		// in .claude/skills/swarm/SKILL.md.
+		expect(expectedCommands.size).toBe(116);
 
 		console.info(
 			`[swarm-subcommand-parity] skill documented commands (raw): ${skillRawCommands.length}`,

--- a/tests/unit/index-commands.test.ts
+++ b/tests/unit/index-commands.test.ts
@@ -61,7 +61,7 @@ describe('Swarm subcommand registration', () => {
 		// approval shortcut (issue #1824), and the action-local
 		// guardrail-reset command. Issue #1825 adds five blueprint commands and
 		// three harness-candidate commands.
-		expect(commandKeys.length).toBe(95);
+		expect(commandKeys.length).toBe(96);
 
 		expect(commands.swarm).toBeDefined();
 	});
@@ -188,6 +188,7 @@ describe('Swarm subcommand registration', () => {
 			'swarm-finalize',
 			'swarm-close',
 			'swarm-diagnosis',
+			'swarm-ci',
 			'swarm-ci-simulate',
 			'swarm-ci-monitor',
 			'swarm-context-map-stats',


### PR DESCRIPTION
Closes #2497

## Summary

Ships `swarm ci` — the advisory headless CI command from #2497 (Workstream F
PR 05, #1224 phase 1) — and the host-decoupled runtime underneath it.

- **New `swarm ci` command** at three surfaces (top-level `bunx opencode-swarm
  ci`, `run ci`, `/swarm ci`; `toolPolicy: 'none'` so it runs with no TTY and
  is neither agent-callable nor human-only-gated). It evaluates a
  checked-out repo's `.swarm/` gate/evidence state **read-only** and exits:
  `0` every evaluated gate passed (and ≥1 evaluated); `1` any violation /
  no-data / corrupt evidence / nothing to evaluate; `2` cancelled
  (SIGINT/SIGTERM); `3` deadline or internal error. Output = Markdown report
  + `[SWARM_CI_JSON]` machine block (`--json` for block-only). Full contract:
  `docs/ci.md`.
- **New host-decoupled runtime under `src/ci/`** (`runtime.ts`,
  `evaluate.ts`, `report.ts`, `quality-checks.ts`, public-surface barrel
  `index.ts`): a bounded harness (overall `--timeout-ms` deadline, signal
  cancellation with exactly-once cleanup, capped 200-event run journal) around
  an evaluation that **composes the existing authoritative readers** —
  per-task required gates via `readTaskEvidenceState`/`getTaskWorkflowSnapshot`
  with #2470 tri-state evidence (valid / missing / corrupt distinct), a
  terminal-workflow guard (`rework_required` and other non-terminal states
  never pass vacuously; `TERMINAL_SUCCESS_STATES` = complete/closed per
  `WORKFLOW_STATE_RANK`), plan-critic approval, QA-profile effective gates
  (DEFAULT_QA_GATES fallback with honest `gate_profile` reporting), and the
  evidence-quality thresholds. **"No data" is never a pass** — the
  vacuous-pass gap proven for `benchmark --ci-gate` headless (6 of 8 checks
  pass on zero data) is closed by honest `no_data` rows; live session-state
  checks are reported `not_evaluable` instead of fabricated.
- **Strict read-only guarantee**: file-backed reads are pure; DB-mediated
  reads (QA profile, plan-critic snapshots — opening the SQLite store creates
  WAL sidecars) run against a bounded (512 MiB) discarded shadow copy of
  `.swarm/`, so the evaluated repo is byte-identical before/after (enforced
  by check C7's sha256 snapshot). The path cannot satisfy or bypass any gate.
- **Benchmark extraction (#1224 phase 1)**: the evidence-quality computation
  moved from `src/commands/benchmark.ts` into the shared
  `src/ci/quality-checks.ts` — one implementation for `/swarm benchmark
  --ci-gate` (byte-compatible output; its three suites green) and `swarm ci`.
- **Guardrails (Phase 4.2)**: `tests/unit/ci/host-decoupling-ratchet.test.ts`
  bans host-state tokens and durable-writer imports across all of `src/ci/**`
  + the handler; `tests/unit/ci/wiring-ratchet.test.ts` walks real import
  edges (incl. re-exports) from the production entry and requires every
  `src/ci` export to be reachable or a sanctioned test seam. Both proven to
  bite via mutation probes (RED on injected violation, GREEN on restore).
- **Scope boundary**: publishing the composite GitHub Action is tracking slot
  #2498 (the Action wraps this command; `src/ci/index.ts` is its import
  surface); the read-only MCP surface is #2499; the full LLM headless
  pipeline (`opencode serve`-backed) remains #1224 phase 2 and is out of
  scope by the issue's own framing.
- **Validation**: frozen acceptance checks C1–C9 all PASS at this head
  (RED/ERROR at base `4ef11b788` → GREEN; the PRESERVING row green at both
  ends), including scrubbed-env (`env -i`, no TTY, no opencode binary)
  execution and byte-identity of the evaluated repo; new suites (7 files, 45
  tests) green in isolation; blast-radius battery green; repo quality gates
  green (typecheck, biome, file-cap, tmpdir, clock, mock-cleanup,
  registry-citations, events, runtime-src-refs, retention, shell-audit,
  core-events, trajectory-store, pending-fragment).

## Acceptance Criteria -> Evidence

| AC | Evidence (command + outcome, or test) |
|---|---|
| AC1 host-decoupled runtime, plugin unchanged | `grep -rnE "opencodeClient|swarmState" src/ci/` → 0 hits; `bun test tests/unit/ci/host-decoupling-ratchet.test.ts` → 3 pass (nested Probe C RED→GREEN); benchmark suites 15/2/14 pass (C8) |
| AC2 `swarm ci` clean noninteractive entry | frozen check C2 PASS: top-level `bun src/cli/index.ts ci` + `run ci` both exit 0 on the satisfied fixture with the [SWARM_CI_JSON] block |
| AC3 machine exit status | frozen check C3 PASS: satisfied=0, violation=1, no_data=1, corrupt=1, no-plan=1 with plan diagnostic; unit-pinned in tests/unit/ci/evaluate.test.ts (14 pass) |
| AC4 Markdown+JSON evidence summary | frozen check C4 PASS (shape incl. no_data+corrupt rows, reader-derived gate vocabulary, environment advisory/tty-false/host-none); tests/unit/ci/report.test.ts 4 pass |
| AC5 bounded runtime | tests/unit/ci/runtime-bounds.test.ts 7 pass (deadline cut, abort→cancelled with exactly-once cleanup, journal cap 200 + drop counting); frozen check C5 PASS |
| AC6 no TTY / host unavailable / cancellation | frozen check C6 PASS (`env -i` scrubbed env, no opencode binary, exit 0 <120s, no human-only refusal); signal-seam unit tests in tests/unit/commands/ci.test.ts |
| AC7 no gate bypass; read-only | frozen check C7 PASS: both entry forms exit 1 on the violation fixture and the whole fixture is byte-identical (sha256, no new files); host-decoupling ratchet bans durable-writer imports |
| AC8 tests + OpenCode regression suite | C8 PRESERVING PASS (9 suites green at base AND head, per-file); 7 new suites (45 tests) green in isolation; blast-radius parity/docs/benchmark suites green |
| AC9 closure contract | C9 PASS (registry entry; docs/commands.md byte-identical to regeneration; README row; docs/releases/pending/2497-advisory-headless-ci.md; no unwired src/ci exports — wiring ratchet); scan-deferred clean |

PR head: 72ebb9d1d0098a2adcb3bbdc1d10b8b26905ce10

## Waivers (or none)

None.

## Invariant audit
- 1 (plugin init):       not touched — nothing here runs at plugin boot; the only `src/index.ts` change (round 2) is the `swarm-ci` TUI-shortcut map entry inside the existing `server()` config block — no init-path work added.
- 2 (runtime portability): not touched — no `bun:` imports or `Bun.*` calls added; `bun run typecheck` clean; no build-config change.
- 3 (subprocesses):      not touched — `swarm ci` spawns no subprocess at all (shadow-copy reads are in-process); no new spawn call sites.
- 4 (.swarm containment): touched — read-only. The evaluator performs zero writes under `.swarm/` (C7 byte-identity check); DB-mediated reads run against an os.tmpdir() shadow copy bounded at 512 MiB; no new `.swarm` creation sites; handler uses `ctx.directory`, never `process.cwd()`.
- 5 (plan durability):   not touched — plan read only via the existing `loadPlanJsonOnly` projection reader; ledger untouched.
- 6 (test_runner safety): not touched — no test_runner usage.
- 7 (test writing):      touched — all new tests are bun:test, per-file isolated, no `mock.module` (DI-free fixtures; canonicalMkdtemp; static date literals; every file <500 lines). Evidence: `bun run check:test-file-cap` → 0 violations; `check:test-tmpdir`/`check:test-clock`/`check:mock-cleanup` clean.
- 8 (session state):     not touched — runtime state is per-run object state, no module-level session globals added.
- 9 (guardrails/retry):  not touched — no retry/fallback paths added.
- 10 (chat/system msg):  not touched.
- 11 (tool registration): touched — this is a COMMAND (registry), not a tool: `COMMAND_REGISTRY['ci']` + handler import (`registry.ts`), barrel re-export (`src/commands/index.ts`), top-level CLI branch + help (`src/cli/index.ts`), regenerated `docs/commands.md` (byte-identical to regeneration; generate-commands-docs test green), README row, `.claude/skills/swarm/SKILL.md` command list, subcommand-parity count 115→116. Evidence: C8 suites + parity tests all green at this head.
- 12 (release/cache):    touched — pending release fragment `docs/releases/pending/2497-advisory-headless-ci.md` shipped; no version/changelog hand edits; `check:pending-fragment` green.

## Test plan

Per-file isolation runs at head `5265aa8` (all green):

```
bun test tests/unit/ci/runtime-bounds.test.ts            # deadline, cancellation cleanup, bounded journal
bun test tests/unit/ci/evaluate.test.ts                  # tri-state, rework guard, exit reasons, read-only snapshot
bun test tests/unit/ci/report.test.ts                    # [SWARM_CI_JSON] contract, markdown tables, --json
bun test tests/unit/ci/quality-checks.test.ts            # shared-service parity + no-data semantics
bun test tests/unit/ci/host-decoupling-ratchet.test.ts   # no host tokens / writer imports in src/ci/**
bun test tests/unit/ci/wiring-ratchet.test.ts            # every export reachable from the production entry
bun test tests/unit/commands/ci.test.ts                  # registry entry, arg validation, exit mapping, signal seam
```

Blast radius (green): benchmark ci-gate/exit-code/load-evidence,
generate-commands-docs, cli run-command, command-names, index.help-text,
registry-type, gate-evidence, swarm-subcommand-parity, index-commands.

End-to-end acceptance (repro-check.sh, disposable base worktree at
`4ef11b788` + head at this branch): C1–C9 verdict PASS, including the
scrubbed-environment run (`env -i`, PATH=bun-dir only, empty HOME) and the
repo byte-identity check across both entry forms. CI note: the repo-wide
`biome ci .` cannot run on dev checkouts that contain stale `.worktrees/*`
(nested root biome configs — pre-existing local-only condition); it runs
clean on CI checkouts, and the changed paths are clean at the pinned
`@biomejs/biome@2.3.14` locally.

Merge status: AWAITING_USER_APPROVAL (issue-tracer merge gate 5.1 — merge
requires separately recorded explicit user approval bound to this PR head).

---

issue-tracer trace: `.agents/issue-traces/2497-host-decoupled-runtime-headless-ci/`
(gitignored; artifacts recorded during the trace). Final review identities:
see `09-final-critic.md` — reviewed-commit equals this PR head.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Review round 2 (swarm-pr-feedback, head `b974ef159`)

The swarm-pr-review of this PR returned REQUEST_CHANGES with three PR-owned red suites plus two contract
defects; Copilot's inline review independently flagged a read-only violation. All are fixed in `b974ef159`
(rebased onto `eb8f255c3` to clear an origin/main-drift false positive in the FR-006 test-file-cap ratchet):

- **PRR-001 (HIGH)** — `swarm-ci` TUI shortcut registered in `opencodeConfig.command`; parity snapshots
  (`registration-parity`, `index-commands` 96 commands) green.
- **PRR-002 (HIGH)** — `src/ci/evaluate.ts|C|dest` registered in `EVIDENCE_WRITE_BLIND_SPOTS`
  (`not-an-evidence-artifact`; shadow copy into `os.tmpdir()`, same shape as the cost-accounting/gate-audit
  precedents); G2 evidence-class suite 25/25.
- **PRR-003** — `ci` added to the `toolPolicy: 'none'` expected set.
- **PRR-007** — the cancel/deadline/error `[SWARM_CI_JSON]` block now carries the full `version: 1`
  `AdvisoryCiReport` shape (no second schema); `exit_reason` widened with `cancelled`/`deadline`/`error`;
  `--json` honored on the diagnostic branch; handler-level tests for exit 2/3 via a `_internals` DI seam.
- **PRR-009** — markdown report cells flatten embedded newlines and escape pipes (repo-controlled plan
  strings can no longer break table structure); regression test added.
- **Copilot finding (verified empirically)** — `computeEvidenceQualitySummary` now reads evidence with
  `{ migrate: false }`, so a legacy flat-retrospective bundle is never rewritten in place (the default
  reader takes the evidence lock and renames over the bundle); regression test with a `.git` project
  marker proves byte-identity and no `.swarm/locks` sentinel.
- **docs** — Windows self-signalling caveat in `docs/ci.md`; release fragment updated for the stable JSON
  shape.

Review evidence: independent reviewer (Kimi K2.7) APPROVE on every item; final critic (K3) initially
NEEDS_REVISION (it caught a red `index-commands` snapshot the reviewer missed, plus the `--json` gap and
the untested diagnostic branch) and returned APPROVE on re-verification after the delta. Non-blocking
findings from the review are filed as #2633.
