### PR TITLE
fix(sandbox): stop emitting invalid SBPL setenv/unsetenv; apply env overrides at command level

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1249,7 +1249,8 @@ under a real `sandbox-exec -f <profile>` invocation.
 When enabled on macOS, `applySandboxExecution` also applies the DYLD
 injection-variable hardening declared by
 `MacOSSandboxExecutor.getEnvOverrides()` — unsetting `DYLD_INSERT_LIBRARIES`,
-`DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, and `DYLD_ROOT_PATH`, and pinning
+`DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `DYLD_ROOT_PATH`, and
+`DYLD_FORCE_FLAT_NAMESPACE`, and pinning
 `PATH` to the base-OS bin directories — inside the wrapped command itself: the
 inner shell runs the unsets and exports before the user command. The SBPL
 profile carries no environment directives because the Sandbox Profile Language

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1250,11 +1250,19 @@ When enabled on macOS, `applySandboxExecution` also applies the DYLD
 injection-variable hardening declared by
 `MacOSSandboxExecutor.getEnvOverrides()` — unsetting `DYLD_INSERT_LIBRARIES`,
 `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, and `DYLD_ROOT_PATH`, and pinning
-`PATH` to the base-OS bin directories — baked into the wrapped command via
-SBPL `(setenv)`/`(unsetenv)` primitives. This wiring is macOS-only: Windows
+`PATH` to the base-OS bin directories — inside the wrapped command itself: the
+inner shell runs the unsets and exports before the user command. The SBPL
+profile carries no environment directives because the Sandbox Profile Language
+cannot mutate the sandboxed process's environment (`setenv`/`unsetenv` are not
+SBPL operations; emitting them made every profile unparseable and silently
+disabled the executor until issue #2590 removed that emission). This wiring is
+macOS-only: Windows
 and Linux `getEnvOverrides()` implementations remain unwired in this release
 (Windows strong mode's `PATH: null` would be a separate, riskier behavior
-change applied to real commands for the first time).
+change applied to real commands for the first time). Note that the #2590 fix
+makes the macOS hardening effective for the first time: commands that need
+non-system `PATH` entries (for example Homebrew or a version manager) must
+extend `PATH` themselves when the macOS sandbox is enabled.
 
 ```json
 {

--- a/docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md
+++ b/docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md
@@ -1,0 +1,27 @@
+Fix: macOS sandbox-exec profiles unparseable — executor silently disabled (#2590)
+
+## Changes
+
+- **macOS sandboxing works again (opt-in `guardrails.sandbox_macos_enabled`).**
+  `sandbox-exec` rejected every generated SBPL profile because `setenv`/`unsetenv`
+  are not Sandbox Profile Language operations — the parser reports
+  `unbound variable: setenv` (exit 65). Because the availability probe embedded the
+  same invalid pair, the probe failed on every macOS host and the whole
+  sandbox-exec executor silently fell back to unsandboxed tool-layer enforcement.
+  The env directives are gone from both the probe and production profiles, and the
+  DYLD_* unset / PATH-pin hardening is now applied inside the wrapped command (the
+  inner shell runs it before the user command) — the only place it can work, since
+  SBPL cannot mutate a process's environment.
+
+## Also fixed
+
+- The declared env hardening is effective for the first time. Commands that need
+  non-system `PATH` entries (Homebrew, version managers) must extend `PATH`
+  themselves when the macOS sandbox is enabled — see the updated
+  `docs/configuration.md` macOS sandbox section.
+
+## Impact
+
+- macOS only. The gate (`guardrails.sandbox_macos_enabled`) still defaults to
+  `false`; users who enabled it previously got a dead executor with a warn log —
+  they now get a working file-write sandbox whose profile parses cleanly.

--- a/docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md
+++ b/docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md
@@ -9,7 +9,9 @@ Fix: macOS sandbox-exec profiles unparseable — executor silently disabled (#25
   same invalid pair, the probe failed on every macOS host and the whole
   sandbox-exec executor silently fell back to unsandboxed tool-layer enforcement.
   The env directives are gone from both the probe and production profiles, and the
-  DYLD_* unset / PATH-pin hardening is now applied inside the wrapped command (the
+  DYLD_* unset (five injection/redirect variables, including
+  `DYLD_FORCE_FLAT_NAMESPACE`) / PATH-pin hardening is now applied inside the wrapped
+  command (the
   inner shell runs it before the user command) — the only place it can work, since
   SBPL cannot mutate a process's environment.
 

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -1439,10 +1439,14 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		];
 
 		try {
-			// Issues #2236 F6b / #2259 / #2475: bake every PLUGIN-OWNED
+			// Issues #2236 F6b / #2259 / #2475 / #2590: bake every PLUGIN-OWNED
 			// executor's declared env hardening into the wrapped command via
 			// wrapCommand's 4th parameter:
-			//   - macOS sandbox-exec emits SBPL (setenv)/(unsetenv).
+			//   - macOS sandbox-exec applies the overrides inside the wrapped
+			//     bash command (unset/export before the user command) — SBPL
+			//     cannot mutate the sandboxed process's environment, and its
+			//     non-existent setenv/unsetenv ops made every profile
+			//     unparseable until #2590 removed that emission.
 			//   - Windows native-runner policies carry strings in env_overrides
 			//     and nulls in env_unsets (removed from the allowlist); the
 			//     runner's managed PATH/TEMP/TMP rewrites keep ordinary commands

--- a/src/sandbox/macos/sandbox-exec-executor.ts
+++ b/src/sandbox/macos/sandbox-exec-executor.ts
@@ -488,9 +488,12 @@ export class MacOSSandboxExecutor implements SandboxExecutor {
 	/**
 	 * Return environment variable overrides required for the macOS sandbox.
 	 *
-	 * DYLD_INSERT_LIBRARIES, DYLD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH, and
-	 * DYLD_ROOT_PATH can be used to bypass sandbox restrictions by injecting
-	 * dynamic libraries. Unsetting them improves sandbox enforcement (defense in depth).
+	 * DYLD_INSERT_LIBRARIES, DYLD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH,
+	 * DYLD_ROOT_PATH, and DYLD_FORCE_FLAT_NAMESPACE can be used to bypass
+	 * sandbox restrictions by injecting or redirecting dynamic-library
+	 * loading. Unsetting them improves sandbox enforcement (defense in
+	 * depth); DYLD_FORCE_FLAT_NAMESPACE matches the Windows executors'
+	 * scrub lists (review PRR-006, PR #2630).
 	 */
 	getEnvOverrides(): Record<string, string | null> {
 		return {
@@ -498,6 +501,7 @@ export class MacOSSandboxExecutor implements SandboxExecutor {
 			DYLD_LIBRARY_PATH: null,
 			DYLD_FRAMEWORK_PATH: null,
 			DYLD_ROOT_PATH: null,
+			DYLD_FORCE_FLAT_NAMESPACE: null,
 			PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
 		};
 	}

--- a/src/sandbox/macos/sandbox-exec-executor.ts
+++ b/src/sandbox/macos/sandbox-exec-executor.ts
@@ -74,20 +74,24 @@ function resolveProbeTargetBinary(): string {
  *
  * F6a item 2 (issue #2236): this deliberately shares the same primitives and
  * ordering as buildSandboxProfile's production profile — a blanket
- * `(deny file-write*)` followed by a scoped `(allow file-write* (subpath …))`,
- * plus a `(setenv …)`/`(unsetenv …)` pair (F6b) — so that probe success
- * implies the production profile's primitives actually parse under this
- * host's sandbox-exec. A trivial `(allow default)`-only probe would pass
- * even when the production profile is unparseable, which is the exact
- * probe-passes/production-fails failure mode this guards against.
+ * `(deny file-write*)` followed by a scoped `(allow file-write* (subpath …))` —
+ * so that probe success implies the production profile's primitives actually
+ * parse under this host's sandbox-exec. A trivial `(allow default)`-only probe
+ * would pass even when the production profile is unparseable, which is the
+ * exact probe-passes/production-fails failure mode this guards against.
+ *
+ * NEVER add env directives here or to buildSandboxProfile: `setenv`/`unsetenv`
+ * are not SBPL operations — the profile parser treats them as unbound
+ * variables and rejects the whole profile (exit 65), which silently disabled
+ * this executor on every macOS host (issue #2590). SBPL cannot mutate the
+ * sandboxed process's environment at all; env overrides are applied inside the
+ * wrapped command instead (see buildEnvOverridePrefix / wrapCommand).
  */
 function buildProbeProfile(tempDir: string): string {
 	return `(version 1)
 (allow default)
 (deny file-write*)
-(allow file-write* (subpath "${sbplEscapePath(tempDir)}"))
-(setenv SWARM_SANDBOX_PROBE "1")
-(unsetenv SWARM_SANDBOX_PROBE)`;
+(allow file-write* (subpath "${sbplEscapePath(tempDir)}"))`;
 }
 
 /**
@@ -196,6 +200,7 @@ export const _internals: {
 	resetProbeMemo: typeof resetProbeMemo;
 	buildSandboxProfile: typeof buildSandboxProfile;
 	buildProbeProfile: typeof buildProbeProfile;
+	buildEnvOverridePrefix: typeof buildEnvOverridePrefix;
 	resolveSandboxExecBinary: typeof resolveSandboxExecBinary;
 	resolveProbeTargetBinary: typeof resolveProbeTargetBinary;
 	exists: typeof existsSync;
@@ -206,6 +211,7 @@ export const _internals: {
 	resetProbeMemo,
 	buildSandboxProfile,
 	buildProbeProfile,
+	buildEnvOverridePrefix,
 	resolveSandboxExecBinary,
 	resolveProbeTargetBinary,
 	exists: existsSync,
@@ -218,6 +224,52 @@ export const _internals: {
  */
 function shellEscape(s: string): string {
 	return s.replace(/'/g, "'\\''");
+}
+
+/**
+ * Build the shell prefix that applies env overrides inside the wrapped
+ * command's `bash -c` payload (issue #2590).
+ *
+ * SBPL cannot mutate the sandboxed process's environment, so the hardening
+ * declared by getEnvOverrides() (DYLD_* unsets, PATH pin) and any per-call
+ * overrides are applied by the inner shell itself, before the user command:
+ * null-valued keys are unset via a single `unset` builtin, string-valued keys
+ * are exported with the value single-quote-escaped via shellEscape. Keys
+ * failing isValidEnvKey are silently dropped — the same contract the (broken)
+ * SBPL emitter applied, and required for shell safety too: an invalid key is
+ * neither a safe shell word nor a safe SBPL token.
+ *
+ * Returns '' when there is nothing to apply, so the no-override payload is
+ * byte-identical to the pre-#2590 wrapped command. The trailing '; ' lets the
+ * prefix compose with arbitrary user payloads.
+ */
+function buildEnvOverridePrefix(
+	envOverrides?: Record<string, string | null>,
+): string {
+	if (!envOverrides) {
+		return '';
+	}
+	const unsetKeys: string[] = [];
+	const exportLines: string[] = [];
+	for (const [key, value] of Object.entries(envOverrides)) {
+		if (!isValidEnvKey(key)) {
+			continue;
+		}
+		if (value === null) {
+			unsetKeys.push(key);
+		} else {
+			exportLines.push(`export ${key}='${shellEscape(value)}'`);
+		}
+	}
+	const parts: string[] = [];
+	if (unsetKeys.length > 0) {
+		parts.push(`unset ${unsetKeys.join(' ')}`);
+	}
+	parts.push(...exportLines);
+	if (parts.length === 0) {
+		return '';
+	}
+	return `${parts.join('; ')}; `;
 }
 
 /**
@@ -246,13 +298,16 @@ function sbplEscapePath(path: string): string {
 }
 
 /**
- * Build a sandbox-exec profile string for the given scope paths, temp dir, and optional env overrides.
+ * Build a sandbox-exec profile string for the given scope paths and temp dir.
+ *
+ * NOTE: there are deliberately NO environment directives in the profile.
+ * `setenv`/`unsetenv` are not SBPL operations — sandbox-exec rejects them as
+ * unbound variables (exit 65), which silently disabled this executor on every
+ * macOS host (issue #2590). SBPL cannot mutate the sandboxed process's
+ * environment at all; env overrides are applied by the inner shell instead
+ * (see buildEnvOverridePrefix / wrapCommand).
  */
-function buildSandboxProfile(
-	scopePaths: string[],
-	tempDir: string,
-	envOverrides?: Record<string, string | null>,
-): string {
+function buildSandboxProfile(scopePaths: string[], tempDir: string): string {
 	// Collect unique paths to allow read-write
 	const rwPaths = [...scopePaths];
 	if (tempDir) {
@@ -264,28 +319,6 @@ function buildSandboxProfile(
 	const rwAllowLines = rwPaths
 		.map((p) => `(allow file-write* (subpath "${sbplEscapePath(p)}"))`)
 		.join('\n');
-
-	// Build SBPL env override primitives.
-	// (setenv KEY "VALUE") sets a var; (unsetenv KEY) removes it.
-	// Keys are validated to prevent SBPL syntax injection (parentheses, etc.).
-	// Values are embedded inside a double-quoted SBPL string, so escape double quotes.
-	const envLines: string[] = [];
-	if (envOverrides) {
-		for (const [key, value] of Object.entries(envOverrides)) {
-			// Reject invalid env var names silently — invalid keys cannot be safely
-			// interpolated into SBPL syntax.
-			if (!isValidEnvKey(key)) {
-				continue;
-			}
-			if (value === null) {
-				envLines.push(`(unsetenv ${key})`);
-			} else {
-				// Escape double quotes and backslashes for SBPL double-quoted string
-				const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-				envLines.push(`(setenv ${key} "${escaped}")`);
-			}
-		}
-	}
 
 	// Core profile: allow non-file ops (network, IPC, process creation) via
 	// (allow default), allow system read-only paths, then confine writes to the
@@ -309,8 +342,7 @@ function buildSandboxProfile(
 (allow file-read* (subpath "/lib"))
 (allow file-read* (subpath "/lib64"))
 (deny file-write*)
-${rwAllowLines}
-${envLines.join('\n')}`;
+${rwAllowLines}`;
 
 	return profile;
 }
@@ -386,6 +418,8 @@ export class MacOSSandboxExecutor implements SandboxExecutor {
 	 * @param scopePaths - Additional scope paths to bind (merged with constructor scope)
 	 * @param tempDir   - Optional temp directory override
 	 * @param envOverrides - Optional per-call env overrides: string sets the var, null unsets it.
+	 *                      Applied by the inner shell BEFORE the user command runs — SBPL
+	 *                      cannot mutate the sandboxed process's environment (issue #2590).
 	 *                      When omitted, no per-call env override is applied.
 	 * @returns A sandbox-exec wrapped command string ready for shell execution,
 	 *          or the raw command string when the sandbox is unavailable (passthrough mode)
@@ -414,7 +448,7 @@ export class MacOSSandboxExecutor implements SandboxExecutor {
 		const temp = tempDir ?? this._tempDir ?? os.tmpdir();
 		const allScopes = [...this._scopePaths, ...scopePaths];
 
-		const profile = buildSandboxProfile(allScopes, temp, envOverrides);
+		const profile = buildSandboxProfile(allScopes, temp);
 
 		// Write profile to a dedicated temp directory (mkdtempSync ensures a unique dir per call)
 		let profilePath: string;
@@ -441,7 +475,12 @@ export class MacOSSandboxExecutor implements SandboxExecutor {
 		// Note: profile files accumulate in os.tmpdir() over time. This is
 		// acceptable — they are small text files with allowlist rules, no secrets.
 		const binary = _internals.resolveSandboxExecBinary();
-		const escapedCommand = shellEscape(command);
+		// Env overrides run FIRST, inside the inner shell, before the user
+		// command (issue #2590): the prefix ends in '; ' so it composes with
+		// arbitrary payloads, and the whole payload is single-quote-escaped
+		// below for the outer `bash -c '…'` context.
+		const envPrefix = buildEnvOverridePrefix(envOverrides);
+		const escapedCommand = shellEscape(`${envPrefix}${command}`);
 		const escapedProfilePath = shellEscape(profilePath);
 		return `${binary} -f '${escapedProfilePath}' bash -c '${escapedCommand}'`;
 	}

--- a/tests/unit/sandbox/macos-env-hardening.test.ts
+++ b/tests/unit/sandbox/macos-env-hardening.test.ts
@@ -55,13 +55,14 @@ afterEach(() => {
 });
 
 describe('MacOSSandboxExecutor.getEnvOverrides() — F6b shape', () => {
-	test('unsets all four DYLD injection variables', () => {
+	test('unsets all five DYLD injection variables', () => {
 		const executor = new MacOSSandboxExecutor([]);
 		const env = executor.getEnvOverrides();
 		expect(env.DYLD_INSERT_LIBRARIES).toBeNull();
 		expect(env.DYLD_LIBRARY_PATH).toBeNull();
 		expect(env.DYLD_FRAMEWORK_PATH).toBeNull();
 		expect(env.DYLD_ROOT_PATH).toBeNull();
+		expect(env.DYLD_FORCE_FLAT_NAMESPACE).toBeNull();
 	});
 
 	test('sets PATH to the base-OS bin dirs only', () => {
@@ -70,11 +71,12 @@ describe('MacOSSandboxExecutor.getEnvOverrides() — F6b shape', () => {
 		expect(env.PATH).toBe('/usr/bin:/bin:/usr/sbin:/sbin');
 	});
 
-	test('returns exactly five keys — no unexpected additions', () => {
+	test('returns exactly six keys — no unexpected additions', () => {
 		const executor = new MacOSSandboxExecutor([]);
 		const env = executor.getEnvOverrides();
 		expect(Object.keys(env).sort()).toEqual(
 			[
+				'DYLD_FORCE_FLAT_NAMESPACE',
 				'DYLD_FRAMEWORK_PATH',
 				'DYLD_INSERT_LIBRARIES',
 				'DYLD_LIBRARY_PATH',
@@ -107,9 +109,9 @@ describe('wrapCommand() env overrides — command-level application (issue #2590
 		const env = executor.getEnvOverrides();
 		const wrapped = executor.wrapCommand('echo hello', [], undefined, env);
 
-		// One `unset` builtin covering all four DYLD injection variables...
+		// One `unset` builtin covering all five DYLD injection variables...
 		expect(wrapped).toContain(
-			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH',
+			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH DYLD_FORCE_FLAT_NAMESPACE',
 		);
 		// ...and an export pinning PATH to the base-OS bin dirs. The value is
 		// single-quote-escaped for the outer bash -c context, so assert the
@@ -136,10 +138,10 @@ describe('wrapCommand() env overrides — command-level application (issue #2590
 		const executor = new MacOSSandboxExecutor([], '/tmp');
 		const env = executor.getEnvOverrides();
 		const wrapped = executor.wrapCommand('echo hello', [], undefined, env);
-		// One `unset` builtin covers all four DYLD keys, in getEnvOverrides()
+		// One `unset` builtin covers all five DYLD keys, in getEnvOverrides()
 		// insertion order; PATH is exported right after.
 		expect(wrapped).toContain(
-			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH',
+			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH DYLD_FORCE_FLAT_NAMESPACE',
 		);
 		expect(wrapped).toContain('export PATH=');
 	});
@@ -155,6 +157,35 @@ describe('wrapCommand() env overrides — command-level application (issue #2590
 		expect(wrapped).not.toContain('unset ');
 		expect(wrapped).not.toContain('export ');
 		expect(wrapped).toContain('sandbox-exec');
+	});
+});
+
+describe('buildEnvOverridePrefix — direct unit tests (PR #2630 review PRR-007)', () => {
+	test('undefined and empty overrides produce an empty prefix', () => {
+		expect(_internals.buildEnvOverridePrefix(undefined)).toBe('');
+		expect(_internals.buildEnvOverridePrefix({})).toBe('');
+	});
+
+	test('null-valued keys group into one unset builtin ordered before exports', () => {
+		const prefix = _internals.buildEnvOverridePrefix({
+			AAA_SET: '1',
+			BBB_UNSET: null,
+		});
+		expect(prefix).toBe("unset BBB_UNSET; export AAA_SET='1'; ");
+		expect(prefix.indexOf('unset')).toBeLessThan(prefix.indexOf('export'));
+	});
+
+	test('values are single-quote-escaped for the outer bash -c context', () => {
+		expect(_internals.buildEnvOverridePrefix({ K: "it's" })).toBe(
+			"export K='it'\\''s'; ",
+		);
+	});
+
+	test('invalid keys are dropped silently', () => {
+		expect(_internals.buildEnvOverridePrefix({ 'BAD;KEY': 'v' })).toBe('');
+		expect(
+			_internals.buildEnvOverridePrefix({ 'BAD;KEY': 'v', OK_KEY: 'kept' }),
+		).toBe("export OK_KEY='kept'; ");
 	});
 });
 

--- a/tests/unit/sandbox/macos-env-hardening.test.ts
+++ b/tests/unit/sandbox/macos-env-hardening.test.ts
@@ -7,9 +7,11 @@
  * DYLD_LIBRARY_PATH, DYLD_FRAMEWORK_PATH, DYLD_ROOT_PATH -> null, plus
  * PATH -> the base-OS bin dirs) had never actually been applied to a
  * sandboxed command. This file covers `MacOSSandboxExecutor`'s own
- * getEnvOverrides() shape and its SBPL (setenv)/(unsetenv) emission through
- * `buildSandboxProfile`/`wrapCommand`'s 4th parameter — the wiring at the
- * `applySandboxExecution` call site (macOS-only gate by `mechanism`) is
+ * getEnvOverrides() shape and its command-level application inside the
+ * wrapped command (`buildEnvOverridePrefix` / `wrapCommand`'s 4th parameter
+ * — issue #2590: SBPL cannot mutate the sandboxed process's environment, so
+ * the overrides ride the inner shell instead of the profile). The wiring at
+ * the `applySandboxExecution` call site (macOS-only gate by `mechanism`) is
  * covered separately in
  * tests/unit/hooks/guardrails-sandbox-env-wiring.test.ts.
  *
@@ -83,7 +85,7 @@ describe('MacOSSandboxExecutor.getEnvOverrides() — F6b shape', () => {
 	});
 });
 
-describe('wrapCommand() env overrides — SBPL emission through buildSandboxProfile (F6b)', () => {
+describe('wrapCommand() env overrides — command-level application (issue #2590)', () => {
 	test('wrapCommand accepts getEnvOverrides() output as its 4th parameter without throwing', () => {
 		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
 		const env = executor.getEnvOverrides();
@@ -100,54 +102,67 @@ describe('wrapCommand() env overrides — SBPL emission through buildSandboxProf
 		expect(result).toContain('-f');
 	});
 
-	test('buildSandboxProfile emits (unsetenv DYLD_*) for every null-valued F6b override', () => {
-		const env = {
-			DYLD_INSERT_LIBRARIES: null,
-			DYLD_LIBRARY_PATH: null,
-			DYLD_FRAMEWORK_PATH: null,
-			DYLD_ROOT_PATH: null,
-			PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
-		};
-		const profile = _internals.buildSandboxProfile(['/scope'], '/tmp', env);
+	test('the DYLD_* unsets and the PATH pin are applied by the inner shell BEFORE the user command', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const env = executor.getEnvOverrides();
+		const wrapped = executor.wrapCommand('echo hello', [], undefined, env);
 
-		expect(profile).toContain('(unsetenv DYLD_INSERT_LIBRARIES)');
-		expect(profile).toContain('(unsetenv DYLD_LIBRARY_PATH)');
-		expect(profile).toContain('(unsetenv DYLD_FRAMEWORK_PATH)');
-		expect(profile).toContain('(unsetenv DYLD_ROOT_PATH)');
+		// One `unset` builtin covering all four DYLD injection variables...
+		expect(wrapped).toContain(
+			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH',
+		);
+		// ...and an export pinning PATH to the base-OS bin dirs. The value is
+		// single-quote-escaped for the outer bash -c context, so assert the
+		// assignment and the verbatim value separately.
+		expect(wrapped).toContain('export PATH=');
+		expect(wrapped).toContain('/usr/bin:/bin:/usr/sbin:/sbin');
+		// Env ops run BEFORE the user command.
+		expect(wrapped.indexOf('unset DYLD_INSERT_LIBRARIES')).toBeLessThan(
+			wrapped.indexOf('echo hello'),
+		);
 	});
 
-	test('buildSandboxProfile emits (setenv PATH "...") for the F6b PATH override', () => {
-		const env = { PATH: '/usr/bin:/bin:/usr/sbin:/sbin' };
-		const profile = _internals.buildSandboxProfile(['/scope'], '/tmp', env);
-		expect(profile).toContain('(setenv PATH "/usr/bin:/bin:/usr/sbin:/sbin")');
+	test('buildSandboxProfile contains NO env directives for the F6b overrides (issue #2590)', () => {
+		// envOverrides is no longer a buildSandboxProfile parameter — the
+		// 2-arg call below is the compile-checked contract. The profile must
+		// never carry env directives: SBPL has no setenv/unsetenv ops and
+		// emitting them made the profile unparseable (#2590).
+		const profile = _internals.buildSandboxProfile(['/scope'], '/tmp');
+		expect(profile).not.toContain('setenv');
+		expect(profile).not.toContain('unsetenv');
 	});
 
-	test('buildSandboxProfile(scopePaths, tempDir, MacOSSandboxExecutor.getEnvOverrides()) round-trips exactly', () => {
-		// Direct regression test: the actual getEnvOverrides() output, fed
-		// through the actual profile builder wrapCommand uses internally.
+	test('getEnvOverrides() round-trips through wrapCommand to the inner-shell prefix', () => {
 		const executor = new MacOSSandboxExecutor([], '/tmp');
 		const env = executor.getEnvOverrides();
-		const profile = _internals.buildSandboxProfile(['/scope'], '/tmp', env);
+		const wrapped = executor.wrapCommand('echo hello', [], undefined, env);
+		// One `unset` builtin covers all four DYLD keys, in getEnvOverrides()
+		// insertion order; PATH is exported right after.
+		expect(wrapped).toContain(
+			'unset DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH DYLD_ROOT_PATH',
+		);
+		expect(wrapped).toContain('export PATH=');
+	});
 
-		for (const key of [
-			'DYLD_INSERT_LIBRARIES',
-			'DYLD_LIBRARY_PATH',
-			'DYLD_FRAMEWORK_PATH',
-			'DYLD_ROOT_PATH',
-		]) {
-			expect(profile).toContain(`(unsetenv ${key})`);
-		}
-		expect(profile).toContain(`(setenv PATH "${env.PATH}")`);
+	test('no-override wrapCommand output carries no env ops (byte-shape preserved)', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const wrapped = executor.wrapCommand(
+			'echo hello',
+			[],
+			undefined,
+			undefined,
+		);
+		expect(wrapped).not.toContain('unset ');
+		expect(wrapped).not.toContain('export ');
+		expect(wrapped).toContain('sandbox-exec');
 	});
 });
 
-// NOTE (F6b, not test-automatable from this host): the assertions above
-// prove the (setenv)/(unsetenv) primitives are PARSEABLE-SHAPED and reach
-// the wrapped command string. They cannot prove the primitives actually
-// alter a live child process's environment — a parseability probe cannot
-// distinguish "valid primitive" from "valid but no-op." Confirming the DYLD
-// variables are genuinely absent from a real sandbox-exec-wrapped child's
-// environment requires spawning that child on a real macOS host and
-// inspecting `/proc`-equivalent env state, which is not reproducible here.
-// This is recorded as an open verification gap in the PR report rather than
-// papered over with a placeholder assertion.
+// NOTE (not test-automatable from this host): the assertions above prove the
+// env overrides are correctly shaped, ordered, and escaped inside the wrapped
+// command string, and that no profile carries env directives (#2590). They
+// cannot prove a live sandbox-exec-wrapped child on real macOS hardware
+// actually observes the DYLD variables unset — that requires spawning the
+// child on macOS and inspecting its environment, which is not reproducible
+// here. This remains an on-host verification item (trace NE1), recorded in the
+// PR report rather than papered over with a placeholder assertion.

--- a/tests/unit/sandbox/macos-envoverride-verification.test.ts
+++ b/tests/unit/sandbox/macos-envoverride-verification.test.ts
@@ -1,142 +1,172 @@
 /**
- * Additional macOS sandbox-exec envOverride verification tests.
+ * macOS sandbox-exec envOverride verification tests (issue #2590 contract).
  *
- * These tests complement the coverage in macos.test.ts by targeting:
- * - Values containing '=' (equals sign) in SBPL double-quoted strings
- * - Cross-platform injection correctness for macOS
+ * Env overrides are applied at the COMMAND level — the inner shell unsets and
+ * exports inside the wrapped `bash -c` payload before the user command runs.
+ * SBPL has no setenv/unsetenv operations (the profile parser rejects them as
+ * unbound variables, exit 65), so the profile itself must stay free of env
+ * directives; the emission that used to live in `buildSandboxProfile` made the
+ * whole executor silently unavailable on every macOS host (#2590).
  *
- * Platform: macOS only (sandbox-exec is macOS-specific)
+ * These tests complement the coverage in macos.test.ts / macos-env-hardening.test.ts:
+ * - values containing '=' preserved verbatim
+ * - values containing single quotes shell-escaped
+ * - invalid keys dropped from the wrapped output
+ * - env ops ordered before the user command
+ * - no-override payloads carry no env ops
+ *
+ * Seam-driven (same pattern as macos-env-hardening.test.ts):
+ * process.platform is overridden to 'darwin' and _internals.probeSandboxExec is
+ * mocked, so the real executor logic is exercised on ANY host — no real
+ * sandbox-exec binary required.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+	_internals,
+	MacOSSandboxExecutor,
+} from '../../../src/sandbox/macos/sandbox-exec-executor';
 
-const isMac = process.platform === 'darwin';
+const originalPlatform = process.platform;
+const originalProbeSandboxExec = _internals.probeSandboxExec;
 
-import { MacOSSandboxExecutor } from '../../../src/sandbox/macos/sandbox-exec-executor';
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, 'platform', { value, configurable: true });
+}
 
-// ---------------------------------------------------------------------------
-// Supplementary envOverride tests — all skipped on non-macOS
-// ---------------------------------------------------------------------------
+function restorePlatform(): void {
+	Object.defineProperty(process, 'platform', {
+		value: originalPlatform,
+		configurable: true,
+	});
+}
 
-describe('MacOSSandboxExecutor — envOverride verification (supplementary)', () => {
+beforeEach(() => {
+	setPlatform('darwin');
+	_internals.probeSandboxExec = mock(() => true);
+	_internals.resetProbeMemo();
+});
+
+afterEach(() => {
+	restorePlatform();
+	_internals.probeSandboxExec = originalProbeSandboxExec;
+	_internals.resetProbeMemo();
+});
+
+describe('MacOSSandboxExecutor — envOverride verification (command-level, #2590)', () => {
 	// -----------------------------------------------------------------------
-	// Equals sign in value — SBPL double-quoted strings treat = as literal
-	// -----------------------------------------------------------------------
-
-	test.skipIf(!isMac)(
-		'value with embedded equals sign is escaped correctly in SBPL double-quoted string',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
-
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				FOO: 'a=b=c',
-			});
-			// SBPL double-quoted string: backslash-escaped double quotes, not equals
-			// The value a=b=c should appear as-is inside the double-quoted SBPL string.
-			// We check that the value with embedded = is present in the SBPL setenv line.
-			expect(result).toContain('(setenv FOO "a=b=c")');
-		},
-	);
-
-	test.skipIf(!isMac)(
-		'value that is just an equals sign is preserved correctly',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
-
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				X: '=',
-			});
-			expect(result).toContain('(setenv X "=")');
-		},
-	);
-
-	// -----------------------------------------------------------------------
-	// Security: key with shell metacharacters is rejected
+	// Equals sign in value — preserved verbatim by the single-quoted shell form
 	// -----------------------------------------------------------------------
 
-	test.skipIf(!isMac)(
-		'key with dollar sign (variable injection) is rejected silently',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
+	test('value with embedded equals sign is preserved verbatim in the wrapped command', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			FOO: 'a=b=c',
+		});
+		expect(result).toContain('export FOO=');
+		expect(result).toContain('a=b=c');
+	});
 
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				$FOO: 'value',
-			});
-			// $FOO is not a valid env var name — must not appear in SBPL primitives
-			expect(result).not.toContain('$FOO');
-			expect(result).not.toContain('(setenv');
-			expect(result).not.toContain('(unsetenv');
-		},
-	);
-
-	test.skipIf(!isMac)(
-		'key with parens (SBPL syntax injection) is rejected silently',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
-
-			// Attempt to inject SBPL syntax: FOO(BAR) should be rejected
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				'FOO(BAR)': 'value',
-			});
-			expect(result).not.toContain('FOO(BAR)');
-			expect(result).not.toContain('(setenv');
-		},
-	);
+	test('value that is just an equals sign is preserved verbatim', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			X: '=',
+		});
+		expect(result).toContain('export X=');
+		// The value's surrounding single quotes are escaped for the outer
+		// bash -c context ('\'' each), so the assignment reads
+		// export X='\''='\'' — the lone = survives verbatim between quotes.
+		expect(result).toContain("'='");
+	});
 
 	// -----------------------------------------------------------------------
-	// Cross-platform injection correctness
+	// Security: key with shell/SBPL metacharacters is rejected
 	// -----------------------------------------------------------------------
 
-	test.skipIf(!isMac)(
-		'setenv SBPL primitive contains the env var name and value verbatim',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
+	test('key with dollar sign (variable injection) is rejected silently', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			$FOO: 'value',
+		});
+		// $FOO is not a valid env var name — must not appear anywhere in the
+		// wrapped command, and the profile must never carry env primitives.
+		expect(result).not.toContain('$FOO');
+		expect(result).not.toContain('(setenv');
+		expect(result).not.toContain('(unsetenv');
+	});
 
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				INJECT_ME: 'injected_value',
-			});
-			// The SBPL profile generated by buildSandboxProfile includes:
-			// (setenv INJECT_ME "injected_value")
-			// When sandbox-exec parses this profile, INJECT_ME is set to injected_value.
-			expect(result).toContain('(setenv INJECT_ME "injected_value")');
-		},
-	);
+	test('key with parens (shell/SBPL syntax injection) is rejected silently', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			'FOO(BAR)': 'value',
+		});
+		expect(result).not.toContain('FOO(BAR)');
+		expect(result).not.toContain('(setenv');
+	});
 
-	test.skipIf(!isMac)(
-		'unsetenv SBPL primitive contains the env var name only (no value)',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
+	// -----------------------------------------------------------------------
+	// Command-level application correctness
+	// -----------------------------------------------------------------------
 
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				REMOVE_ME: null,
-			});
-			expect(result).toContain('(unsetenv REMOVE_ME)');
-		},
-	);
+	test('env ops precede the user command in the wrapped payload', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			INJECT_ME: 'injected_value',
+		});
+		const exportIdx = result.indexOf('export INJECT_ME=');
+		const cmdIdx = result.indexOf('echo hello');
+		expect(exportIdx).toBeGreaterThanOrEqual(0);
+		expect(cmdIdx).toBeGreaterThan(exportIdx);
+		expect(result).toContain('injected_value');
+	});
 
-	test.skipIf(!isMac)(
-		'mixed valid and invalid keys: valid keys are applied, invalid silently dropped',
-		() => {
-			const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
-			if (!executor.isAvailable()) return;
+	test('null value unsets the key before the user command', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			REMOVE_ME: null,
+		});
+		const unsetIdx = result.indexOf('unset REMOVE_ME');
+		const cmdIdx = result.indexOf('echo hello');
+		expect(unsetIdx).toBeGreaterThanOrEqual(0);
+		expect(cmdIdx).toBeGreaterThan(unsetIdx);
+	});
 
-			const result = executor.wrapCommand('echo hello', [], undefined, {
-				VALID_KEY: 'valid_value',
-				'INVALID;KEY': 'should_be_dropped',
-				ANOTHER_VALID: 'another_value',
-			});
-			// Valid keys appear in SBPL
-			expect(result).toContain('(setenv VALID_KEY "valid_value")');
-			expect(result).toContain('(setenv ANOTHER_VALID "another_value")');
-			// Invalid key must not appear
-			expect(result).not.toContain('INVALID');
-			expect(result).not.toContain('should_be_dropped');
-		},
-	);
+	test('value containing a single quote is shell-escaped (payload stays parseable)', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			SET_ME: "it's a = test",
+		});
+		// shellEscape turns the apostrophe into '\'' so the outer
+		// single-quoted bash -c payload still parses; the value characters
+		// survive verbatim around the escape.
+		expect(result).toContain('export SET_ME=');
+		expect(result).toContain('a = test');
+		// The raw unescaped apostrophe must never terminate the outer quoting:
+		// every single quote after SET_ME= must be part of an escape sequence.
+		const after = result.slice(result.indexOf('export SET_ME='));
+		expect(after).toContain("'\\''");
+	});
+
+	test('mixed valid and invalid keys: valid keys applied, invalid silently dropped', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, {
+			VALID_KEY: 'valid_value',
+			'INVALID;KEY': 'should_be_dropped',
+			ANOTHER_VALID: 'another_value',
+		});
+		expect(result).toContain('export VALID_KEY=');
+		expect(result).toContain('valid_value');
+		expect(result).toContain('export ANOTHER_VALID=');
+		expect(result).toContain('another_value');
+		expect(result).not.toContain('INVALID');
+		expect(result).not.toContain('should_be_dropped');
+	});
+
+	test('no-override wrap output carries no env ops and no profile env directives', () => {
+		const executor = new MacOSSandboxExecutor(['/scope'], '/tmp');
+		const result = executor.wrapCommand('echo hello', [], undefined, undefined);
+		expect(result).not.toContain('unset ');
+		expect(result).not.toContain('export ');
+		expect(result).toContain('sandbox-exec');
+	});
 });

--- a/tests/unit/sandbox/macos-executor-activation.test.ts
+++ b/tests/unit/sandbox/macos-executor-activation.test.ts
@@ -1,0 +1,274 @@
+/**
+ * macOS sandbox-exec executor — tests activated by the issue #2590 fix.
+ *
+ * The #2590 fix removed the invalid SBPL `(setenv …)`/`(unsetenv …)` emission
+ * that made the availability probe fail on EVERY macOS host, so the executor
+ * was always "unavailable" and these macOS-gated integration tests silently
+ * skipped. With a working probe they run for the first time — and four of
+ * their premises were wrong (CI run 34090088557, 2026-09-07: AC-004, AC-008,
+ * AC-010, and the recovery memo sequence all failed). This file hosts the
+ * corrected variants, split out of the over-cap sandbox-integration.test.ts /
+ * recovery.test.ts per the FR-006 growth ratchet (PR #2630 review
+ * PRR-001/002/003/004).
+ *
+ * Corrections vs the pre-fix variants:
+ *   - AC-004: no `|| true` (it masks the sandbox denial by forcing exit 0,
+ *     and spawnWrapped's success IS the exit code) + asserts the download
+ *     file was not created.
+ *   - AC-008: absolute 250ms/call ceiling instead of a <10% percentage over
+ *     a trivial echo baseline (per-command sandbox cost is fixed; CI measured
+ *     191.73% overhead) + positive control that the wrapped write landed.
+ *   - AC-010: writes under os.homedir() instead of root-owned /Users.
+ *   - Recovery: resets the probe memo AFTER executor1's construction seals
+ *     it, so the false-probe mock actually reaches executor2.
+ *
+ * Seam-driven where possible; AC-001/002/003/005-009-style live variants need
+ * a real macOS host (skipIf(!isMac)), matching the original tests' contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SandboxError } from '../../../src/sandbox/executor';
+import {
+	MacOSSandboxExecutor,
+	_internals as macosInternals,
+} from '../../../src/sandbox/macos/sandbox-exec-executor';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const isMac = process.platform === 'darwin';
+const ITERATIONS = 100;
+
+function makeTempDir(prefix: string): string {
+	// canonicalMkdtemp realpath-resolves the temp root (FR-011): closes the
+	// macOS /var -> /private/var symlink gap.
+	return canonicalMkdtemp(prefix);
+}
+
+interface SpawnResult {
+	success: boolean;
+	exitCode: number | null;
+	stderr: string;
+	stdout: string;
+}
+
+function spawnWrapped(
+	executor: {
+		wrapCommand: (cmd: string, scopes: string[], temp?: string) => string;
+	},
+	command: string,
+	scopePaths: string[],
+	tempDir?: string,
+): SpawnResult {
+	const wrapped = executor.wrapCommand(command, scopePaths, tempDir);
+	const result = spawnSync(wrapped, {
+		shell: true,
+		encoding: 'utf-8',
+		timeout: 10_000,
+	});
+
+	return {
+		success: result.status === 0,
+		exitCode: result.status,
+		stderr: result.stderr ?? '',
+		stdout: result.stdout ?? '',
+	};
+}
+
+function spawnRaw(command: string): SpawnResult {
+	const result = spawnSync(command, {
+		shell: true,
+		encoding: 'utf-8',
+	});
+
+	return {
+		success: result.status === 0,
+		exitCode: result.status,
+		stderr: result.stderr ?? '',
+		stdout: result.stdout ?? '',
+	};
+}
+
+async function getMacExecutor() {
+	return MacOSSandboxExecutor;
+}
+
+describe('macOS sandbox-exec activation tests (issue #2590 follow-ups)', () => {
+	describe('AC-004: curl download outside scope is denied (PRR-001 fix)', () => {
+		test.skipIf(!isMac)(
+			'macOS: sandbox-exec blocks curl download outside scope',
+			async () => {
+				const Executor = await getMacExecutor();
+				const scopeDir = makeTempDir('ac004-scope-');
+
+				try {
+					const executor = new Executor([scopeDir]);
+
+					if (!executor.isAvailable()) {
+						return;
+					}
+
+					// Attempt to download to /tmp (outside the allowed scope: the
+					// executor's writable scope is [scopeDir] + its temp dir, and
+					// hosted macOS runners set TMPDIR to a per-user dir, so /tmp
+					// is NOT inside the writable scope). NO `|| true`: the
+					// success criterion is the wrapped command's exit code, so
+					// `|| true` would mask the sandbox denial by forcing exit 0
+					// and make this test unpassable by construction.
+					const downloadPath = '/tmp/ac004-download.txt';
+					spawnRaw(`rm -f ${downloadPath}`);
+					const result = spawnWrapped(
+						executor,
+						`curl -o ${downloadPath} https://example.com 2>&1`,
+						[scopeDir],
+					);
+
+					// sandbox-exec should deny the write: curl exits non-zero AND
+					// the download file must not exist.
+					expect(result.success).toBe(false);
+					expect(existsSync(downloadPath)).toBe(false);
+				} finally {
+					rmSync(scopeDir, { recursive: true, force: true });
+				}
+			},
+		);
+	});
+
+	describe('AC-008: per-call overhead ceiling (PRR-003 fix)', () => {
+		test.skipIf(!isMac)(
+			'macOS: sandbox-exec wrapped commands stay under the per-call ceiling',
+			async () => {
+				const Executor = await getMacExecutor();
+				const scopeDir = makeTempDir('ac008-scope-');
+
+				try {
+					const executor = new Executor([scopeDir]);
+
+					if (!executor.isAvailable()) {
+						return;
+					}
+
+					const testFile = path.join(scopeDir, 'ac008-test.txt');
+					const echoCmd = `echo "ac008" > "${testFile}"`;
+
+					// 100 real wrapped spawns: each pays wrapCommand's fixed cost
+					// (mkdtempSync + profile write + sandbox-exec launch + SBPL
+					// compile). ISSUE #2590 CI evidence (2026-09-07): a
+					// percentage bound over a trivial `bash -c echo` baseline is
+					// structurally unachievable for a spawn-per-command sandbox
+					// (CI measured 191.73% overhead against the original <10%
+					// bound). The acceptance intent — sandboxing must not make
+					// commands unusably slow — is preserved as an ABSOLUTE
+					// per-wrapped-call ceiling with ~20x headroom over the
+					// CI-measured ~12ms/call.
+					const perCallCeilingMs = 250;
+					// performance.now() (monotonic) is the correct clock for
+					// elapsed-time measurement — immune to wall-clock steps and
+					// the repo convention for perf assertions (cf.
+					// capability-probe.test.ts). The freezeClock gate targets
+					// logic-time determinism, not perf ceilings.
+					const wrappedStart = performance.now();
+					for (let i = 0; i < ITERATIONS; i++) {
+						const wrapped = executor.wrapCommand(echoCmd, [scopeDir]);
+						spawnSync(wrapped, {
+							shell: true,
+							encoding: 'utf-8',
+							timeout: 10_000,
+						});
+					}
+					const wrappedMs = performance.now() - wrappedStart;
+
+					const wrappedPerCallMs = wrappedMs / ITERATIONS;
+					console.log(
+						`[ac008] wrappedMs=${wrappedMs} perWrappedCallMs=${wrappedPerCallMs.toFixed(1)} (ceiling ${perCallCeilingMs})`,
+					);
+					expect(wrappedPerCallMs).toBeLessThan(perCallCeilingMs);
+					// Positive control: the wrapped writes must actually work.
+					expect(existsSync(testFile)).toBe(true);
+				} finally {
+					rmSync(scopeDir, { recursive: true, force: true });
+				}
+			},
+		);
+	});
+
+	describe('AC-010: broad-scope writes succeed (PRR-004 fix)', () => {
+		test.skipIf(!isMac)(
+			'macOS: writes succeed when scope is very broad',
+			async () => {
+				const Executor = await getMacExecutor();
+
+				// Use the user's home directory (broad scope on macOS). The
+				// previous /Users target failed on hosted CI runners regardless
+				// of the sandbox: /Users is root-owned (755), so the runner user
+				// gets EACCES at the OS layer even when the sandbox allows the
+				// subpath (issue #2590 CI, 2026-09-07).
+				const broadScope = os.homedir();
+
+				const executor = new Executor([broadScope]);
+
+				if (!executor.isAvailable()) {
+					return;
+				}
+
+				// Write to a path inside the broad scope — should succeed
+				const testFile = path.join(
+					broadScope,
+					`ac010-broad-scope-${process.pid}.txt`,
+				);
+				const result = spawnWrapped(
+					executor,
+					`echo "ac010 legitimate" > "${testFile}"`,
+					[broadScope],
+				);
+
+				expect(result.success).toBe(true);
+
+				// Cleanup
+				try {
+					spawnSync(`rm -f "${testFile}"`, {
+						shell: true,
+						encoding: 'utf-8',
+					});
+				} catch {
+					// ignore cleanup errors
+				}
+			},
+		);
+	});
+
+	describe('Recovery: probe-memo reset before the unavailable-executor assertion (PRR-002 fix)', () => {
+		const originalProbeSandboxExec = macosInternals.probeSandboxExec;
+
+		beforeEach(() => {
+			macosInternals.resetProbeMemo();
+		});
+
+		afterEach(() => {
+			macosInternals.probeSandboxExec = originalProbeSandboxExec;
+			macosInternals.resetProbeMemo();
+		});
+
+		test.skipIf(!isMac)(
+			'MacOSSandboxExecutor: wrapCommand throws SandboxError when the probe turns false mid-session',
+			() => {
+				const rawCmd = 'echo recovery-probe';
+				// executor1's construction runs the REAL probe and memoizes the
+				// result for the process lifetime (expiresAt=Infinity on
+				// success); the memo must be reset AFTER installing the false
+				// mock or executor2 inherits the sealed true and never throws
+				// (issue #2590 CI, 2026-09-07).
+				const executor1 = new MacOSSandboxExecutor([]);
+				executor1.disable('reason 1');
+				expect(() => executor1.wrapCommand(rawCmd, [])).toThrow(SandboxError);
+
+				macosInternals.probeSandboxExec = mock(() => false);
+				macosInternals.resetProbeMemo();
+				const executor2 = new MacOSSandboxExecutor([]);
+				expect(() => executor2.wrapCommand(rawCmd, [])).toThrow(SandboxError);
+			},
+		);
+	});
+});

--- a/tests/unit/sandbox/macos-probe.test.ts
+++ b/tests/unit/sandbox/macos-probe.test.ts
@@ -204,10 +204,14 @@ describe('buildProbeProfile — F6a item 2 shape parity with production', () => 
 		);
 	});
 
