### PR TITLE
fix(ci): harden issue pipeline publication

### DIFF
--- a/docs/releases/pending/2498-gated-github-action-follow-up.md
+++ b/docs/releases/pending/2498-gated-github-action-follow-up.md
@@ -7,3 +7,5 @@ Hardens the gated implementation pipeline’s publication path:
 - Issue URL references now discard query strings and fragments before deriving
   the implementation branch and pull-request metadata, with regression coverage
   for fragment-bearing URLs.
+- Malformed `/issues/<non-number>` references are rejected before pipeline
+  side effects with the standard parse diagnostic.

--- a/docs/releases/pending/2498-gated-github-action-follow-up.md
+++ b/docs/releases/pending/2498-gated-github-action-follow-up.md
@@ -1,0 +1,9 @@
+# Gated GitHub Action follow-up (issue #2498)
+
+Hardens the gated implementation pipeline’s publication path:
+
+- Existing pull-request detection now uses a bounded, configurable `gh pr view`
+  lookup so publication cannot hang indefinitely on a stalled GitHub CLI call.
+- Issue URL references now discard query strings and fragments before deriving
+  the implementation branch and pull-request metadata, with regression coverage
+  for fragment-bearing URLs.

--- a/scripts/swarm-implement-pipeline.sh
+++ b/scripts/swarm-implement-pipeline.sh
@@ -52,8 +52,15 @@ append_summary() {
 issue_number_from_ref() {
 	# Accepts a bare number, an issue URL, or owner/repo#N; prints the number.
 	case "$1" in
+		*'/issues/'*)
+			# Strip query strings/fragments from issue URLs before the numeric
+			# validation below; a URL fragment is not part of the issue number.
+			local issue_path="${1#*/issues/}"
+			issue_path="${issue_path%%\?*}"
+			issue_path="${issue_path%%\#*}"
+			printf '%s\n' "$issue_path"
+			;;
 		*'#'*) printf '%s\n' "$1" | sed 's/^.*#//' ;;
-		*'/issues/'*) printf '%s\n' "$1" | sed 's|.*/issues/||' ;;
 		*) printf '%s\n' "$1" ;;
 	esac
 }
@@ -183,7 +190,7 @@ if [ "$SWARM_CI_EXIT" -eq 0 ]; then
 		# Idempotent at the PR boundary too: a re-trigger against an issue
 		# whose PR already exists reuses it instead of failing a duplicate
 		# create (the C5 idempotency contract extended from branch to PR).
-		if gh pr view "$BRANCH" --json url > /dev/null 2>&1; then
+		if timeout "${PR_CHECK_TIMEOUT_SECONDS:-30}" gh pr view "$BRANCH" --json url > /dev/null 2>&1; then
 			printf '%s\n' "publish=existing" > "$EVIDENCE_DIR/publish-decision.txt"
 			exit 0
 		fi

--- a/scripts/swarm-implement-pipeline.sh
+++ b/scripts/swarm-implement-pipeline.sh
@@ -58,7 +58,13 @@ issue_number_from_ref() {
 			local issue_path="${1#*/issues/}"
 			issue_path="${issue_path%%\?*}"
 			issue_path="${issue_path%%\#*}"
-			printf '%s\n' "$issue_path"
+			if [[ "$issue_path" =~ ^[0-9]+$ ]]; then
+				printf '%s\n' "$issue_path"
+			else
+				# Keep the assignment successful under set -e so the shared
+				# validation below emits the standard parse error and exit 3.
+				printf '\n'
+			fi
 			;;
 		*'#'*) printf '%s\n' "$1" | sed 's/^.*#//' ;;
 		*) printf '%s\n' "$1" ;;

--- a/tests/unit/scripts/swarm-implement-pipeline.test.ts
+++ b/tests/unit/scripts/swarm-implement-pipeline.test.ts
@@ -82,6 +82,25 @@ describe('swarm-implement pipeline driver (#2498)', () => {
 		expect(otherIssue.stdout).toBe('swarm/implement-4242\n');
 	}, 30000);
 
