### PR TITLE
fix(knowledge): bound reviewer directives_to_verify block to one obligation per entry

### DIFF
--- a/docs/releases/pending/2628-bounded-directives-to-verify.md
+++ b/docs/releases/pending/2628-bounded-directives-to-verify.md
@@ -1,0 +1,45 @@
+# Bounded reviewer directive-compliance block (#2628)
+
+## What changed
+
+- The reviewer `<directives_to_verify>` block is now **per-entry bounded**.
+  Previously the block carried one obligation per receipt membership — one per
+  `(trace_id, entry_id)` pair — so a long-lived cohort where knowledge entries
+  were retrieved across many traces grew the block O(entries × trace_ids)
+  (measured 813 KB in the field) until the reviewer's session could not be
+  created and the verification gate permanently blocked.
+- `readPhaseDirectivesToVerify` now returns at most one obligation per entry:
+  a membership whose terminal is `violated` is preferred (it carries the
+  remediation obligation), otherwise the most recently committed membership;
+  ties break by greatest trace_id.
+- The rendered block obeys a hard character ceiling
+  (`min(inject_char_budget ?? 24000, DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP)`,
+  mirroring the #2045 delegate-block bound). Overflow drops non-critical
+  directives first (lowest priority first) with a count note; **critical
+  directives are always rendered**, and when criticals alone exceed the budget
+  the block carries a distinct `critical overflow` notice instead of hiding a
+  phase-blocking obligation. Per-entry lesson/verification_predicate prose is
+  truncated to 400 characters; pair identity and priority stay exact.
+- The phase-complete critical-directive gate now resolves obligations per
+  ENTRY rather than per membership: verifying a directive once (on the shown
+  representative) satisfies the entry's other exposures in the same phase
+  window. An unremediated violation still blocks the phase, and a later
+  `applied` terminal remediates an earlier violated one (an earlier applied
+  never hides a later violation). Architect overrides behave exactly as
+  before.
+- The reviewer output-contract text no longer asks for "one verdict per
+  trace_id × entry_id combination"; it asks for one verdict per listed
+  obligation, copied exactly as before.
+- New guardrail: `tests/unit/hooks/prompt-block-budget-guardrail.test.ts`
+  statically verifies that every prompt-block builder under `src/` references
+  an explicit bounding mechanism (char cap, char/token budget, or item cap),
+  so the next injection surface cannot ship unbounded.
+
+## Why
+
+Long-lived projects with heavy knowledge usage accumulated one verification
+obligation per historical retrieval exposure. The injected block crossed the
+model's input window at reviewer session creation, so review/verification
+gates could never start and the swarm stalled. Bounding the obligation unit to
+the directive (entry) removes the unbounded axis; the hard cap protects the
+remaining vertical axis.

--- a/docs/releases/pending/2628-bounded-directives-to-verify.md
+++ b/docs/releases/pending/2628-bounded-directives-to-verify.md
@@ -20,6 +20,11 @@
   the block carries a distinct `critical overflow` notice instead of hiding a
   phase-blocking obligation. Per-entry lesson/verification_predicate prose is
   truncated to 400 characters; pair identity and priority stay exact.
+- Violation-class terminals now reach the reviewer for remediation: a
+  membership whose terminal is `contradicted` (like `violated`) is shown in the
+  compliance block as a remediation obligation, so a contradicted critical
+  directive can be resolved by a later reviewer verification instead of
+  permanently blocking the phase.
 - The phase-complete critical-directive gate now resolves obligations per
   ENTRY rather than per membership: verifying a directive once (on the shown
   representative) satisfies the entry's other exposures in the same phase

--- a/docs/releases/pending/2628-bounded-directives-to-verify.md
+++ b/docs/releases/pending/2628-bounded-directives-to-verify.md
@@ -9,8 +9,9 @@
   (measured 813 KB in the field) until the reviewer's session could not be
   created and the verification gate permanently blocked.
 - `readPhaseDirectivesToVerify` now returns at most one obligation per entry:
-  a membership whose terminal is `violated` is preferred (it carries the
-  remediation obligation), otherwise the most recently committed membership;
+  a membership whose terminal is `violated` or `contradicted` is preferred
+  (it carries the remediation obligation), otherwise the most recently
+  committed membership;
   ties break by greatest trace_id.
 - The rendered block obeys a hard character ceiling
   (`min(inject_char_budget ?? 24000, DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP)`,

--- a/src/agents/reviewer-directive-compliance.ts
+++ b/src/agents/reviewer-directive-compliance.ts
@@ -49,7 +49,7 @@ export interface DirectiveToVerify {
 	session_id: string;
 	cohort_id?: string;
 	source_link_id?: string;
-	prior_terminal_outcome?: 'violated';
+	prior_terminal_outcome?: 'violated' | 'contradicted';
 	prior_terminal_event_id?: string;
 	priority: DirectivePriority;
 	lesson?: string;
@@ -97,13 +97,21 @@ function renderOptionalText(value: string): string {
 	return JSON.stringify(value);
 }
 
-/** Truncate prose payloads so one huge entry cannot consume the budget. */
+/** Truncate prose payloads so one huge entry cannot consume the budget. The
+ * post-stringify `</` escape (`\/` is valid JSON and round-trips through
+ * JSON.parse) keeps a crafted lesson from embedding a literal
+ * `</directives_to_verify>` close tag that would truncate the parsed
+ * verify-set at reconcile time. */
 function renderTruncatedOptionalText(value: string): string {
 	const truncated =
 		value.length > MAX_FIELD_RENDER_CHARS
 			? `${value.slice(0, MAX_FIELD_RENDER_CHARS)}...`
 			: value;
-	return renderOptionalText(truncated);
+	// The per-field cap is a prose-hygiene limit measured in UTF-16 code units;
+	// budget admission is measured in UTF-8 bytes (Buffer.byteLength below), so
+	// multi-byte content cannot widen the block's ceiling — it only changes how
+	// much prose one field carries.
+	return renderOptionalText(truncated).replace(/<\//g, '<\\/');
 }
 
 function parseOptionalText(value: string): string | undefined {
@@ -162,9 +170,20 @@ export function buildDirectiveComplianceBlock(
 	charBudget?: number,
 ): string | null {
 	if (directives.length === 0) return null;
-	const effectiveBudget = Math.min(
-		charBudget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
-		DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+	// Reserve the fixed post-loop tail (notices allowance + closing tag + blank
+	// line + the static output spec) so admission accounting covers the ENTIRE
+	// rendered block, keeping the ceiling genuinely hard (PR #2636 review).
+	const tailReserve =
+		Buffer.byteLength(
+			`</directives_to_verify>\n\n${DIRECTIVE_COMPLIANCE_OUTPUT_SPEC}`,
+			'utf-8',
+		) + 256; // + bounded allowance for the two count-only notice lines
+	const effectiveBudget = Math.max(
+		0,
+		Math.min(
+			charBudget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+			DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+		) - tailReserve,
 	);
 	const sorted = [...directives].sort((a, b) => {
 		const pr =
@@ -282,11 +301,12 @@ export function parseDirectivesToVerifyBlock(
 			if (sourceLinkId) current.source_link_id = sourceLinkId;
 			continue;
 		}
-		const priorOutcomeM = /^\s+prior_terminal_outcome:\s*(violated)\s*$/.exec(
-			line,
-		);
+		const priorOutcomeM =
+			/^\s+prior_terminal_outcome:\s*(violated|contradicted)\s*$/.exec(line);
 		if (priorOutcomeM) {
-			current.prior_terminal_outcome = 'violated';
+			current.prior_terminal_outcome = priorOutcomeM[1] as
+				| 'violated'
+				| 'contradicted';
 			continue;
 		}
 		const priorEventM =

--- a/src/agents/reviewer-directive-compliance.ts
+++ b/src/agents/reviewer-directive-compliance.ts
@@ -20,6 +20,26 @@ import type { DirectivePriority } from '../hooks/knowledge-types.js';
 /** Marker tag wrapping the per-phase "directives to verify" block. */
 export const DIRECTIVES_TO_VERIFY_TAG = '<directives_to_verify>';
 
+/**
+ * Hard character ceiling for the rendered compliance block (issue #2628,
+ * mirroring the #2045 delegate-block bound). The effective budget is
+ * `min(inject_char_budget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+ * DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP)`; overflow drops NON-critical entries
+ * only — critical obligations are always rendered (see below), so a phase's
+ * blocking set can never be hidden from the one agent that resolves it.
+ */
+export const DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP = 24_000;
+
+/** Default budget when the caller has no configured injection budget. */
+export const DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET = 24_000;
+
+/**
+ * Per-entry lesson/verification_predicate render cap. The pair identity,
+ * priority, and predicate PRESENCE stay exact; only the prose payload is
+ * truncated so a single huge entry cannot eat the whole budget.
+ */
+const MAX_FIELD_RENDER_CHARS = 400;
+
 /** A directive the reviewer must produce a verdict for. */
 export interface DirectiveToVerify {
 	/** Exact retrieval membership this verdict must close. */
@@ -38,13 +58,15 @@ export interface DirectiveToVerify {
 
 /**
  * Static spec embedded in the reviewer system prompt. Documents the mandatory
- * DIRECTIVE_COMPLIANCE output section and its verdict grammar.
+ * DIRECTIVE_COMPLIANCE output section and its verdict grammar. Since #2628 the
+ * shown set carries at most one obligation per entry, so "every listed pair"
+ * is the whole contract — pair identity is still copied exactly.
  */
-export const DIRECTIVE_COMPLIANCE_OUTPUT_SPEC = `DIRECTIVE_COMPLIANCE: one line per retrieval membership shown during this phase. Copy the encoded trace_id and entry_id tokens exactly from the DIRECTIVES TO VERIFY block. Use exactly one of:
+export const DIRECTIVE_COMPLIANCE_OUTPUT_SPEC = `DIRECTIVE_COMPLIANCE: one line per listed obligation. Copy the encoded trace_id and entry_id tokens exactly from the DIRECTIVES TO VERIFY block. Use exactly one of:
   VERIFIED:<trace_id>:<entry_id> evidence=<file:line | predicate_passed>
   VIOLATED:<trace_id>:<entry_id> evidence=<file:line | failing_predicate>
   N/A:<trace_id>:<entry_id> reason=<why it does not apply to this change>
-Every listed trace_id + entry_id pair MUST appear exactly once. The same entry_id may appear under more than one trace_id and requires one verdict per pair. If a directive carries a verification_predicate, you MUST run it and report predicate_passed / failing_predicate as the evidence. Omitting a listed CRITICAL pair is itself a VIOLATED verdict.`;
+Every listed trace_id + entry_id pair MUST appear exactly once in your verdicts. If a directive carries a verification_predicate, you MUST run it and report predicate_passed / failing_predicate as the evidence. Omitting a listed CRITICAL pair is itself a VIOLATED verdict.`;
 
 const PRIORITY_RANK: Record<DirectivePriority, number> = {
 	critical: 0,
@@ -75,6 +97,15 @@ function renderOptionalText(value: string): string {
 	return JSON.stringify(value);
 }
 
+/** Truncate prose payloads so one huge entry cannot consume the budget. */
+function renderTruncatedOptionalText(value: string): string {
+	const truncated =
+		value.length > MAX_FIELD_RENDER_CHARS
+			? `${value.slice(0, MAX_FIELD_RENDER_CHARS)}...`
+			: value;
+	return renderOptionalText(truncated);
+}
+
 function parseOptionalText(value: string): string | undefined {
 	try {
 		const parsed = JSON.parse(value);
@@ -84,16 +115,57 @@ function parseOptionalText(value: string): string | undefined {
 	}
 }
 
+function renderDirectiveLines(d: DirectiveToVerify): string[] {
+	const lines = [
+		`- trace_id: ${encodeDirectiveCorrelationId(d.trace_id)}`,
+		`  entry_id: ${encodeDirectiveCorrelationId(d.entry_id)}`,
+		`  session_id: ${encodeDirectiveCorrelationId(d.session_id)}`,
+	];
+	if (d.cohort_id) {
+		lines.push(`  cohort_id: ${encodeDirectiveCorrelationId(d.cohort_id)}`);
+	}
+	if (d.source_link_id) {
+		lines.push(
+			`  source_link_id: ${encodeDirectiveCorrelationId(d.source_link_id)}`,
+		);
+	}
+	if (d.prior_terminal_outcome) {
+		lines.push(`  prior_terminal_outcome: ${d.prior_terminal_outcome}`);
+	}
+	if (d.prior_terminal_event_id) {
+		lines.push(
+			`  prior_terminal_event_id: ${encodeDirectiveCorrelationId(d.prior_terminal_event_id)}`,
+		);
+	}
+	lines.push(`  priority: ${d.priority}`);
+	if (d.lesson)
+		lines.push(`  lesson: ${renderTruncatedOptionalText(d.lesson)}`);
+	if (d.verification_predicate) {
+		lines.push(
+			`  verification_predicate: ${renderTruncatedOptionalText(d.verification_predicate)}`,
+		);
+	}
+	return lines;
+}
+
 /**
  * Render the per-phase "DIRECTIVES TO VERIFY" block injected into the reviewer's
- * delegation prompt. Deterministic (sorted by priority then entry + trace).
- * Returns null
- * when there is nothing to verify (no block emitted).
+ * delegation prompt. Deterministic (sorted by priority then entry + trace) and
+ * bounded (issue #2628): non-critical entries that no longer fit the effective
+ * budget are dropped lowest-priority-first with a count note; CRITICAL entries
+ * are always rendered — even beyond the budget, with a distinct overflow notice
+ * — because hiding one would permanently block the phase-complete gate. Returns
+ * null when there is nothing to verify (no block emitted).
  */
 export function buildDirectiveComplianceBlock(
 	directives: DirectiveToVerify[],
+	charBudget?: number,
 ): string | null {
 	if (directives.length === 0) return null;
+	const effectiveBudget = Math.min(
+		charBudget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+		DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+	);
 	const sorted = [...directives].sort((a, b) => {
 		const pr =
 			(PRIORITY_RANK[a.priority] ?? 2) - (PRIORITY_RANK[b.priority] ?? 2);
@@ -108,33 +180,34 @@ export function buildDirectiveComplianceBlock(
 	lines.push(
 		'Produce a DIRECTIVE_COMPLIANCE verdict for EVERY trace_id + entry_id pair below. Copy the encoded tokens exactly and run any verification_predicate provided.',
 	);
+	let usedBytes = Buffer.byteLength(lines.join('\n'), 'utf-8');
+	const omittedNonCritical: string[] = [];
+	let criticalOverflowCount = 0;
 	for (const d of sorted) {
-		lines.push(`- trace_id: ${encodeDirectiveCorrelationId(d.trace_id)}`);
-		lines.push(`  entry_id: ${encodeDirectiveCorrelationId(d.entry_id)}`);
-		lines.push(`  session_id: ${encodeDirectiveCorrelationId(d.session_id)}`);
-		if (d.cohort_id) {
-			lines.push(`  cohort_id: ${encodeDirectiveCorrelationId(d.cohort_id)}`);
+		const entryLines = renderDirectiveLines(d);
+		const entryBytes = Buffer.byteLength(entryLines.join('\n'), 'utf-8') + 1;
+		if (d.priority === 'critical') {
+			lines.push(...entryLines);
+			usedBytes += entryBytes;
+			if (usedBytes > effectiveBudget) criticalOverflowCount += 1;
+			continue;
 		}
-		if (d.source_link_id) {
-			lines.push(
-				`  source_link_id: ${encodeDirectiveCorrelationId(d.source_link_id)}`,
-			);
+		if (usedBytes + entryBytes > effectiveBudget) {
+			omittedNonCritical.push(d.entry_id);
+			continue;
 		}
-		if (d.prior_terminal_outcome) {
-			lines.push(`  prior_terminal_outcome: ${d.prior_terminal_outcome}`);
-		}
-		if (d.prior_terminal_event_id) {
-			lines.push(
-				`  prior_terminal_event_id: ${encodeDirectiveCorrelationId(d.prior_terminal_event_id)}`,
-			);
-		}
-		lines.push(`  priority: ${d.priority}`);
-		if (d.lesson) lines.push(`  lesson: ${renderOptionalText(d.lesson)}`);
-		if (d.verification_predicate) {
-			lines.push(
-				`  verification_predicate: ${renderOptionalText(d.verification_predicate)}`,
-			);
-		}
+		lines.push(...entryLines);
+		usedBytes += entryBytes;
+	}
+	if (criticalOverflowCount > 0) {
+		lines.push(
+			`critical overflow: ${criticalOverflowCount} critical directive(s) rendered beyond the char budget`,
+		);
+	}
+	if (omittedNonCritical.length > 0) {
+		lines.push(
+			`(+${omittedNonCritical.length} non-critical directive(s) omitted this phase; they remain live and will resurface)`,
+		);
 	}
 	lines.push('</directives_to_verify>');
 	lines.push('');

--- a/src/hooks/delegate-directive-injection.ts
+++ b/src/hooks/delegate-directive-injection.ts
@@ -21,6 +21,8 @@
 
 import {
 	buildDirectiveComplianceBlock,
+	DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+	DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
 	parseDirectivesToVerifyBlock,
 } from '../agents/reviewer-directive-compliance.js';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
@@ -243,9 +245,17 @@ export async function injectDelegateDirectivesBefore(
 		// Reviewer delegations also receive the per-phase "directives to verify"
 		// block so the reviewer can emit a DIRECTIVE_COMPLIANCE verdict per ID
 		// (Change 2, Task 2.1). Sourced from this phase's retrieved events.
+		// Issue #2628: the block obeys the same budget-clamp pattern as the
+		// delegate block (configured budget clamped to the hard cap).
 		if (stripKnownSwarmPrefix(targetAgent).toLowerCase() === 'reviewer') {
 			const toVerify = await readPhaseDirectivesToVerify(directory, phaseLabel);
-			const complianceBlock = buildDirectiveComplianceBlock(toVerify);
+			const complianceBlock = buildDirectiveComplianceBlock(
+				toVerify,
+				Math.min(
+					config.inject_char_budget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+					DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+				),
+			);
 			if (complianceBlock) prefixParts.push(complianceBlock);
 		}
 

--- a/src/hooks/knowledge-injector.ts
+++ b/src/hooks/knowledge-injector.ts
@@ -9,6 +9,8 @@
 import { createHash } from 'node:crypto';
 import {
 	buildDirectiveComplianceBlock,
+	DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+	DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
 	parseDirectivesToVerifyBlock,
 } from '../agents/reviewer-directive-compliance.js';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
@@ -817,7 +819,16 @@ async function injectForDelegateIntoMessages(
 	if (block) injectKnowledgeMessage(output, block, sessionId);
 	if (isReviewer && !alreadyVerified) {
 		const toVerify = await readPhaseDirectivesToVerify(directory, phaseLabel);
-		const complianceBlock = buildDirectiveComplianceBlock(toVerify);
+		// Issue #2628: same budget-clamp pattern as the Task prompt-prepend path
+		// (configured budget clamped to the compliance hard cap) so both reviewer
+		// dispatch paths render the block under the same bound.
+		const complianceBlock = buildDirectiveComplianceBlock(
+			toVerify,
+			Math.min(
+				config.inject_char_budget ?? DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+				DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+			),
+		);
 		if (complianceBlock) {
 			injectReviewerComplianceMessage(output, complianceBlock, sessionId);
 		}

--- a/src/hooks/phase-complete-directive-gate.ts
+++ b/src/hooks/phase-complete-directive-gate.ts
@@ -20,6 +20,7 @@
 import { recordKnowledgeEvent } from './knowledge-events.js';
 import {
 	queryLiveMemberships,
+	type ReceiptMembership,
 	type ReceiptUnavailable,
 	validateAndCommitTerminalBatch,
 } from './knowledge-receipt-ledger.js';
@@ -175,6 +176,19 @@ function classifyDirectiveGateFailure(
 
 /**
  * Evaluate all critical directives shown during the phase. Fail-closed.
+ *
+ * Since #2628 the reviewer-facing obligation unit is the ENTRY (one shown
+ * obligation per entry), so resolution is evaluated per entry: an entry is
+ * resolved when (a) at least one of its phase-window memberships carries a
+ * satisfying terminal (authorized override, applied, or ignored/n_a with a
+ * reason), AND (b) every violated/contradicted membership is remediated by an
+ * `applied` terminal committed STRICTLY LATER on some membership of the same
+ * entry (an earlier applied never hides a later violation; the same-membership
+ * case is the historical in-place remediation flow, where the current terminal
+ * is `applied` and the violated state moved to terminal_history). The reported
+ * trace_id is the representative the reviewer was shown: a violated membership
+ * when one exists, else the most recently committed one (ties by greatest
+ * trace_id) — mirroring `pickDirectiveRepresentatives` in phase-directives.ts.
  */
 export async function evaluatePhaseCriticalDirectives(params: {
 	directory: string;
@@ -218,34 +232,79 @@ export async function evaluatePhaseCriticalDirectives(params: {
 			};
 		}
 
+		const byEntry = new Map<string, ReceiptMembership[]>();
+		for (const membership of criticals) {
+			const group = byEntry.get(membership.entry_id) ?? [];
+			group.push(membership);
+			byEntry.set(membership.entry_id, group);
+		}
+
+		const isSatisfied = (membership: ReceiptMembership): boolean => {
+			const terminal = membership.terminal;
+			if (terminal?.authorized_transition) return true;
+			if (terminal?.outcome === 'applied') return true;
+			return (
+				(terminal?.outcome === 'ignored' || terminal?.outcome === 'n_a') &&
+				Boolean(terminal.reason?.trim())
+			);
+		};
+		const isViolation = (outcome: string): boolean =>
+			outcome === 'violated' || outcome === 'contradicted';
+
 		const unresolved: DirectiveGateResult['unresolved'] = [];
 		const overridden: string[] = [];
-		for (const membership of criticals) {
-			const terminal = membership.terminal;
-			if (terminal?.authorized_transition) {
-				overridden.push(membership.entry_id);
-				continue;
+		for (const [entryId, members] of byEntry) {
+			for (const membership of members) {
+				if (membership.terminal?.authorized_transition) {
+					overridden.push(entryId);
+				}
 			}
-			if (terminal?.outcome === 'applied') continue;
-			if (
-				(terminal?.outcome === 'ignored' || terminal?.outcome === 'n_a') &&
-				terminal.reason?.trim()
-			)
-				continue;
+			const hasSatisfied = members.some((membership) =>
+				isSatisfied(membership),
+			);
+			const violated = members.filter(
+				(membership) =>
+					membership.terminal !== undefined &&
+					// An authorized override is a terminal disposition (the architect
+					// accepted the violation), not an unremediated one — mirrors the
+					// pre-#2628 short-circuit.
+					!membership.terminal.authorized_transition &&
+					isViolation(membership.terminal.outcome),
+			);
+			const unremediated = violated.filter(
+				(membership) =>
+					!members.some(
+						(other) =>
+							other.terminal?.outcome === 'applied' &&
+							other.terminal.committed_at > membership.terminal!.committed_at,
+					),
+			);
+			if (hasSatisfied && unremediated.length === 0) continue;
+			// Representative membership: violated preferred (the obligation the
+			// reviewer was asked to remediate), else most recently committed, ties
+			// by greatest trace_id — same precedence as the shown block.
+			const representative = [...members].sort((a, b) => {
+				const aViolated =
+					a.terminal !== undefined && isViolation(a.terminal.outcome) ? 0 : 1;
+				const bViolated =
+					b.terminal !== undefined && isViolation(b.terminal.outcome) ? 0 : 1;
+				if (aViolated !== bViolated) return aViolated - bViolated;
+				if (a.committed_at !== b.committed_at) {
+					return a.committed_at < b.committed_at ? 1 : -1;
+				}
+				return a.trace_id < b.trace_id ? 1 : -1;
+			})[0];
 			unresolved.push({
-				id: membership.entry_id,
-				trace_id: membership.trace_id,
-				reason:
-					terminal?.outcome === 'violated' ||
-					terminal?.outcome === 'contradicted'
-						? 'unremediated_violation'
-						: 'no_verdict',
+				id: entryId,
+				trace_id: representative.trace_id,
+				reason: violated.length > 0 ? 'unremediated_violation' : 'no_verdict',
 			});
 		}
+		unresolved.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 		return {
 			blocked: unresolved.length > 0,
 			unresolved,
-			overridden,
+			overridden: [...new Set(overridden)],
 			failedClosed: false,
 		};
 	} catch (error) {

--- a/src/hooks/phase-directives.ts
+++ b/src/hooks/phase-directives.ts
@@ -72,19 +72,23 @@ export interface DirectiveCandidate {
 
 /**
  * True when `next` is a better per-entry representative than `incumbent`.
- * Precedence (#2628): a membership whose current terminal is `violated` wins
- * (it carries the remediation obligation via prior_terminal_*), then the most
- * recently committed membership, then the lexicographically greatest trace_id
- * (code-unit order — locale-independent determinism).
+ * Precedence (#2628): a membership whose current terminal is a violation
+ * (`violated` or `contradicted`) wins (it carries the remediation obligation
+ * via prior_terminal_*), then the most recently committed membership, then the
+ * lexicographically greatest trace_id (code-unit order — locale-independent
+ * determinism).
  */
 export function isPreferredDirectiveCandidate(
 	next: DirectiveCandidate,
 	incumbent: DirectiveCandidate,
 ): boolean {
-	const nextViolated = next.directive.prior_terminal_outcome === 'violated';
-	const incumbentViolated =
-		incumbent.directive.prior_terminal_outcome === 'violated';
-	if (nextViolated !== incumbentViolated) return nextViolated;
+	const nextViolation =
+		next.directive.prior_terminal_outcome === 'violated' ||
+		next.directive.prior_terminal_outcome === 'contradicted';
+	const incumbentViolation =
+		incumbent.directive.prior_terminal_outcome === 'violated' ||
+		incumbent.directive.prior_terminal_outcome === 'contradicted';
+	if (nextViolation !== incumbentViolation) return nextViolation;
 	if (next.committed_at !== incumbent.committed_at) {
 		return next.committed_at > incumbent.committed_at;
 	}
@@ -133,7 +137,17 @@ export async function readPhaseDirectivesToVerify(
 		const entries = await readEntriesById(directory);
 		const candidates: DirectiveCandidate[] = [];
 		for (const membership of result.memberships) {
-			if (membership.terminal && membership.terminal.outcome !== 'violated') {
+			// Violation-class terminals (violated / contradicted) stay in the
+			// shown set as remediation obligations — the gate treats both as
+			// blocking, so the reviewer must see them to resolve the phase
+			// (PR #2636 review: a contradicted-only entry previously blocked
+			// the phase with no reviewer path). Satisfying terminals are
+			// already resolved and drop out.
+			if (
+				membership.terminal &&
+				membership.terminal.outcome !== 'violated' &&
+				membership.terminal.outcome !== 'contradicted'
+			) {
 				continue;
 			}
 			const e = entries.get(membership.entry_id);
@@ -142,6 +156,7 @@ export async function readPhaseDirectivesToVerify(
 			// source of truth — also excludes `quarantined_unactionable` (failed
 			// the actionability gate; should not be re-injected as a directive).
 			if (!isActiveStatus(e.status)) continue;
+			const outcome = membership.terminal?.outcome;
 			candidates.push({
 				committed_at: membership.committed_at,
 				directive: {
@@ -151,12 +166,12 @@ export async function readPhaseDirectivesToVerify(
 					cohort_id: membership.cohort_id,
 					source_link_id: membership.source_link_id,
 					prior_terminal_outcome:
-						membership.terminal?.outcome === 'violated'
-							? 'violated'
+						outcome === 'violated' || outcome === 'contradicted'
+							? outcome
 							: undefined,
 					prior_terminal_event_id:
-						membership.terminal?.outcome === 'violated'
-							? membership.terminal.event_id
+						outcome === 'violated' || outcome === 'contradicted'
+							? membership.terminal?.event_id
 							: undefined,
 					priority: membership.critical
 						? 'critical'

--- a/src/hooks/phase-directives.ts
+++ b/src/hooks/phase-directives.ts
@@ -60,10 +60,64 @@ export async function readEntriesById(
 }
 
 /**
+ * One candidate obligation per receipt membership, before per-entry collapse.
+ * `committed_at` and the terminal fields come from the membership so the
+ * representative selection below is deterministic.
+ */
+export interface DirectiveCandidate {
+	directive: DirectiveToVerify;
+	/** Membership commit time (ISO-8601 UTC from the receipt ledger). */
+	committed_at: string;
+}
+
+/**
+ * True when `next` is a better per-entry representative than `incumbent`.
+ * Precedence (#2628): a membership whose current terminal is `violated` wins
+ * (it carries the remediation obligation via prior_terminal_*), then the most
+ * recently committed membership, then the lexicographically greatest trace_id
+ * (code-unit order — locale-independent determinism).
+ */
+export function isPreferredDirectiveCandidate(
+	next: DirectiveCandidate,
+	incumbent: DirectiveCandidate,
+): boolean {
+	const nextViolated = next.directive.prior_terminal_outcome === 'violated';
+	const incumbentViolated =
+		incumbent.directive.prior_terminal_outcome === 'violated';
+	if (nextViolated !== incumbentViolated) return nextViolated;
+	if (next.committed_at !== incumbent.committed_at) {
+		return next.committed_at > incumbent.committed_at;
+	}
+	return next.directive.trace_id > incumbent.directive.trace_id;
+}
+
+/**
+ * Collapse membership-derived candidates to at most one per unique entry_id
+ * (issue #2628). The reviewer's obligation unit is the directive (entry), not
+ * the (trace_id, entry_id) pair — pair multiplicity re-created one verification
+ * per historical exposure and grew the injected block O(entries x trace_ids).
+ * Snapshot semantics: the result is a pure function of the membership list at
+ * read time; a membership committed between dispatch and settle can shift the
+ * representative (pre-existing skew class, not widened here).
+ */
+export function pickDirectiveRepresentatives(
+	candidates: DirectiveCandidate[],
+): DirectiveCandidate[] {
+	const byEntry = new Map<string, DirectiveCandidate>();
+	for (const candidate of candidates) {
+		const incumbent = byEntry.get(candidate.directive.entry_id);
+		if (!incumbent || isPreferredDirectiveCandidate(candidate, incumbent)) {
+			byEntry.set(candidate.directive.entry_id, candidate);
+		}
+	}
+	return [...byEntry.values()];
+}
+
+/**
  * Resolve the directives the reviewer must verify for a phase: the entries
  * behind the phase's retrieved IDs, with priority + lesson + verification
- * predicate. Archived/quarantined entries are excluded. Fail-open: returns [] on
- * any error.
+ * predicate, deduplicated to ONE obligation per entry. Archived/quarantined
+ * entries are excluded. Fail-open: returns [] on any error.
  */
 export async function readPhaseDirectivesToVerify(
 	directory: string,
@@ -77,7 +131,7 @@ export async function readPhaseDirectivesToVerify(
 		});
 		if (!result.ok || result.memberships.length === 0) return [];
 		const entries = await readEntriesById(directory);
-		const out: DirectiveToVerify[] = [];
+		const candidates: DirectiveCandidate[] = [];
 		for (const membership of result.memberships) {
 			if (membership.terminal && membership.terminal.outcome !== 'violated') {
 				continue;
@@ -88,26 +142,33 @@ export async function readPhaseDirectivesToVerify(
 			// source of truth — also excludes `quarantined_unactionable` (failed
 			// the actionability gate; should not be re-injected as a directive).
 			if (!isActiveStatus(e.status)) continue;
-			out.push({
-				trace_id: membership.trace_id,
-				entry_id: membership.entry_id,
-				session_id: membership.session_id,
-				cohort_id: membership.cohort_id,
-				source_link_id: membership.source_link_id,
-				prior_terminal_outcome:
-					membership.terminal?.outcome === 'violated' ? 'violated' : undefined,
-				prior_terminal_event_id:
-					membership.terminal?.outcome === 'violated'
-						? membership.terminal.event_id
-						: undefined,
-				priority: membership.critical
-					? 'critical'
-					: (e.directive_priority ?? 'medium'),
-				lesson: e.lesson,
-				verification_predicate: e.verification_predicate,
+			candidates.push({
+				committed_at: membership.committed_at,
+				directive: {
+					trace_id: membership.trace_id,
+					entry_id: membership.entry_id,
+					session_id: membership.session_id,
+					cohort_id: membership.cohort_id,
+					source_link_id: membership.source_link_id,
+					prior_terminal_outcome:
+						membership.terminal?.outcome === 'violated'
+							? 'violated'
+							: undefined,
+					prior_terminal_event_id:
+						membership.terminal?.outcome === 'violated'
+							? membership.terminal.event_id
+							: undefined,
+					priority: membership.critical
+						? 'critical'
+						: (e.directive_priority ?? 'medium'),
+					lesson: e.lesson,
+					verification_predicate: e.verification_predicate,
+				},
 			});
 		}
-		return out;
+		return pickDirectiveRepresentatives(candidates).map(
+			(candidate) => candidate.directive,
+		);
 	} catch {
 		return [];
 	}

--- a/src/hooks/reviewer-verdict-parser.ts
+++ b/src/hooks/reviewer-verdict-parser.ts
@@ -4,11 +4,16 @@
  *
  * Parses a reviewer's `DIRECTIVE_COMPLIANCE` block (VERIFIED / VIOLATED / N/A
  * lines) and reconciles it against the exact retrieval memberships the reviewer
- * was asked to verify, committing one authoritative terminal per pair:
+ * was asked to verify, committing one authoritative terminal per shown pair:
  *
  *   VERIFIED:<trace_id>:<entry_id> -> outcome:'applied'
  *   VIOLATED:<trace_id>:<entry_id> -> outcome:'violated'
  *   N/A:<trace_id>:<entry_id>      -> outcome:'n_a'
+ *
+ * Since #2628 the shown set carries at most one pair per entry, so the pair
+ * shown is the entry's single obligation for the phase; the phase-complete gate
+ * resolves the ENTRY once that pair's terminal commits (see
+ * phase-complete-directive-gate.ts).
  *
  * Anti-spoofing: verdicts for pairs that were not in the verify-set are dropped.
  * An omitted CRITICAL pair gets a `violated` / `reviewer_omitted` terminal.

--- a/src/hooks/reviewer-verdict-parser.ts
+++ b/src/hooks/reviewer-verdict-parser.ts
@@ -254,7 +254,8 @@ export async function reconcileReviewerVerdicts(
 	for (const group of groups.values()) {
 		const first = group[0].directive;
 		const remediationAuthorization =
-			first.prior_terminal_outcome === 'violated' &&
+			(first.prior_terminal_outcome === 'violated' ||
+				first.prior_terminal_outcome === 'contradicted') &&
 			first.prior_terminal_event_id &&
 			group.some((item) => item.type !== 'violated')
 				? {

--- a/tests/unit/agents/reviewer-directive-compliance-prompt.test.ts
+++ b/tests/unit/agents/reviewer-directive-compliance-prompt.test.ts
@@ -66,11 +66,11 @@ describe('buildDirectiveComplianceBlock', () => {
 			'  lesson: "Document edge cases"',
 			'</directives_to_verify>',
 			'',
-			'DIRECTIVE_COMPLIANCE: one line per retrieval membership shown during this phase. Copy the encoded trace_id and entry_id tokens exactly from the DIRECTIVES TO VERIFY block. Use exactly one of:',
+			'DIRECTIVE_COMPLIANCE: one line per listed obligation. Copy the encoded trace_id and entry_id tokens exactly from the DIRECTIVES TO VERIFY block. Use exactly one of:',
 			'  VERIFIED:<trace_id>:<entry_id> evidence=<file:line | predicate_passed>',
 			'  VIOLATED:<trace_id>:<entry_id> evidence=<file:line | failing_predicate>',
 			'  N/A:<trace_id>:<entry_id> reason=<why it does not apply to this change>',
-			'Every listed trace_id + entry_id pair MUST appear exactly once. The same entry_id may appear under more than one trace_id and requires one verdict per pair. If a directive carries a verification_predicate, you MUST run it and report predicate_passed / failing_predicate as the evidence. Omitting a listed CRITICAL pair is itself a VIOLATED verdict.',
+			'Every listed trace_id + entry_id pair MUST appear exactly once in your verdicts. If a directive carries a verification_predicate, you MUST run it and report predicate_passed / failing_predicate as the evidence. Omitting a listed CRITICAL pair is itself a VIOLATED verdict.',
 		].join('\n');
 
 		expect(block).toBe(expected);

--- a/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
+++ b/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
@@ -349,7 +349,8 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 		// Deterministic clock: the gate requires the applied terminal's
 		// committed_at to be STRICTLY greater than the violated terminal's, and
 		// wall-clock granularity can tie two adjacent commits on fast CI hosts.
-		const clock = { tick: Date.now() - 10_000 };
+		const realNowMs = ledgerInternals.nowMs;
+		const clock = { tick: 1_000_000 };
 		ledgerInternals.nowMs = () => (clock.tick += 1_000);
 		try {
 			await seedDisplay(PHASE, 'gate-violated', [id], SESSION);
@@ -357,7 +358,7 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 			await seedDisplay(PHASE, 'gate-applied', [id], SESSION);
 			await seedTerminal('gate-applied', id, 'applied', SESSION);
 		} finally {
-			ledgerInternals.nowMs = () => Date.now();
+			ledgerInternals.nowMs = realNowMs;
 		}
 
 		const result = await evaluatePhaseCriticalDirectives({
@@ -378,7 +379,8 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 		const kp = resolveSwarmKnowledgePath(dir);
 		const id = 'directive-2628-contradicted-000000000008';
 		await appendKnowledge(kp, makeEntry(id, 'critical'));
-		const clock = { tick: Date.now() - 10_000 };
+		const realNowMs = ledgerInternals.nowMs;
+		const clock = { tick: 1_000_000 };
 		ledgerInternals.nowMs = () => (clock.tick += 1_000);
 		try {
 			await seedDisplay(PHASE, 'gate-contradicted', [id], SESSION);
@@ -398,7 +400,7 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 			await seedDisplay(PHASE, 'gate-contradicted-applied', [id], SESSION);
 			await seedTerminal('gate-contradicted-applied', id, 'applied', SESSION);
 		} finally {
-			ledgerInternals.nowMs = () => Date.now();
+			ledgerInternals.nowMs = realNowMs;
 		}
 
 		const result = await evaluatePhaseCriticalDirectives({

--- a/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
+++ b/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
@@ -28,6 +28,7 @@ import {
 import { appendKnowledgeEvent } from '../../../src/hooks/knowledge-events.js';
 import {
 	commitDisplayedMembership,
+	_internals as ledgerInternals,
 	queryLiveMemberships,
 	validateAndCommitTerminalBatch,
 } from '../../../src/hooks/knowledge-receipt-ledger.js';
@@ -109,7 +110,7 @@ async function seedDisplay(
 async function seedTerminal(
 	traceId: string,
 	entryId: string,
-	outcome: 'applied' | 'violated',
+	outcome: 'applied' | 'violated' | 'contradicted',
 	sessionId = 'session-1',
 ): Promise<void> {
 	const terminal = await validateAndCommitTerminalBatch(dir, {
@@ -345,13 +346,19 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 		const kp = resolveSwarmKnowledgePath(dir);
 		const id = 'directive-2628-later-rem-00000000000005';
 		await appendKnowledge(kp, makeEntry(id, 'critical'));
-		await seedDisplay(PHASE, 'gate-violated', [id], SESSION);
-		await seedTerminal('gate-violated', id, 'violated', SESSION);
-		// Committed strictly later (separate awaits guarantee monotonic journal
-		// order; the gate requires the applied committed_at to be strictly
-		// greater than the violated's).
-		await seedDisplay(PHASE, 'gate-applied', [id], SESSION);
-		await seedTerminal('gate-applied', id, 'applied', SESSION);
+		// Deterministic clock: the gate requires the applied terminal's
+		// committed_at to be STRICTLY greater than the violated terminal's, and
+		// wall-clock granularity can tie two adjacent commits on fast CI hosts.
+		const clock = { tick: Date.now() - 10_000 };
+		ledgerInternals.nowMs = () => (clock.tick += 1_000);
+		try {
+			await seedDisplay(PHASE, 'gate-violated', [id], SESSION);
+			await seedTerminal('gate-violated', id, 'violated', SESSION);
+			await seedDisplay(PHASE, 'gate-applied', [id], SESSION);
+			await seedTerminal('gate-applied', id, 'applied', SESSION);
+		} finally {
+			ledgerInternals.nowMs = () => Date.now();
+		}
 
 		const result = await evaluatePhaseCriticalDirectives({
 			directory: dir,
@@ -361,6 +368,45 @@ describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', ()
 
 		expect(result).toMatchObject({ blocked: false, failedClosed: false });
 		expect(result.unresolved).toEqual([]);
+	});
+
+	it('shows a contradicted-terminal entry to the reviewer as a remediation obligation (#2636 review)', async () => {
+		// A 'contradicted' terminal blocks the phase gate (isViolation includes
+		// it), so the reviewer must SEE the obligation to remediate it. Before
+		// this fix the read filter skipped contradicted terminals entirely and
+		// the phase could never resolve through the reviewer path.
+		const kp = resolveSwarmKnowledgePath(dir);
+		const id = 'directive-2628-contradicted-000000000008';
+		await appendKnowledge(kp, makeEntry(id, 'critical'));
+		const clock = { tick: Date.now() - 10_000 };
+		ledgerInternals.nowMs = () => (clock.tick += 1_000);
+		try {
+			await seedDisplay(PHASE, 'gate-contradicted', [id], SESSION);
+			await seedTerminal('gate-contradicted', id, 'contradicted', SESSION);
+
+			const directives = await readPhaseDirectivesToVerify(dir, PHASE);
+			expect(directives).toHaveLength(1);
+			expect(directives[0]).toMatchObject({
+				trace_id: 'gate-contradicted',
+				entry_id: id,
+				prior_terminal_outcome: 'contradicted',
+			});
+			expect(directives[0]?.prior_terminal_event_id).toBeString();
+
+			// A strictly-later applied terminal on a sibling membership
+			// remediates the contradiction and resolves the entry.
+			await seedDisplay(PHASE, 'gate-contradicted-applied', [id], SESSION);
+			await seedTerminal('gate-contradicted-applied', id, 'applied', SESSION);
+		} finally {
+			ledgerInternals.nowMs = () => Date.now();
+		}
+
+		const result = await evaluatePhaseCriticalDirectives({
+			directory: dir,
+			sessionId: SESSION,
+			phaseLabel: PHASE,
+		});
+		expect(result).toMatchObject({ blocked: false, failedClosed: false });
 	});
 
 	it('reports the shown (violated-preferred) trace for an unresolved entry', async () => {

--- a/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
+++ b/tests/unit/hooks/directive-compliance-bounded-2628.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Issue #2628 regression tests — the reviewer "directives to verify" pipeline
+ * is per-entry bounded:
+ *
+ * - readPhaseDirectivesToVerify dedupes to ONE obligation per entry
+ *   (deterministic representative selection).
+ * - buildDirectiveComplianceBlock renders under a hard char budget; overflow
+ *   drops non-criticals with a count note and NEVER drops a critical (distinct
+ *   overflow notice when criticals alone exceed the budget).
+ * - evaluatePhaseCriticalDirectives resolves a critical ENTRY when a sibling
+ *   membership carries a satisfying terminal, with later-applied-remediates
+ *   semantics for violated siblings.
+ * - Reconciliation stays consistent with the shown block on both the Task
+ *   path (parse of the shown block) and the lane-settle path (fresh read).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+	buildDirectiveComplianceBlock,
+	DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET,
+	DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP,
+	type DirectiveToVerify,
+	parseDirectivesToVerifyBlock,
+} from '../../../src/agents/reviewer-directive-compliance.js';
+import { appendKnowledgeEvent } from '../../../src/hooks/knowledge-events.js';
+import {
+	commitDisplayedMembership,
+	queryLiveMemberships,
+	validateAndCommitTerminalBatch,
+} from '../../../src/hooks/knowledge-receipt-ledger.js';
+import {
+	appendKnowledge,
+	resolveSwarmKnowledgePath,
+} from '../../../src/hooks/knowledge-store.js';
+import type { SwarmKnowledgeEntry } from '../../../src/hooks/knowledge-types.js';
+import { evaluatePhaseCriticalDirectives } from '../../../src/hooks/phase-complete-directive-gate.js';
+import {
+	type DirectiveCandidate,
+	isPreferredDirectiveCandidate,
+	pickDirectiveRepresentatives,
+	readEntriesById,
+	readPhaseDirectivesToVerify,
+} from '../../../src/hooks/phase-directives.js';
+import { reconcileReviewerVerdicts } from '../../../src/hooks/reviewer-verdict-parser.js';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+let dir: string;
+let prevHome: string | undefined;
+let prevLocalAppData: string | undefined;
+let prevXdgDataHome: string | undefined;
+let traceSequence: number;
+
+function makeEntry(
+	id: string,
+	priority: SwarmKnowledgeEntry['directive_priority'],
+	lesson = `Lesson for ${id} — always validate inputs before processing`,
+): SwarmKnowledgeEntry {
+	return {
+		id,
+		tier: 'swarm',
+		lesson,
+		category: 'process',
+		tags: ['validation'],
+		scope: 'global',
+		confidence: 0.85,
+		status: 'established',
+		confirmed_by: [],
+		project_name: 'issue-2628',
+		retrieval_outcomes: {
+			applied_count: 0,
+			succeeded_after_count: 0,
+			failed_after_count: 0,
+			shown_count: 0,
+			applied_explicit_count: 0,
+			ignored_count: 0,
+		},
+		schema_version: 2,
+		created_at: '2026-09-07T00:00:00.000Z',
+		updated_at: '2026-09-07T00:00:00.000Z',
+		directive_priority: priority,
+	};
+}
+
+async function seedDisplay(
+	phase: string,
+	traceId: string,
+	entryIds: string[],
+	sessionId = 'session-1',
+): Promise<void> {
+	const entries = await readEntriesById(dir);
+	const displayed = await commitDisplayedMembership(dir, {
+		trace_id: traceId,
+		session_id: sessionId,
+		agent: 'architect',
+		phase,
+		entries: entryIds.map((entry_id, index) => ({
+			entry_id,
+			critical: entries.get(entry_id)?.directive_priority === 'critical',
+			rank: index + 1,
+			score: 1.0 - index * 0.1,
+		})),
+	});
+	if (!displayed.ok) throw new Error(displayed.detail);
+}
+
+async function seedTerminal(
+	traceId: string,
+	entryId: string,
+	outcome: 'applied' | 'violated',
+	sessionId = 'session-1',
+): Promise<void> {
+	const terminal = await validateAndCommitTerminalBatch(dir, {
+		trace_id: traceId,
+		session_id: sessionId,
+		items: [{ entry_id: entryId, outcome }],
+	});
+	if (!terminal.ok) throw new Error(terminal.detail);
+}
+
+beforeEach(async () => {
+	dir = canonicalMkdtemp('directive-bounded-2628-');
+	writeFileSync(path.join(dir, '.git'), 'gitdir: fixture');
+	traceSequence = 0;
+	prevHome = process.env.HOME;
+	prevLocalAppData = process.env.LOCALAPPDATA;
+	prevXdgDataHome = process.env.XDG_DATA_HOME;
+	const isolatedHome = path.join(dir, 'home');
+	await mkdir(isolatedHome, { recursive: true });
+	process.env.HOME = isolatedHome;
+	process.env.LOCALAPPDATA = path.join(dir, 'localappdata');
+	process.env.XDG_DATA_HOME = path.join(dir, 'xdg-data');
+});
+
+afterEach(() => {
+	if (prevHome === undefined) delete process.env.HOME;
+	else process.env.HOME = prevHome;
+	if (prevLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+	else process.env.LOCALAPPDATA = prevLocalAppData;
+	if (prevXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+	else process.env.XDG_DATA_HOME = prevXdgDataHome;
+	if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+});
+
+function nextTrace(): string {
+	return `trace-${String(++traceSequence).padStart(3, '0')}`;
+}
+
+describe('#2628 per-entry dedupe (readPhaseDirectivesToVerify)', () => {
+	it('returns one directive per entry across many traces', async () => {
+		const kp = resolveSwarmKnowledgePath(dir);
+		const ids = [
+			'directive-2628-a-0000-000000000001',
+			'directive-2628-b-0000-000000000002',
+			'directive-2628-c-0000-000000000003',
+		];
+		for (const [index, id] of ids.entries()) {
+			await appendKnowledge(
+				kp,
+				makeEntry(id, index === 0 ? 'critical' : 'high'),
+			);
+		}
+		for (let t = 0; t < 8; t++) {
+			await seedDisplay('Phase 1', nextTrace(), ids);
+		}
+
+		const directives = await readPhaseDirectivesToVerify(dir, 'Phase 1');
+
+		expect(directives).toHaveLength(3);
+		expect(new Set(directives.map((d) => d.entry_id)).size).toBe(3);
+	});
+
+	it('prefers a violated membership as the entry representative', async () => {
+		const kp = resolveSwarmKnowledgePath(dir);
+		const id = 'directive-2628-rem-0000-000000000004';
+		await appendKnowledge(kp, makeEntry(id, 'critical'));
+		// Oldest trace carries the violated terminal; newer traces stay live.
+		await seedDisplay('Phase 1', 'trace-rem-old', [id]);
+		await seedTerminal('trace-rem-old', id, 'violated');
+		await seedDisplay('Phase 1', 'trace-rem-mid', [id]);
+		await seedDisplay('Phase 1', 'trace-rem-new', [id]);
+
+		const directives = await readPhaseDirectivesToVerify(dir, 'Phase 1');
+
+		expect(directives).toHaveLength(1);
+		expect(directives[0]).toMatchObject({
+			trace_id: 'trace-rem-old',
+			entry_id: id,
+			prior_terminal_outcome: 'violated',
+		});
+		expect(directives[0]?.prior_terminal_event_id).toBeString();
+	});
+
+	it('breaks committed_at ties by greatest trace_id (pure helper)', () => {
+		const directive = (traceId: string): DirectiveCandidate => ({
+			committed_at: '2026-09-07T00:00:00.000Z',
+			directive: {
+				trace_id: traceId,
+				entry_id: 'directive-2628-tie',
+				session_id: 'session-1',
+				priority: 'high',
+			},
+		});
+		const candidates = [directive('trace-aaa'), directive('trace-zzz')];
+
+		expect(
+			pickDirectiveRepresentatives(candidates)[0]?.directive.trace_id,
+		).toBe('trace-zzz');
+		expect(isPreferredDirectiveCandidate(candidates[1]!, candidates[0]!)).toBe(
+			true,
+		);
+		expect(isPreferredDirectiveCandidate(candidates[0]!, candidates[1]!)).toBe(
+			false,
+		);
+	});
+});
+
+describe('#2628 bounded rendering (buildDirectiveComplianceBlock)', () => {
+	it('drops non-criticals first under a tight budget with a count note', () => {
+		const directives: DirectiveToVerify[] = [
+			{
+				trace_id: 'trace-crit',
+				entry_id: 'd-crit',
+				session_id: 'session-1',
+				priority: 'critical',
+				lesson: 'critical obligation',
+			},
+			...Array.from({ length: 30 }, (_, i) => ({
+				trace_id: `trace-med-${i}`,
+				entry_id: `d-med-${i}`,
+				session_id: 'session-1',
+				priority: 'medium' as const,
+				lesson: `medium obligation ${i}`,
+			})),
+		];
+
+		const block = buildDirectiveComplianceBlock(directives, 900);
+
+		expect(block).not.toBeNull();
+		expect(block).toContain('- trace_id: trace-crit');
+		expect(block).toContain('  entry_id: d-crit');
+		expect(block).toMatch(/omitted/i);
+		expect(Buffer.byteLength(block ?? '', 'utf-8')).toBeLessThan(40000);
+		// The omitted entries are absent from the shown set.
+		expect(block).not.toContain('entry_id: d-med-29');
+	});
+
+	it('never drops a critical and emits the distinct overflow notice', () => {
+		const directives: DirectiveToVerify[] = Array.from(
+			{ length: 40 },
+			(_, i) => ({
+				trace_id: `trace-crit-${i}`,
+				entry_id: `d-crit-${i}`,
+				session_id: 'session-1',
+				priority: 'critical' as const,
+				lesson: `critical obligation ${i} — ${'x'.repeat(120)}`,
+			}),
+		);
+
+		const block = buildDirectiveComplianceBlock(directives, 2000);
+
+		expect(block).not.toBeNull();
+		for (const d of directives) {
+			expect(block).toContain(`entry_id: ${d.entry_id}`);
+		}
+		expect(block).toMatch(/critical overflow/i);
+	});
+
+	it('truncates oversized lessons while keeping pair identity exact', () => {
+		const longLesson = 'L'.repeat(1200);
+		const block = buildDirectiveComplianceBlock([
+			{
+				trace_id: 'trace-huge',
+				entry_id: 'd-huge',
+				session_id: 'session-1',
+				priority: 'high',
+				lesson: longLesson,
+			},
+		]);
+
+		expect(block).toContain('- trace_id: trace-huge');
+		expect(block).not.toContain(longLesson);
+		const parsed = parseDirectivesToVerifyBlock(block ?? '');
+		expect(parsed).toHaveLength(1);
+		expect(parsed[0]?.lesson?.length).toBeLessThanOrEqual(404);
+	});
+
+	it('clamps the caller budget to the hard cap and defaults sanely', () => {
+		expect(DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP).toBeLessThanOrEqual(40_000);
+		expect(DIRECTIVE_COMPLIANCE_DEFAULT_CHAR_BUDGET).toBeGreaterThan(0);
+	});
+
+	it('round-trips the shown pairs through the anti-spoofing parser', () => {
+		const directives: DirectiveToVerify[] = [
+			{
+				trace_id: 'trace:rt one',
+				entry_id: 'entry:rt one',
+				session_id: 'session:rt',
+				cohort_id: 'cohort:rt',
+				source_link_id: 'link:rt',
+				prior_terminal_outcome: 'violated',
+				prior_terminal_event_id: 'event:rt',
+				priority: 'critical',
+				lesson: 'A lesson\nwith newlines',
+				verification_predicate: 'grep:value:src/**/*.ts',
+			},
+			{
+				trace_id: 'trace:rt two',
+				entry_id: 'entry:rt two',
+				session_id: 'session:rt',
+				priority: 'low',
+			},
+		];
+
+		const block = buildDirectiveComplianceBlock(directives, 24_000);
+		expect(block).not.toBeNull();
+		expect(parseDirectivesToVerifyBlock(block ?? '')).toEqual(directives);
+	});
+
+	it('no longer documents the per-pair multiplicity contract (#2628 AC7)', () => {
+		const block = buildDirectiveComplianceBlock(
+			[
+				{
+					trace_id: 'trace-spec',
+					entry_id: 'd-spec',
+					session_id: 'session-1',
+					priority: 'medium',
+				},
+			],
+			24_000,
+		);
+
+		expect(block).not.toContain('requires one verdict per pair');
+		expect(block).toContain('DIRECTIVE_COMPLIANCE:');
+	});
+});
+
+describe('#2628 per-entry gate resolution (evaluatePhaseCriticalDirectives)', () => {
+	const PHASE = 'Phase 1';
+	const SESSION = 'session-1';
+
+	it('resolves the entry when a later applied remediates an earlier violated sibling', async () => {
+		const kp = resolveSwarmKnowledgePath(dir);
+		const id = 'directive-2628-later-rem-00000000000005';
+		await appendKnowledge(kp, makeEntry(id, 'critical'));
+		await seedDisplay(PHASE, 'gate-violated', [id], SESSION);
+		await seedTerminal('gate-violated', id, 'violated', SESSION);
+		// Committed strictly later (separate awaits guarantee monotonic journal
+		// order; the gate requires the applied committed_at to be strictly
+		// greater than the violated's).
+		await seedDisplay(PHASE, 'gate-applied', [id], SESSION);
+		await seedTerminal('gate-applied', id, 'applied', SESSION);
+
+		const result = await evaluatePhaseCriticalDirectives({
+			directory: dir,
+			sessionId: SESSION,
+			phaseLabel: PHASE,
+		});
+
+		expect(result).toMatchObject({ blocked: false, failedClosed: false });
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it('reports the shown (violated-preferred) trace for an unresolved entry', async () => {
+		const kp = resolveSwarmKnowledgePath(dir);
+		const id = 'directive-2628-rep-000000000000006';
+		await appendKnowledge(kp, makeEntry(id, 'critical'));
+		await seedDisplay(PHASE, 'gate-rep-old', [id], SESSION);
+		await seedTerminal('gate-rep-old', id, 'violated', SESSION);
+		await seedDisplay(PHASE, 'gate-rep-new', [id], SESSION);
+
+		const result = await evaluatePhaseCriticalDirectives({
+			directory: dir,
+			sessionId: SESSION,
+			phaseLabel: PHASE,
+		});
+
+		expect(result.blocked).toBe(true);
+		expect(result.unresolved).toEqual([
+			{
+				id,
+				trace_id: 'gate-rep-old',
+				reason: 'unremediated_violation',
+			},
+		]);
+	});
+});
+
+describe('#2628 reconciliation consistency (lane-settle path)', () => {
+	it('keeps the fresh-read verify-set consistent with the shown block', async () => {
+		const kp = resolveSwarmKnowledgePath(dir);
+		const id = 'directive-2628-rec-000000000000007';
+		await appendKnowledge(kp, makeEntry(id, 'critical'));
+		for (let t = 0; t < 5; t++) {
+			await seedDisplay('Phase 1', nextTrace(), [id]);
+		}
+
+		const shown = await readPhaseDirectivesToVerify(dir, 'Phase 1');
+		expect(shown).toHaveLength(1);
+		const block = buildDirectiveComplianceBlock(shown);
+		expect(block).not.toBeNull();
+
+		// The reviewer verdicts exactly what was shown (Task-path parse).
+		const shownPairs = parseDirectivesToVerifyBlock(block ?? '');
+		expect(shownPairs).toHaveLength(1);
+		const transcript = `VERIFIED:${encodeURIComponent(shownPairs[0]!.trace_id)}:${encodeURIComponent(shownPairs[0]!.entry_id)} evidence=src/x.ts:1`;
+
+		// The lane-settle path re-reads the ledger fresh.
+		const fresh = await readPhaseDirectivesToVerify(dir, 'Phase 1');
+		const result = await reconcileReviewerVerdicts({
+			directory: dir,
+			transcript,
+			directivesToVerify: fresh,
+			sessionId: 'session-1',
+			agent: 'reviewer',
+		});
+
+		expect(result.omittedCriticals).toEqual([]);
+		expect(result.uncertainties).toEqual([]);
+		expect(result.emitted).toHaveLength(1);
+
+		const state = await queryLiveMemberships(dir, {
+			phase: 'Phase 1',
+			include_terminal: true,
+			include_phase_closed: false,
+		});
+		expect(state.ok).toBe(true);
+		const terminals = state.ok
+			? state.memberships.filter((m) => m.terminal)
+			: [];
+		expect(terminals.length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/tests/unit/hooks/phase-complete-directive-gate.test.ts
+++ b/tests/unit/hooks/phase-complete-directive-gate.test.ts
@@ -75,7 +75,17 @@ describe('evaluatePhaseCriticalDirectives V2 authority', () => {
 		]);
 	});
 
-	it('does not let a terminal on one trace hide the repeated entry on another', async () => {
+	it('resolves an entry verified once even when retrieved under multiple traces (#2628 intent)', async () => {
+		// #2628 intent amendment: the reviewer is shown ONE obligation per entry
+		// (per-entry dedupe in readPhaseDirectivesToVerify), so the gate's
+		// resolution unit moved from membership (pair) to entry. Pre-#2628 this
+		// scenario stayed blocked on the terminal-less sibling trace ("does not
+		// let a terminal on one trace hide the repeated entry on another"),
+		// which re-created one verdict per historical exposure. The
+		// no-hidden-resolution invariant is preserved where it matters by the
+		// two assertions that follow this test: an EARLIER applied never
+		// resolves a LATER violated sibling, and a different unterminal'd entry
+		// still blocks.
 		await display('trace-closed');
 		await display('trace-open');
 		await terminal('trace-closed', 'applied');
@@ -86,8 +96,50 @@ describe('evaluatePhaseCriticalDirectives V2 authority', () => {
 			phaseLabel: PHASE,
 		});
 
+		expect(result).toMatchObject({ blocked: false, failedClosed: false });
+		expect(result.unresolved).toEqual([]);
+	});
+
+	it('does not let an earlier applied terminal resolve a later violated sibling (#2628)', async () => {
+		await display('trace-remediated');
+		await display('trace-violated');
+		await terminal('trace-remediated', 'applied');
+		await terminal('trace-violated', 'violated');
+
+		const result = await evaluatePhaseCriticalDirectives({
+			directory,
+			sessionId: 'session-a',
+			phaseLabel: PHASE,
+		});
+
+		expect(result.blocked).toBe(true);
 		expect(result.unresolved).toEqual([
-			{ id: ENTRY, trace_id: 'trace-open', reason: 'no_verdict' },
+			{
+				id: ENTRY,
+				trace_id: 'trace-violated',
+				reason: 'unremediated_violation',
+			},
+		]);
+	});
+
+	it('still blocks a different unterminal entry alongside a resolved one (#2628)', async () => {
+		await display('trace-closed', ENTRY);
+		await terminal('trace-closed', 'applied');
+		await display('trace-open', 'entry-other-unterminal');
+
+		const result = await evaluatePhaseCriticalDirectives({
+			directory,
+			sessionId: 'session-a',
+			phaseLabel: PHASE,
+		});
+
+		expect(result.blocked).toBe(true);
+		expect(result.unresolved).toEqual([
+			{
+				id: 'entry-other-unterminal',
+				trace_id: 'trace-open',
+				reason: 'no_verdict',
+			},
 		]);
 	});
 

--- a/tests/unit/hooks/phase-directives.test.ts
+++ b/tests/unit/hooks/phase-directives.test.ts
@@ -259,7 +259,15 @@ describe('phase-directives', () => {
 			expect(directives).toHaveLength(2);
 		});
 
-		it('preserves the same entry retrieved under distinct traces', async () => {
+		it('returns ONE obligation per entry when the same entry is retrieved under distinct traces (#2628)', async () => {
+			// #2628 intent: the reviewer's obligation unit is the directive
+			// (entry), not the (trace_id, entry_id) pair. Pair multiplicity
+			// re-created one verification per historical exposure and grew the
+			// injected compliance block O(entries x trace_ids) until reviewer
+			// sessions could not be created. The retained membership is
+			// deterministic: most recently committed, ties by greatest trace_id
+			// (this seed commits trace-a before trace-b, so trace-b wins either
+			// way).
 			const id = 'directive-shared-across-traces';
 			await appendKnowledge(
 				resolveSwarmKnowledgePath(dir),
@@ -270,12 +278,11 @@ describe('phase-directives', () => {
 
 			const directives = await readPhaseDirectivesToVerify(dir, 'Phase 1');
 
-			expect(
-				directives.map(({ trace_id, entry_id }) => ({ trace_id, entry_id })),
-			).toEqual([
-				{ trace_id: 'trace-a', entry_id: id },
-				{ trace_id: 'trace-b', entry_id: id },
-			]);
+			expect(directives).toHaveLength(1);
+			expect(directives[0]).toMatchObject({
+				trace_id: 'trace-b',
+				entry_id: id,
+			});
 		});
 
 		it('re-enumerates violated terminals for remediation but excludes resolved terminals', async () => {

--- a/tests/unit/hooks/prompt-block-budget-guardrail.test.ts
+++ b/tests/unit/hooks/prompt-block-budget-guardrail.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Defect-class guardrail for issue #2628 — every prompt-block builder defined
+ * under src/ must be bounded.
+ *
+ * Class: "prompt-injected block whose size is driven by an unbounded
+ * ledger/list-derived multiplicity, rendered without dedupe or a hard
+ * character budget." The #2628 compliance block and the #2045 delegate block
+ * are the two known instances; this scan keeps any future `build*Block`
+ * prompt builder in the same bounded contract: its module must reference a
+ * char-budget constant (`*_CHAR_CAP`) or the builder must take a budget
+ * parameter (`charBudget`). Scan-scope note: the repo's prompt-block naming
+ * convention is the `build*Block` prefix (both known builders follow it);
+ * a differently-named future builder escapes this heuristic rung and must be
+ * added here.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import * as path from 'node:path';
+
+const SRC_ROOT = path.resolve(import.meta.dir, '../../../src');
+
+const BUILDER_PATTERN =
+	/export (?:async )?function build[A-Za-z0-9]*Block\s*\(/g;
+// Bounding mechanisms observed across the repo's block builders (sweep,
+// 2026-09-07): hard char caps (CHAR_CAP), per-block char budgets
+// (CHAR_BUDGET / charBudget), token budgets (tokenBudget), file-count caps
+// (maxFiles), and item-count caps (*_CAP). A builder module counts as bounded
+// when ANY of these appear in the module (constant, parameter, or slice cap).
+const BOUND_EVIDENCE =
+	/CHAR_CAP|CHAR_BUDGET|char_budget|charBudget|tokenBudget|maxFiles|[A-Z_]*_CAP\b/;
+
+function* walkTsFiles(root: string): Generator<string> {
+	for (const name of readdirSync(root)) {
+		const full = path.join(root, name);
+		const stat = statSync(full);
+		if (stat.isDirectory()) {
+			yield* walkTsFiles(full);
+		} else if (name.endsWith('.ts') && !name.endsWith('.test.ts')) {
+			yield full;
+		}
+	}
+}
+
+describe('prompt-block budget guardrail (#2628 defect class)', () => {
+	it('finds the known prompt-block builders (anti-vacuous control)', () => {
+		const builders = new Map<string, string[]>();
+		for (const file of walkTsFiles(SRC_ROOT)) {
+			const content = readFileSync(file, 'utf-8');
+			const names = [...content.matchAll(BUILDER_PATTERN)].map(
+				(m) => m[1] ?? m[0],
+			);
+			if (names.length > 0) builders.set(file, names);
+		}
+		// Both shipped builders must still exist for this scan to mean anything.
+		const allNames = [...builders.values()].flat().join('\n');
+		expect(allNames).toContain('buildDirectiveComplianceBlock');
+		expect(allNames).toContain('buildDelegateDirectiveBlock');
+	});
+
+	it('bounds every prompt-block builder with a char cap or budget parameter', () => {
+		const unbounded: string[] = [];
+		let builderFiles = 0;
+		for (const file of walkTsFiles(SRC_ROOT)) {
+			const content = readFileSync(file, 'utf-8');
+			const matches = [...content.matchAll(BUILDER_PATTERN)];
+			if (matches.length === 0) continue;
+			builderFiles += 1;
+			if (!BOUND_EVIDENCE.test(content)) {
+				unbounded.push(
+					`${path.relative(SRC_ROOT, file)}: ${matches.map((m) => m[0]).join(', ')}`,
+				);
+			}
+		}
+		expect(builderFiles).toBeGreaterThan(0);
+		expect(unbounded).toEqual([]);
+	});
+});

--- a/tests/unit/hooks/prompt-block-budget-guardrail.test.ts
+++ b/tests/unit/hooks/prompt-block-budget-guardrail.test.ts
@@ -76,3 +76,25 @@ describe('prompt-block budget guardrail (#2628 defect class)', () => {
 		expect(unbounded).toEqual([]);
 	});
 });
+
+describe('compliance budget wiring pin (#2636 review PRR-005)', () => {
+	it('pins the budget clamp wiring at both injection call sites', () => {
+		// The two reviewer-dispatch paths must pass the clamped compliance
+		// budget (configured knob clamped to the hard cap) to
+		// buildDirectiveComplianceBlock. This source-level pin catches a
+		// silent revert to the unbounded one-argument call.
+		const taskPath = readFileSync(
+			path.resolve(SRC_ROOT, 'hooks/delegate-directive-injection.ts'),
+			'utf-8',
+		);
+		const lanePath = readFileSync(
+			path.resolve(SRC_ROOT, 'hooks/knowledge-injector.ts'),
+			'utf-8',
+		);
+		const wiring = /DIRECTIVE_COMPLIANCE_(?:DEFAULT_CHAR_BUDGET|HARD_CHAR_CAP)/;
+		expect(taskPath).toMatch(wiring);
+		expect(lanePath).toMatch(wiring);
+		expect(taskPath).toMatch(/buildDirectiveComplianceBlock\(\s*toVerify,/);
+		expect(lanePath).toMatch(/buildDirectiveComplianceBlock\(\s*toVerify,/);
+	});
+});


### PR DESCRIPTION
Closes #2628

## Summary

The reviewer `directives_to_verify` auto-injected block is O(entries × trace_ids) and can
overflow the model window at session creation, permanently blocking review/verification
gates (field measurement: 813,213 bytes / 1,948 pairs = 24 entries × ≥560 trace_ids;
local repro: 587,947 bytes at 1,440 pairs, ~408 bytes/pair). Root cause:
`readPhaseDirectivesToVerify` emits one `DirectiveToVerify` per live receipt membership
(pair), and `buildDirectiveComplianceBlock` renders every element with no dedupe and no
character budget. The fix makes the obligation unit the **entry** everywhere: per-entry
dedupe at the source, a hard char cap with critical-preserving overflow at the renderer,
and matching per-entry resolution in the phase-complete critical-directive gate.

## Root Cause

- `src/hooks/phase-directives.ts` (`readPhaseDirectivesToVerify`, formerly :81-109):
  one `DirectiveToVerify` per live `(trace_id, entry_id)` membership — the reviewer's
  obligation re-accumulated once per historical retrieval exposure.
- `src/agents/reviewer-directive-compliance.ts` (`buildDirectiveComplianceBlock`,
  formerly :93-143): renders every element with full JSON-quoted `lesson` +
  `verification_predicate` — no dedupe, no char budget (the #2045-bound delegate block
  lives in the same subsystem; the compliance block never got the equivalent bound).
- Injected into every reviewer session at creation from both paths
  (`delegate-directive-injection.ts` and `knowledge-injector.ts`), so overflow was fatal.
- Fix constraint: `evaluatePhaseCriticalDirectives` consumed per-membership, so dedupe
  alone would have converted the overflow into a permanent phase block.

## Fix

- `readPhaseDirectivesToVerify` collapses to at most one obligation per entry via the new
  exported pure helper `pickDirectiveRepresentatives`: prefer a membership whose terminal
  is `violated` (remediation obligation, carrying `prior_terminal_*`), else the most
  recently committed, ties by greatest `trace_id` (code-unit order).
- `buildDirectiveComplianceBlock` renders under
  `min(inject_char_budget ?? 24_000, DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP = 24_000)` (the
  #2045 knob pattern, wired at both injection sites). Overflow drops **non-criticals**
  first (lowest priority first) with a bounded count note; **criticals are always
  rendered**, with a distinct `critical overflow` notice when they alone exceed the
  budget (dropping one would permanently block the phase gate). Per-entry
  lesson/predicate prose truncates at 400 chars; pair identity and priority stay exact.
- `evaluatePhaseCriticalDirectives` resolves per entry: a satisfying terminal
  (override / applied / ignored|n_a with reason) on ANY phase-window membership resolves
  the entry, AND every violated/contradicted membership must be remediated by a strictly
  later `applied` on some membership of the same entry (an earlier applied never hides a
  later violation). Unresolved entries report the representative the reviewer was shown.
  Authorized overrides behave exactly as before.
- `DIRECTIVE_COMPLIANCE_OUTPUT_SPEC` and the rendered header no longer promise one
  verdict per trace×entry combination; `parseDirectivesToVerifyBlock` is unchanged
  (old prompts still parse).

## Recurrence Prevention (defect class)

- Defect class: prompt-injected block whose size is driven by an unbounded
  ledger/list-derived multiplicity, rendered without dedupe or an explicit budget.
- Sweep result: 8 exported `build*Block` builders enumerated; all dispositioned —
  1 FIX (this change), 1 already-bounded precedent (#2045), 3 bounded by design
  (system-enhancer per-block budget / ORIENTATION_MISSION_CHAR_BUDGET), 1 `maxFiles` cap,
  1 `tokenBudget` param, 1 item caps.
- Guardrail: `tests/unit/hooks/prompt-block-budget-guardrail.test.ts` — static source scan
  in the unit corpus asserting every prompt-block builder module references an explicit
  bounding mechanism (CHAR_CAP / CHAR_BUDGET / charBudget / tokenBudget / maxFiles / *_CAP).
  Demonstrated to bite: the pre-fix renderer blob has the builder and **zero** bounding
  evidence; the fixed file carries `DIRECTIVE_COMPLIANCE_HARD_CHAR_CAP` + `charBudget`.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; diff touches runtime hook
  injection and the phase gate only (`git diff --name-only` shows no src/index.ts entry).
- 2 (runtime portability): not touched — no runtime `bun:` imports or `Bun.*`
  calls added in `src/` (the only `bun:`-prefixed additions are `bun:test`
  imports in the two new test files, mandated by invariant 7 and erased from
  any runtime bundle); dist/ not committed.
- 3 (subprocesses): not touched — no spawn/exec changes in the diff.
- 4 (.swarm containment): not touched — no new `.swarm/` write paths; guidance-carrier
  injection mechanism (`insertGuidanceCarrier` + `deliveredGuidanceDelta`) untouched.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched — no test-runner scope changes.
- 7 (test writing): touched — two new test files follow bun:test only, no `mock.module`,
  `canonicalMkdtemp` fixtures, under the 500-line cap; evidence: `check:test-file-cap`
  0 violations, `check-invariants.sh` 7/7 pass, `check-test-tmpdir.sh` 0 blocking.
- 8 (session state): not touched — no new module-level session-keyed state; dedupe/cap
  are pure functions of the read-time membership list.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): touched — the compliance block content changed but the delivery
  mechanism is unchanged: still spliced via `insertReviewerComplianceMessage` →
  `insertGuidanceCarrier` (user-role carrier, in-place splice); evidence:
  `system-splice-ratchet-2526` + `host-message-role-contract-2526` suites pass (8/0).
- 11 (tool registration): not touched — no tool/agent-map changes (`drift:check
  --enforce` clean).
- 12 (release/cache): touched — ships the mandatory
  `docs/releases/pending/2628-bounded-directives-to-verify.md` fragment; no hand edits to
  `package.json#version`, `CHANGELOG.md`, or `.release-please-manifest.json`.

## Test plan

- Regression test: `bun test tests/unit/hooks/directive-compliance-bounded-2628.test.ts`
  -> 12 pass / 0 fail / 78 expects
- Frozen acceptance checks (issue-tracer, RED-at-base → GREEN-at-head):
  `repro-check.sh run` C1-C7+C9 RED→GREEN, C8 GREEN→GREEN — all 9 PASS;
  `verify-checkpoint` 9/9 OK
- Impacted suites (isolation): phase-directives (21/0), phase-complete-directive-gate
  (19/0), reviewer-directive-compliance-prompt (9/0), reviewer-verdict-reconciliation-v2,
  delegation-lifecycle-reviewer-verdict, delegate-directive-injection*, lane-injection,
  system-splice-ratchet-2526 + host-message-role-contract-2526 (8/0) -> PASS
- Lint/type/build/security checks: `bun run typecheck` clean; `bunx biome ci` on all 12
  changed files clean; `bun run check:test-file-cap` 0 violations;
  `bun run check:registry-citations` pass; atomic-write ratchet 7/0;
  `scripts/check-invariants.sh` 7/7; `scripts/check-test-tmpdir.sh` 0 blocking;
  `bun run drift:check --enforce` no drift
- Deferred-work scan: `.opencode/skills/issue-tracer/scripts/scan-deferred.sh` -> clean

## Regression Protection

- New: `tests/unit/hooks/directive-compliance-bounded-2628.test.ts` — dedupe, selection
  precedence, committed_at tie-break (pure helper), budget + omission note, never-drop-
  critical + overflow notice, lesson truncation, gate cross-membership remediation both
  directions, reconciliation consistency (shown block vs fresh read), block round-trip.
- New: `tests/unit/hooks/prompt-block-budget-guardrail.test.ts` — defect-class guardrail
  with an anti-vacuous control (both known builders must remain present).
- Amended with intent: `phase-directives.test.ts` (pair-multiplicity pin → per-entry
  contract), `phase-complete-directive-gate.test.ts` (per-membership pin → per-entry
  resolution + no-hidden-resolution invariant assertions: earlier applied never resolves a
  later violated sibling; a different unterminal'd entry still blocks).
- Negative/boundary cases pinned: unverdicted critical still blocks (`no_verdict`),
  authorized-override violated terminal still resolves (override short-circuit preserved),
  single-membership phases unchanged (PRESERVING row C8 GREEN→GREEN).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 at most one obligation per entry | Frozen check C1 RED→GREEN (48→6 directives / 6 unique entries); unit "returns one directive per entry across many traces" |
| AC2 deterministic representative (violated-preferred, recency, trace_id tie) | Frozen check C2 RED→GREEN; unit "prefers a violated membership…"; unit "breaks committed_at ties by greatest trace_id"; mutation probe inverting the comparator flips C2 RED |
| AC3 hard ceiling, non-criticals dropped first, criticals never hidden | Frozen check C3 RED→GREEN (102,459→24,564 bytes; omission note; critical present); units "drops non-criticals first…" / "clamps the caller budget…" |
| AC4 reconciliation consistent on Task + lane-settle paths | Frozen check C4 RED→GREEN (emitted 5→1, zero omittedCriticals/uncertainties); unit "keeps the fresh-read verify-set consistent with the shown block" |
| AC5 phase gate resolves per entry; violations still block | Frozen check C5 RED→GREEN; gate units: later-applied-remediates / earlier-applied-does-not-resolve / different-entry-still-blocks |
| AC6 heavy cohort (24×60) bounded O(entries) | Frozen check C6 RED→GREEN (1,440 pairs / 600,907 B → 24 directives / 10,863 B) |
| AC7 spec no longer promises per-pair verdicts | Frozen check C7 RED→GREEN; unit "no longer documents the per-pair multiplicity contract (#2628 AC7)" |
| AC8 single-membership behavior preserved | Frozen PRESERVING check C8 GREEN→GREEN; full phase-directives suite 21/21 |
| AC9 criticals-exceed-budget renders all + distinct notice | Frozen check C9 RED→GREEN (100 criticals all rendered + notice); unit "never drops a critical and emits the distinct overflow notice" |

## Risk and Rollback

- Risk level: medium (gate resolution semantics widened — but fail-closed direction, and
  the widening is exactly the obligation-unit change the fix requires, pinned on both
  sides by C5 and the amended gate tests).
- Rollback: revert the commit; no persistence, migration, or on-disk format change; the
  parser accepts pre- and post-fix blocks either way.
- Residual risk: a `verification_predicate` longer than 400 chars renders truncated in
  the shown block (documented; predicate_check metadata fails safe as `error`; lane-settle
  runs the full predicate from the producer).

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.

PR head: dae54a3710446ade6a870af4cd916a866bdb83ab

## Issue Closure

Closes #2628
