### PR TITLE
fix(guardrails): scope gate denials by cause and action

### DIFF
--- a/docs/releases/pending/2574-gate-denial-guidance.md
+++ b/docs/releases/pending/2574-gate-denial-guidance.md
@@ -1,0 +1,23 @@
+# Gate-denial guidance stays action-specific (#2574)
+
+## What changed
+
+- Gate-denial streaks now use a bounded stable action projection that preserves
+  task role, routing, scope, and target identity while ignoring retry-varying
+  prompts and payload content.
+- Structured gate causes are preferred when supplied as own data properties;
+  generic `BLOCKED`, `WRITE BLOCKED`, and legacy sandbox prefixes remain
+  unclassified.
+- Hard-rung guidance and advisories identify only the exact action digest and
+  offer diagnose, repair/rescope, handoff, abort, and Full-Auto exit choices.
+
+## Why
+
+Previously, distinct actions and denial causes could pool into one streak, and a
+successful unrelated action could clear it. The hard guidance also told the
+agent to stop all tool calls, obscuring safe recovery paths.
+
+## Migration
+
+No migration is required. The public tracker and circuit bounds remain
+unchanged.

--- a/src/hooks/gate-denial-tracker.ts
+++ b/src/hooks/gate-denial-tracker.ts
@@ -202,6 +202,14 @@ function gateActionArgs(tool: string, args: unknown): Record<string, unknown> {
 		boundedActionScalar,
 	);
 	if (taskId !== undefined) projection.taskId = taskId;