-	test('includes a setenv/unsetenv pair so an invalid env primitive is caught by the probe (F6b caveat)', () => {
+	test('contains NO setenv/unsetenv — they are not SBPL ops and broke the probe (issue #2590)', () => {
 		const profile = _internals.buildProbeProfile('/tmp/swarm-probe');
-		expect(profile).toContain('(setenv');
-		expect(profile).toContain('(unsetenv');
+		// `setenv`/`unsetenv` are rejected by sandbox-exec as unbound variables
+		// (exit 65); emitting them disabled the whole executor on every macOS
+		// host. `not.toContain('setenv')` alone subsumes 'unsetenv', but the
+		// explicit pair documents both forbidden spellings.
+		expect(profile).not.toContain('(setenv');
+		expect(profile).not.toContain('(unsetenv');
 	});
 
 	test('is NOT the trivial (allow default)-only profile — a trivial probe would pass even when production is unparseable', () => {

--- a/tests/unit/sandbox/recovery.test.ts
+++ b/tests/unit/sandbox/recovery.test.ts
@@ -653,19 +653,6 @@ describe('Sandbox recovery scenarios', () => {
 			},
 		);
 
-		test.skipIf(!isMac)(
-			'MacOSSandboxExecutor: wrapCommand throws SandboxError when unavailable (any reason)',
-			() => {
-				const executor1 = new MacOSSandboxExecutor([]);
-				executor1.disable('reason 1');
-				expect(() => executor1.wrapCommand(rawCmd, [])).toThrow(SandboxError);
-
-				macosInternals.probeSandboxExec = mock(() => false);
-				const executor2 = new MacOSSandboxExecutor([]);
-				expect(() => executor2.wrapCommand(rawCmd, [])).toThrow(SandboxError);
-			},
-		);
-
 		test.skipIf(!isWindows)(
 			'WindowsSandboxExecutor: wrapCommand throws SandboxError when unavailable (any reason)',
 			() => {

--- a/tests/unit/sandbox/sandbox-integration.test.ts
+++ b/tests/unit/sandbox/sandbox-integration.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	realpathSync,
@@ -424,43 +425,21 @@ describe('AC-004: Curl/wget download to path outside scope fails', () => {
 					return;
 				}
 
-				// Attempt to download to /root (outside bwrap mounts)
+				// Attempt to download to /root (outside bwrap mounts).
+				// NO `|| true`: spawnWrapped's success is the wrapped command's
+				// exit code, so `|| true` would mask the sandbox denial by
+				// forcing exit 0 and make this test unpassable by construction.
+				const downloadPath = '/root/ac004-download.txt';
+				spawnRaw(`rm -f ${downloadPath}`);
 				const result = spawnWrapped(
 					executor,
-					`curl -o /root/ac004-download.txt https://example.com 2>&1 || true`,
+					`curl -o ${downloadPath} https://example.com 2>&1`,
 					[scopeDir],
 				);
 
 				// Should fail — /root is not mounted in bwrap
 				expect(result.success).toBe(false);
-			} finally {
-				rmSync(scopeDir, { recursive: true, force: true });
-			}
-		},
-	);
-
-	test.skipIf(!isMac)(
-		'macOS: sandbox-exec blocks curl download outside scope',
-		async () => {
-			const Executor = await getMacExecutor();
-			const scopeDir = makeTempDir('ac004-scope-');
-
-			try {
-				const executor = new Executor([scopeDir]);
-
-				if (!executor.isAvailable()) {
-					return;
-				}
-
-				// Attempt to download to /tmp (outside the allowed scope)
-				const result = spawnWrapped(
-					executor,
-					`curl -o /tmp/ac004-download.txt https://example.com 2>&1 || true`,
-					[scopeDir],
-				);
-
-				// sandbox-exec should deny this
-				expect(result.success).toBe(false);
+				expect(existsSync(downloadPath)).toBe(false);
 			} finally {
 				rmSync(scopeDir, { recursive: true, force: true });
 			}
@@ -858,56 +837,6 @@ describe('AC-008: Performance overhead < 10%', () => {
 		},
 	);
 
-	test.skipIf(!isMac)(
-		'macOS: sandbox-exec overhead < 10% for repeated writes',
-		async () => {
-			const Executor = await getMacExecutor();
-			const scopeDir = makeTempDir('ac008-scope-');
-
-			try {
-				const executor = new Executor([scopeDir]);
-
-				if (!executor.isAvailable()) {
-					return;
-				}
-
-				// Baseline: spawnSync with plain bash -c (no sandbox)
-				// Both baseline and wrapped use equivalent process spawning — only difference
-				// is whether sandbox-exec wrapping is applied.
-				const testFile = path.join(scopeDir, 'ac008-test.txt');
-				const content = 'x'.repeat(FILE_SIZE_KB * 1024);
-				const echoCmd = `echo "${content.substring(0, 32)}" > "${testFile}"`;
-
-				const baselineStart = Date.now();
-				for (let i = 0; i < ITERATIONS; i++) {
-					spawnSync(`bash -c '${echoCmd}'`, {
-						shell: true,
-						encoding: 'utf-8',
-						timeout: 10_000,
-					});
-				}
-				const baselineMs = Date.now() - baselineStart;
-
-				// Wrapped: spawnSync with sandbox-exec-wrapped command
-				const wrappedStart = Date.now();
-				for (let i = 0; i < ITERATIONS; i++) {
-					const wrapped = executor.wrapCommand(echoCmd, [scopeDir]);
-					spawnSync(wrapped, {
-						shell: true,
-						encoding: 'utf-8',
-						timeout: 10_000,
-					});
-				}
-				const wrappedMs = Date.now() - wrappedStart;
-
-				const overhead = ((wrappedMs - baselineMs) / baselineMs) * 100;
-				expect(overhead).toBeLessThan(10);
-			} finally {
-				rmSync(scopeDir, { recursive: true, force: true });
-			}
-		},
-	);
-
 	// Windows AC-008 is skipped because the PowerShell-based wrapper is too slow
 	// for 100 iterations (each wrap spawns a new powershell -ExecutionPolicy Bypass -Command).
 	// Windows is documented as best-effort restricted execution, not a true sandbox.
@@ -1062,39 +991,6 @@ describe('AC-010: Full scope = no false positives', () => {
 			);
 
 			// With broad scope, legitimate writes should succeed
-			expect(result.success).toBe(true);
-
-			// Cleanup
-			try {
-				spawnSync(`rm -f "${testFile}"`, { shell: true, encoding: 'utf-8' });
-			} catch {
-				// ignore cleanup errors
-			}
-		},
-	);
-
-	test.skipIf(!isMac)(
-		'macOS: writes succeed when scope is very broad',
-		async () => {
-			const Executor = await getMacExecutor();
-
-			// Use /Users (broad scope on macOS)
-			const broadScope = '/Users';
-
-			const executor = new Executor([broadScope]);
-
-			if (!executor.isAvailable()) {
-				return;
-			}
-
-			// Write to a path inside /Users (within broad scope) — should succeed
-			const testFile = `/Users/ac010-false-positive-${process.pid}.txt`;
-			const result = spawnWrapped(
-				executor,
-				`echo "ac010 legitimate" > "${testFile}"`,
-				[broadScope],
-			);
-
 			expect(result.success).toBe(true);
 
 			// Cleanup


### PR DESCRIPTION
Closes #2590

## Summary

`setenv`/`unsetenv` are not Sandbox Profile Language operations: macOS `sandbox-exec`
rejects them as unbound variables (exit 65). Both the availability probe
(`buildProbeProfile`, sandbox-exec-executor.ts:89-90 at base) and the production profile
(`buildSandboxProfile`, :281/:285) emitted them, so the probe failed on every macOS
host, the executor reported itself unavailable, and macOS sandboxing silently fell back
to unsandboxed tool-layer enforcement — the DYLD_*/PATH hardening had never been applied
even once. This PR removes the emission and applies env overrides where they can
actually work: inside the wrapped command's inner shell, before the user command (the
same design the Windows PowerShell wrapper already uses). The emission came in with
per-lane runtime isolation (#1226) and predates the #2236 probe fix, so it was never
validated against a real sandbox-exec.

## Root Cause

SBPL cannot mutate the sandboxed process's environment — there is no env op in the
Seatbelt grammar (`-D k=v` + `(param "KEY")` injects values into profile expressions
only). The probe profile's line 5 was `(setenv SWARM_SANDBOX_PROBE "1")`, matching the
reported `unbound variable: setenv … line 5` (exit 65) exactly. `probeSandboxExec()`
gates on exit code 0 only, so the executor was structurally dead on every macOS host
with only a warn-level log (fail-open by design; the `guardrails.sandbox_macos_enabled`
gate defaults to `false`, which hid the dead executor).

## Fix

- `buildProbeProfile`: drop the `(setenv …)`/`(unsetenv …)` pair; probe parity with the
  production file-write primitives is preserved (deny-then-scoped-allow).
- `buildSandboxProfile`: remove the `envOverrides` parameter and the envLines block
  entirely, so the profile builder structurally cannot receive env overrides
  (compile-checked 2-arg contract).
- `wrapCommand`: new `buildEnvOverridePrefix()` applies overrides inside the wrapped
  `bash -c` payload before the user command — one `unset` builtin for null-valued keys,
  `export K='<shellEscape(v)>'` for string values, invalid keys (`isValidEnvKey`)
  dropped, empty/undefined overrides produce a byte-identical payload to before.
- `tool-before.ts` wiring comment updated; `docs/configuration.md` macOS section
  rewritten (command-level application; the hardening is effective for the first time —
  commands needing Homebrew/version-manager PATH entries must extend `PATH` themselves).
- Release fragment: `docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md`.

## Invariant audit

- 1 (plugin init):       not touched — no init-path change; all edits are inside the sandbox executor, its hook comment, docs, and tests.
- 2 (runtime portability): not touched — no new imports (node builtins already in file); `bun run typecheck` exit 0; no `bun:`-scheme or `Bun.*` usage added (grep clean).
- 3 (subprocesses):      touched — verified bounded/unchanged: the fix is pure string composition; no spawn flags, timeouts, or stdin handling changed; probe/wrap spawn paths byte-equivalent apart from profile content and the composed payload (`git diff origin/main...HEAD -- src/sandbox/macos/sandbox-exec-executor.ts`).
- 4 (.swarm containment): not touched — no `.swarm/` writes; no `process.cwd()` callers added.
- 5 (plan durability):   not touched — no plan-schema/ledger surface involved.
- 6 (test_runner safety): not touched — no `test_runner` usage; validation used shell commands and targeted `bun test` files.
- 7 (test writing):      touched — verified compliant: bun:test only; no new `mock.module` (seam-driven `_internals` patching with try/finally restore, the established macos-env-hardening pattern); all modified test files under 500 lines (241/215/194 lines); `os.tmpdir()`-based paths only.
- 8 (session state):     not touched — no session-scoped state added; `buildEnvOverridePrefix` is per-call and stateless.
- 9 (guardrails/retry):  touched (comment-only in tool-before.ts) — verified: only the explanatory comment block changed; `pluginOwnsExecutorEnv` gating and all enforcement logic untouched.
- 10 (chat/system msg):  not touched — no message/hook-output surface involved.
- 11 (tool registration): not touched — no tool/agent-map/command changes; `bun test tests/unit/sandbox/*` and targeted suites green.
- 12 (release/cache):    touched — verified: `docs/releases/pending/2590-macos-sandbox-exec-sbpl-setenv.md` shipped; no `package.json#version`/CHANGELOG/`.release-please-manifest.json` edits (release-please owns them).

## Round 2 — CI-activated macOS test fixes (commit 4d851ba32)

The first CI run exposed that the fix ACTIVATED pre-existing macOS-gated tests that had
never executed (the broken probe always reported the executor unavailable). A full
swarm-pr-review (6 lanes + 11 risk-family micro-lanes + reviewer + critic) validated
four test-premise defects, all fixed in 4d851ba32 per swarm-pr-feedback:

- **AC-004** (mac+linux): `|| true` masked the sandbox denial by forcing exit 0 —
  unpassable by construction. Removed; now also asserts the download file was NOT
  created.
- **AC-008**: the <10% overhead bound over a trivial echo baseline is structurally
  unachievable for a spawn-per-command sandbox (CI measured 191.73%). Redesigned as an
  absolute 250ms/call ceiling (~20x headroom over CI-measured ~12ms/call) + positive
  control that the wrapped write landed.
- **AC-010**: wrote to /Users (root-owned on hosted runners → EACCES regardless of
  sandbox). Retargeted to the user's home directory.
- **recovery.test.ts**: executor1 sealed the probe memo with a real `true` before the
  false mock was installed; memo is now reset mid-test.
- **Hardening (PR review PRR-006/007)**: `DYLD_FORCE_FLAT_NAMESPACE` added to the
  macOS unset set (parity with both Windows executors); direct unit tests for
  `buildEnvOverridePrefix`.
- The corrected macOS variants live in the new
  `tests/unit/sandbox/macos-executor-activation.test.ts` (FR-006 growth ratchet: both
  over-cap files now sit below their origin/main baselines). Both implementation
  review and final critic re-ran on 4d851ba32 and APPROVED.

## Test plan

- Frozen acceptance checks (5, authored by an independent check-author context, frozen at a red checkpoint): `repro-check.sh run` → C1/C2/C3/C5 base-RED→head-GREEN PASS, C4 PASS (amended AC_CHANGED_BY_USER for the six-key getEnvOverrides shape, fresh base-RED→head-GREEN replay); `repro-check.sh verify-checkpoint` → OK ×5. Logs: `.agents/issue-traces/2590-sbpl-setenv-sandbox-disabled/repro/C*.log`.
- Regression/impacted suites: `bun test` on macos-probe / macos-env-hardening / macos-envoverride-verification / sandbox-integration / recovery / macos-executor-activation / guardrails-sandbox-env-wiring → 0 fail (84 pass / 32 skip on Windows; macOS-gated variants run on the macOS CI shards).
- Guardrail mutation probe (implementer + reviewer + critic each ran it): re-adding the `(setenv …)` emission flips C1 (probe builder) / C2+C5 (production builder) RED; restore → GREEN; tree clean after restore.
- Empirical quoting verification (reviewer + critic, real bash on Windows Git Bash): the exact nested-escaped `bash -c` payload executes with verbatim values (`it's a = test` round-trips, DYLD var unset, PATH pinned); an apostrophe-injection payload round-trips harmlessly (no escape).
- Lint/type: `bun run typecheck` → clean; `bunx biome check` on all touched TS files → clean.
- Deferred-work scan: `scan-deferred.sh` → clean.

## Recurrence Prevention (defect class)

- Defect class: env-hardening directives emitted into a target grammar/surface that structurally rejects them, so a whole enforcement mechanism silently no-ops while tests pin the broken emission as correct.
- Sweep result: 3 predicates (setenv mentions in src, SBPL-form directives, getEnvOverrides declaration siblings) → 19 hits, 19 dispositions (08a-recurrence-sweep.md): the two macOS emission sites fixed; bwrap/PowerShell/native-runner siblings verified to use their own valid grammars; the historical #1226 fragment left accurate.
- Guardrail: frozen checks C1 (probe builder) and C5 (production builder artifact) demonstrably bite — RED under re-added emission, GREEN after restore (implementer, reviewer, and critic each ran the probe independently). Permanent in-repo pins: flipped assertions in macos-probe.test.ts, macos-envoverride-verification.test.ts, and the compile-checked 2-arg `buildSandboxProfile` contract.

## Regression Protection

- `tests/unit/sandbox/macos-probe.test.ts` — probe profile must contain NO `(setenv`/`(unsetenv`; probe parity (deny-then-scoped-allow, non-trivial profile) preserved.
- `tests/unit/sandbox/macos-env-hardening.test.ts` — `getEnvOverrides()` shape unchanged; DYLD_*/PATH applied by the inner shell BEFORE the user command; `buildSandboxProfile` 2-arg contract carries no env directives; no-override payload carries no env ops (critic-adopted pin).
- `tests/unit/sandbox/macos-envoverride-verification.test.ts` — rewritten from `skipIf(!isMac)` (never ran in CI) to seam-driven tests that run on every host: equals-in-value verbatim, lone-`=` value, `$`/paren key rejection, apostrophe escaping, mixed keys, ordering, no-override shape.
- Adversarial: single-quote-bearing values are escaped through the outer `bash -c` quoting (verified empirically with real bash by two independent gates).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 probe profile free of env directives, parity preserved | `repro-check.sh run` C1: base RED → head GREEN PASS; `macos-probe.test.ts` "contains NO setenv/unsetenv" + parity tests green |
| AC2 production profile free of env directives | `repro-check.sh run` C2: base RED → head GREEN PASS; `buildSandboxProfile` no-env-directives test green |
| AC3 env overrides applied at command level before the user command | `repro-check.sh run` C3: base RED → head GREEN PASS; real-bash execution of the wrapped payload by reviewer and critic (verbatim values, unset effective) |
| AC4 preserved behaviors (parity, override shape, invalid-key drop, wrapper shape) | `repro-check.sh run` C4: GREEN at base and head PASS |
| AC5 defect-class guardrail bites on the real artifact | `repro-check.sh run` C5: base RED → head GREEN PASS; mutation probes RED→GREEN by implementer, reviewer (probe+production builders), and critic |
| NE1 live sandbox-exec parse on macOS (HOST_ONLY) | Substitute evidence: reporter's empirical exit-0 matrix for every remaining profile op (macOS 26.6.2) + maintainer confirmation in issue comment 1; the shipped profiles are a strict subset of that validated op set |

## Risk and Rollback

- Risk level: low — macOS-only path behind a default-false gate; no public API change; no spawn-mechanics change. One intended behavior change (documented): the declared DYLD_*/PATH hardening becomes effective for the first time under opt-in macOS sandboxing.
- Rollback: single-commit revert (`git revert 2bbcd50fc`); no data, schema, or config migration.
- Residual risk: an opt-in macOS user whose commands relied on a non-system PATH will need to extend PATH themselves (documented in docs/configuration.md and the release fragment). The maintainer-flagged follow-up — making probe failure louder than a warn (robustness against any future invalid directive) — is intentionally a separate item, per the maintainer's issue comment.

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.

PR head: 2bbcd50fc653d3346d3263628dd69efd423f5362

## Issue Closure

Closes #2590


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


