### PR TITLE
feat(mcp): read-only MCP verification surface over stdio (#2499)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "opencode-swarm",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opencode-ai/plugin": "^1.18.3",
         "@opencode-ai/sdk": "^1.18.3",
         "@vscode/tree-sitter-wasm": "^0.3.0",
@@ -52,6 +53,10 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
 
+    "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -76,6 +81,12 @@
 
     "@vscode/tree-sitter-wasm": ["@vscode/tree-sitter-wasm@0.3.0", "", {}, "sha512-4kjB1jgLyG9VimGfyJb1F8/GFdrx55atsBCH/9r2D/iZHAUDCvZ5zhWXB7sRQ2z2WkkuNYm/0pgQtUm1jhdf7A=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "arity-n": ["arity-n@1.0.4", "", {}, "sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ=="],
@@ -86,39 +97,121 @@
 
     "bash-parser": ["bash-parser@0.5.0", "", { "dependencies": { "array-last": "^1.1.1", "babylon": "^6.9.1", "compose-function": "^3.0.3", "curry": "^1.2.0", "deep-freeze": "0.0.1", "filter-iterator": "0.0.1", "filter-obj": "^1.1.0", "has-own-property": "^0.1.0", "identity-function": "^1.0.0", "iterable-lookahead": "^1.0.0", "iterable-transform-replace": "^1.1.1", "magic-string": "^0.16.0", "map-iterable": "^1.0.1", "map-obj": "^2.0.0", "object-pairs": "^0.1.0", "object-values": "^1.0.0", "reverse-arguments": "^1.0.0", "shell-quote-word": "^1.0.1", "to-pascal-case": "^1.0.0", "transform-spread-iterable": "^1.1.0", "unescape-js": "^1.0.5" } }, "sha512-AQR43o4W4sj4Jf+oy4cFtGgyBps4B+MYnJg6Xds8VVC7yomFtQekhOORQNHfQ8D6YJ0XENykr3TpxMn3rUtgeg=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "compose-function": ["compose-function@3.0.3", "", { "dependencies": { "arity-n": "^1.0.4" } }, "sha512-xzhzTJ5eC+gmIzvZq+C3kCJHsp9os6tJkrigDRZclyGtOKINbZtE8n1Tzmeh32jW+BUDPbvZpibwvJHBLGMVwg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "curry": ["curry@1.2.0", "", {}, "sha512-PAdmqPH2DUYTCc/aknv6RxRxmqdRHclvbz+wP8t1Xpg2Nu13qg+oLb6/5iFoDmf4dbmC9loYoy9PwwGbFt/AqA=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "deep-freeze": ["deep-freeze@0.0.1", "", {}, "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "effect": ["effect@4.0.0-beta.83", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.7.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g=="],
+
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "filter-iterator": ["filter-iterator@0.0.1", "", {}, "sha512-v4lhL7Qa8XpbW3LN46CEnmhGk3eHZwxfNl5at20aEkreesht4YKb/Ba3BUIbnPhAC/r3dmu7ABaGk6MAvh2alA=="],
 
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-own-property": ["has-own-property@0.1.0", "", {}, "sha512-14qdBKoonU99XDhWcFKZTShK+QV47qU97u8zzoVo9cL5TZ3BmBHXogItSt9qJjR0KUMFRhcCW8uGIGl8nkl7Aw=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.7", "", {}, "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
     "identity-function": ["identity-function@1.0.0", "", {}, "sha512-kNrgUK0qI+9qLTBidsH85HjDLpZfrrS0ElquKKe/fJFdB3D7VeKdXXEvOPDUHSHOzdZKCAAaQIWWyp0l2yq6pw=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-iterable": ["is-iterable@1.1.1", "", {}, "sha512-EdOZCr0NsGE00Pot+x1ZFx9MJK3C6wy91geZpXwvwexDLJvA4nzYyZf7r+EIwSeVsOLDdBz7ATg9NqKTzuNYuQ=="],
 
     "is-number": ["is-number@4.0.0", "", {}, "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -126,9 +219,15 @@
 
     "iterable-transform-replace": ["iterable-transform-replace@1.2.0", "", { "dependencies": { "curry": "^1.2.0" } }, "sha512-AVCCj7CTUifWQ0ubraDgx5/e6tOWaL5qh/C8BDTjH0GuhNyFMCSsSmDtYpa4Y3ReAAQNSjUWfQ+ojhmjX10pdQ=="],
 
+    "jose": ["jose@6.2.12", "", {}, "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw=="],
+
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
@@ -138,33 +237,81 @@
 
     "map-obj": ["map-obj@2.0.0", "", {}, "sha512-TzQSV2DiMYgoF5RycneKVUzIa9bQsj/B3tTgsE3dOGqlzHnGIDaC7XBE7grnA+8kZPnfqSGFe95VHc2oc0VFUQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
     "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
+    "negotiator": ["negotiator@1.1.0", "", { "dependencies": { "content-type": "^2.1.0" } }, "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-pairs": ["object-pairs@0.1.0", "", {}, "sha512-3ECr6K831I4xX/Mduxr9UC+HPOz/d6WKKYj9p4cmC8Lg8p7g8gitzsxNX5IWlSIgFWN/a4JgrJaoAMKn20oKwA=="],
 
     "object-values": ["object-values@1.0.0", "", {}, "sha512-+8hwcz/JnQ9EpLIXzN0Rs7DLsBpJNT/xYehtB/jU93tHYr5BFEO8E+JGQNOSqE7opVzz5cGksKFHt7uUJVLSjQ=="],
 
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
+
     "quick-lru": ["quick-lru@7.3.0", "", {}, "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "reverse-arguments": ["reverse-arguments@1.0.0", "", {}, "sha512-/x8uIPdTafBqakK0TmPNJzgkLP+3H+yxpUJhCQHsLBg1rYEVNR2D8BRYNWQhVBjyOd7oo1dZRVzIkwMY2oqfYQ=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -172,7 +319,17 @@
 
     "shell-quote-word": ["shell-quote-word@1.0.1", "", {}, "sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg=="],
 
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string.fromcodepoint": ["string.fromcodepoint@0.2.1", "", {}, "sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg=="],
 
@@ -182,9 +339,13 @@
 
     "to-space-case": ["to-space-case@1.0.0", "", { "dependencies": { "to-no-case": "^1.0.0" } }, "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
     "transform-spread-iterable": ["transform-spread-iterable@1.4.1", "", { "dependencies": { "curry": "^1.2.0" } }, "sha512-/GnF26X3zC8wfWyRzvuXX/Vb31TrU3Rwipmr4MC5hTi6X/yOXxXUSw4+pcHmKJ2+0KRrcS21YWZw77ukhVJBdQ=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -192,7 +353,11 @@
 
     "unescape-js": ["unescape-js@1.1.4", "", { "dependencies": { "string.fromcodepoint": "^0.2.1" } }, "sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vlq": ["vlq@0.2.3", "", {}, "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="],
 
@@ -200,12 +365,22 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "negotiator/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
   }
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,6 +17,16 @@ project tree (no `.swarm/` state, no evidence, no git hygiene edits). The
 authorized write surface (#2500) and adds no write tools today — the
 registry's write-tool denylist fails closed either way.
 
+The read-only guarantee extends into the recall paths. `swarm_memory_recall`
+degrades to `available:false` unless the configured memory provider's store
+artifact (`memory.db` / `memories.jsonl`) already exists, then recalls through
+the registered tool's compute core with usage telemetry disabled — so a query
+never creates the sqlite store, runs migrations, or appends recall-usage rows.
+`knowledge_recall` skips the receipt-ledger rollup read while the
+`knowledge-receipts-v2.jsonl` journal does not exist, so a query never performs
+the ledger's one-time genesis. Pinned by
+`tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`.
+
 ## Tools
 
 | Tool | Capability |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,105 @@
+# Read-only MCP verification surface (`swarm mcp serve`)
+
+Any [Model Context Protocol](https://modelcontextprotocol.io) client can query
+Swarm verification state read-only for one configured project root — without
+running the OpenCode TUI (#2499, source issue #1227 phase 1).
+
+```bash
+opencode-swarm mcp serve --dir /path/to/project
+# or from a checkout:
+bunx opencode-swarm mcp serve --dir /path/to/project
+```
+
+The server speaks MCP over **stdio**, binds to exactly ONE project root per
+process, and is **read-only by default**: it never writes anywhere under the
+project tree (no `.swarm/` state, no evidence, no git hygiene edits). The
+`--allow-write` flag is a forward-compatibility seam for the explicitly
+authorized write surface (#2500) and adds no write tools today — the
+registry's write-tool denylist fails closed either way.
+
+## Tools
+
+| Tool | Capability |
+| --- | --- |
+| `knowledge_recall` | semantic knowledge-base recall (the same `searchKnowledge` core the in-session tool uses, without receipt-ledger writes) |
+| `swarm_memory_recall` | scoped Swarm memory recall (degrades to `available: false` when memory is disabled or no store exists — a query never creates one) |
+| `evidence_check` | completed-task evidence completeness over `.swarm/plan.md` + `.swarm/evidence/` |
+| `syntax_check` | tree-sitter syntax check over changed files |
+| `placeholder_scan` | TODO/FIXME/stub placeholder scan |
+| `sast_scan` | static analysis security scan (offline rules only — no Semgrep subprocess is ever spawned) |
+| `quality_budget` | complexity / API-surface / duplication / test-ratio budgets |
+| `plan_conflict_check` | declared-scope disjointness matrix for proposed parallel tasks |
+| `diff` | git diff contract analysis (degrades on non-git roots) |
+| `symbols` | tree-sitter symbol extraction/search |
+
+Tool names and descriptions come from the plugin's registered tool metadata,
+so what an MCP client sees matches the in-session tools exactly.
+
+## Security model
+
+- **Single root binding.** One server process = one `--dir` project root. The
+  root is validated at startup and every file-path argument is re-validated
+  per call against the canonical root.
+- **Containment.** Path arguments escaping the root — `..` traversal,
+  absolute paths outside the root, and symlink/junction indirection — are
+  rejected with a containment error; the outside-root file content never
+  enters a response. The checks reuse the same `path-security` helpers the
+  write tools rely on.
+- **Redaction then bounds.** Every response passes through the repo's secret
+  redaction (12 pattern families) FIRST, then is bounded to 65,536 serialized
+  characters, so a large corpus can never produce an unbounded response and
+  truncation can never split a secret pattern in half.
+- **No subprocesses.** The SAST adapter forces offline-only mode; no
+  `Bun.spawn`/`child_process` call is reachable from the MCP surface.
+
+## Client setup
+
+### Claude Code
+
+```json
+{
+  "mcpServers": {
+    "opencode-swarm": {
+      "command": "bunx",
+      "args": ["opencode-swarm", "mcp", "serve", "--dir", "/path/to/project"]
+    }
+  }
+}
+```
+
+(Or `claude mcp add opencode-swarm -- bunx opencode-swarm mcp serve --dir /path/to/project`.)
+
+### Cursor
+
+`.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "opencode-swarm": {
+      "command": "bunx",
+      "args": ["opencode-swarm", "mcp", "serve", "--dir", "/path/to/project"]
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot / other MCP clients)
+
+`.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "opencode-swarm": {
+      "type": "stdio",
+      "command": "bunx",
+      "args": ["opencode-swarm", "mcp", "serve", "--dir", "/path/to/project"]
+    }
+  }
+}
+```
+
+Any other MCP client works the same way: spawn
+`opencode-swarm mcp serve --dir <root>` as a stdio child and speak
+newline-delimited JSON-RPC 2.0 (`initialize` → `tools/list` → `tools/call`).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -21,11 +21,16 @@ The read-only guarantee extends into the recall paths. `swarm_memory_recall`
 degrades to `available:false` unless the configured memory provider's store
 artifact (`memory.db` / `memories.jsonl`) already exists, then recalls through
 the registered tool's compute core with usage telemetry disabled — so a query
-never creates the sqlite store, runs migrations, or appends recall-usage rows.
+never creates the sqlite store and never appends recall-usage rows.
 `knowledge_recall` skips the receipt-ledger rollup read while the
-`knowledge-receipts-v2.jsonl` journal does not exist, so a query never performs
-the ledger's one-time genesis. Pinned by
-`tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`.
+`knowledge-receipts-v2.jsonl` journal is absent or empty, so a query never
+performs the ledger's one-time genesis. Against an already-initialized,
+current-schema store these recalls are write-free (identical file set and
+sizes), pinned by `tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`.
+Two transitional write paths remain by design and are outside that promise: a
+stale-schema `memory.db` is migrated on open (normal upgrade behavior), and a
+local-jsonl store with a truncated tail is self-healed (rewritten plus an
+audit row) on read.
 
 ## Tools
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -12,7 +12,9 @@ bunx opencode-swarm mcp serve --dir /path/to/project
 
 The server speaks MCP over **stdio**, binds to exactly ONE project root per
 process, and is **read-only by default**: it never writes anywhere under the
-project tree (no `.swarm/` state, no evidence, no git hygiene edits). The
+project tree (no `.swarm/` state, no evidence, no git hygiene edits). Diff
+refs are validated against flag-shaped values, so a tool argument cannot
+redirect git output into a file. The
 `--allow-write` flag is a forward-compatibility seam for the explicitly
 authorized write surface (#2500) and adds no write tools today — the
 registry's write-tool denylist fails closed either way.
@@ -33,6 +35,9 @@ local-jsonl store with a truncated tail is self-healed (rewritten plus an
 audit row) on read.
 
 ## Tools
+
+(`knowledge_query` is deferred out of the Phase-1 surface — its capability
+area is covered by `knowledge_recall`; it becomes available in-session.)
 
 | Tool | Capability |
 | --- | --- |
@@ -60,12 +65,15 @@ so what an MCP client sees matches the in-session tools exactly.
   rejected with a containment error; the outside-root file content never
   enters a response. The checks reuse the same `path-security` helpers the
   write tools rely on.
-- **Redaction then bounds.** Every response passes through the repo's secret
-  redaction (12 pattern families) FIRST, then is bounded to 65,536 serialized
-  characters, so a large corpus can never produce an unbounded response and
-  truncation can never split a secret pattern in half.
-- **No subprocesses.** The SAST adapter forces offline-only mode; no
-  `Bun.spawn`/`child_process` call is reachable from the MCP surface.
+- **Redaction then bounds.** Every response — success and error text alike —
+  passes through the repo's secret redaction (12 pattern families) FIRST, then
+  is bounded to 65,536 serialized characters, so a large corpus can never
+  produce an unbounded response and truncation can never split a secret
+  pattern in half. Containment errors never disclose the host-side root path.
+- **Bounded subprocess reach.** The SAST adapter forces offline-only mode, so
+  the Semgrep subprocess is unreachable from the MCP surface. The `diff`
+  adapter does transit git (read-only) via the registered tool; its refs are
+  dash-validated so an argument cannot redirect git output into a file.
 
 ## Client setup
 

--- a/docs/releases/pending/2499-readonly-mcp-verification-surface.md
+++ b/docs/releases/pending/2499-readonly-mcp-verification-surface.md
@@ -47,6 +47,9 @@ the registered tool's compute core with usage telemetry disabled
 (`gateway.recall(..., {recordUsage: false})`); `knowledge_recall` skips the
 receipt-ledger rollup read while the receipts journal is absent or empty
 (rank-neutral — both yield empty rollups). A committed suite
-(`tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`) pins byte-identical
-project trees for both recall tools in enabled configurations, with
-load-bearing-flag falsifiability tests for both seams.
+(`tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`) pins write-free
+recalls (identical file set and sizes) for both recall tools in enabled
+configurations against initialized, current-schema stores, with
+load-bearing-flag falsifiability tests for both seams. Stale-schema sqlite
+stores (migrated on open) and truncated local-jsonl tails (self-healed on
+read) remain documented transitional write paths.

--- a/docs/releases/pending/2499-readonly-mcp-verification-surface.md
+++ b/docs/releases/pending/2499-readonly-mcp-verification-surface.md
@@ -37,3 +37,16 @@ quality/scope checks) was reachable only through the OpenCode plugin host or
 the CLI. Any MCP-capable client (Claude Code, Cursor, VS Code, JetBrains)
 can now query it read-only for one project root — the largest audience
 expansion without rewriting the orchestration core (#1227).
+
+### Hardening (final-critic round)
+
+The recall adapters are now write-free in the configurations where their
+writers actually live: `swarm_memory_recall` probes the configured provider's
+initialized store artifact before constructing anything and recalls through
+the registered tool's compute core with usage telemetry disabled
+(`gateway.recall(..., {recordUsage: false})`); `knowledge_recall` skips the
+receipt-ledger rollup read while the receipts journal is absent or empty
+(rank-neutral — both yield empty rollups). A committed suite
+(`tests/unit/mcp/readonly-recall-no-writes-2499.test.ts`) pins byte-identical
+project trees for both recall tools in enabled configurations, with
+load-bearing-flag falsifiability tests for both seams.

--- a/docs/releases/pending/2499-readonly-mcp-verification-surface.md
+++ b/docs/releases/pending/2499-readonly-mcp-verification-surface.md
@@ -22,7 +22,7 @@
   (traversal, absolute-outside-root, and symlink/junction escapes rejected,
   reusing `path-security` helpers), responses redacted (`redactSecrets`)
   before being bounded to 65,536 serialized chars (redact-then-bound order),
-  and SAST forced offline-only so no subprocess is reachable from the server.
+  with SAST forced offline-only so the Semgrep subprocess is unreachable from the server (the diff adapter transit git read-only, with dash-validated refs).
 - `docs/mcp.md` documents the server, its tools, the security model, and
   client setup for Claude Code, Cursor, and VS Code.
 - MCP conformance and two-client evidence: the official SDK client AND a
@@ -53,3 +53,19 @@ configurations against initialized, current-schema stores, with
 load-bearing-flag falsifiability tests for both seams. Stale-schema sqlite
 stores (migrated on open) and truncated local-jsonl tails (self-healed on
 read) remain documented transitional write paths.
+
+### Review feedback (swarm-pr-feedback round)
+
+- `diff` base refs are dash-validated (a flag-shaped ref could previously
+  redirect git output into a file inside the root); covered by committed
+  rejection tests.
+- The MCP `symbols` adapter now exposes the registered tool's real contract
+  (`workspace` boolean, `exported_only`) instead of an unwired string field
+  and dead `limit`.
+- Error responses now pass the same redact+bound pipeline as success
+  responses, and containment errors no longer disclose the host-side root
+  path.
+- The `knowledge_query` deferral is documented here and in `docs/mcp.md`.
+- Disclosure: adding `@modelcontextprotocol/sdk` pulls a transitive HTTP
+  stack the stdio-only usage never imports (upstream SDK packaging; not
+  reachable from the stdio server path).

--- a/docs/releases/pending/2499-readonly-mcp-verification-surface.md
+++ b/docs/releases/pending/2499-readonly-mcp-verification-surface.md
@@ -1,0 +1,39 @@
+### Read-only MCP verification surface: `swarm mcp serve` exposes verification state to any MCP client
+
+**What changed**
+
+- New `opencode-swarm mcp serve --dir <project-root> [--allow-write]` CLI
+  entry (#2499, source #1227 phase 1): a stdio MCP server built on the
+  official `@modelcontextprotocol/sdk` (new runtime dependency, `^1.30.0`).
+  One server process binds to exactly one configured project root and is
+  read-only by default — serving never writes anything under the project
+  tree (pinned by a byte-identical-tree acceptance check).
+- Ten read-only tools with names/descriptions sourced from the registered
+  `TOOL_METADATA` (exact parity): `knowledge_recall`, `swarm_memory_recall`,
+  `evidence_check`, `syntax_check`, `placeholder_scan`, `sast_scan`,
+  `quality_budget`, `plan_conflict_check`, `diff`, `symbols`. Every tool maps
+  to an existing registered production implementation — the four
+  evidence-persisting cores (`syntaxCheck`, `placeholderScan`, `sastScan`,
+  `qualityBudget`) gained persistence-free compute exports
+  (`computeSyntaxCheck` etc.) so the registered tools keep their exact
+  behavior (byte-identical wrapper path) while the MCP adapters run the same
+  analysis without writing `.swarm/` state.
+- Security envelope: per-call path containment against the canonical root
+  (traversal, absolute-outside-root, and symlink/junction escapes rejected,
+  reusing `path-security` helpers), responses redacted (`redactSecrets`)
+  before being bounded to 65,536 serialized chars (redact-then-bound order),
+  and SAST forced offline-only so no subprocess is reachable from the server.
+- `docs/mcp.md` documents the server, its tools, the security model, and
+  client setup for Claude Code, Cursor, and VS Code.
+- MCP conformance and two-client evidence: the official SDK client AND a
+  hand-rolled raw JSON-RPC stdio client both complete
+  initialize → tools/list → tools/call round trips against a real served
+  child process (frozen acceptance checks C4/C5).
+
+**Why**
+
+Swarm's verification layer (knowledge recall, evidence queries, syntax/SAST/
+quality/scope checks) was reachable only through the OpenCode plugin host or
+the CLI. Any MCP-capable client (Claude Code, Cursor, VS Code, JetBrains)
+can now query it read-only for one project root — the largest audience
+expansion without rewriting the orchestration core (#1227).

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 		"check:retrieval-quality": "bun run scripts/retrieval-quality-regression.ts"
 	},
 	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.30.0",
 		"@opencode-ai/plugin": "^1.18.3",
 		"@opencode-ai/sdk": "^1.18.3",
 		"@vscode/tree-sitter-wasm": "^0.3.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -960,6 +960,14 @@ async function main(): Promise<void> {
 		// behaviors (did-you-mean, deprecation warnings, policy gates).
 		const exitCode = await run(['ci', ...args.slice(1)]);
 		process.exit(exitCode);
+	} else if (command === 'mcp') {
+		// Read-only MCP verification server over stdio (#2499). Long-running
+		// and CLI-only: it owns process stdin/stdout, so it cannot be a
+		// /swarm registry command. The handler dynamic-imports the SDK-backed
+		// server so it stays out of this entry chunk.
+		const { handleMcpCommand } = await import('./mcp.js');
+		const exitCode = await handleMcpCommand(args.slice(1));
+		process.exit(exitCode);
 	} else {
 		console.error(`Unknown command: ${command}`);
 		console.error('Run with --help for usage information');

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -21,7 +21,9 @@ export interface McpServeArgs {
 	allowWrite: boolean;
 }
 
-export function parseMcpServeArgs(argv: string[]): McpServeArgs | { error: string } {
+export function parseMcpServeArgs(
+	argv: string[],
+): McpServeArgs | { error: string } {
 	let root = '';
 	let allowWrite = false;
 	for (let i = 0; i < argv.length; i++) {
@@ -67,7 +69,9 @@ export function resolveMcpRoot(
 
 export async function handleMcpCommand(argv: string[]): Promise<number> {
 	if (argv[0] !== 'serve') {
-		console.error("Usage: opencode-swarm mcp serve --dir <project-root> [--allow-write]");
+		console.error(
+			'Usage: opencode-swarm mcp serve --dir <project-root> [--allow-write]',
+		);
 		return argv.length === 0 ? 1 : 1;
 	}
 	const parsed = parseMcpServeArgs(argv.slice(1));

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -1,0 +1,96 @@
+/**
+ * `swarm mcp serve` CLI handler (#2499).
+ *
+ * Starts the read-only MCP verification server over stdio for ONE
+ * configured project root. This is a long-running CLI-only entry — it is
+ * deliberately NOT a `/swarm` registry command, because a stdio server must
+ * own the process stdin/stdout that an in-session command cannot.
+ *
+ * The MCP server module is DYNAMICALLY imported so the official SDK lands
+ * in a split chunk of the CLI bundle rather than growing the
+ * `dist/cli/index.js` entry (2.4 MB packaging cap), and the plugin bundle
+ * (`dist/index.js`) never imports it at all (init-bounded, invariant 1/2).
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { validateProjectDirectory } from '../utils/path-security.js';
+
+export interface McpServeArgs {
+	root: string;
+	allowWrite: boolean;
+}
+
+export function parseMcpServeArgs(argv: string[]): McpServeArgs | { error: string } {
+	let root = '';
+	let allowWrite = false;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === '--dir') {
+			root = argv[i + 1] ?? '';
+			i += 1;
+		} else if (arg.startsWith('--dir=')) {
+			root = arg.slice('--dir='.length);
+		} else if (arg === '--allow-write') {
+			// Recognized forward-compat seam (#2500): never errors, adds no
+			// write tools in Phase 1 (the registry denylist stays fail-closed).
+			allowWrite = true;
+		} else {
+			return { error: `unknown argument: ${arg}` };
+		}
+	}
+	if (!root) {
+		return { error: 'mcp serve requires --dir <project-root>' };
+	}
+	return { root, allowWrite };
+}
+
+/** Resolve + fail-closed validate the configured project root. */
+export function resolveMcpRoot(
+	input: string,
+): { root: string } | { error: string } {
+	const resolved = path.isAbsolute(input)
+		? path.normalize(input)
+		: path.resolve(process.cwd(), input);
+	try {
+		validateProjectDirectory(resolved);
+	} catch (error) {
+		return {
+			error: `invalid --dir: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	if (!existsSync(resolved) || !statSync(resolved).isDirectory()) {
+		return { error: `invalid --dir: not an existing directory: ${resolved}` };
+	}
+	return { root: resolved };
+}
+
+export async function handleMcpCommand(argv: string[]): Promise<number> {
+	if (argv[0] !== 'serve') {
+		console.error("Usage: opencode-swarm mcp serve --dir <project-root> [--allow-write]");
+		return argv.length === 0 ? 1 : 1;
+	}
+	const parsed = parseMcpServeArgs(argv.slice(1));
+	if ('error' in parsed) {
+		console.error(`mcp serve: ${parsed.error}`);
+		return 1;
+	}
+	const rootResult = resolveMcpRoot(parsed.root);
+	if ('error' in rootResult) {
+		console.error(`mcp serve: ${rootResult.error}`);
+		return 1;
+	}
+	try {
+		// Dynamic import: keeps the SDK out of the CLI entry chunk.
+		const { runMcpServer } = await import('../mcp/server.js');
+		return await runMcpServer({
+			root: rootResult.root,
+			allowWrite: parsed.allowWrite,
+		});
+	} catch (error) {
+		console.error(
+			`mcp serve: failed to start: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return 1;
+	}
+}

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -72,7 +72,7 @@ export async function handleMcpCommand(argv: string[]): Promise<number> {
 		console.error(
 			'Usage: opencode-swarm mcp serve --dir <project-root> [--allow-write]',
 		);
-		return argv.length === 0 ? 1 : 1;
+		return 1;
 	}
 	const parsed = parseMcpServeArgs(argv.slice(1));
 	if ('error' in parsed) {

--- a/src/hooks/search-knowledge.ts
+++ b/src/hooks/search-knowledge.ts
@@ -21,6 +21,8 @@
  *   (critical force-include) → emit a `retrieved` event → return trace_id.
  */
 
+import { existsSync, statSync } from 'node:fs';
+import path from 'node:path';
 import { stripKnownSwarmPrefix } from '../config/schema.js';
 import {
 	buildSynonymIndex,
@@ -120,6 +122,13 @@ export interface SearchKnowledgeParams {
 	 * passes false so an explicit query is not silently role-gated.
 	 */
 	applyRoleScope?: boolean;
+	/**
+	 * Skip the receipt-authority rollup read when the receipts-v2 journal does
+	 * not exist yet (default false). Read-only surfaces (#2499 MCP) set this so
+	 * a query never materializes the ledger; ranking is unchanged because an
+	 * absent ledger yields empty rollups anyway.
+	 */
+	skipLedgerGenesis?: boolean;
 }
 
 export interface SearchKnowledgeResult {
@@ -270,6 +279,7 @@ export async function searchKnowledge(
 		applyScopeFilter = true,
 		forceReadHive = false,
 		applyRoleScope = true,
+		skipLedgerGenesis = false,
 	} = params;
 
 	const traceId = newTraceId();
@@ -312,8 +322,20 @@ export async function searchKnowledge(
 				skipScopeFilter: !applyScopeFilter,
 			},
 		);
+		// A read-only surface must not perform the one-time ledger genesis that
+		// `runLocked` inside the rollup read triggers on an absent or empty
+		// journal; both yield empty rollups, so skipping is rank-neutral.
+		const journalPath = path.join(
+			directory,
+			'.swarm',
+			'knowledge-receipts-v2.jsonl',
+		);
+		const journalReadable =
+			existsSync(journalPath) && statSync(journalPath).size > 0;
 		const counterRollups =
-			await readAuthoritativeKnowledgeCounterRollups(directory);
+			skipLedgerGenesis && !journalReadable
+				? new Map<string, never>()
+				: await readAuthoritativeKnowledgeCounterRollups(directory);
 
 		// Tier post-filter (hive-only) + inactive-status exclusion.
 		// G4 (#1716): use the canonical `isActiveStatus` helper so any future

--- a/src/mcp/adapters/knowledge-memory.ts
+++ b/src/mcp/adapters/knowledge-memory.ts
@@ -1,0 +1,126 @@
+/**
+ * Knowledge + memory adapters for the read-only MCP surface (#2499).
+ *
+ * `knowledge_recall` calls `searchKnowledge` — the exact retrieval core the
+ * registered `knowledge_recall` tool uses — WITHOUT the receipt-ledger writes
+ * (those commits are session display-membership bookkeeping, not part of
+ * retrieval). `swarm_memory_recall` goes through the registered tool with a
+ * synthetic sessionless context, but ONLY after read-only probes confirm the
+ * feature is enabled AND a store already exists, so no `.swarm/` state is
+ * ever materialized by a query.
+ */
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import { loadPluginConfigWithMeta } from '../../config';
+import { KnowledgeConfigSchema } from '../../config/schema.js';
+import { searchKnowledge } from '../../hooks/search-knowledge.js';
+import { swarm_memory_recall } from '../../tools/swarm-memory-recall.js';
+import type { McpReadTool } from '../registry.js';
+import { mcpToolContext, safeParseJson } from './verification.js';
+
+const knowledgeRecallSchema = z.object({
+	query: z.string().min(3).describe('Natural language search query'),
+	top_n: z
+		.number()
+		.int()
+		.min(1)
+		.max(20)
+		.optional()
+		.describe('Maximum results (default: 5)'),
+	tier: z
+		.enum(['all', 'swarm', 'hive'])
+		.optional()
+		.describe("Knowledge tier to search (default: 'all')"),
+});
+
+const memoryRecallSchema = z.object({
+	query: z.string().min(3).describe('Natural language recall query'),
+});
+
+export const knowledgeRecallAdapter: McpReadTool = {
+	name: 'knowledge_recall',
+	description:
+		'Performs semantic natural-language search across the knowledge base for relevant past decisions, patterns, and lessons learned.',
+	kind: 'read',
+	pathFields: [],
+	inputSchema: knowledgeRecallSchema,
+	execute: async (rawArgs, root) => {
+		const args = knowledgeRecallSchema.parse(rawArgs);
+		// Read-only probes first: never materialize a knowledge store from a query.
+		const knowledgePath = path.join(root, '.swarm', 'knowledge');
+		if (!existsSync(knowledgePath)) {
+			return {
+				results: [],
+				total: 0,
+				available: false,
+				reason: 'no_knowledge_base',
+				message:
+					'No knowledge base exists under this project root yet; a read-only query never creates one.',
+			};
+		}
+		let knowledgeConfig = KnowledgeConfigSchema.parse({});
+		try {
+			const { config } = loadPluginConfigWithMeta(root);
+			knowledgeConfig = KnowledgeConfigSchema.parse(config.knowledge ?? {});
+		} catch {
+			// Default config when the project config cannot be loaded (read-only).
+		}
+		const { trace_id, results } = await searchKnowledge({
+			directory: root,
+			config: knowledgeConfig,
+			query: args.query,
+			mode: 'manual',
+			agent: 'mcp',
+			sessionId: 'mcp',
+			tier: args.tier,
+			maxResults: args.top_n,
+			// Preserve the registered tool's manual-recall semantics.
+			applyScopeFilter: false,
+			forceReadHive: true,
+			applyRoleScope: false,
+		});
+		return { trace_id, results, total: results.length };
+	},
+};
+
+export const swarmMemoryRecallAdapter: McpReadTool = {
+	name: 'swarm_memory_recall',
+	description:
+		'recall scoped Swarm memory for the current repository as untrusted background',
+	kind: 'read',
+	pathFields: [],
+	inputSchema: memoryRecallSchema,
+	execute: async (rawArgs, root) => {
+		const args = memoryRecallSchema.parse(rawArgs);
+		// Probe 1: feature flag (reads .opencode config — never writes).
+		const { config } = loadPluginConfigWithMeta(root);
+		if (config.memory?.enabled !== true) {
+			return {
+				available: false,
+				reason: 'memory_disabled',
+				message: 'Swarm memory is disabled. Set swarm.memory.enabled=true.',
+			};
+		}
+		// Probe 2: an existing store. `createConfiguredMemoryProviderForRoot`
+		// lazily creates storage directories, so a storeless root must degrade
+		// instead of constructing any provider.
+		if (!existsSync(path.join(root, '.swarm', 'memory'))) {
+			return {
+				available: false,
+				reason: 'no_store',
+				message:
+					'No memory store exists under this project root; a read-only query never creates one.',
+			};
+		}
+		// Registered production path with a sessionless synthetic context.
+		const result = await swarm_memory_recall.execute(
+			{ query: args.query },
+			// The registered tool reads only directory/sessionID off the context;
+			// the empty session id keeps attribution session-scoped and read-only.
+			{ ...mcpToolContext(root), sessionID: '' },
+		);
+		return typeof result === 'string' ? safeParseJson(result) : result;
+	},
+};

--- a/src/mcp/adapters/knowledge-memory.ts
+++ b/src/mcp/adapters/knowledge-memory.ts
@@ -2,12 +2,14 @@
  * Knowledge + memory adapters for the read-only MCP surface (#2499).
  *
  * `knowledge_recall` calls `searchKnowledge` — the exact retrieval core the
- * registered `knowledge_recall` tool uses — WITHOUT the receipt-ledger writes
- * (those commits are session display-membership bookkeeping, not part of
- * retrieval). `swarm_memory_recall` goes through the registered tool with a
- * synthetic sessionless context, but ONLY after read-only probes confirm the
- * feature is enabled AND a store already exists, so no `.swarm/` state is
- * ever materialized by a query.
+ * registered `knowledge_recall` tool uses — with `skipLedgerGenesis` so a
+ * query never performs the receipt ledger's one-time `runLocked` genesis.
+ * `swarm_memory_recall` calls the registered tool's compute core with
+ * `{recordUsage: false}` (identical retrieval, no telemetry write) — but ONLY
+ * after read-only probes confirm the feature is enabled AND the configured
+ * provider's store artifact already exists, so no `.swarm/` state (sqlite
+ * `memory.db` genesis, WAL/SHM files, migration reports) is ever materialized
+ * by a query.
  */
 
 import { existsSync } from 'node:fs';
@@ -16,7 +18,7 @@ import { z } from 'zod';
 import { loadPluginConfigWithMeta } from '../../config';
 import { KnowledgeConfigSchema } from '../../config/schema.js';
 import { searchKnowledge } from '../../hooks/search-knowledge.js';
-import { swarm_memory_recall } from '../../tools/swarm-memory-recall.js';
+import { computeSwarmMemoryRecall } from '../../tools/swarm-memory-recall.js';
 import type { McpReadTool } from '../registry.js';
 import { mcpToolContext, safeParseJson } from './verification.js';
 
@@ -80,6 +82,8 @@ export const knowledgeRecallAdapter: McpReadTool = {
 			applyScopeFilter: false,
 			forceReadHive: true,
 			applyRoleScope: false,
+			// Read-only surface: never materialize the receipts ledger (#2499).
+			skipLedgerGenesis: true,
 		});
 		return { trace_id, results, total: results.length };
 	},
@@ -103,10 +107,15 @@ export const swarmMemoryRecallAdapter: McpReadTool = {
 				message: 'Swarm memory is disabled. Set swarm.memory.enabled=true.',
 			};
 		}
-		// Probe 2: an existing store. `createConfiguredMemoryProviderForRoot`
-		// lazily creates storage directories, so a storeless root must degrade
-		// instead of constructing any provider.
-		if (!existsSync(path.join(root, '.swarm', 'memory'))) {
+		// Probe 2: the configured provider's INITIALIZED store artifact. The
+		// sqlite provider lazily creates `memory.db` (migrations + WAL/SHM) on
+		// construction, so a root whose provider has never persisted anything
+		// must degrade instead of letting a query perform that genesis.
+		const storeArtifact =
+			(config.memory.provider ?? 'sqlite') === 'sqlite'
+				? path.join(root, '.swarm', 'memory', 'memory.db')
+				: path.join(root, '.swarm', 'memory', 'memories.jsonl');
+		if (!existsSync(storeArtifact)) {
 			return {
 				available: false,
 				reason: 'no_store',
@@ -114,13 +123,16 @@ export const swarmMemoryRecallAdapter: McpReadTool = {
 					'No memory store exists under this project root; a read-only query never creates one.',
 			};
 		}
-		// Registered production path with a sessionless synthetic context.
-		const result = await swarm_memory_recall.execute(
+		// Registered production compute core with a sessionless synthetic
+		// context and usage telemetry disabled — identical retrieval, no write.
+		const result = await computeSwarmMemoryRecall(
 			{ query: args.query },
+			root,
 			// The registered tool reads only directory/sessionID off the context;
 			// the empty session id keeps attribution session-scoped and read-only.
 			{ ...mcpToolContext(root), sessionID: '' },
+			{ recordUsage: false },
 		);
-		return typeof result === 'string' ? safeParseJson(result) : result;
+		return safeParseJson(result);
 	},
 };

--- a/src/mcp/adapters/scope-repo.ts
+++ b/src/mcp/adapters/scope-repo.ts
@@ -1,0 +1,112 @@
+/**
+ * Scope/repo adapters for the read-only MCP surface (#2499).
+ *
+ * `plan_conflict_check` validates declared-scope disjointness (the
+ * scope-validation capability) via `executePlanConflictCheck` — the same
+ * exported core the registered tool calls; it reads `.swarm/plan.json` and
+ * `.swarm/scopes/` fail-open and writes nothing. `diff` and `symbols` go
+ * through the registered production tools (pure reads; `diff` guards
+ * non-git roots).
+ */
+
+import { z } from 'zod';
+import {
+	executePlanConflictCheck,
+	plan_conflict_check_args,
+} from '../../tools/plan-conflict-check.js';
+import { diff as diffTool } from '../../tools/diff.js';
+import { symbols as symbolsTool } from '../../tools/symbols.js';
+import type { McpReadTool } from '../registry.js';
+import { mcpToolContext, safeParseJson } from './verification.js';
+
+const planConflictCheckSchema = z.object({
+	task_ids: plan_conflict_check_args.task_ids,
+	use_cochange: plan_conflict_check_args.use_cochange,
+	phase_id: plan_conflict_check_args.phase_id,
+});
+
+const diffSchema = z.object({
+	base: z
+		.string()
+		.optional()
+		.describe('Base ref to diff against (default: HEAD)'),
+	paths: z
+		.array(z.string())
+		.optional()
+		.describe('Optional file paths to restrict diff scope'),
+	summaryOnly: z
+		.boolean()
+		.optional()
+		.describe('Return only the file list summary'),
+});
+
+const symbolsSchema = z.object({
+	file: z.string().optional().describe('Specific file to extract symbols from'),
+	workspace: z
+		.string()
+		.optional()
+		.describe('Workspace-relative directory to search'),
+	name: z.string().optional().describe('Symbol name pattern to search'),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(500)
+		.optional()
+		.describe('Max results'),
+});
+
+export const planConflictCheckAdapter: McpReadTool = {
+	name: 'plan_conflict_check',
+	description:
+		'read-only advisory check (#1656): compute a pairwise file-conflict matrix for N proposed parallel task groups using declared scopes and optional git co-change; returns a verdict (all_disjoint / conflicts_present / unknown_scopes), per-pair evidence, and a suggested serialization order. Writes nothing — the execution gate independently recomputes the verdict inline at dispatch time via the same helper. Call BEFORE attempting parallel dispatch to confirm disjointness.',
+	kind: 'read',
+	pathFields: [],
+	inputSchema: planConflictCheckSchema,
+	execute: (rawArgs, root) =>
+		executePlanConflictCheck(planConflictCheckSchema.parse(rawArgs), root),
+};
+
+export const diffAdapter: McpReadTool = {
+	name: 'diff',
+	description:
+		'Analyze git diff for changed files, exports, interfaces, and function signatures. Returns structured output with contract change detection.',
+	kind: 'read',
+	pathFields: ['paths'],
+	inputSchema: diffSchema,
+	execute: async (rawArgs, root) => {
+		const args = diffSchema.parse(rawArgs);
+		try {
+			const result = await diffTool.execute(args, mcpToolContext(root));
+			return typeof result === 'string' ? safeParseJson(result) : result;
+		} catch (error) {
+			// Non-git working trees make `git diff` throw; degrade read-only
+			// instead of surfacing a stack error (#2499 R6).
+			const message =
+				error instanceof Error ? error.message : 'git diff unavailable';
+			if (/not a git|enoent|fatal|repository/i.test(message)) {
+				return {
+					available: false,
+					reason: 'not_a_git_worktree',
+					files: [],
+					message: 'The configured root is not a git working tree.',
+				};
+			}
+			throw error;
+		}
+	},
+};
+
+export const symbolsAdapter: McpReadTool = {
+	name: 'symbols',
+	description:
+		'Extract and search code symbols (functions, classes, methods, interfaces) across the repository using tree-sitter. Use for understanding code structure and finding definitions.',
+	kind: 'read',
+	pathFields: ['file', 'workspace'],
+	inputSchema: symbolsSchema,
+	execute: async (rawArgs, root) => {
+		const args = symbolsSchema.parse(rawArgs);
+		const result = await symbolsTool.execute(args, mcpToolContext(root));
+		return typeof result === 'string' ? safeParseJson(result) : result;
+	},
+};

--- a/src/mcp/adapters/scope-repo.ts
+++ b/src/mcp/adapters/scope-repo.ts
@@ -42,12 +42,18 @@ const diffSchema = z.object({
 
 const symbolsSchema = z.object({
 	file: z.string().optional().describe('Specific file to extract symbols from'),
+	// The registered tool gates workspace mode on a strict boolean
+	// (obj.workspace === true); a string could never enable it, and the tool
+	// has no subdirectory-scoping parameter (#2499 review finding).
 	workspace: z
-		.string()
+		.boolean()
 		.optional()
-		.describe('Workspace-relative directory to search'),
+		.describe('Search the whole workspace instead of a single file'),
 	name: z.string().optional().describe('Symbol name pattern to search'),
-	limit: z.number().int().min(1).max(500).optional().describe('Max results'),
+	exported_only: z
+		.boolean()
+		.optional()
+		.describe('Only include exported symbols (default true)'),
 });
 
 export const planConflictCheckAdapter: McpReadTool = {

--- a/src/mcp/adapters/scope-repo.ts
+++ b/src/mcp/adapters/scope-repo.ts
@@ -10,11 +10,11 @@
  */
 
 import { z } from 'zod';
+import { diff as diffTool } from '../../tools/diff.js';
 import {
 	executePlanConflictCheck,
 	plan_conflict_check_args,
 } from '../../tools/plan-conflict-check.js';
-import { diff as diffTool } from '../../tools/diff.js';
 import { symbols as symbolsTool } from '../../tools/symbols.js';
 import type { McpReadTool } from '../registry.js';
 import { mcpToolContext, safeParseJson } from './verification.js';
@@ -47,13 +47,7 @@ const symbolsSchema = z.object({
 		.optional()
 		.describe('Workspace-relative directory to search'),
 	name: z.string().optional().describe('Symbol name pattern to search'),
-	limit: z
-		.number()
-		.int()
-		.min(1)
-		.max(500)
-		.optional()
-		.describe('Max results'),
+	limit: z.number().int().min(1).max(500).optional().describe('Max results'),
 });
 
 export const planConflictCheckAdapter: McpReadTool = {

--- a/src/mcp/adapters/verification.ts
+++ b/src/mcp/adapters/verification.ts
@@ -1,0 +1,160 @@
+/**
+ * Verification adapters for the read-only MCP surface (#2499).
+ *
+ * Each adapter calls the SAME registered production implementation the
+ * in-session tool uses — the persistence-free compute cores exported by the
+ * tool modules (`computeSyntaxCheck`, `computePlaceholderScan`,
+ * `computeSastScan`, `computeQualityBudget`) and the registered
+ * `evidence_check` tool (a pure filesystem read). No parallel
+ * reimplementation of any verification logic lives here.
+ */
+
+import type { ToolContext } from '@opencode-ai/plugin';
+import { z } from 'zod';
+import { evidence_check } from '../../tools/evidence-check.js';
+import { computePlaceholderScan } from '../../tools/placeholder-scan.js';
+import { computeQualityBudget } from '../../tools/quality-budget.js';
+import { computeSastScan } from '../../tools/sast-scan.js';
+import { computeSyntaxCheck } from '../../tools/syntax-check.js';
+import type { McpReadTool } from '../registry.js';
+
+/** Synthetic tool context pinning the MCP server's single configured root. */
+export function mcpToolContext(root: string): ToolContext {
+	return { directory: root } as ToolContext;
+}
+
+export function safeParseJson(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return { raw: text };
+	}
+}
+
+const syntaxCheckSchema = z.object({
+	changed_files: z
+		.array(
+			z.object({
+				path: z.string().describe('Repository-relative file path'),
+				additions: z.number().describe('Added line count from the diff'),
+			}),
+		)
+		.describe('Files to check (from diff gate)'),
+	mode: z
+		.enum(['changed', 'all'])
+		.optional()
+		.describe(
+			"Check mode: 'changed' checks only additions > 0 entries; 'all' checks every entry",
+		),
+	languages: z
+		.array(z.string())
+		.optional()
+		.describe('Restrict to specific languages'),
+});
+
+const placeholderScanSchema = z.object({
+	changed_files: z
+		.array(z.string())
+		.describe('Repository-relative file paths to scan'),
+});
+
+const sastScanSchema = z.object({
+	changed_files: z
+		.array(z.string())
+		.describe('Repository-relative file paths to scan'),
+	severity_threshold: z
+		.enum(['low', 'medium', 'high', 'critical'])
+		.optional()
+		.describe('Minimum severity to report (default: medium)'),
+});
+
+const qualityBudgetSchema = z.object({
+	changed_files: z
+		.array(z.string())
+		.describe('Repository-relative file paths to analyze'),
+});
+
+const evidenceCheckSchema = z.object({
+	required_types: z
+		.string()
+		.optional()
+		.describe(
+			'Comma-separated evidence types required per task (default: "reviewer,test_engineer")',
+		),
+});
+
+export const syntaxCheckAdapter: McpReadTool = {
+	name: 'syntax_check',
+	description:
+		'Check syntax of source files using tree-sitter parsers. Supports JS/TS, Python, Go, Rust, Java, C/C++, C#, PHP, Ruby. Returns JSON with syntax errors found per file.',
+	kind: 'read',
+	pathFields: ['changed_files'],
+	inputSchema: syntaxCheckSchema,
+	execute: (rawArgs, root) =>
+		computeSyntaxCheck(syntaxCheckSchema.parse(rawArgs), root),
+};
+
+export const placeholderScanAdapter: McpReadTool = {
+	name: 'placeholder_scan',
+	description:
+		'Scan changed files for placeholder content: TODO/FIXME comments, stub implementations, and placeholder markers that indicate unfinished work.',
+	kind: 'read',
+	pathFields: ['changed_files'],
+	inputSchema: placeholderScanSchema,
+	execute: (rawArgs, root) =>
+		computePlaceholderScan(
+			{ changed_files: placeholderScanSchema.parse(rawArgs).changed_files },
+			root,
+		),
+};
+
+export const sastScanAdapter: McpReadTool = {
+	name: 'sast_scan',
+	description: 'static analysis security scan',
+	kind: 'read',
+	pathFields: ['changed_files'],
+	inputSchema: sastScanSchema,
+	execute: (rawArgs, root) => {
+		const args = sastScanSchema.parse(rawArgs);
+		// Structural offline guard (#2499 R3): the MCP surface never spawns the
+		// Semgrep subprocess — only the built-in pattern rules run.
+		return computeSastScan(
+			{
+				changed_files: args.changed_files,
+				severity_threshold: args.severity_threshold,
+				offline_only: true,
+			},
+			root,
+		);
+	},
+};
+
+export const qualityBudgetAdapter: McpReadTool = {
+	name: 'quality_budget',
+	description:
+		'check quality budgets (complexity, API surface, duplication, test ratio) for changed files',
+	kind: 'read',
+	pathFields: ['changed_files'],
+	inputSchema: qualityBudgetSchema,
+	execute: (rawArgs, root) =>
+		computeQualityBudget(
+			{ changed_files: qualityBudgetSchema.parse(rawArgs).changed_files },
+			root,
+		),
+};
+
+export const evidenceCheckAdapter: McpReadTool = {
+	name: 'evidence_check',
+	description:
+		'Verify completed tasks in the plan have required evidence. Reads .swarm/plan.md for completed tasks and .swarm/evidence/ for evidence files. Returns JSON with completeness ratio and gaps for tasks missing required evidence types.',
+	kind: 'read',
+	pathFields: [],
+	inputSchema: evidenceCheckSchema,
+	execute: async (rawArgs, root) => {
+		const args = evidenceCheckSchema.parse(rawArgs);
+		// Registered production path: the evidence_check tool is a pure
+		// filesystem read (no host state, no persistence).
+		const result = await evidence_check.execute(args, mcpToolContext(root));
+		return typeof result === 'string' ? safeParseJson(result) : result;
+	},
+};

--- a/src/mcp/pipeline.ts
+++ b/src/mcp/pipeline.ts
@@ -1,0 +1,89 @@
+/**
+ * Response pipeline for the read-only MCP verification surface (#2499).
+ *
+ * Every tool response leaving the MCP server passes through
+ * `applyResponsePipeline`: secrets are redacted FIRST (redacting before
+ * bounding matters — truncating first can split a secret pattern in half and
+ * defeat redaction), then the serialized payload is bounded so a large
+ * corpus can never produce an unbounded MCP response.
+ */
+
+import { redactSecrets } from '../memory/redaction.js';
+
+/** Frozen acceptance cap (repro/check-mcp-bounded-output.sh, C8): the
+ * JSON-serialized pipeline output may never exceed this many characters. */
+export const MCP_MAX_RESPONSE_CHARS = 65_536;
+
+const TRUNCATION_NOTE = '\n[swarm-mcp: response truncated to bound]';
+
+function redactStringsDeep(value: unknown, depth = 0): unknown {
+	if (depth > 32 || value === null || value === undefined) {
+		return value;
+	}
+	if (typeof value === 'string') {
+		return redactSecrets(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => redactStringsDeep(item, depth + 1));
+	}
+	if (value instanceof Map) {
+		const next = new Map();
+		for (const [k, v] of value) {
+			next.set(redactStringsDeep(k, depth + 1), redactStringsDeep(v, depth + 1));
+		}
+		return next;
+	}
+	if (value instanceof Set) {
+		const next = new Set();
+		for (const item of value) next.add(redactStringsDeep(item, depth + 1));
+		return next;
+	}
+	if (typeof value === 'object') {
+		// Dates and other non-plain objects pass through untouched; only plain
+		// record shapes are walked.
+		const proto = Object.getPrototypeOf(value);
+		if (proto !== Object.prototype && proto !== null) {
+			return value;
+		}
+		const next: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(value)) {
+			next[k] = redactStringsDeep(v, depth + 1);
+		}
+		return next;
+	}
+	return value;
+}
+
+function serializeBounded(value: unknown): string {
+	const json = JSON.stringify(value, null, 2) ?? 'null';
+	if (json.length <= MCP_MAX_RESPONSE_CHARS) {
+		return json;
+	}
+	// Deterministic bound: keep the head of the serialized form and append the
+	// truncation marker inside the cap.
+	const keep = Math.max(0, MCP_MAX_RESPONSE_CHARS - TRUNCATION_NOTE.length);
+	return `${json.slice(0, keep)}${TRUNCATION_NOTE}`;
+}
+
+export interface ResponsePipelineResult {
+	/** The redacted (still structured) payload. */
+	redacted: unknown;
+	/** The bounded serialized form actually sent to the client. */
+	serialized: string;
+	truncated: boolean;
+}
+
+/**
+ * Redact every string in the payload (top-level and nested, including MCP
+ * `content` arrays), then bound the serialized output to
+ * {@link MCP_MAX_RESPONSE_CHARS} characters.
+ */
+export function applyResponsePipeline(payload: unknown): ResponsePipelineResult {
+	const redacted = redactStringsDeep(payload);
+	const serialized = serializeBounded(redacted);
+	return {
+		redacted,
+		serialized,
+		truncated: serialized.includes(TRUNCATION_NOTE),
+	};
+}

--- a/src/mcp/pipeline.ts
+++ b/src/mcp/pipeline.ts
@@ -68,10 +68,25 @@ function serializeBounded(value: unknown): string {
 	if (json.length <= INTERNAL_TEXT_BUDGET) {
 		return json;
 	}
-	// Deterministic bound: keep the head of the serialized form and append the
-	// truncation marker inside the internal budget.
-	const keep = Math.max(0, INTERNAL_TEXT_BUDGET - TRUNCATION_NOTE.length);
-	return `${json.slice(0, keep)}${TRUNCATION_NOTE}`;
+	// Deterministic bound: keep the head of the serialized form and append
+	// the truncation marker. Quote/backslash escaping can expand the string
+	// when the caller re-serializes the return value, so shrink until the
+	// FULL escaped envelope fits the cap (bounded: ~escape-expansion halving
+	// per iteration, hard-capped at 40 iterations).
+	let keep = Math.max(0, INTERNAL_TEXT_BUDGET - TRUNCATION_NOTE.length);
+	let text = `${json.slice(0, keep)}${TRUNCATION_NOTE}`;
+	for (let i = 0; i < 40; i++) {
+		const envelope = JSON.stringify({ text, truncated: true });
+		if (envelope.length <= MCP_MAX_RESPONSE_CHARS) {
+			return text;
+		}
+		keep = Math.floor(keep / 2);
+		if (keep <= 0) {
+			return TRUNCATION_NOTE;
+		}
+		text = `${json.slice(0, keep)}${TRUNCATION_NOTE}`;
+	}
+	return text;
 }
 
 export interface ResponsePipelineResult {

--- a/src/mcp/pipeline.ts
+++ b/src/mcp/pipeline.ts
@@ -14,6 +14,12 @@ import { redactSecrets } from '../memory/redaction.js';
  * JSON-serialized pipeline output may never exceed this many characters. */
 export const MCP_MAX_RESPONSE_CHARS = 65_536;
 
+/** The serialized payload itself is bounded below the cap so that the
+ * pipeline's full return value (`{ text, truncated }`) — including JSON
+ * wrapper keys and quote-escaping when the caller re-serializes it — still
+ * fits inside {@link MCP_MAX_RESPONSE_CHARS}. */
+const INTERNAL_TEXT_BUDGET = MCP_MAX_RESPONSE_CHARS - 2048;
+
 const TRUNCATION_NOTE = '\n[swarm-mcp: response truncated to bound]';
 
 function redactStringsDeep(value: unknown, depth = 0): unknown {
@@ -29,7 +35,10 @@ function redactStringsDeep(value: unknown, depth = 0): unknown {
 	if (value instanceof Map) {
 		const next = new Map();
 		for (const [k, v] of value) {
-			next.set(redactStringsDeep(k, depth + 1), redactStringsDeep(v, depth + 1));
+			next.set(
+				redactStringsDeep(k, depth + 1),
+				redactStringsDeep(v, depth + 1),
+			);
 		}
 		return next;
 	}
@@ -56,34 +65,35 @@ function redactStringsDeep(value: unknown, depth = 0): unknown {
 
 function serializeBounded(value: unknown): string {
 	const json = JSON.stringify(value, null, 2) ?? 'null';
-	if (json.length <= MCP_MAX_RESPONSE_CHARS) {
+	if (json.length <= INTERNAL_TEXT_BUDGET) {
 		return json;
 	}
 	// Deterministic bound: keep the head of the serialized form and append the
-	// truncation marker inside the cap.
-	const keep = Math.max(0, MCP_MAX_RESPONSE_CHARS - TRUNCATION_NOTE.length);
+	// truncation marker inside the internal budget.
+	const keep = Math.max(0, INTERNAL_TEXT_BUDGET - TRUNCATION_NOTE.length);
 	return `${json.slice(0, keep)}${TRUNCATION_NOTE}`;
 }
 
 export interface ResponsePipelineResult {
-	/** The redacted (still structured) payload. */
-	redacted: unknown;
-	/** The bounded serialized form actually sent to the client. */
-	serialized: string;
+	/** The bounded, redacted serialized form actually sent to the client. */
+	text: string;
+	/** True when the serialized form was cut to fit the cap. */
 	truncated: boolean;
 }
 
 /**
  * Redact every string in the payload (top-level and nested, including MCP
  * `content` arrays), then bound the serialized output to
- * {@link MCP_MAX_RESPONSE_CHARS} characters.
+ * {@link MCP_MAX_RESPONSE_CHARS} characters. The RETURN VALUE itself is
+ * bounded — the full (unbounded) redacted payload never leaves the pipeline.
  */
-export function applyResponsePipeline(payload: unknown): ResponsePipelineResult {
+export function applyResponsePipeline(
+	payload: unknown,
+): ResponsePipelineResult {
 	const redacted = redactStringsDeep(payload);
-	const serialized = serializeBounded(redacted);
+	const text = serializeBounded(redacted);
 	return {
-		redacted,
-		serialized,
-		truncated: serialized.includes(TRUNCATION_NOTE),
+		text,
+		truncated: text.includes(TRUNCATION_NOTE),
 	};
 }

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -18,8 +18,15 @@
 import type { z } from 'zod';
 
 import { TOOL_METADATA } from '../tools/tool-metadata.js';
-import { knowledgeRecallAdapter, swarmMemoryRecallAdapter } from './adapters/knowledge-memory.js';
-import { diffAdapter, planConflictCheckAdapter, symbolsAdapter } from './adapters/scope-repo.js';
+import {
+	knowledgeRecallAdapter,
+	swarmMemoryRecallAdapter,
+} from './adapters/knowledge-memory.js';
+import {
+	diffAdapter,
+	planConflictCheckAdapter,
+	symbolsAdapter,
+} from './adapters/scope-repo.js';
 import {
 	evidenceCheckAdapter,
 	placeholderScanAdapter,

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,0 +1,116 @@
+/**
+ * Tool registry for the read-only MCP verification surface (#2499).
+ *
+ * `buildMcpToolRegistry` composes the read-only tool set for ONE configured
+ * project root. Descriptions are sourced from `TOOL_METADATA` — the same
+ * registry the plugin host uses — so MCP tool names are a subset of
+ * registered tool names with exact description parity (frozen by
+ * repro/check-mcp-registry-capability-coverage.sh, C2).
+ *
+ * The write boundary is fail-closed (frozen by
+ * repro/check-mcp-readonly-default-no-writes.sh, C6): every tool name is
+ * validated against a write-capable denylist and a match THROWS — with or
+ * without `allowWrite`. Phase 1 ships zero write tools; `allowWrite` is the
+ * documented forward-compat seam for the #2500 write surface and adds
+ * nothing today.
+ */
+
+import type { z } from 'zod';
+
+import { TOOL_METADATA } from '../tools/tool-metadata.js';
+import { knowledgeRecallAdapter, swarmMemoryRecallAdapter } from './adapters/knowledge-memory.js';
+import { diffAdapter, planConflictCheckAdapter, symbolsAdapter } from './adapters/scope-repo.js';
+import {
+	evidenceCheckAdapter,
+	placeholderScanAdapter,
+	qualityBudgetAdapter,
+	sastScanAdapter,
+	syntaxCheckAdapter,
+} from './adapters/verification.js';
+
+/** Write-capable tool-name shapes. Mirrors the frozen C6 denylist. */
+export const WRITE_TOOL_NAME_PATTERN =
+	/write_|record_|submit_|repair_|prepare_|rebind_|invalidate_|authorize_|external_skill_(promote|reject|delete|revoke)|swarm_apply_patch|save_plan|update_task_status|declare_scope|set_qa_gates|knowledge_add|knowledge_remove|knowledge_archive|checkpoint|phase_complete|complete_pr_workflow|abort_pr_workflow|approve_plan_critic|swarm_memory_propose|swarm_memory_outcome|spec_write|lint_spec|skill_generate|skill_regenerate|skill_retire|skill_improve|skill_apply|run_stale_reconciliation|epic_record_divergence|lean_turbo_acquire_locks|lean_turbo_plan_lanes|lean_turbo_critic|lean_turbo_review|lean_turbo_run_phase|convene_general_council|swarm_command/;
+
+export interface McpReadTool {
+	/** Registered plugin tool name (a TOOL_METADATA key). */
+	name: string;
+	/** Exact TOOL_METADATA description (parity assigned at build time). */
+	description: string;
+	kind: 'read';
+	/** Argument field names carrying file-path values (containment-checked). */
+	pathFields: string[];
+	/** MCP input schema (mirrors the registered tool's zod args). */
+	inputSchema: z.ZodObject<z.ZodRawShape>;
+	execute(args: Record<string, unknown>, root: string): Promise<unknown>;
+}
+
+export interface McpToolRegistry {
+	tools: McpReadTool[];
+}
+
+export interface BuildMcpToolRegistryOptions {
+	/** The single configured project root (one server = one root). */
+	root: string;
+	/** Alias for `root` (accepted for harness compatibility). */
+	directory?: string;
+	/**
+	 * Forward-compat seam for the #2500 explicitly-authorized write surface.
+	 * Phase 1 has no write tools, so this flag never adds anything; the
+	 * write-name denylist stays fail-closed either way.
+	 */
+	allowWrite?: boolean;
+}
+
+const READ_ADAPTERS: McpReadTool[] = [
+	knowledgeRecallAdapter,
+	swarmMemoryRecallAdapter,
+	evidenceCheckAdapter,
+	syntaxCheckAdapter,
+	placeholderScanAdapter,
+	sastScanAdapter,
+	qualityBudgetAdapter,
+	planConflictCheckAdapter,
+	diffAdapter,
+	symbolsAdapter,
+];
+
+export function buildMcpToolRegistry(
+	options: BuildMcpToolRegistryOptions,
+): McpToolRegistry {
+	const root = options.root || options.directory || '';
+	if (!root) {
+		throw new Error('buildMcpToolRegistry: a project root is required');
+	}
+	const tools: McpToolRegistry['tools'] = [];
+	for (const adapter of READ_ADAPTERS) {
+		const metadata = TOOL_METADATA[adapter.name as keyof typeof TOOL_METADATA];
+		if (!metadata) {
+			throw new Error(
+				`buildMcpToolRegistry: ${adapter.name} is not a registered tool (TOOL_METADATA parity violated)`,
+			);
+		}
+		if (WRITE_TOOL_NAME_PATTERN.test(adapter.name)) {
+			// Fail-closed write boundary: denylist matches throw even with
+			// allowWrite (Phase 1 ships no write tools at all).
+			throw new Error(
+				`buildMcpToolRegistry: refusing to register write-capable tool ${adapter.name} on the read-only MCP surface`,
+			);
+		}
+		if (adapter.kind !== 'read') {
+			throw new Error(
+				`buildMcpToolRegistry: only read tools are registrable (got ${adapter.kind} for ${adapter.name})`,
+			);
+		}
+		tools.push({
+			name: adapter.name,
+			// Exact-parity description sourced from the registered metadata.
+			description: metadata.description,
+			kind: 'read',
+			pathFields: adapter.pathFields,
+			inputSchema: adapter.inputSchema,
+			execute: adapter.execute,
+		});
+	}
+	return { tools };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,8 +27,12 @@ export class McpContainmentError extends Error {
 		readonly value: string,
 		readonly root: string,
 	) {
+		// The message deliberately omits `root`: it is returned to the MCP
+		// client verbatim, and disclosing the host-side project root would leak
+		// filesystem topology (#2499 review finding). The field is kept on the
+		// error object for local diagnostics.
 		super(
-			`path rejected by containment: field ${field} value ${value} resolves outside the configured root ${root}`,
+			`path rejected by containment: field ${field} value ${value} is outside the configured project root`,
 		);
 		this.name = 'McpContainmentError';
 	}
@@ -126,26 +130,26 @@ export function createMcpServer(options: RunMcpServerOptions): McpServer {
 				inputSchema: tool.inputSchema,
 			},
 			async (args: Record<string, unknown>) => {
-				for (const field of tool.pathFields) {
-					validatePathField(field, args[field], root);
-				}
+				// Containment validation sits INSIDE the try: a rejection must
+				// surface as a graceful isError result, not a protocol-level
+				// exception that bypasses the response pipeline (#2499 review).
 				try {
+					for (const field of tool.pathFields) {
+						validatePathField(field, args[field], root);
+					}
 					const raw = await tool.execute(args, root);
 					const { text } = applyResponsePipeline(raw);
 					return {
 						content: [{ type: 'text' as const, text }],
 					};
 				} catch (error) {
-					if (error instanceof McpContainmentError) {
-						return {
-							content: [{ type: 'text' as const, text: error.message }],
-							isError: true,
-						};
-					}
-					const message =
-						error instanceof Error ? error.message : String(error);
+					// Error text takes the same redact+bound pipeline as success
+					// payloads: the read-only contract covers ALL outbound text
+					// (#2499 review finding — errors previously bypassed it).
+					const raw = error instanceof Error ? error.message : String(error);
+					const { text } = applyResponsePipeline({ error: raw });
 					return {
-						content: [{ type: 'text' as const, text: `error: ${message}` }],
+						content: [{ type: 'text' as const, text }],
 						isError: true,
 					};
 				}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -34,11 +34,7 @@ export class McpContainmentError extends Error {
 	}
 }
 
-function validatePathValue(
-	field: string,
-	value: string,
-	root: string,
-): void {
+function validatePathValue(field: string, value: string, root: string): void {
 	if (typeof value !== 'string' || value === '') return;
 	if (path.isAbsolute(value) || /^[A-Za-z]:[/\\]/.test(value)) {
 		// Absolute argument: acceptable only when it stays inside the root,
@@ -92,7 +88,10 @@ export function validatePathField(
 		}
 		return;
 	}
-	if (typeof value === 'object' && typeof (value as { file?: unknown }).file === 'string') {
+	if (
+		typeof value === 'object' &&
+		typeof (value as { file?: unknown }).file === 'string'
+	) {
 		validatePathValue(`${field}.file`, (value as { file: string }).file, root);
 	}
 }
@@ -132,9 +131,9 @@ export function createMcpServer(options: RunMcpServerOptions): McpServer {
 				}
 				try {
 					const raw = await tool.execute(args, root);
-					const { serialized } = applyResponsePipeline(raw);
+					const { text } = applyResponsePipeline(raw);
 					return {
-						content: [{ type: 'text' as const, text: serialized }],
+						content: [{ type: 'text' as const, text }],
 					};
 				} catch (error) {
 					if (error instanceof McpContainmentError) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,181 @@
+/**
+ * MCP stdio server for the read-only verification surface (#2499).
+ *
+ * One server instance = one configured project root. Every tool call is
+ * containment-checked (path arguments must resolve inside the canonical
+ * root, including symlink/junction escapes), executed through the registered
+ * production implementations, and the response is redacted-then-bounded by
+ * the response pipeline before it leaves the server.
+ */
+
+import path from 'node:path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+	isCanonicalPathWithinRoot,
+	validateTargetWithinRoot,
+} from '../utils/path-security.js';
+import { buildMcpToolRegistry } from './registry.js';
+import { applyResponsePipeline } from './pipeline.js';
+
+const SERVER_NAME = 'opencode-swarm';
+
+/** Containment rejection carried as a tool-level error result. */
+export class McpContainmentError extends Error {
+	constructor(
+		readonly field: string,
+		readonly value: string,
+		readonly root: string,
+	) {
+		super(
+			`path rejected by containment: field ${field} value ${value} resolves outside the configured root ${root}`,
+		);
+		this.name = 'McpContainmentError';
+	}
+}
+
+function validatePathValue(
+	field: string,
+	value: string,
+	root: string,
+): void {
+	if (typeof value !== 'string' || value === '') return;
+	if (path.isAbsolute(value) || /^[A-Za-z]:[/\\]/.test(value)) {
+		// Absolute argument: acceptable only when it stays inside the root,
+		// lexically AND canonically (symlink/junction escape rejected).
+		const resolved = path.resolve(value);
+		const relative = path.relative(root, resolved);
+		if (relative.startsWith('..') || path.isAbsolute(relative)) {
+			throw new McpContainmentError(field, value, root);
+		}
+		if (!isCanonicalPathWithinRoot(resolved, root)) {
+			throw new McpContainmentError(field, value, root);
+		}
+		return;
+	}
+	// Relative argument: the write-tool containment contract resolves against
+	// the root and rejects traversal/control chars/symlink escapes itself.
+	const reason = validateTargetWithinRoot(value, root);
+	if (reason !== null) {
+		throw new McpContainmentError(field, value, root);
+	}
+	const resolved = path.resolve(root, value);
+	if (!isCanonicalPathWithinRoot(resolved, root)) {
+		// Symlink/junction escape: lexically inside, canonically outside.
+		throw new McpContainmentError(field, value, root);
+	}
+}
+
+/** Walk a declared path field's value shape and validate every path. */
+export function validatePathField(
+	field: string,
+	value: unknown,
+	root: string,
+): void {
+	if (value === undefined || value === null) return;
+	if (typeof value === 'string') {
+		validatePathValue(field, value, root);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			if (typeof item === 'string') {
+				validatePathValue(field, item, root);
+			} else if (item && typeof item === 'object') {
+				const obj = item as Record<string, unknown>;
+				if (typeof obj.path === 'string') {
+					validatePathValue(`${field}[].path`, obj.path, root);
+				} else if (typeof obj.file === 'string') {
+					validatePathValue(`${field}[].file`, obj.file, root);
+				}
+			}
+		}
+		return;
+	}
+	if (typeof value === 'object' && typeof (value as { file?: unknown }).file === 'string') {
+		validatePathValue(`${field}.file`, (value as { file: string }).file, root);
+	}
+}
+
+export interface RunMcpServerOptions {
+	root: string;
+	allowWrite?: boolean;
+	/** Test seam: inject transports instead of stdio (InMemoryTransport pair). */
+	transport?: { connect(server: unknown): Promise<void> } | undefined;
+	version?: string;
+}
+
+/**
+ * Build the MCP server (tools registered, containment + pipeline wired).
+ * Exported for unit tests that drive the server over in-memory transports.
+ */
+export function createMcpServer(options: RunMcpServerOptions): McpServer {
+	const root = options.root;
+	const registry = buildMcpToolRegistry({
+		root,
+		allowWrite: options.allowWrite,
+	});
+	const server = new McpServer({
+		name: SERVER_NAME,
+		version: options.version ?? '0.0.0',
+	});
+	for (const tool of registry.tools) {
+		server.registerTool(
+			tool.name,
+			{
+				description: tool.description,
+				inputSchema: tool.inputSchema,
+			},
+			async (args: Record<string, unknown>) => {
+				for (const field of tool.pathFields) {
+					validatePathField(field, args[field], root);
+				}
+				try {
+					const raw = await tool.execute(args, root);
+					const { serialized } = applyResponsePipeline(raw);
+					return {
+						content: [{ type: 'text' as const, text: serialized }],
+					};
+				} catch (error) {
+					if (error instanceof McpContainmentError) {
+						return {
+							content: [{ type: 'text' as const, text: error.message }],
+							isError: true,
+						};
+					}
+					const message =
+						error instanceof Error ? error.message : String(error);
+					return {
+						content: [{ type: 'text' as const, text: `error: ${message}` }],
+						isError: true,
+					};
+				}
+			},
+		);
+	}
+	return server;
+}
+
+/** Serve the read-only verification surface over stdio until stdin closes. */
+export async function runMcpServer(
+	options: RunMcpServerOptions,
+): Promise<number> {
+	const server = createMcpServer(options);
+	const transport =
+		options.transport !== undefined
+			? options.transport
+			: new StdioServerTransport();
+	// The SDK's connect signature takes a Transport; the test seam's looser
+	// shape is funneled through unchanged.
+	await server.connect(
+		transport as unknown as Parameters<McpServer['connect']>[0],
+	);
+	if (options.transport === undefined) {
+		// Stdio mode: hold the process open while the transport reads stdin.
+		// The normal shutdown path is the client closing stdin (EOF), which
+		// closes the transport and empties the event loop so the process exits
+		// without this promise ever settling.
+		await new Promise<void>(() => {});
+	}
+	return 0;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,8 +15,8 @@ import {
 	isCanonicalPathWithinRoot,
 	validateTargetWithinRoot,
 } from '../utils/path-security.js';
-import { buildMcpToolRegistry } from './registry.js';
 import { applyResponsePipeline } from './pipeline.js';
+import { buildMcpToolRegistry } from './registry.js';
 
 const SERVER_NAME = 'opencode-swarm';
 

--- a/src/memory/gateway.ts
+++ b/src/memory/gateway.ts
@@ -94,6 +94,15 @@ export interface ProposeMemoryInput {
 	evidenceRefs?: string[];
 }
 
+/**
+ * Recall options for read-only surfaces. `recordUsage: false` skips the
+ * recall-usage telemetry write (the sqlite/jsonl `recordRecallUsage` insert)
+ * while keeping the identical retrieval path (#2499).
+ */
+export interface RecallUsageOptions {
+	recordUsage?: boolean;
+}
+
 export interface RecallMemoryInput {
 	query: string;
 	task?: string;
@@ -202,7 +211,10 @@ export class MemoryGateway {
 		return scopes;
 	}
 
-	async recall(input: RecallMemoryInput): Promise<RecallBundle> {
+	async recall(
+		input: RecallMemoryInput,
+		options?: RecallUsageOptions,
+	): Promise<RecallBundle> {
 		this.assertEnabled();
 		const query = normalizeMemoryText(input.query);
 		if (query.length < 3) {
@@ -259,6 +271,11 @@ export class MemoryGateway {
 					}
 				: undefined,
 		});
+		if (options?.recordUsage === false) {
+			// Read-only surfaces (#2499 MCP verification) recall without the
+			// usage-telemetry write; every other caller keeps the default.
+			return bundle;
+		}
 		await this.provider.recordRecallUsage?.({
 			bundleId: bundle.id,
 			query,

--- a/src/tools/diff.ts
+++ b/src/tools/diff.ts
@@ -36,6 +36,13 @@ function validateBase(base: string): string | null {
 	if (base.length > MAX_REF_LENGTH) {
 		return `base ref exceeds maximum length of ${MAX_REF_LENGTH}`;
 	}
+	// Reject flag-shaped refs: SAFE_REF_PATTERN admits '-'-prefixed strings,
+	// and the execFileSync argv splices `base` before flags like --numstat, so
+	// an unguarded `--output` would make git consume the next argv as an
+	// output filename (write vector; #2499 review finding).
+	if (base.startsWith('-')) {
+		return 'base ref must not begin with a dash';
+	}
 	if (!SAFE_REF_PATTERN.test(base)) {
 		return 'base contains invalid characters for git ref';
 	}

--- a/src/tools/placeholder-scan.ts
+++ b/src/tools/placeholder-scan.ts
@@ -1037,6 +1037,24 @@ export async function placeholderScan(
 	directory: string,
 	gateOverrides?: GateConfigOverrides['placeholder_scan'],
 ): Promise<PlaceholderScanResult> {
+	return computePlaceholderScan(input, directory, gateOverrides, {
+		persistEvidence: true,
+	});
+}
+
+/**
+ * Persistence-free compute core of the placeholder scan (#2499).
+ *
+ * Never persists evidence unless `persistEvidence: true` is passed, so
+ * read-only surfaces (the MCP verification server) can run the exact same
+ * analysis without writing `.swarm/` state.
+ */
+export async function computePlaceholderScan(
+	input: PlaceholderScanInput,
+	directory: string,
+	gateOverrides?: GateConfigOverrides['placeholder_scan'],
+	options?: { persistEvidence?: boolean },
+): Promise<PlaceholderScanResult> {
 	// Feature flag (issue #2524): a user's `gates.placeholder_scan.enabled: false`
 	// disables the gate — non-blocking pass with an explicit summary, before any
 	// evidence write (same contract as syntax_check / sast_scan).
@@ -1237,24 +1255,27 @@ export async function placeholderScan(
 		0,
 	);
 
-	// Save evidence
-	await _internals.saveEvidence(directory, 'placeholder_scan', {
-		task_id: 'placeholder_scan',
-		type: 'placeholder',
-		timestamp: new Date().toISOString(),
-		agent: 'placeholder_scan',
-		verdict,
-		summary: `Scanned ${filesScanned} files, found ${findings.length} placeholder(s)`,
-		files_scanned: filesScanned,
-		findings_count: findings.length,
-		files_with_findings: filesWithFindings.size,
-		findings,
-		...(diffScoped && {
-			diff_scoped: true,
-			added_lines_files: addedLinesFiles,
-			added_lines_total: addedLinesTotal,
-		}),
-	});
+	// Persist evidence only for the evidence-contract callers (the registered
+	// tool wrapper passes persistEvidence: true; read-only surfaces omit it).
+	if (options?.persistEvidence === true) {
+		await _internals.saveEvidence(directory, 'placeholder_scan', {
+			task_id: 'placeholder_scan',
+			type: 'placeholder',
+			timestamp: new Date().toISOString(),
+			agent: 'placeholder_scan',
+			verdict,
+			summary: `Scanned ${filesScanned} files, found ${findings.length} placeholder(s)`,
+			files_scanned: filesScanned,
+			findings_count: findings.length,
+			files_with_findings: filesWithFindings.size,
+			findings,
+			...(diffScoped && {
+				diff_scoped: true,
+				added_lines_files: addedLinesFiles,
+				added_lines_total: addedLinesTotal,
+			}),
+		});
+	}
 
 	return {
 		verdict,

--- a/src/tools/quality-budget.ts
+++ b/src/tools/quality-budget.ts
@@ -73,6 +73,24 @@ export async function qualityBudget(
 	directory: string,
 	abortSignal?: AbortSignal,
 ): Promise<QualityBudgetResult> {
+	return computeQualityBudget(input, directory, abortSignal, {
+		persistEvidence: true,
+	});
+}
+
+/**
+ * Persistence-free compute core of the quality budget check (#2499).
+ *
+ * Never persists evidence unless `persistEvidence: true` is passed, so
+ * read-only surfaces (the MCP verification server) can run the exact same
+ * analysis without writing `.swarm/` state.
+ */
+export async function computeQualityBudget(
+	input: QualityBudgetInput,
+	directory: string,
+	abortSignal?: AbortSignal,
+	options?: { persistEvidence?: boolean },
+): Promise<QualityBudgetResult> {
 	abortSignal?.throwIfAborted();
 	// Validate input
 	const validation = validateInput(input);
@@ -141,41 +159,44 @@ export async function qualityBudget(
 	// Determine verdict: fail if any errors, pass otherwise
 	const verdict: 'pass' | 'fail' = errorsCount > 0 ? 'fail' : 'pass';
 
-	// Save evidence
+	// Persist evidence only for the evidence-contract callers (the registered
+	// tool wrapper passes persistEvidence: true; read-only surfaces omit it).
 	abortSignal?.throwIfAborted();
-	await saveEvidence(
-		directory,
-		'quality_budget',
-		{
-			task_id: 'quality_budget',
-			type: 'quality_budget',
-			timestamp: new Date().toISOString(),
-			agent: 'quality_budget',
-			verdict,
-			summary: `Quality budget check: ${metrics.files_analyzed.length} files analyzed, ${metrics.violations.length} violation(s) found (${errorsCount} errors, ${warningsCount} warnings)`,
-			metrics: {
-				complexity_delta: metrics.complexity_delta,
-				public_api_delta: metrics.public_api_delta,
-				duplication_ratio: metrics.duplication_ratio,
-				test_to_code_ratio: metrics.test_to_code_ratio,
-				base_resolved: metrics.base_resolved,
+	if (options?.persistEvidence === true) {
+		await saveEvidence(
+			directory,
+			'quality_budget',
+			{
+				task_id: 'quality_budget',
+				type: 'quality_budget',
+				timestamp: new Date().toISOString(),
+				agent: 'quality_budget',
+				verdict,
+				summary: `Quality budget check: ${metrics.files_analyzed.length} files analyzed, ${metrics.violations.length} violation(s) found (${errorsCount} errors, ${warningsCount} warnings)`,
+				metrics: {
+					complexity_delta: metrics.complexity_delta,
+					public_api_delta: metrics.public_api_delta,
+					duplication_ratio: metrics.duplication_ratio,
+					test_to_code_ratio: metrics.test_to_code_ratio,
+					base_resolved: metrics.base_resolved,
+				},
+				thresholds: {
+					max_complexity_delta: thresholds.max_complexity_delta,
+					max_public_api_delta: thresholds.max_public_api_delta,
+					max_duplication_ratio: thresholds.max_duplication_ratio,
+					min_test_to_code_ratio: thresholds.min_test_to_code_ratio,
+				},
+				violations: metrics.violations.map((v) => ({
+					type: v.type,
+					message: v.message,
+					severity: v.severity,
+					files: v.files,
+				})),
+				files_analyzed: metrics.files_analyzed,
 			},
-			thresholds: {
-				max_complexity_delta: thresholds.max_complexity_delta,
-				max_public_api_delta: thresholds.max_public_api_delta,
-				max_duplication_ratio: thresholds.max_duplication_ratio,
-				min_test_to_code_ratio: thresholds.min_test_to_code_ratio,
-			},
-			violations: metrics.violations.map((v) => ({
-				type: v.type,
-				message: v.message,
-				severity: v.severity,
-				files: v.files,
-			})),
-			files_analyzed: metrics.files_analyzed,
-		},
-		abortSignal,
-	);
+			abortSignal,
+		);
+	}
 	abortSignal?.throwIfAborted();
 
 	return {

--- a/src/tools/sast-scan.ts
+++ b/src/tools/sast-scan.ts
@@ -370,6 +370,23 @@ export async function sastScan(
 	directory: string,
 	gates?: GateConfigOverrides,
 ): Promise<SastScanResult> {
+	return computeSastScan(input, directory, gates, { persistEvidence: true });
+}
+
+/**
+ * Persistence-free compute core of the SAST scan (#2499).
+ *
+ * Never persists evidence unless `persistEvidence: true` is passed, so
+ * read-only surfaces (the MCP verification server) can run the exact same
+ * analysis without writing `.swarm/` state. The MCP adapter also forces
+ * `offline_only: true` so no Semgrep subprocess is ever spawned.
+ */
+export async function computeSastScan(
+	input: SastScanInput,
+	directory: string,
+	gates?: GateConfigOverrides,
+	options?: { persistEvidence?: boolean },
+): Promise<SastScanResult> {
 	const {
 		changed_files,
 		severity_threshold = 'medium',
@@ -621,22 +638,24 @@ export async function sastScan(
 		if (abort_signal?.aborted) {
 			return cancelledScanResult(allFindings, filesScanned);
 		}
-		await saveEvidence(
-			directory,
-			'sast_scan',
-			{
-				task_id: 'sast_scan',
-				type: 'sast',
-				timestamp: new Date().toISOString(),
-				agent: 'sast_scan',
-				verdict: 'fail',
-				summary: `Semgrep execution failed: ${semgrepError}`,
-				...summary,
-				findings: finalFindings,
-				baseline_used: false,
-			},
-			abort_signal,
-		);
+		if (options?.persistEvidence === true) {
+			await saveEvidence(
+				directory,
+				'sast_scan',
+				{
+					task_id: 'sast_scan',
+					type: 'sast',
+					timestamp: new Date().toISOString(),
+					agent: 'sast_scan',
+					verdict: 'fail',
+					summary: `Semgrep execution failed: ${semgrepError}`,
+					...summary,
+					findings: finalFindings,
+					baseline_used: false,
+				},
+				abort_signal,
+			);
+		}
 		return {
 			verdict: 'fail',
 			error: `Semgrep execution failed: ${semgrepError}`,
@@ -750,22 +769,24 @@ export async function sastScan(
 		if (abort_signal?.aborted) {
 			return cancelledScanResult(allFindings, filesScanned);
 		}
-		await saveEvidence(
-			directory,
-			'sast_scan',
-			{
-				task_id: 'sast_scan',
-				type: 'sast',
-				timestamp: new Date().toISOString(),
-				agent: 'sast_scan',
-				verdict: 'pass',
-				summary: `Baseline capture: scanned ${filesScanned} files, recorded ${captureFindings.length} finding(s)`,
-				...summary,
-				findings: finalFindings,
-				baseline_used: false,
-			},
-			abort_signal,
-		);
+		if (options?.persistEvidence === true) {
+			await saveEvidence(
+				directory,
+				'sast_scan',
+				{
+					task_id: 'sast_scan',
+					type: 'sast',
+					timestamp: new Date().toISOString(),
+					agent: 'sast_scan',
+					verdict: 'pass',
+					summary: `Baseline capture: scanned ${filesScanned} files, recorded ${captureFindings.length} finding(s)`,
+					...summary,
+					findings: finalFindings,
+					baseline_used: false,
+				},
+				abort_signal,
+			);
+		}
 
 		return {
 			verdict: 'pass',
@@ -905,31 +926,33 @@ export async function sastScan(
 	if (abort_signal?.aborted) {
 		return cancelledScanResult(allFindings, filesScanned);
 	}
-	await saveEvidence(
-		directory,
-		'sast_scan',
-		{
-			task_id: 'sast_scan',
-			type: 'sast',
-			timestamp: new Date().toISOString(),
-			agent: 'sast_scan',
-			verdict,
-			summary: nonCodeOnly
-				? `No scannable code files in input (${nonCodeSkipped} non-code file(s) skipped); nothing to scan`
-				: `Scanned ${filesScanned} files, found ${finalFindings.length} finding(s) using ${engine}`,
-			...summary,
-			findings: finalFindings,
-			...(baselineUsed && {
-				new_findings: newFindings,
-				pre_existing_findings: preExistingFindings,
-				moved_findings: movedFindings,
-				...(truncatedPreExisting ? { truncated_pre_existing: true } : {}),
-				...(truncatedMoved ? { truncated_moved_findings: true } : {}),
-				baseline_used: true,
-			}),
-		},
-		abort_signal,
-	);
+	if (options?.persistEvidence === true) {
+		await saveEvidence(
+			directory,
+			'sast_scan',
+			{
+				task_id: 'sast_scan',
+				type: 'sast',
+				timestamp: new Date().toISOString(),
+				agent: 'sast_scan',
+				verdict,
+				summary: nonCodeOnly
+					? `No scannable code files in input (${nonCodeSkipped} non-code file(s) skipped); nothing to scan`
+					: `Scanned ${filesScanned} files, found ${finalFindings.length} finding(s) using ${engine}`,
+				...summary,
+				findings: finalFindings,
+				...(baselineUsed && {
+					new_findings: newFindings,
+					pre_existing_findings: preExistingFindings,
+					moved_findings: movedFindings,
+					...(truncatedPreExisting ? { truncated_pre_existing: true } : {}),
+					...(truncatedMoved ? { truncated_moved_findings: true } : {}),
+					baseline_used: true,
+				}),
+			},
+			abort_signal,
+		);
+	}
 
 	const result: SastScanResult = {
 		verdict,

--- a/src/tools/swarm-memory-recall.ts
+++ b/src/tools/swarm-memory-recall.ts
@@ -37,71 +37,86 @@ export const swarm_memory_recall: ReturnType<typeof createSwarmTool> =
 				.optional()
 				.describe('Maximum memories to return'),
 		},
-		execute: async (args: unknown, directory: string, ctx): Promise<string> => {
-			const { config } = _internals.loadPluginConfigWithMeta(directory);
-			if (config.memory?.enabled !== true) {
-				return JSON.stringify({
-					success: false,
-					disabled: true,
-					message: 'Swarm memory is disabled. Set swarm.memory.enabled=true.',
-				});
-			}
-			const parsed = RecallArgsSchema.safeParse(args);
-			if (!parsed.success) {
-				return JSON.stringify({
-					success: false,
-					error: parsed.error.issues.map((issue) => issue.message).join('; '),
-				});
-			}
-			const agent = getContextAgent(ctx);
-			// B.1 — ADDITIVE unit identity. Resolve from THIS session's
-			// currentTaskId only (never a parent session); `?? undefined`
-			// normalizes the null sentinel so an absent id records as NULL and
-			// attribution degrades to session-scoped runId. When the caller (e.g.
-			// the architect) recalls mid-task, currentTaskId is populated and the
-			// recall joins to the reward's unit — one of the cases B.2 makes
-			// effective.
-			const unitId = ctx?.sessionID
-				? (_internals.getAgentSession(ctx.sessionID)?.currentTaskId ??
-					undefined)
-				: undefined;
-			const gateway = _internals.createMemoryGateway(
-				{
-					directory,
-					sessionID: ctx?.sessionID,
-					agentRole: agent,
-					agentId: agent,
-					runId: ctx?.sessionID,
-					unitId,
-				},
-				{
-					config: config.memory,
-				},
-			);
-			try {
-				const bundle = await gateway.recall(parsed.data);
-				return JSON.stringify(
-					{
-						success: true,
-						bundle_id: bundle.id,
-						memory_ids: bundle.items.map((item) => item.record.id),
-						total: bundle.items.length,
-						token_estimate: bundle.tokenEstimate,
-						signals: bundle.items.map((item) => ({
-							memory_id: item.record.id,
-							relation: item.relation,
-							...item.signals,
-						})),
-						prompt_block: bundle.promptBlock,
-					},
-					null,
-					2,
-				);
-			} finally {
-				await gateway.dispose();
-			}
-		},
+		execute: async (args: unknown, directory: string, ctx): Promise<string> =>
+			computeSwarmMemoryRecall(args, directory, ctx),
 	});
+
+/**
+ * Compute core for `swarm_memory_recall` (#2499). The registered tool wraps
+ * this with default options so its behavior is byte-identical; the read-only
+ * MCP surface calls it with `{recordUsage: false}` so a query performs the
+ * identical retrieval without the recall-usage telemetry write.
+ */
+export async function computeSwarmMemoryRecall(
+	args: unknown,
+	directory: string,
+	ctx: { sessionID?: string; agent?: unknown } | undefined,
+	options?: { recordUsage?: boolean },
+): Promise<string> {
+	const { config } = _internals.loadPluginConfigWithMeta(directory);
+	if (config.memory?.enabled !== true) {
+		return JSON.stringify({
+			success: false,
+			disabled: true,
+			message: 'Swarm memory is disabled. Set swarm.memory.enabled=true.',
+		});
+	}
+	const parsed = RecallArgsSchema.safeParse(args);
+	if (!parsed.success) {
+		return JSON.stringify({
+			success: false,
+			error: parsed.error.issues.map((issue) => issue.message).join('; '),
+		});
+	}
+	const agent = getContextAgent(ctx);
+	// B.1 — ADDITIVE unit identity. Resolve from THIS session's
+	// currentTaskId only (never a parent session); `?? undefined`
+	// normalizes the null sentinel so an absent id records as NULL and
+	// attribution degrades to session-scoped runId. When the caller (e.g.
+	// the architect) recalls mid-task, currentTaskId is populated and the
+	// recall joins to the reward's unit — one of the cases B.2 makes
+	// effective.
+	const unitId = ctx?.sessionID
+		? (_internals.getAgentSession(ctx.sessionID)?.currentTaskId ?? undefined)
+		: undefined;
+	const gateway = _internals.createMemoryGateway(
+		{
+			directory,
+			sessionID: ctx?.sessionID,
+			agentRole: agent,
+			agentId: agent,
+			runId: ctx?.sessionID,
+			unitId,
+		},
+		{
+			config: config.memory,
+		},
+	);
+	try {
+		const bundle = await gateway.recall(parsed.data, {
+			recordUsage: options?.recordUsage !== false,
+		});
+		return JSON.stringify(
+			{
+				success: true,
+				bundle_id: bundle.id,
+				memory_ids: bundle.items.map((item) => item.record.id),
+				total: bundle.items.length,
+				token_estimate: bundle.tokenEstimate,
+				signals: bundle.items.map((item) => ({
+					memory_id: item.record.id,
+					relation: item.relation,
+					...item.signals,
+				})),
+				prompt_block: bundle.promptBlock,
+			},
+			null,
+			2,
+		);
+	} finally {
+		await gateway.dispose();
+	}
+}
 
 const RecallArgsSchema = z.object({
 	query: z.string().min(3),

--- a/src/tools/syntax-check.ts
+++ b/src/tools/syntax-check.ts
@@ -133,12 +133,29 @@ function extractSyntaxErrors(
 /**
  * Run syntax check on changed files
  *
- * Respects gates.syntax_check.enabled - returns skipped if disabled
+ * Respects gates.syntax_check.enabled - returns skipped if disabled.
+ * Persists evidence (the registered tool's contract).
  */
 export async function syntaxCheck(
 	input: SyntaxCheckInput,
 	directory: string,
 	gates?: GateConfigOverrides,
+): Promise<SyntaxCheckResult> {
+	return computeSyntaxCheck(input, directory, gates, { persistEvidence: true });
+}
+
+/**
+ * Persistence-free compute core of the syntax check (#2499).
+ *
+ * Never persists evidence unless `persistEvidence: true` is passed, so
+ * read-only surfaces (the MCP verification server) can run the exact same
+ * analysis without writing `.swarm/` state.
+ */
+export async function computeSyntaxCheck(
+	input: SyntaxCheckInput,
+	directory: string,
+	gates?: GateConfigOverrides,
+	options?: { persistEvidence?: boolean },
 ): Promise<SyntaxCheckResult> {
 	// Check feature flag
 	if (gates?.syntax_check?.enabled === false) {
@@ -343,19 +360,22 @@ export async function syntaxCheck(
 				? `No files were checked — ${emptyCheckReasons.join('; ')}. This is NOT a passing syntax check.`
 				: `All ${filesChecked} files passed syntax check`;
 
-	// Save evidence
-	await evidenceInternals.saveEvidence(directory, 'syntax_check', {
-		task_id: 'syntax_check',
-		type: 'syntax',
-		timestamp: new Date().toISOString(),
-		agent: 'syntax_check',
-		verdict,
-		summary,
-		files_checked: filesChecked,
-		files_failed: filesFailed,
-		skipped_count: skippedCount,
-		files: results,
-	});
+	// Persist evidence only for the evidence-contract callers (the registered
+	// tool wrapper passes persistEvidence: true; read-only surfaces omit it).
+	if (options?.persistEvidence === true) {
+		await evidenceInternals.saveEvidence(directory, 'syntax_check', {
+			task_id: 'syntax_check',
+			type: 'syntax',
+			timestamp: new Date().toISOString(),
+			agent: 'syntax_check',
+			verdict,
+			summary,
+			files_checked: filesChecked,
+			files_failed: filesFailed,
+			skipped_count: skippedCount,
+			files: results,
+		});
+	}
 
 	return {
 		verdict,

--- a/tests/unit/mcp/diff-ref-guard-2499.test.ts
+++ b/tests/unit/mcp/diff-ref-guard-2499.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { diff as diffTool } from '../../../src/tools/diff';
+
+/**
+ * #2499 review feedback: the MCP `diff` adapter must reject flag-shaped
+ * base refs. SAFE_REF_PATTERN admits '-'-prefixed strings, and the git argv
+ * splices `base` before flags like --numstat, so an unguarded `--output`
+ * made git consume the next argv element as an output filename (a write
+ * vector from a read-only surface).
+ */
+
+describe('diff base ref flag guard (#2499 review)', () => {
+	test('a flag-shaped base ref is rejected before any git invocation', async () => {
+		const result = await diffTool.execute(
+			{ base: '--output' },
+			{ directory: process.cwd() },
+		);
+		const parsed: unknown =
+			typeof result === 'string' ? JSON.parse(result) : result;
+		const text = JSON.stringify(parsed);
+		expect(text).toContain('must not begin with a dash');
+	});
+
+	test('legitimate refs still pass validation shape', async () => {
+		const result = await diffTool.execute(
+			{ base: 'HEAD~1' },
+			{ directory: process.cwd() },
+		);
+		const text = typeof result === 'string' ? result : JSON.stringify(result);
+		expect(text).not.toContain('must not begin with a dash');
+	});
+});

--- a/tests/unit/mcp/offline-wiring-2499.test.ts
+++ b/tests/unit/mcp/offline-wiring-2499.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, test } from 'bun:test';
 import {
 	handleMcpCommand,
 	parseMcpServeArgs,
@@ -22,7 +22,11 @@ describe('MCP offline guard (#2499 R3)', () => {
 				}
 				if (!entry.name.endsWith('.ts')) continue;
 				const source = fs.readFileSync(full, 'utf-8');
-				if (/from\s+['"]node:child_process|Bun\.spawn|child_process\.spawn/.test(source)) {
+				if (
+					/from\s+['"]node:child_process|Bun\.spawn|child_process\.spawn/.test(
+						source,
+					)
+				) {
 					offenders.push(path.relative(mcpDir, full));
 				}
 			}

--- a/tests/unit/mcp/offline-wiring-2499.test.ts
+++ b/tests/unit/mcp/offline-wiring-2499.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import {
+	handleMcpCommand,
+	parseMcpServeArgs,
+	resolveMcpRoot,
+} from '../../../src/cli/mcp';
+import { computeSyntaxCheck } from '../../../src/tools/syntax-check';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('MCP offline guard (#2499 R3)', () => {
+	test('no child_process or Bun.spawn import is reachable from src/mcp', () => {
+		const mcpDir = path.join(import.meta.dir, '..', '..', '..', 'src', 'mcp');
+		const offenders: string[] = [];
+		const walk = (dir: string): void => {
+			for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(full);
+					continue;
+				}
+				if (!entry.name.endsWith('.ts')) continue;
+				const source = fs.readFileSync(full, 'utf-8');
+				if (/from\s+['"]node:child_process|Bun\.spawn|child_process\.spawn/.test(source)) {
+					offenders.push(path.relative(mcpDir, full));
+				}
+			}
+		};
+		walk(mcpDir);
+		expect(offenders).toEqual([]);
+	});
+});
+
+describe('MCP CLI wiring (#2499)', () => {
+	test('parses --dir and the recognized --allow-write flag', () => {
+		const parsed = parseMcpServeArgs(['--dir', '/some/root', '--allow-write']);
+		expect(parsed).toEqual({ root: '/some/root', allowWrite: true });
+	});
+
+	test('parses --dir=value form', () => {
+		const parsed = parseMcpServeArgs(['--dir=/some/root']);
+		expect(parsed).toEqual({ root: '/some/root', allowWrite: false });
+	});
+
+	test('missing --dir is an error', () => {
+		expect('error' in parseMcpServeArgs([])).toBe(true);
+	});
+
+	test('unknown arguments are errors', () => {
+		expect('error' in parseMcpServeArgs(['--dir', '/x', '--boom'])).toBe(true);
+	});
+
+	test('resolveMcpRoot accepts an existing directory', () => {
+		const root = canonicalMkdtemp('mcp-cli-root-2499-');
+		const resolved = resolveMcpRoot(root);
+		expect('root' in resolved && resolved.root).toBe(root);
+	});
+
+	test('resolveMcpRoot rejects a nonexistent directory', () => {
+		const resolved = resolveMcpRoot(
+			path.join(canonicalMkdtemp('mcp-cli-missing-2499-'), 'nope'),
+		);
+		expect('error' in resolved).toBe(true);
+	});
+
+	test('handleMcpCommand without `serve` prints usage and exits 1', async () => {
+		expect(await handleMcpCommand([])).toBe(1);
+	});
+
+	test('handleMcpCommand with an invalid --dir fails closed with exit 1', async () => {
+		expect(
+			await handleMcpCommand(['serve', '--dir', 'Z:\\definitely\\not\\a\\dir']),
+		).toBe(1);
+	});
+});
+
+describe('Persistence-free compute cores (#2499 R1)', () => {
+	test('computeSyntaxCheck runs without persisting evidence', async () => {
+		const root = canonicalMkdtemp('mcp-compute-2499-');
+		fs.writeFileSync(path.join(root, 'probe.ts'), 'const x: number = 1;\n');
+		const result = await computeSyntaxCheck(
+			{ changed_files: [{ path: 'probe.ts', additions: 1 }] },
+			root,
+		);
+		expect(result.verdict).toBe('pass');
+		// Read-only guarantee: no .swarm state was materialized by the compute.
+		expect(fs.existsSync(path.join(root, '.swarm'))).toBe(false);
+	});
+});

--- a/tests/unit/mcp/pipeline-containment-2499.test.ts
+++ b/tests/unit/mcp/pipeline-containment-2499.test.ts
@@ -3,7 +3,10 @@ import {
 	applyResponsePipeline,
 	MCP_MAX_RESPONSE_CHARS,
 } from '../../../src/mcp/pipeline';
-import { McpContainmentError, validatePathField } from '../../../src/mcp/server';
+import {
+	McpContainmentError,
+	validatePathField,
+} from '../../../src/mcp/server';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
 
 describe('MCP response pipeline (#2499)', () => {
@@ -19,29 +22,31 @@ describe('MCP response pipeline (#2499)', () => {
 			],
 			safe: 'nothing to redact here',
 		};
-		const { serialized, redacted } = applyResponsePipeline(payload);
-		expect(serialized).not.toContain('ghp_0123');
-		expect(serialized).not.toContain('AKIAIOSFODNN7EXAMPLE');
-		expect(serialized).not.toContain('sk-proj-0123');
-		expect(serialized).not.toContain('MY_SERVICE_TOKEN="abc123');
-		expect(serialized).toContain('[REDACTED:');
-		expect(serialized).toContain('nothing to redact here');
-		expect((redacted as { safe: string }).safe).toBe('nothing to redact here');
+		const { text } = applyResponsePipeline(payload);
+		expect(text).not.toContain('ghp_0123');
+		expect(text).not.toContain('AKIAIOSFODNN7EXAMPLE');
+		expect(text).not.toContain('sk-proj-0123');
+		expect(text).not.toContain('MY_SERVICE_TOKEN="abc123');
+		expect(text).toContain('[REDACTED:');
+		expect(text).toContain('nothing to redact here');
 	});
 
 	test('bounds a 2 MiB payload to the frozen cap with a truncation marker', () => {
 		const huge = 'x'.repeat(2 * 1024 * 1024);
-		const { serialized, truncated } = applyResponsePipeline({ huge });
-		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
-		expect(serialized.length).toBe(MCP_MAX_RESPONSE_CHARS);
+		const { text, truncated } = applyResponsePipeline({ huge });
+		expect(text.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+		// The whole RETURN VALUE is bounded, not just one field (frozen C8).
+		expect(JSON.stringify({ text, truncated }).length).toBeLessThanOrEqual(
+			MCP_MAX_RESPONSE_CHARS,
+		);
 		expect(truncated).toBe(true);
-		expect(serialized).toContain('response truncated to bound');
+		expect(text).toContain('response truncated to bound');
 	});
 
 	test('bounds a 50k-line log-shaped payload', () => {
 		const lines = Array.from({ length: 50_000 }, (_, i) => `line-${i}`);
-		const { serialized } = applyResponsePipeline({ lines });
-		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+		const { text } = applyResponsePipeline({ lines });
+		expect(text.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
 	});
 
 	test('bounds a 20k-row wide array', () => {
@@ -50,17 +55,17 @@ describe('MCP response pipeline (#2499)', () => {
 			name: `row-${i}`,
 			value: i * 2,
 		}));
-		const { serialized } = applyResponsePipeline({ rows });
-		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+		const { text } = applyResponsePipeline({ rows });
+		expect(text.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
 	});
 
 	test('small payloads pass through untruncated with content preserved', () => {
-		const { serialized, truncated } = applyResponsePipeline({
+		const { text, truncated } = applyResponsePipeline({
 			verdict: 'pass',
 			summary: 'All 2 files passed syntax check',
 		});
 		expect(truncated).toBe(false);
-		expect(serialized).toContain('All 2 files passed syntax check');
+		expect(text).toContain('All 2 files passed syntax check');
 	});
 
 	test('redaction runs BEFORE bounding (split secrets cannot survive)', () => {
@@ -69,8 +74,8 @@ describe('MCP response pipeline (#2499)', () => {
 		// leak through the truncation window by being split around.
 		const huge = 'y'.repeat(MCP_MAX_RESPONSE_CHARS * 2);
 		const secret = 'ghp_0123456789abcdefghijklmnopqrstuvwxyzAB';
-		const { serialized } = applyResponsePipeline({ head: huge, tail: secret });
-		expect(serialized.includes('ghp_0123456789')).toBe(false);
+		const { text } = applyResponsePipeline({ head: huge, tail: secret });
+		expect(text.includes('ghp_0123456789')).toBe(false);
 	});
 });
 
@@ -78,7 +83,8 @@ describe('MCP path containment (#2499)', () => {
 	const root = canonicalMkdtemp('mcp-containment-2499-');
 
 	test('positive control: an in-root path validates', () => {
-		const { writeFileSync, mkdirSync } = require('node:fs') as typeof import('node:fs');
+		const { writeFileSync, mkdirSync } =
+			require('node:fs') as typeof import('node:fs');
 		mkdirSync(`${root}/src`, { recursive: true });
 		writeFileSync(`${root}/src/probe.ts`, 'export const x = 1;\n');
 		expect(() =>
@@ -95,7 +101,11 @@ describe('MCP path containment (#2499)', () => {
 
 	test('unnormalized .. traversal is rejected', () => {
 		expect(() =>
-			validatePathField('changed_files', [`${root}/../outside/secret.ts`], root),
+			validatePathField(
+				'changed_files',
+				[`${root}/../outside/secret.ts`],
+				root,
+			),
 		).toThrow(McpContainmentError);
 	});
 

--- a/tests/unit/mcp/pipeline-containment-2499.test.ts
+++ b/tests/unit/mcp/pipeline-containment-2499.test.ts
@@ -118,23 +118,32 @@ describe('MCP path containment (#2499)', () => {
 
 	test('a symlinked escape is rejected (lexical-in, canonical-out)', () => {
 		const outside = canonicalMkdtemp('mcp-outside-link-2499-');
-		const { symlinkSync } = require('node:fs') as typeof import('node:fs');
-		const link = `${root}/leak-link`;
+		const fs = require('node:fs') as typeof import('node:fs');
+		// Expand 8.3 short-name temp segments (RUNNER~1 on Windows CI): removing
+		// a symlink whose path keeps the short form can fail with EFAULT.
+		const realRoot = fs.realpathSync(root);
+		const link = `${realRoot}/leak-link`;
 		let linkCreated = false;
 		try {
-			symlinkSync(outside, link, 'dir');
+			fs.symlinkSync(outside, link, 'dir');
 			linkCreated = true;
 		} catch {
-			// Windows without symlink privilege: this vector is covered by the
-			// frozen C7 junction check instead; skip without failing.
+			// Symlink privilege unavailable on this host (Windows CI runners):
+			// skip the symlink-specific vector explicitly rather than failing.
+			console.log(
+				'SKIP: symlink privilege unavailable; symlink escape vector not exercised',
+			);
 		}
 		if (linkCreated) {
 			expect(() =>
 				validatePathField('changed_files', [`leak-link/secret.ts`], root),
 			).toThrow(McpContainmentError);
-			(require('node:fs') as typeof import('node:fs')).rmSync(link, {
-				force: true,
-			});
+			try {
+				fs.rmSync(link, { force: true });
+			} catch {
+				// Cleanup is best-effort: some hosts EFAULT on rm of a symlink
+				// under short-name temp paths; the mkdtemp teardown retries.
+			}
 		}
 	});
 

--- a/tests/unit/mcp/pipeline-containment-2499.test.ts
+++ b/tests/unit/mcp/pipeline-containment-2499.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	applyResponsePipeline,
+	MCP_MAX_RESPONSE_CHARS,
+} from '../../../src/mcp/pipeline';
+import { McpContainmentError, validatePathField } from '../../../src/mcp/server';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('MCP response pipeline (#2499)', () => {
+	test('redacts repo secret pattern families from every string level', () => {
+		const payload = {
+			token: 'ghp_0123456789abcdefghijklmnopqrstuvwxyzAB',
+			nested: {
+				aws: 'AKIAIOSFODNN7EXAMPLE',
+				list: ['sk-proj-0123456789abcdefghijklmnopqrstuvwxyz012345'],
+			},
+			content: [
+				{ type: 'text', text: 'secret: MY_SERVICE_TOKEN="abc123def456ghi789"' },
+			],
+			safe: 'nothing to redact here',
+		};
+		const { serialized, redacted } = applyResponsePipeline(payload);
+		expect(serialized).not.toContain('ghp_0123');
+		expect(serialized).not.toContain('AKIAIOSFODNN7EXAMPLE');
+		expect(serialized).not.toContain('sk-proj-0123');
+		expect(serialized).not.toContain('MY_SERVICE_TOKEN="abc123');
+		expect(serialized).toContain('[REDACTED:');
+		expect(serialized).toContain('nothing to redact here');
+		expect((redacted as { safe: string }).safe).toBe('nothing to redact here');
+	});
+
+	test('bounds a 2 MiB payload to the frozen cap with a truncation marker', () => {
+		const huge = 'x'.repeat(2 * 1024 * 1024);
+		const { serialized, truncated } = applyResponsePipeline({ huge });
+		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+		expect(serialized.length).toBe(MCP_MAX_RESPONSE_CHARS);
+		expect(truncated).toBe(true);
+		expect(serialized).toContain('response truncated to bound');
+	});
+
+	test('bounds a 50k-line log-shaped payload', () => {
+		const lines = Array.from({ length: 50_000 }, (_, i) => `line-${i}`);
+		const { serialized } = applyResponsePipeline({ lines });
+		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+	});
+
+	test('bounds a 20k-row wide array', () => {
+		const rows = Array.from({ length: 20_000 }, (_, i) => ({
+			id: i,
+			name: `row-${i}`,
+			value: i * 2,
+		}));
+		const { serialized } = applyResponsePipeline({ rows });
+		expect(serialized.length).toBeLessThanOrEqual(MCP_MAX_RESPONSE_CHARS);
+	});
+
+	test('small payloads pass through untruncated with content preserved', () => {
+		const { serialized, truncated } = applyResponsePipeline({
+			verdict: 'pass',
+			summary: 'All 2 files passed syntax check',
+		});
+		expect(truncated).toBe(false);
+		expect(serialized).toContain('All 2 files passed syntax check');
+	});
+
+	test('redaction runs BEFORE bounding (split secrets cannot survive)', () => {
+		// A secret placed at the very end of a huge payload: redaction must
+		// process it while the payload is still complete, so it can never
+		// leak through the truncation window by being split around.
+		const huge = 'y'.repeat(MCP_MAX_RESPONSE_CHARS * 2);
+		const secret = 'ghp_0123456789abcdefghijklmnopqrstuvwxyzAB';
+		const { serialized } = applyResponsePipeline({ head: huge, tail: secret });
+		expect(serialized.includes('ghp_0123456789')).toBe(false);
+	});
+});
+
+describe('MCP path containment (#2499)', () => {
+	const root = canonicalMkdtemp('mcp-containment-2499-');
+
+	test('positive control: an in-root path validates', () => {
+		const { writeFileSync, mkdirSync } = require('node:fs') as typeof import('node:fs');
+		mkdirSync(`${root}/src`, { recursive: true });
+		writeFileSync(`${root}/src/probe.ts`, 'export const x = 1;\n');
+		expect(() =>
+			validatePathField('changed_files', ['src/probe.ts'], root),
+		).not.toThrow();
+		expect(() =>
+			validatePathField(
+				'changed_files',
+				[{ path: 'src/probe.ts', additions: 1 }],
+				root,
+			),
+		).not.toThrow();
+	});
+
+	test('unnormalized .. traversal is rejected', () => {
+		expect(() =>
+			validatePathField('changed_files', [`${root}/../outside/secret.ts`], root),
+		).toThrow(McpContainmentError);
+	});
+
+	test('an absolute outside-root path is rejected', () => {
+		const outside = canonicalMkdtemp('mcp-outside-2499-');
+		expect(() =>
+			validatePathField('changed_files', [`${outside}/secret.ts`], root),
+		).toThrow(McpContainmentError);
+	});
+
+	test('a symlinked escape is rejected (lexical-in, canonical-out)', () => {
+		const outside = canonicalMkdtemp('mcp-outside-link-2499-');
+		const { symlinkSync } = require('node:fs') as typeof import('node:fs');
+		const link = `${root}/leak-link`;
+		let linkCreated = false;
+		try {
+			symlinkSync(outside, link, 'dir');
+			linkCreated = true;
+		} catch {
+			// Windows without symlink privilege: this vector is covered by the
+			// frozen C7 junction check instead; skip without failing.
+		}
+		if (linkCreated) {
+			expect(() =>
+				validatePathField('changed_files', [`leak-link/secret.ts`], root),
+			).toThrow(McpContainmentError);
+			(require('node:fs') as typeof import('node:fs')).rmSync(link, {
+				force: true,
+			});
+		}
+	});
+
+	test('object-shaped values with .path are walked', () => {
+		expect(() =>
+			validatePathField(
+				'changed_files',
+				[{ path: `${root}/../outside/secret.ts`, additions: 1 }],
+				root,
+			),
+		).toThrow(McpContainmentError);
+	});
+
+	test('undefined/null values are skipped (optional path fields)', () => {
+		expect(() => validatePathField('paths', undefined, root)).not.toThrow();
+		expect(() => validatePathField('paths', null, root)).not.toThrow();
+	});
+});

--- a/tests/unit/mcp/readonly-recall-no-writes-2499.test.ts
+++ b/tests/unit/mcp/readonly-recall-no-writes-2499.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
 import {
 	existsSync,
 	mkdirSync,
 	readdirSync,
+	readFileSync,
 	statSync,
 	writeFileSync,
 } from 'node:fs';
@@ -25,14 +27,28 @@ import { canonicalMkdtemp } from '../../helpers/tmpdir';
  * ledger genesis).
  */
 
-function snapshotTree(root: string): Map<string, number> {
-	const files = new Map<string, number>();
+// Maps each file to "size:sha256" so a same-size rewrite (e.g. a SQLite page
+// churn) is detected, not just file-set membership. `volatileSidecars`
+// normalizes sqlite's `-shm`/`-wal` files to a size-only signature: they are
+// shared-memory indexes that legitimately churn on any read (even read-only
+// queries re-map the WAL index) and carry no durable state — the no-write
+// guarantee covers the durable store and all non-sidecar files.
+const VOLATILE_SIDECAR = /-shm$/;
+
+function snapshotTree(root: string): Map<string, string> {
+	const files = new Map<string, string>();
 	const walk = (dir: string, rel: string) => {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			const relPath = rel ? `${rel}/${entry.name}` : entry.name;
 			const abs = path.join(dir, entry.name);
 			if (entry.isDirectory()) walk(abs, relPath);
-			else files.set(relPath, statSync(abs).size);
+			else {
+				const data = readFileSync(abs);
+				const sig = VOLATILE_SIDECAR.test(relPath)
+					? `volatile:${data.length}`
+					: `${data.length}:${createHash('sha256').update(data).digest('hex')}`;
+				files.set(relPath, sig);
+			}
 		}
 	};
 	walk(root, '');
@@ -40,17 +56,17 @@ function snapshotTree(root: string): Map<string, number> {
 }
 
 function diffTree(
-	before: Map<string, number>,
-	after: Map<string, number>,
+	before: Map<string, string>,
+	after: Map<string, string>,
 ): string[] {
 	const changes: string[] = [];
-	for (const [name, size] of after) {
-		if (!before.has(name)) changes.push(`new ${name} (${size}b)`);
+	for (const [name, sig] of after) {
+		if (!before.has(name)) changes.push(`new ${name} (${sig})`);
 	}
-	for (const [name, size] of before) {
+	for (const [name, sig] of before) {
 		if (!after.has(name)) changes.push(`gone ${name}`);
-		else if (after.get(name) !== size) {
-			changes.push(`changed ${name} ${size}b -> ${after.get(name)}b`);
+		else if (after.get(name) !== sig) {
+			changes.push(`changed ${name} ${before.get(name)} -> ${sig}`);
 		}
 	}
 	return changes;

--- a/tests/unit/mcp/readonly-recall-no-writes-2499.test.ts
+++ b/tests/unit/mcp/readonly-recall-no-writes-2499.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { readAuthoritativeKnowledgeCounterRollups } from '../../../src/hooks/knowledge-events';
+import {
+	knowledgeRecallAdapter,
+	swarmMemoryRecallAdapter,
+} from '../../../src/mcp/adapters/knowledge-memory';
+import { computeSwarmMemoryRecall } from '../../../src/tools/swarm-memory-recall';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+/**
+ * #2499 final-critic hardening: the two recall adapters must leave the
+ * project tree byte-identical in the configurations where their writers
+ * actually live — a memory-enabled root and a knowledge-present root. The
+ * frozen C6 check only exercises a storeless fixture, so these committed
+ * tests pin the enabled-configuration no-write contract directly
+ * (swarm_memory_recall telemetry + sqlite genesis; knowledge receipts-v2
+ * ledger genesis).
+ */
+
+function snapshotTree(root: string): Map<string, number> {
+	const files = new Map<string, number>();
+	const walk = (dir: string, rel: string) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(abs, relPath);
+			else files.set(relPath, statSync(abs).size);
+		}
+	};
+	walk(root, '');
+	return files;
+}
+
+function diffTree(
+	before: Map<string, number>,
+	after: Map<string, number>,
+): string[] {
+	const changes: string[] = [];
+	for (const [name, size] of after) {
+		if (!before.has(name)) changes.push(`new ${name} (${size}b)`);
+	}
+	for (const [name, size] of before) {
+		if (!after.has(name)) changes.push(`gone ${name}`);
+		else if (after.get(name) !== size) {
+			changes.push(`changed ${name} ${size}b -> ${after.get(name)}b`);
+		}
+	}
+	return changes;
+}
+
+function seedKnowledge(root: string) {
+	mkdirSync(path.join(root, '.swarm', 'knowledge'), { recursive: true });
+	writeFileSync(
+		path.join(root, '.swarm', 'knowledge', 'knowledge.json'),
+		JSON.stringify({
+			version: 2,
+			entries: [
+				{
+					id: 'k1',
+					title: 'handles',
+					lesson: 'always close file handles after use',
+					tags: ['fs'],
+					status: 'active',
+					tier: 'swarm',
+					source: 'manual',
+					created: '2026-01-01T00:00:00Z',
+					updated: '2026-01-01T00:00:00Z',
+					scope: [],
+				},
+			],
+		}),
+	);
+}
+
+function seedMemoryRoot(root: string) {
+	mkdirSync(path.join(root, '.swarm', 'memory'), { recursive: true });
+	mkdirSync(path.join(root, '.opencode'), { recursive: true });
+	writeFileSync(
+		path.join(root, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify({ memory: { enabled: true } }),
+	);
+}
+
+describe('MCP recall adapters never write (#2499 final-critic hardening)', () => {
+	test('knowledge_recall never materializes the receipts-v2 ledger', async () => {
+		const root = canonicalMkdtemp('mcp-know-nowrite-2499-');
+		seedKnowledge(root);
+		const before = snapshotTree(root);
+		const result = (await knowledgeRecallAdapter.execute(
+			{ query: 'file handles' },
+			root,
+		)) as { results: unknown[]; total: number };
+		expect(result.total).toBe(result.results.length);
+		expect(
+			existsSync(path.join(root, '.swarm', 'knowledge-receipts-v2.jsonl')),
+		).toBe(false);
+		expect(diffTree(before, snapshotTree(root))).toEqual([]);
+	}, 30000);
+
+	test('knowledge_recall leaves an empty pre-existing journal untouched', async () => {
+		const root = canonicalMkdtemp('mcp-know-emptyjournal-2499-');
+		seedKnowledge(root);
+		const journal = path.join(root, '.swarm', 'knowledge-receipts-v2.jsonl');
+		writeFileSync(journal, '');
+		const before = snapshotTree(root);
+		await knowledgeRecallAdapter.execute({ query: 'file handles' }, root);
+		expect(statSync(journal).size).toBe(0);
+		expect(diffTree(before, snapshotTree(root))).toEqual([]);
+	}, 30000);
+
+	test('skipLedgerGenesis is load-bearing: the rollup read it skips is the genesis writer', async () => {
+		// The guarded call is readAuthoritativeKnowledgeCounterRollups: its
+		// runLocked open materializes the journal. Driving it directly (the
+		// exact call skipLedgerGenesis skips) proves the flag — not some other
+		// read-path difference — is what prevents genesis.
+		const root = canonicalMkdtemp('mcp-know-flag-2499-');
+		await readAuthoritativeKnowledgeCounterRollups(root);
+		expect(
+			existsSync(path.join(root, '.swarm', 'knowledge-receipts-v2.jsonl')),
+		).toBe(true);
+	}, 30000);
+
+	test('swarm_memory_recall degrades on a storeless memory-enabled root without genesis', async () => {
+		const root = canonicalMkdtemp('mcp-mem-storeless-2499-');
+		seedMemoryRoot(root);
+		const before = snapshotTree(root);
+		const result = (await swarmMemoryRecallAdapter.execute(
+			{ query: 'anything' },
+			root,
+		)) as { available: boolean; reason: string };
+		expect(result.available).toBe(false);
+		expect(result.reason).toBe('no_store');
+		expect(existsSync(path.join(root, '.swarm', 'memory', 'memory.db'))).toBe(
+			false,
+		);
+		expect(diffTree(before, snapshotTree(root))).toEqual([]);
+	}, 30000);
+
+	test('swarm_memory_recall reads an initialized store byte-identically (telemetry-free path)', async () => {
+		const root = canonicalMkdtemp('mcp-mem-initialized-2499-');
+		seedMemoryRoot(root);
+		// Setup (allowed to write): one recording recall initializes the store.
+		await computeSwarmMemoryRecall({ query: 'seed' }, root, {
+			sessionID: 'setup',
+		});
+		expect(existsSync(path.join(root, '.swarm', 'memory', 'memory.db'))).toBe(
+			true,
+		);
+		const before = snapshotTree(root);
+		const result = (await swarmMemoryRecallAdapter.execute(
+			{ query: 'anything' },
+			root,
+		)) as { success: boolean };
+		expect(result.success).toBe(true);
+		expect(diffTree(before, snapshotTree(root))).toEqual([]);
+	}, 60000);
+
+	test('recordUsage is load-bearing: the default (recording) recall mutates the tree', async () => {
+		const root = canonicalMkdtemp('mcp-mem-flag-2499-');
+		seedMemoryRoot(root);
+		await computeSwarmMemoryRecall({ query: 'seed' }, root, {
+			sessionID: 'setup',
+		});
+		const before = snapshotTree(root);
+		await computeSwarmMemoryRecall({ query: 'anything' }, root, {
+			sessionID: 'setup',
+		});
+		expect(diffTree(before, snapshotTree(root)).length).toBeGreaterThan(0);
+	}, 60000);
+});

--- a/tests/unit/mcp/registry-readonly-2499.test.ts
+++ b/tests/unit/mcp/registry-readonly-2499.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import {
+	buildMcpToolRegistry,
+	WRITE_TOOL_NAME_PATTERN,
+} from '../../../src/mcp/registry';
+import { TOOL_METADATA } from '../../../src/tools/tool-metadata';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+describe('MCP tool registry (#2499)', () => {
+	const root = canonicalMkdtemp('mcp-registry-2499-');
+
+	test('registers at least six tools covering the six capability areas', () => {
+		const registry = buildMcpToolRegistry({ root });
+		expect(registry.tools.length).toBeGreaterThanOrEqual(6);
+		const text = registry.tools
+			.map((t) => `${t.name} ${t.description}`)
+			.join('\n');
+		expect(text).toMatch(/knowledge|memory/);
+		expect(text).toMatch(/evidence/);
+		expect(text).toMatch(/syntax/);
+		expect(text).toMatch(/sast/);
+		expect(text).toMatch(/quality/);
+		expect(text).toMatch(/scope/);
+	});
+
+	test('every tool name is a TOOL_METADATA key with exact description parity', () => {
+		const registry = buildMcpToolRegistry({ root });
+		for (const tool of registry.tools) {
+			const metadata = TOOL_METADATA[tool.name as keyof typeof TOOL_METADATA];
+			expect(metadata).toBeDefined();
+			expect(tool.description).toBe(metadata.description.trim());
+		}
+	});
+
+	test('read-only default: zero write-capable tools, with AND without allowWrite', () => {
+		for (const allowWrite of [undefined, true]) {
+			const registry = buildMcpToolRegistry({ root, allowWrite });
+			const writeTools = registry.tools.filter((t) =>
+				WRITE_TOOL_NAME_PATTERN.test(t.name),
+			);
+			expect(writeTools).toEqual([]);
+			expect(registry.tools.every((t) => t.kind === 'read')).toBe(true);
+		}
+	});
+
+	test('the `directory` option is a synonym for `root`', () => {
+		const registry = buildMcpToolRegistry({ root, directory: root });
+		expect(registry.tools.length).toBeGreaterThan(0);
+	});
+
+	test('directory-only invocation also resolves the root', () => {
+		const registry = buildMcpToolRegistry({ directory: root });
+		expect(registry.tools.length).toBeGreaterThan(0);
+	});
+
+	test('write-boundary denylist matches known write tool names', () => {
+		for (const name of [
+			'save_plan',
+			'update_task_status',
+			'declare_scope',
+			'knowledge_add',
+			'swarm_memory_propose',
+			'phase_complete',
+			'swarm_command',
+		]) {
+			expect(WRITE_TOOL_NAME_PATTERN.test(name)).toBe(true);
+		}
+	});
+
+	test('a missing root fails closed', () => {
+		expect(() =>
+			buildMcpToolRegistry({ root: '' } as { root: string }),
+		).toThrow(/root is required/);
+	});
+});

--- a/tests/unit/mcp/server-composition-2499.test.ts
+++ b/tests/unit/mcp/server-composition-2499.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -40,17 +40,22 @@ describe('MCP server composition (#2499 review feedback)', () => {
 		const root = canonicalMkdtemp('mcp-compose-2499-');
 		mkdirSync(path.join(root, 'in-root'), { recursive: true });
 		writeFileSync(path.join(root, 'in-root', 'a.ts'), 'export const a = 1;\n');
+		// Relative traversal: the caller does NOT embed the root in the input,
+		// so any root path in the response would come from the server side —
+		// exactly what the no-disclosure contract forbids (on CI the caller
+		// embedding an absolute root would itself echo into the raw value).
+		const realRoot = realpathSync(root);
 		await withServer(root, async (client) => {
 			const result = await client.callTool({
 				name: 'placeholder_scan',
 				arguments: {
-					changed_files: [`${root}/../outside/secret.ts`],
+					changed_files: ['../outside/secret.ts'],
 				},
 			});
 			expect(result.isError).toBe(true);
 			const text = JSON.stringify(result.content);
 			expect(text).toContain('path rejected by containment');
-			expect(text).not.toContain(root);
+			expect(text).not.toContain(realRoot);
 		});
 	}, 30000);
 

--- a/tests/unit/mcp/server-composition-2499.test.ts
+++ b/tests/unit/mcp/server-composition-2499.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../../../src/mcp/server';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+/**
+ * #2499 review feedback: composition-level coverage for the MCP server —
+ * a containment rejection surfacing as an MCP isError RESULT (not a thrown
+ * protocol error), the host root path never appearing in client-visible
+ * text, and error text taking the same redaction pipeline as success
+ * payloads. Uses the SDK's in-memory transport pair so the full
+ * containment -> catch -> pipeline path runs in-process.
+ */
+
+async function withServer(
+	root: string,
+	run: (client: Client) => Promise<void>,
+): Promise<void> {
+	const server = createMcpServer({ root, allowWrite: false });
+	const [clientTransport, serverTransport] =
+		InMemoryTransport.createLinkedPair();
+	const client = new Client({ name: 'compose-test', version: '0.0.0' });
+	await Promise.all([
+		server.connect(serverTransport),
+		client.connect(clientTransport),
+	]);
+	try {
+		await run(client);
+	} finally {
+		await client.close();
+		await server.close();
+	}
+}
+
+describe('MCP server composition (#2499 review feedback)', () => {
+	test('containment rejection surfaces as isError and never leaks the host root path', async () => {
+		const root = canonicalMkdtemp('mcp-compose-2499-');
+		mkdirSync(path.join(root, 'in-root'), { recursive: true });
+		writeFileSync(path.join(root, 'in-root', 'a.ts'), 'export const a = 1;\n');
+		await withServer(root, async (client) => {
+			const result = await client.callTool({
+				name: 'placeholder_scan',
+				arguments: {
+					changed_files: [`${root}/../outside/secret.ts`],
+				},
+			});
+			expect(result.isError).toBe(true);
+			const text = JSON.stringify(result.content);
+			expect(text).toContain('path rejected by containment');
+			expect(text).not.toContain(root);
+		});
+	}, 30000);
+
+	test('error text takes the redaction pipeline (secret-shaped path material is redacted)', async () => {
+		const root = canonicalMkdtemp('mcp-compose-err-2499-');
+		mkdirSync(path.join(root, 'changed'), { recursive: true });
+		await withServer(root, async (client) => {
+			const result = await client.callTool({
+				name: 'placeholder_scan',
+				arguments: {
+					changed_files: [
+						{
+							path: 'changed/ghp_0123456789abcdefghijklmnopqrstuvwxyzAB.ts',
+							additions: 1,
+						},
+					],
+				},
+			});
+			const text = JSON.stringify(result.content);
+			expect(text).not.toContain('ghp_0123456789');
+		});
+	}, 30000);
+});

--- a/tests/unit/tools/diff.test.ts
+++ b/tests/unit/tools/diff.test.ts
@@ -259,17 +259,15 @@ index 1234567..abcdefg 100644
 	});
 
 	describe('validate base parameter — malformed refs', () => {
-		// SECURITY FINDING: Ref starting with dash passes validation
-		// CURRENT BEHAVIOR: Passes validation, git is invoked but fails
-		// EXPECTED: Should be rejected by validation
-		test('SECURITY FINDING: ref starting with dash passes validation', async () => {
+		// Formerly a SECURITY FINDING marker: dash-prefixed refs used to pass
+		// validation and reach the git argv. validateBase now rejects them
+		// before the subprocess (#2499 review fix).
+		test('rejects ref starting with a dash before git is invoked', async () => {
 			const result = await diff.execute({ base: '-p' });
 			const parsed = JSON.parse(result);
 
-			// CURRENT: Validation passes but git fails
-			// This is a defense-in-depth issue - validation should catch it earlier
-			expect(parsed.error).toBeDefined(); // Git fails with error
-			expect(mockExecFileSync).toHaveBeenCalled(); // Git was invoked (should have been blocked earlier)
+			expect(parsed.error).toContain('must not begin with a dash');
+			expect(mockExecFileSync).not.toHaveBeenCalled();
 		});
 
 		test('rejects ref with newline character', async () => {
@@ -338,9 +336,11 @@ index 1234567..abcdefg 100644
 
 		test('accepts commit hashes (40 char hex)', async () => {
 			mockExecFileSync.mockReturnValue('');
-			mockExecFileSync.mockReturnValue('');
 
-			const result = await diff.execute({ base: 'a' * 40 });
+			// 'a' * 40 is NaN in JS (no string multiplication) — the dash guard
+			// exposed that latent fixture bug because validateBase now calls
+			// .startsWith before the pattern coercion. Use a real 40-hex hash.
+			const result = await diff.execute({ base: 'a'.repeat(40) });
 			const parsed = JSON.parse(result);
 
 			expect(parsed.error).toBeUndefined();


### PR DESCRIPTION
Closes #2499

## Summary

Workstream F PR 07 (source #1227 phase 1): an official `@modelcontextprotocol/sdk` stdio server exposing the repo's registered verification paths as a read-only query surface for external tooling. `opencode-swarm mcp serve --dir <root>` binds to exactly one project root per process and registers 10 read-only tools (`knowledge_recall`, `swarm_memory_recall`, `evidence_check`, `syntax_check`, `placeholder_scan`, `sast_scan`, `quality_budget`, `plan_conflict_check`, `diff`, `symbols`) — names and descriptions taken verbatim from `TOOL_METADATA`, every tool routed through the registered production cores (compute-core extraction from the four verification tools; no parallel reimplementation; SAST forced `offline_only`). Every path argument is contained to the single root (lexical + canonical, traversal/absolute/symlink rejected), responses are secret-redacted then bounded to 65,536 chars, and the surface is read-only by construction: a frozen write-tool denylist fails closed with and without the forward-compat `--allow-write` seam, no subprocess or evidence persistence exists under `src/mcp/`, and `src/index.ts` is untouched (CLI-only dynamic import keeps the SDK out of the plugin bundle; CLI stays within the 2.4 MB cap). Final-critic hardening: the recall adapters are write-free in enabled configurations (memory recall probes the configured provider's initialized store artifact and skips usage telemetry via the new additive `gateway.recall` option; knowledge recall skips the receipt-ledger genesis while the journal is absent or empty — rank-neutral), pinned by `tests/unit/mcp/readonly-recall-no-writes-2499.test.ts` with load-bearing-flag falsifiability tests. `knowledge_query` is deferred out of the Phase-1 surface per the issue's documented deferral policy. Client setup (Claude Code, Cursor, VS Code) documented in `docs/mcp.md`.

## Invariant audit

- 1 (plugin init): not touched — `src/index.ts` has zero MCP references; the server is reached only via a dynamic import from the CLI entry, so the plugin bundle init path is unchanged. Evidence: `grep -n "mcp" src/index.ts` -> no hits; frozen C12 green.
- 2 (runtime portability): touched — new `@modelcontextprotocol/sdk@^1.30.0` runtime dependency, dynamically imported so it lands in a split chunk. Evidence: frozen C12 (build + packaging caps + bundle-portability suites) green at head; `bunx tsc --noEmit` clean; zero `bun:` imports under `src/mcp/` (structural test `offline-wiring-2499.test.ts`).
- 3 (subprocesses): touched — the CLI `mcp serve` child is spawned by frozen checks C1/C4/C5 with bounded, killable stdio handling inside the check drivers; production `src/mcp/` code spawns nothing. Evidence: `grep -rE "node:child_process|Bun.spawn" src/mcp/` -> no hits; C4/C5 pass against real spawned children.
- 4 (.swarm containment): touched — read-only probes only; storeless roots degrade to `available:false` and never materialize `.swarm/` state (final-critic hardening). Evidence: `tests/unit/mcp/readonly-recall-no-writes-2499.test.ts` 6/6; frozen C6 byte-identity assertion on its fixture.
- 5 (plan durability): not touched — no plan-ledger surface is read or written by the MCP tools.
- 6 (test_runner safety): not touched — no `test_runner` usage anywhere in the new surface.
- 7 (test writing): touched — four new bun:test suites, each under 500 lines, `canonicalMkdtemp` fixtures, no `mock.module`. Evidence: `scripts/check-test-file-cap.sh` pass; `bun run check:test-clock` pass; `bun run check:invariants` (mock-cleanup) pass.
- 8 (session state): not touched — the MCP surface creates no session/global state (the memory adapter passes a sessionless synthetic context).
- 9 (guardrails/retry): not touched — read-only adapters reuse registered tool paths; no retry/circuit surface added.
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched-by-reuse — no new registered plugin tools; the MCP registry derives from `TOOL_METADATA` (parity enforced by frozen C2 and `registry-readonly-2499.test.ts`). No COMMAND_REGISTRY change — `mcp serve` deliberately owns stdio, documented in `docs/mcp.md`.
- 12 (release/cache): touched — release fragment `docs/releases/pending/2499-readonly-mcp-verification-surface.md` shipped; `bun run check:pending-fragment` pass; no version/CHANGELOG hand-edits.

## Test plan

- Frozen acceptance checks C1-C12 (12/12 GREEN at head, independently re-run by the implementation reviewer in two rounds; `repro-check.sh verify-checkpoint` -> 12 OK / 0 CHANGED): CLI entry probe over a real spawned `mcp serve` child (C1), registry capability/parity (C2), anti-reimplementation import guard (C3), official-SDK client conformance over stdio (C4), raw NDJSON JSON-RPC client (C5), read-only default + no-writes (C6), containment escape rejection (C7), response bounding (C8), redaction (C9), client docs (C10), verification-core preservation suites (C11), build/packaging/bundle-portability caps (C12).
- Committed suites: `bun test tests/unit/mcp/` -> 35 pass / 0 fail across 4 files (registry-readonly, pipeline-containment, offline-wiring, readonly-recall-no-writes).
- Blast radius (one file per process, CI mode): 21 suites over the touched modules (search-knowledge x4, knowledge injector x5, knowledge reader/store/contextual x3, memory x5, swarm-memory tools x4) -> 0 fail.
- Quality gates: `bunx @biomejs/biome@2.3.14 ci .` exit 0; `bunx tsc --noEmit` clean; `bun run check:registry-citations` + `atomic-write-ratchet` 7/0 pass; `check:events`, `check:invariants`, `drift:check`, `check:test-clock`, `check:pending-fragment` all pass.

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 `mcp serve` CLI entry answers MCP initialize | Frozen C1: `bash repro/check-cli-mcp-serve-entry.sh` -> `CHECK-PASS: C1 mcp serve --dir answered MCP initialize over stdio` (base RED: `Unknown command: mcp`) |
| AC2 surface reuses registered paths, no reimplementation | Frozen C3 -> CHECK-PASS (seven production-core imports); corroborated by C2/C4/C5 tool counts |
| AC3 registry parity with TOOL_METADATA + six capabilities | Frozen C2 -> `CHECK-PASS: C2 registry exposes 10 tools with TOOL_METADATA name/description parity covering all six capabilities`; `tests/unit/mcp/registry-readonly-2499.test.ts` 7/7 |
| AC4 official-SDK client conformance over stdio | Frozen C4 -> CHECK-PASS (SDK client: initialize -> listTools -> callTool -> close against a real child) |
| AC5 second, independent client | Frozen C5 -> CHECK-PASS (hand-rolled NDJSON JSON-RPC client, no SDK) |
| AC6 read-only by default, no project-tree mutation | Frozen C6 -> CHECK-PASS (zero write tools with/without --allow-write; fixture byte-identity) + final-critic hardening `tests/unit/mcp/readonly-recall-no-writes-2499.test.ts` 6/6 (enabled-configuration recall no-write contract, incl. sqlite genesis and receipts-ledger genesis prevention) |
| AC7 containment of all path arguments to the single root | Frozen C7 -> CHECK-PASS (traversal / absolute-outside / symlink-junction rejected; positive in-root control passes) + `pipeline-containment-2499.test.ts` |
| AC8 bounded responses | Frozen C8 -> CHECK-PASS (<= 65536 chars incl. quote-escaped envelopes for 2 MiB inputs) |
| AC9 redaction of known secret shapes | Frozen C9 -> CHECK-PASS (`[REDACTED:*]`, nested content arrays; redact-before-bound pinned by unit suite) |
| AC10 client documentation | Frozen C10 -> CHECK-PASS (`docs/mcp.md`, 3 clients) |
| AC11 registered-tool behavior preserved | Frozen C11 + C12 -> CHECK-PASS (verification-core suites, build, packaging caps, bundle portability); wrappers persist evidence exactly as before |

## Recurrence Prevention (defect class)

- Defect class: a newly exposed programmatic surface bypassing registered production paths, containment, or write-freedom (parallel reimplementation, store-materializing reads, uncontained paths, unredacted/unbounded payloads, host-decoupled entries).
- Sweep result: 08a recurrence sweep — 7 predicates, 9 hits, all dispositioned (1 sanctioned compute-core consumer; 2 sanctioned direct-CLI cwd sites; 1 sanctioned SDK dependency; 1 documented stdio-owning CLI branch; 4 registered-path synthetic-context adapter calls; zero write-capable imports and zero subprocess/evidence references under `src/mcp/`).
- Guardrail: frozen checks C3 (anti-reimplementation, base RED / head GREEN), C6 (read-only), C7 (containment), C8/C9 (bound/redaction), C4/C5 (two-client conformance), plus the committed structural suite `offline-wiring-2499.test.ts`; the enabled-configuration recall guardrails are pinned by `readonly-recall-no-writes-2499.test.ts` with falsifiability tests proving both flags load-bearing.

## Waivers (or none)

- `knowledge_query` is deferred out of the Phase-1 surface per issue-summary A2's documented deferral policy (its capability area is covered by `knowledge_recall`; no AC requires it) — plan amended with plan-critic Round-3 approval.
- Transitional write paths (stale-schema sqlite migration on open; truncated local-jsonl self-heal on read) are documented in `docs/mcp.md` as outside the read-only recall promise for already-initialized, current-schema stores (final-critic Round-2 scoping).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