+	if (normalizedTool === 'update_task_status') {
+		const status = readFirstNormalizedOwnDataValue(
+			record,
+			['status'],
+			boundedActionScalar,
+		);
+		if (status !== undefined) projection.status = status;
+	}
 	const phase = readFirstNormalizedOwnDataValue(
 		record,
 		['phase', 'phase_number'],

--- a/src/hooks/gate-denial-tracker.ts
+++ b/src/hooks/gate-denial-tracker.ts
@@ -8,21 +8,18 @@
  *
  * This module owns that counter. `noteGateDenial` is called from the single
  * catch site wrapping the fail-closed chain in `src/index.ts`. It:
- *   1. classifies the denial by the leading code token of the error message,
- *   2. increments a per-(sessionID, toolName, discriminator, code) streak,
+ *   1. classifies the denial by its bounded structured cause (falling back to
+ *      the leading code token of the error message),
+ *   2. increments a per-(sessionID, invocationID, stable action, cause) streak,
  *   3. APPENDS (never rewrites) escalating guidance to the error message so the
  *      model reads it in the tool-rejection text, and
  *   4. at the hard rung, pushes an advisory + emits telemetry.
  *
- * The DISCRIMINATOR (reviewer round-4 REQUIRED 2) is the canonicalized
- * `subagent_type` of a `Task` call, and the empty string for every other tool.
- * Without it the reset was too wide: `resetGateDenialStreaks` drops a whole
- * (session, tool) prefix on any successful completion of that tool, so ONE
- * successful `Task` → `explorer` erased a 4-deep `ACCEPTANCE_FIELD_REQUIRED`
- * streak on `Task` → `coder`. Under the interleaving the loop actually
- * exhibits — deny coder, delegate an explorer to investigate, deny coder again —
- * the STOP rung was unreachable. Sub-scoping both the count and the reset by
- * dispatch target makes a success clear only what plausibly succeeded.
+ * The action projection intentionally retains only stable routing fields. It
+ * canonicalizes the `Task` role and target aliases, while omitting prompts,
+ * command content, and other retry-varying payloads. The same projection is
+ * used by note, reset, and the test peek/expiry seams, so a success can clear
+ * only what plausibly succeeded.
  *
  * Invariants this module must not break:
  *   - The caller ALWAYS rethrows. Decoration is append-only, so the leading
@@ -44,6 +41,7 @@
  * import would create a cycle.
  */
 
+import { createHash } from 'node:crypto';
 import { stripKnownSwarmPrefix } from '../config/schema';
 import { SPAWN_CIRCUIT_DENIAL_CODE } from '../dispatch/spawn-circuit.js';
 import {
@@ -85,17 +83,191 @@ export const DEFAULT_GATE_DENIAL_STOP_THRESHOLD = 5;
  * streak into singletons.
  */
 const MAX_CODE_LENGTH = 64;
+const MAX_ACTION_STRING_LENGTH = 128;
+const MAX_ACTION_PATH_PREFIX_ITEMS = 64;
+const STABLE_TARGET_KEYS = ['url', 'uri', 'source_url', 'pr_url'] as const;
 
 /** Classification used when the message carries no recognisable code token. */
 export const UNCLASSIFIED_GATE_DENIAL_CODE = 'UNCLASSIFIED';
 
-function gateActionArgs(
-	tool: string,
-	_args: unknown,
-	discriminator: string,
-): Record<string, unknown> {
-	if (normalizeToolNameLowerCase(tool ?? '') !== 'task') return {};
-	return discriminator ? { subagent_type: discriminator } : {};
+function readOwnDataValue(record: unknown, key: string): unknown {
+	if (!record || typeof record !== 'object' || Array.isArray(record))
+		return undefined;
+	try {
+		const descriptor = Object.getOwnPropertyDescriptor(record, key);
+		return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function readFirstNormalizedOwnDataValue<T>(
+	record: unknown,
+	keys: readonly string[],
+	normalize: (value: unknown) => T | undefined,
+): T | undefined {
+	for (const key of keys) {
+		const value = readOwnDataValue(record, key);
+		try {
+			const normalized = normalize(value);
+			if (normalized !== undefined) return normalized;
+		} catch {
+			/* A malformed argument cannot break the fail-closed caller. */
+		}
+	}
+	return undefined;
+}
+
+function boundedActionString(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	// Keep the semantic value intact here. `createActionIdentity` applies the
+	// shared bounded hashing policy to public fields and path collections; raw
+	// prefix truncation would make two long targets collide.
+	return trimmed;
+}
+
+function boundedActionScalar(
+	value: unknown,
+): string | number | boolean | undefined {
+	if (typeof value === 'string') return boundedActionString(value);
+	if (typeof value === 'number' && Number.isFinite(value)) return value;
+	if (typeof value === 'boolean') return value;
+	return undefined;
+}
+
+function boundedStableTarget(value: unknown): string | undefined {
+	const normalized = boundedActionString(value);
+	if (normalized === undefined || hasControlCharacters(normalized)) {
+		return undefined;
+	}
+	return normalized;
+}
+
+interface PathAliasProjection {
+	value: string | string[];
+	tailDigest?: string;
+}
+
+function boundedPathAlias(value: unknown): PathAliasProjection | undefined {
+	if (typeof value === 'string') {
+		const normalized = boundedActionString(value);
+		return normalized === undefined ? undefined : { value: normalized };
+	}
+	if (!Array.isArray(value)) return undefined;
+	try {
+		const paths = value
+			.map((entry) => boundedActionString(entry))
+			.filter((entry): entry is string => entry !== undefined);
+		if (paths.length === 0) return undefined;
+		const normalizedPaths = [...new Set(paths)].sort();
+		if (normalizedPaths.length <= MAX_ACTION_PATH_PREFIX_ITEMS) {
+			return { value: normalizedPaths };
+		}
+		const tailHasher = createHash('sha256');
+		tailHasher.update(
+			`tail-count:${normalizedPaths.length - MAX_ACTION_PATH_PREFIX_ITEMS};`,
+		);
+		for (
+			let index = MAX_ACTION_PATH_PREFIX_ITEMS;
+			index < normalizedPaths.length;
+			index += 1
+		) {
+			const pathValue = normalizedPaths[index];
+			// Index and value length framing keeps concatenations unambiguous while
+			// the hash keeps raw paths out of the action projection.
+			tailHasher.update(`entry-index:${index};length:${pathValue.length};`);
+			tailHasher.update(pathValue);
+		}
+		const tailDigest = tailHasher.digest('hex').slice(0, 16);
+		return { value: normalizedPaths, tailDigest };
+	} catch {
+		return undefined;
+	}
+}
+
+function gateActionArgs(tool: string, args: unknown): Record<string, unknown> {
+	const projection: Record<string, unknown> = {};
+	const normalizedTool = normalizeToolNameLowerCase(tool ?? '');
+	if (normalizedTool === 'task') {
+		const discriminator = gateDenialDiscriminator(tool, args);
+		if (discriminator) projection.subagent_type = discriminator;
+	}
+
+	const record = args;
+	const taskId = readFirstNormalizedOwnDataValue(
+		record,
+		['taskId', 'task_id', 'id'],
+		boundedActionScalar,
+	);
+	if (taskId !== undefined) projection.taskId = taskId;
+	const phase = readFirstNormalizedOwnDataValue(
+		record,
+		['phase', 'phase_number'],
+		boundedActionScalar,
+	);
+	if (phase !== undefined) projection.phase = phase;
+	const mode = readFirstNormalizedOwnDataValue(
+		record,
+		['mode', 'execution_mode'],
+		boundedActionScalar,
+	);
+	if (mode !== undefined) projection.mode = mode;
+	const background = readFirstNormalizedOwnDataValue(
+		record,
+		['background', 'run_in_background', 'runInBackground'],
+		(value) => {
+			if (typeof value === 'boolean') return value;
+			if (typeof value !== 'string') return undefined;
+			const normalized = value.trim().toLowerCase();
+			return normalized === 'true'
+				? true
+				: normalized === 'false'
+					? false
+					: undefined;
+		},
+	);
+	if (background !== undefined) projection.background = background;
+	const workingDirectory = readFirstNormalizedOwnDataValue(
+		record,
+		['working_directory', 'workingDirectory'],
+		boundedActionScalar,
+	);
+	if (workingDirectory !== undefined) {
+		projection.working_directory = workingDirectory;
+	}
+	const scopeId = readFirstNormalizedOwnDataValue(
+		record,
+		['scope_id', 'scopeId', 'scope'],
+		boundedActionScalar,
+	);
+	if (scopeId !== undefined) projection.scope_id = scopeId;
+	const pathAlias = readFirstNormalizedOwnDataValue(
+		record,
+		['filePath', 'file', 'path', 'paths', 'files'],
+		boundedPathAlias,
+	);
+	if (pathAlias !== undefined) {
+		projection.path = pathAlias.value;
+		if (pathAlias.tailDigest !== undefined) {
+			projection.path_tail_digest = pathAlias.tailDigest;
+		}
+	}
+	const stableTarget = readFirstNormalizedOwnDataValue(
+		record,
+		STABLE_TARGET_KEYS,
+		boundedStableTarget,
+	);
+	if (stableTarget !== undefined) projection.url = stableTarget;
+	return projection;
+}
+
+function gateActionIdentity(tool: string, args: unknown) {
+	return createActionIdentity({
+		tool: normalizeToolNameLowerCase(tool ?? ''),
+		args: gateActionArgs(tool, args),
+	});
 }
 
 /**
@@ -126,8 +298,7 @@ const MAX_DISCRIMINATOR_LENGTH = 64;
 export function gateDenialDiscriminator(tool: string, args: unknown): string {
 	try {
 		if (normalizeToolNameLowerCase(tool ?? '') !== 'task') return '';
-		const subagentType = (args as Record<string, unknown> | undefined)
-			?.subagent_type;
+		const subagentType = readOwnDataValue(args, 'subagent_type');
 		if (typeof subagentType !== 'string' || subagentType.length === 0) {
 			return '';
 		}
@@ -160,7 +331,63 @@ export function deriveGateDenialCode(message: string): string {
 	if (candidate.length === 0 || candidate.length > MAX_CODE_LENGTH) {
 		return UNCLASSIFIED_GATE_DENIAL_CODE;
 	}
+	if (isGenericLegacyGateCode(candidate)) {
+		return UNCLASSIFIED_GATE_DENIAL_CODE;
+	}
 	return candidate;
+}
+
+function isGenericLegacyGateCode(candidate: string): boolean {
+	const normalized = candidate.trim().replace(/\s+/g, ' ').toUpperCase();
+	return (
+		normalized === 'BLOCKED' ||
+		normalized === 'WRITE BLOCKED' ||
+		normalized.startsWith('[SANDBOX] BLOCKED') ||
+		normalized.startsWith('SANDBOX BLOCKED') ||
+		normalized.startsWith('SANDBOX_')
+	);
+}
+
+function boundedStructuredGateCode(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const candidate = value.trim();
+	if (
+		candidate.length === 0 ||
+		candidate.length > MAX_CODE_LENGTH ||
+		hasControlCharacters(candidate)
+	) {
+		return undefined;
+	}
+	if (isGenericLegacyGateCode(candidate)) return undefined;
+	return candidate;
+}
+
+function hasControlCharacters(value: string): boolean {
+	for (const character of value) {
+		const code = character.charCodeAt(0);
+		if (code <= 0x1f || code === 0x7f) return true;
+	}
+	return false;
+}
+
+/**
+ * Resolve a denial cause from an own data property only. Accessors and
+ * inherited values are intentionally ignored so a hostile/frozen error cannot
+ * make tracking invoke arbitrary code. The message parser remains the
+ * trajectory logger's message-only boundary.
+ */
+export function deriveStructuredGateDenialCode(
+	err: unknown,
+): string | undefined {
+	for (const key of ['gateCode', 'code'] as const) {
+		const candidate = boundedStructuredGateCode(readOwnDataValue(err, key));
+		if (candidate !== undefined) return candidate;
+	}
+	return undefined;
+}
+
+function deriveGateDenialCause(err: unknown, message: string): string {
+	return deriveStructuredGateDenialCode(err) ?? deriveGateDenialCode(message);
 }
 
 /**
@@ -182,6 +409,9 @@ export function isAbortLikeError(err: unknown): boolean {
 
 /** The append-only warn rung. Exported so tests assert the exact wording. */
 export function gateDenialWarnText(count: number, code: string): string {
+	if (code === UNCLASSIFIED_GATE_DENIAL_CODE) {
+		return `\n[swarm] This is denial #${count} with no stable cause classification. Do NOT retry the same dispatch; diagnose the current blocker and present it to the user if it persists.`;
+	}
 	return `\n[swarm] This is denial #${count} with the same cause (${code}). Do NOT retry the same dispatch; fix the named cause or present the blocker to the user.`;
 }
 
@@ -193,8 +423,12 @@ export function gateDenialStopText(
 	count: number,
 	code: string,
 	tool: string,
+	actionPattern = tool,
 ): string {
-	return `\n[swarm] GATE DENIAL LOOP: ${count} consecutive ${code} denial(s) for tool ${tool}. STOP tool calls and report the blocker to the user with the full error text.`;
+	const safePattern = actionPattern
+		.slice(0, MAX_ACTION_STRING_LENGTH)
+		.replace(/[^a-zA-Z0-9_.:-]/g, '_');
+	return `\n[swarm] GATE DENIAL LOOP: ${count} consecutive ${code} denial(s) for action ${safePattern}. Do not retry this exact action unchanged. Diagnose the current cause, then repair or rescope it; otherwise handoff, abort, or exit Full-Auto.`;
 }
 
 export interface GateDenialOptions {
@@ -280,20 +514,16 @@ export function noteGateDenial(
 		// 9); every retry of an open action is already denied before any
 		// host launch, so containment does not depend on a second STOP rung.
 		const errorObject = err as { message: string };
-		const code = deriveGateDenialCode(errorObject.message);
+		const code = deriveGateDenialCause(err, errorObject.message);
 		if (code === SPAWN_CIRCUIT_DENIAL_CODE) {
 			return NOT_COUNTED;
 		}
 
 		const originalMessage = errorObject.message;
 		const normalizedTool = normalizeToolNameLowerCase(tool ?? '');
-		const discriminator = gateDenialDiscriminator(tool, args);
 		const session = ensureAgentSession(sessionID);
 		const invocationID = session.activeInvocationId ?? 0;
-		const action = createActionIdentity({
-			tool: normalizedTool,
-			args: gateActionArgs(tool, args, discriminator),
-		});
+		const action = gateActionIdentity(tool, args);
 		const generationToken = armActionCircuitAttempt(
 			sessionID,
 			invocationID,
@@ -341,7 +571,14 @@ export function noteGateDenial(
 
 		let appended = '';
 		if (warned) appended += gateDenialWarnText(count, code);
-		if (stopped) appended += gateDenialStopText(count, code, normalizedTool);
+		if (stopped) {
+			appended += gateDenialStopText(
+				count,
+				code,
+				normalizedTool,
+				action.pattern,
+			);
+		}
 
 		let decorated = false;
 		try {
@@ -355,12 +592,17 @@ export function noteGateDenial(
 		}
 
 		if (stopped) {
+			const stopText = gateDenialStopText(
+				count,
+				code,
+				normalizedTool,
+				action.pattern,
+			);
+			const advisoryKey = `[swarm:gate-denial-loop:${code}:${action.digest.slice(0, 12)}]`;
 			try {
-				pushAdvisory(
-					session,
-					`[swarm:gate-denial-loop:${code}] GATE DENIAL LOOP: ${count} consecutive ${code} denial(s) for tool ${normalizedTool}. STOP tool calls and report the blocker to the user with the full error text.`,
-					{ dedupeKey: `[swarm:gate-denial-loop:${code}]` },
-				);
+				pushAdvisory(session, `${advisoryKey}${stopText}`, {
+					dedupeKey: advisoryKey,
+				});
 			} catch {
 				/* advisory delivery is best-effort; never blocks the rethrow */
 			}
@@ -411,10 +653,7 @@ export function resetGateDenialStreaks(
 	try {
 		const session = getAgentSession(sessionID);
 		const invocationID = session?.activeInvocationId ?? 0;
-		const action = createActionIdentity({
-			tool: normalizeToolNameLowerCase(tool ?? ''),
-			args: gateActionArgs(tool, args, gateDenialDiscriminator(tool, args)),
-		});
+		const action = gateActionIdentity(tool, args);
 		clearActionCircuit(sessionID, invocationID, action.digest, {
 			reason: 'success',
 		});
@@ -447,15 +686,15 @@ export const _test_exports = {
 		sessionID: string,
 		tool: string,
 		code: string,
-		discriminator = '',
+		target: unknown = undefined,
 	): number =>
 		peekActionCircuitCount(
 			sessionID,
 			getAgentSession(sessionID)?.activeInvocationId ?? 0,
-			createActionIdentity({
-				tool: normalizeToolNameLowerCase(tool),
-				args: gateActionArgs(tool, undefined, discriminator),
-			}).digest,
+			gateActionIdentity(
+				tool,
+				typeof target === 'string' ? { subagent_type: target } : target,
+			).digest,
 			`policy.gate_denial:${code}`,
 		),
 	/** Force a streak's TTL into the past so eviction can be tested. */
@@ -463,15 +702,15 @@ export const _test_exports = {
 		sessionID: string,
 		tool: string,
 		code: string,
-		discriminator = '',
+		target: unknown = undefined,
 	): void => {
 		expireActionCircuit(
 			sessionID,
 			getAgentSession(sessionID)?.activeInvocationId ?? 0,
-			createActionIdentity({
-				tool: normalizeToolNameLowerCase(tool),
-				args: gateActionArgs(tool, undefined, discriminator),
-			}).digest,
+			gateActionIdentity(
+				tool,
+				typeof target === 'string' ? { subagent_type: target } : target,
+			).digest,
 			`policy.gate_denial:${code}`,
 		);
 	},

--- a/tests/unit/hooks/gate-denial-guidance-2574.test.ts
+++ b/tests/unit/hooks/gate-denial-guidance-2574.test.ts
@@ -79,6 +79,41 @@ describe('issue #2574 stable action and cause identity', () => {
 		).toBe(1);
 	});
 
+	test('semantic status transitions do not pool one update_task_status action', () => {
+		const session = '2574-status-action';
+		startAgentSession(session, 'architect');
+		const completed = { task_id: '1.1', status: 'completed' };
+		const blocked = { task_id: '1.1', status: 'blocked' };
+
+		expect(
+			noteGateDenial(
+				session,
+				'update_task_status',
+				cause('CAUSE'),
+				undefined,
+				completed,
+			).count,
+		).toBe(1);
+		expect(
+			noteGateDenial(
+				session,
+				'update_task_status',
+				cause('CAUSE'),
+				undefined,
+				blocked,
+			).count,
+		).toBe(1);
+		expect(
+			noteGateDenial(
+				session,
+				'update_task_status',
+				cause('CAUSE'),
+				undefined,
+				completed,
+			).count,
+		).toBe(2);
+	});
+
 	test('C2: identical stable action and cause still reaches the ladder', () => {
 		const session = '2574-c2';
 		startAgentSession(session, 'architect');

--- a/tests/unit/hooks/gate-denial-guidance-2574.test.ts
+++ b/tests/unit/hooks/gate-denial-guidance-2574.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import {
+	_test_exports,
+	clearGateDenialStreaks,
+	DEFAULT_GATE_DENIAL_STOP_THRESHOLD,
+	deriveGateDenialCode,
+	deriveStructuredGateDenialCode,
+	noteGateDenial,
+	resetGateDenialStreaks,
+	UNCLASSIFIED_GATE_DENIAL_CODE,
+} from '../../../src/hooks/gate-denial-tracker';
+import {
+	resetSwarmState,
+	startAgentSession,
+	swarmState,
+} from '../../../src/state';
+import {
+	initTelemetry,
+	resetTelemetryForTesting,
+} from '../../../src/telemetry';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const cause = (code = 'SCOPE_NOT_DECLARED', detail = 'denied') =>
+	new Error(`${code}: ${detail}`);
+
+let tempDir = '';
+
+function advisoriesFor(sessionID: string): string[] {
+	return swarmState.agentSessions.get(sessionID)?.pendingAdvisoryMessages ?? [];
+}
+
+beforeEach(() => {
+	resetTelemetryForTesting();
+	resetSwarmState();
+	clearGateDenialStreaks();
+	tempDir = canonicalMkdtemp('gate-denial-2574-');
+	initTelemetry(tempDir);
+});
+
+afterEach(() => {
+	resetTelemetryForTesting();
+	resetSwarmState();
+	clearGateDenialStreaks();
+	if (tempDir && fs.existsSync(tempDir)) {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe('issue #2574 stable action and cause identity', () => {
+	test('C1: distinct canonical paths do not pool a shared structured cause', () => {
+		const session = '2574-c1-action';
+		startAgentSession(session, 'architect');
+		const first = Object.assign(cause('MESSAGE_A'), { gateCode: 'CAUSE' });
+		const second = Object.assign(cause('MESSAGE_B'), { gateCode: 'CAUSE' });
+
+		expect(
+			noteGateDenial(session, 'read', first, undefined, { filePath: 'a.ts' })
+				.count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'read', second, undefined, { filePath: 'b.ts' })
+				.count,
+		).toBe(1);
+	});
+
+	test('C1: distinct structured causes do not pool a shared canonical path', () => {
+		const session = '2574-c1-cause';
+		startAgentSession(session, 'architect');
+		const first = Object.assign(cause('MESSAGE_A'), { gateCode: 'CAUSE_A' });
+		const second = Object.assign(cause('MESSAGE_B'), { code: 'CAUSE_B' });
+		expect(
+			noteGateDenial(session, 'read', first, undefined, { path: 'same.ts' })
+				.count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'read', second, undefined, { path: 'same.ts' })
+				.count,
+		).toBe(1);
+	});
+
+	test('C2: identical stable action and cause still reaches the ladder', () => {
+		const session = '2574-c2';
+		startAgentSession(session, 'architect');
+		const args = { filePath: 'same.ts' };
+		let outcome = noteGateDenial(
+			session,
+			'read',
+			cause('CAUSE'),
+			undefined,
+			args,
+		);
+		for (let index = 1; index < DEFAULT_GATE_DENIAL_STOP_THRESHOLD; index++) {
+			outcome = noteGateDenial(
+				session,
+				'read',
+				cause('CAUSE'),
+				undefined,
+				args,
+			);
+		}
+		expect(outcome.count).toBe(DEFAULT_GATE_DENIAL_STOP_THRESHOLD);
+		expect(outcome.stopped).toBe(true);
+	});
+
+	test('C3: reset, peek, and expiry target one semantic action', () => {
+		const session = '2574-c3';
+		startAgentSession(session, 'architect');
+		const first = { path: 'first.ts' };
+		const second = { path: 'second.ts' };
+		noteGateDenial(session, 'read', cause('CAUSE'), undefined, first);
+		noteGateDenial(session, 'read', cause('CAUSE'), undefined, first);
+		noteGateDenial(session, 'read', cause('CAUSE'), undefined, second);
+
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', first)).toBe(2);
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', second)).toBe(1);
+		resetGateDenialStreaks(session, 'read', second);
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', first)).toBe(2);
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', second)).toBe(0);
+		_test_exports.expireStreak(session, 'read', 'CAUSE', first);
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', first)).toBe(2);
+		noteGateDenial(session, 'other', cause('CAUSE'));
+		expect(_test_exports.peekStreak(session, 'read', 'CAUSE', first)).toBe(0);
+	});
+
+	test('C4: sessions and invocations remain independent', () => {
+		startAgentSession('2574-c4-a', 'architect');
+		startAgentSession('2574-c4-b', 'architect');
+		const args = { filePath: 'same.ts' };
+		noteGateDenial('2574-c4-a', 'read', cause('CAUSE'), undefined, args);
+		swarmState.agentSessions.get('2574-c4-a')!.activeInvocationId = 1;
+		noteGateDenial('2574-c4-a', 'read', cause('CAUSE'), undefined, args);
+		expect(_test_exports.peekStreak('2574-c4-a', 'read', 'CAUSE', args)).toBe(
+			1,
+		);
+		expect(_test_exports.peekStreak('2574-c4-b', 'read', 'CAUSE', args)).toBe(
+			0,
+		);
+	});
+
+	test('C5: hard guidance keeps executable recovery choices', () => {
+		const session = '2574-c5';
+		startAgentSession(session, 'architect');
+		let last = cause('SCOPE_NOT_DECLARED');
+		for (let index = 0; index < DEFAULT_GATE_DENIAL_STOP_THRESHOLD; index++) {
+			last = cause('SCOPE_NOT_DECLARED');
+			noteGateDenial(session, 'read', last, undefined, { path: 'safe.ts' });
+		}
+		expect(last.message).toContain('Diagnose the current cause');
+		expect(last.message).toContain('repair or rescope');
+		expect(last.message).toContain('handoff, abort, or exit Full-Auto');
+		expect(last.message).not.toContain('STOP tool calls');
+	});
+
+	test('volatile payloads are excluded while stable aliases and Task prefixes converge', () => {
+		const session = '2574-aliases';
+		startAgentSession(session, 'architect');
+		const first = {
+			subagent_type: 'mega_coder',
+			task_id: 'task-1',
+			phase_number: 2,
+			execution_mode: 'full-auto',
+			run_in_background: true,
+			workingDirectory: 'workspace',
+			scopeId: 'scope-1',
+			filePath: 'src/app.ts',
+			prompt: 'first volatile prompt',
+			content: 'first volatile content',
+		};
+		const second = {
+			subagent_type: 'coder',
+			taskId: 'task-1',
+			phase: 2,
+			mode: 'full-auto',
+			background: true,
+			working_directory: 'workspace',
+			scope_id: 'scope-1',
+			path: 'src/app.ts',
+			prompt: 'second volatile prompt',
+			content: 'second volatile content',
+		};
+		expect(
+			noteGateDenial(session, 'Task', cause('CAUSE'), undefined, first).count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'Task', cause('CAUSE'), undefined, second).count,
+		).toBe(2);
+	});
+
+	test('stable URL targets isolate counts and reset without pooling volatile fields', () => {
+		const session = '2574-url-targets';
+		startAgentSession(session, 'architect');
+		const first = {
+			url: 'https://example.test/first',
+			query: 'retry-varying query one',
+			command: 'retry-varying command one',
+			metadata: { attempt: 1 },
+		};
+		const second = {
+			url: 'https://example.test/second',
+			query: 'retry-varying query two',
+			command: 'retry-varying command two',
+			metadata: { attempt: 2 },
+		};
+		expect(
+			noteGateDenial(session, 'web_fetch', cause('CAUSE'), undefined, first)
+				.count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'web_fetch', cause('CAUSE'), undefined, second)
+				.count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'web_fetch', cause('CAUSE'), undefined, {
+				...first,
+				query: 'changed query',
+				command: 'changed command',
+				metadata: { attempt: 3 },
+			}).count,
+		).toBe(2);
+		resetGateDenialStreaks(session, 'web_fetch', second);
+		expect(_test_exports.peekStreak(session, 'web_fetch', 'CAUSE', first)).toBe(
+			2,
+		);
+		expect(
+			_test_exports.peekStreak(session, 'web_fetch', 'CAUSE', second),
+		).toBe(0);
+	});
+
+	test('distinct path tails remain distinct after the first 64 path entries', () => {
+		const session = '2574-path-tail';
+		startAgentSession(session, 'architect');
+		const sharedPrefix = Array.from(
+			{ length: 64 },
+			(_, index) => `shared-${index}.ts`,
+		);
+		const first = { paths: [...sharedPrefix, 'tail-a.ts'] };
+		const second = { paths: [...sharedPrefix, 'tail-b.ts'] };
+
+		expect(
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, first).count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, second).count,
+		).toBe(1);
+	});
+
+	test('a middle tail difference remains distinct beyond sampled head and tail windows', () => {
+		const session = '2574-path-middle-tail';
+		startAgentSession(session, 'architect');
+		const shared = Array.from(
+			{ length: 129 },
+			(_, index) => `path-${String(index).padStart(3, '0')}`,
+		);
+		const first = { paths: shared };
+		const second = {
+			paths: shared.map((value) =>
+				value === 'path-096' ? 'path-096-z' : value,
+			),
+		};
+
+		// Index 96 is outside both the old first-32 and last-32 tail samples;
+		// a sampled digest would collide here despite equal collection length.
+		expect(
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, first).count,
+		).toBe(1);
+		expect(
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, second).count,
+		).toBe(1);
+	});
+
+	test('an unusable earlier path alias does not mask a later valid alias', () => {
+		const unusableAliases = [null, '', 42] as const;
+		const counts = unusableAliases.map((unusable, index) => {
+			const session = `2574-later-path-${index}`;
+			startAgentSession(session, 'architect');
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, {
+				filePath: unusable,
+				path: 'first.ts',
+			});
+			return noteGateDenial(session, 'read', cause('CAUSE'), undefined, {
+				filePath: unusable,
+				path: 'second.ts',
+			}).count;
+		});
+
+		expect(counts).toEqual([1, 1, 1]);
+	});
+});
+
+describe('issue #2574 structured cause boundaries', () => {
+	test('structured causes use own data properties without invoking getters', () => {
+		const err = cause('MESSAGE_CAUSE');
+		let getterCalls = 0;
+		Object.defineProperty(err, 'gateCode', {
+			configurable: true,
+			get: () => {
+				getterCalls += 1;
+				return 'GETTER_CAUSE';
+			},
+		});
+		expect(deriveStructuredGateDenialCode(err)).toBeUndefined();
+		expect(getterCalls).toBe(0);
+		expect(deriveGateDenialCode('BLOCKED: generic')).toBe(
+			UNCLASSIFIED_GATE_DENIAL_CODE,
+		);
+		expect(deriveGateDenialCode('WRITE BLOCKED: generic')).toBe(
+			UNCLASSIFIED_GATE_DENIAL_CODE,
+		);
+		expect(deriveGateDenialCode('[sandbox] BLOCKED: generic')).toBe(
+			UNCLASSIFIED_GATE_DENIAL_CODE,
+		);
+	});
+
+	test('a generic gateCode falls through to a later specific own-data code', () => {
+		const err = Object.assign(cause('MESSAGE_CAUSE'), {
+			gateCode: 'BLOCKED',
+			code: 'SPECIFIC_GATE_CAUSE',
+		});
+		expect(deriveStructuredGateDenialCode(err)).toBe('SPECIFIC_GATE_CAUSE');
+	});
+
+	test('unclassified warnings do not claim a proven shared cause', () => {
+		const session = '2574-generic-warning';
+		startAgentSession(session, 'architect');
+		let last = new Error('BLOCKED: first generic reason');
+		for (let index = 0; index < 3; index++) {
+			last = new Error(`BLOCKED: generic reason ${index}`);
+			noteGateDenial(session, 'read', last, undefined, { path: 'same.ts' });
+		}
+		expect(last.message).toContain('no stable cause classification');
+		expect(last.message).not.toContain('with the same cause');
+	});
+
+	test('advisories are action-local and do not expose target paths', () => {
+		const session = '2574-advisory';
+		startAgentSession(session, 'architect');
+		const secretPath = 'private-secret-path.ts';
+		for (let index = 0; index < DEFAULT_GATE_DENIAL_STOP_THRESHOLD; index++) {
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, {
+				path: secretPath,
+			});
+		}
+		for (let index = 0; index < DEFAULT_GATE_DENIAL_STOP_THRESHOLD; index++) {
+			noteGateDenial(session, 'read', cause('CAUSE'), undefined, {
+				path: 'other.ts',
+			});
+		}
+		const advisories = advisoriesFor(session);
+		expect(advisories).toHaveLength(2);
+		expect(advisories.join('\n')).not.toContain(secretPath);
+		expect(advisories[0]).toContain('Diagnose the current cause');
+	});
+});

--- a/tests/unit/hooks/gate-denial-scoping.test.ts
+++ b/tests/unit/hooks/gate-denial-scoping.test.ts
@@ -27,7 +27,6 @@ import {
 	clearGateDenialStreaks,
 	DEFAULT_GATE_DENIAL_STOP_THRESHOLD,
 	gateDenialDiscriminator,
-	gateDenialStopText,
 	noteGateDenial,
 	resetGateDenialStreaks,
 	UNCLASSIFIED_GATE_DENIAL_CODE,
@@ -143,11 +142,10 @@ describe('#2063 B1 — per-discriminator streak scoping (reviewer r4)', () => {
 		expect(outcome.count).toBe(DEFAULT_GATE_DENIAL_STOP_THRESHOLD);
 		expect(outcome.stopped).toBe(true);
 		expect(fifth.message).toContain(
-			gateDenialStopText(
-				DEFAULT_GATE_DENIAL_STOP_THRESHOLD,
-				ACCEPTANCE,
-				'task',
-			),
+			`GATE DENIAL LOOP: ${DEFAULT_GATE_DENIAL_STOP_THRESHOLD} consecutive ${ACCEPTANCE} denial(s) for action `,
+		);
+		expect(fifth.message).toContain(
+			'Do not retry this exact action unchanged.',
 		);
 		expect(advisoriesFor(session)).toHaveLength(1);
 		expect(events.filter((e) => e.event === 'gate_denial_loop')).toHaveLength(

--- a/tests/unit/hooks/gate-denial-tracker.test.ts
+++ b/tests/unit/hooks/gate-denial-tracker.test.ts
@@ -131,9 +131,10 @@ describe('escalation ladder', () => {
 		startAgentSession(session, 'architect');
 
 		let last: Error | null = null;
+		const args = { path: 'C:/private/secret-project/file.ts' };
 		for (let i = 0; i < DEFAULT_GATE_DENIAL_STOP_THRESHOLD; i++) {
 			last = denial();
-			noteGateDenial(session, 'Task', last);
+			noteGateDenial(session, 'Task', last, undefined, args);
 		}
 		const err = last as Error;
 
@@ -152,6 +153,7 @@ describe('escalation ladder', () => {
 		expect(advisories[0]).toMatch(
 			new RegExp(`^\\[swarm:gate-denial-loop:${DENY}:[0-9a-f]{12}\\]`),
 		);
+		expect(advisories[0]).not.toContain(args.path);
 
 		const emitted = events.filter((e) => e.event === 'gate_denial_loop');
 		expect(emitted).toHaveLength(1);

--- a/tests/unit/hooks/gate-denial-tracker.test.ts
+++ b/tests/unit/hooks/gate-denial-tracker.test.ts
@@ -18,7 +18,6 @@ import {
 	DEFAULT_GATE_DENIAL_STOP_THRESHOLD,
 	DEFAULT_GATE_DENIAL_WARN_THRESHOLD,
 	deriveGateDenialCode,
-	gateDenialStopText,
 	gateDenialWarnText,
 	isAbortLikeError,
 	noteGateDenial,
@@ -138,19 +137,21 @@ describe('escalation ladder', () => {
 		}
 		const err = last as Error;
 
-		// Both rungs are present at the hard rung — warn first, then STOP.
-		expect(err.message).toBe(
-			`${DENY}: task 1.1 has no active scope binding` +
-				gateDenialWarnText(5, DENY) +
-				gateDenialStopText(5, DENY, 'task'),
-		);
+		// Both rungs are present at the hard rung — warn first, then recovery.
+		expect(err.message).toContain(gateDenialWarnText(5, DENY));
 		expect(err.message).toContain(
-			'STOP tool calls and report the blocker to the user with the full error text.',
+			`GATE DENIAL LOOP: 5 consecutive ${DENY} denial(s) for action `,
 		);
+		expect(err.message).toContain('Do not retry this exact action unchanged.');
+		expect(err.message).toContain('Diagnose the current cause');
+		expect(err.message).toContain('repair or rescope');
+		expect(err.message).toContain('handoff, abort, or exit Full-Auto');
 
 		const advisories = advisoriesFor(session);
 		expect(advisories).toHaveLength(1);
-		expect(advisories[0]).toContain(`[swarm:gate-denial-loop:${DENY}]`);
+		expect(advisories[0]).toMatch(
+			new RegExp(`^\\[swarm:gate-denial-loop:${DENY}:[0-9a-f]{12}\\]`),
+		);
 
 		const emitted = events.filter((e) => e.event === 'gate_denial_loop');
 		expect(emitted).toHaveLength(1);


### PR DESCRIPTION
Closes #2574

## Summary

- Scope gate-denial streaks by stable action identity, structured denial cause, session, and invocation so distinct actions cannot pool or cross-reset.
- Preserve bounded, privacy-safe target identity for paths and URL/URI aliases while excluding retry-varying prompts, commands, queries, metadata, and arbitrary payloads.
- Include the semantic `status` selector for `update_task_status` so completed and blocked transitions remain action-local.
- Keep recovery guidance action-local and prove emitted advisories do not expose raw private paths.
- Add focused regressions, a pending release fragment, and recurrence guardrails.

## Invariant audit

- 1 (plugin init): not touched - no initialization or startup work changed.
- 2 (runtime portability): touched - tracker changes use existing portable APIs; `bun run build` and Node dist import pass.
- 3 (subprocesses): not touched - no subprocess call sites changed.
- 4 (.swarm containment): not touched - no runtime state or containment logic changed.
- 5 (plan durability): not touched - no plan ledger or projection changed.
- 6 (test_runner safety): touched - scoped CI-equivalent per-file runner used for impacted suites; no broad test_runner scope used.
- 7 (test writing): touched - `bun:test` regressions use existing temporary-directory helpers; test-tmpdir and mock-cleanup gates pass with only pre-existing warnings.
- 8 (session state): touched - action-circuit keys and reset paths preserve session/invocation ownership; focused scoping suites pass.
- 9 (guardrails/retry): touched - status-transition identity and advisory privacy regressions pass; the complete invariant/guardrail ratchet set passes.
- 10 (chat/system msg): not touched - no chat transform code changed.
- 11 (tool registration): not touched - no tools, agents, commands, or metadata changed; registration check remains green.
- 12 (release/cache): touched - pending release fragment is present and the pending-fragment gate passes.

## Test plan

- `bun run typecheck`
- `bun run lint:ci`
- `bun run build`
- `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"`
- `bun --smol test tests/unit/hooks/gate-denial-guidance-2574.test.ts tests/unit/hooks/gate-denial-tracker.test.ts --timeout 30000`
- `bun run test:unit:ci tests/unit/hooks/gate-denial-guidance-2574.test.ts tests/unit/hooks/gate-denial-tracker.test.ts tests/unit/hooks/gate-denial-scoping.test.ts tests/unit/hooks/gate-denial-wiring.test.ts tests/unit/hooks/execution-stall-wiring.test.ts tests/unit/hooks/internals-guard.test.ts tests/unit/failures/action-circuit.test.ts tests/unit/hooks/spawn-circuit-2507.test.ts`
- Full repository quality/ratchet checks listed in the commit-pr evidence; all passed, with only documented pre-existing advisory warnings.
- Remote `package-check` and `smoke` are required to revalidate this follow-up head; local package smoke was limited by sandbox npm-cache permissions/timeouts.

## Feedback closure

- Hermes review finding: the hard-stop advisory test now asserts the raw private path is absent from the emitted advisory body.
- Local swarm-pr-review finding B-C001: `update_task_status.status` is now included in the bounded action projection, with a regression proving `completed` and `blocked` do not pool.
- Unverified digest-collision and low/info maintainability notes were reviewed and left unchanged because no reproducible correctness defect or acceptance requirement was established.

Migration: none required.