+	test('regression F1: issue URLs discard fragments before deriving the branch', () => {
+		// Before the fix, the URL fragment remained attached to the issue number,
+		// so validation rejected an otherwise valid issue URL.
+		const repo = makeDemoRepo();
+		const result = runPipeline(
+			repo,
+			['https://github.com/example/project/issues/2650#discussion_r123'],
+			{ SWARM_PIPELINE_DRY_RUN: '1' },
+		);
+
+		expect(result.status).toBe(0);
+		expect(
+			readFileSync(
+				path.join(repo, '.swarm/pipeline-evidence/pr-body.md'),
+				'utf8',
+			),
+		).toContain('swarm/implement-2650');
+	}, 30000);
+
 	test('dry run creates the branch, evidence bundle, and PR body; second run is idempotent', () => {
 		const repo = makeDemoRepo();
 		const first = runPipeline(repo, ['1234'], { SWARM_PIPELINE_DRY_RUN: '1' });

--- a/tests/unit/scripts/swarm-implement-pipeline.test.ts
+++ b/tests/unit/scripts/swarm-implement-pipeline.test.ts
@@ -101,6 +101,21 @@ describe('swarm-implement pipeline driver (#2498)', () => {
 		).toContain('swarm/implement-2650');
 	}, 30000);
 
+	test('malformed issue URLs fail before pipeline side effects', () => {
+		const repo = makeDemoRepo();
+		const result = runPipeline(
+			repo,
+			['https://github.com/example/project/issues/triage'],
+			{ SWARM_PIPELINE_DRY_RUN: '1' },
+		);
+
+		expect(result.status).toBe(3);
+		expect(result.stderr).toContain('cannot parse an issue number');
+		expect(
+			existsSync(path.join(repo, '.swarm/pipeline-evidence/phases.txt')),
+		).toBe(false);
+	}, 30000);
+
 	test('dry run creates the branch, evidence bundle, and PR body; second run is idempotent', () => {
 		const repo = makeDemoRepo();
 		const first = runPipeline(repo, ['1234'], { SWARM_PIPELINE_DRY_RUN: '1' });


### PR DESCRIPTION
Follow-up to #2650 (merged before the final review-fix push).

## Summary
- Bound the existing-PR lookup in the gated implementation pipeline with a configurable 30-second timeout.
- Strip query strings and fragments from issue URLs before numeric validation.
- Add a regression test for fragment-bearing issue URLs.

## Invariant audit
- 1 (plugin init): not touched - no plugin initialization code changed.
- 2 (runtime portability): not touched - no plugin bundle or runtime-resolution code changed.
- 3 (subprocesses): touched - the `gh pr view` publication lookup now has an explicit timeout; Git Bash `bash -n` and focused CI tests pass.
- 4 (.swarm containment): not touched - existing pipeline evidence path is unchanged.
- 5 (plan durability): not touched - no plan state or ledger code changed.
- 6 (test_runner safety): not touched - validation used bounded shell commands and one explicit test file.
- 7 (test writing): touched - added one falsifiable `bun:test` regression without mocks; Biome and focused tests pass.
- 8 (session state): not touched - no session/global state changed.
- 9 (guardrails/retry): not touched - no agent retry or guardrail policy changed.
- 10 (chat/system msg): not touched - no chat transform code changed.
- 11 (tool registration): not touched - no tool or agent map changed.
- 12 (release/cache): not touched - no release/cache behavior changed; existing issue fragment remains in main.

## Test plan
- [x] `git diff --check`
- [x] Git Bash `bash -n scripts/swarm-implement-pipeline.sh`
- [x] `bunx @biomejs/biome@2.3.14 check tests/unit/scripts/swarm-implement-pipeline.test.ts`
- [x] `bun --smol test tests/unit/scripts/swarm-implement-pipeline.test.ts --timeout 60000` — 5 passed, 0 failed, 26 expectations
- [x] `bun run test:unit:ci tests/unit/scripts/swarm-implement-pipeline.test.ts` with Git Bash first on PATH
- [x] `bun run check:test-clock` — 0 new violations
- [x] `bun run check:test-file-cap`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run check:invariants`
- [x] `bun run check:bash-portability`
- [x] `bun run check:gate-portability`
- [x] `bun run check:pending-fragment`
- [x] `bun run package:smoke`

The full local `bun run lint:ci` scan still reports pre-existing diagnostics in untouched files on the merged main baseline; the changed-file Biome gate is clean and the merged PR's remote quality check was green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

