### PR TITLE
fix(ci): harden advisory runtime follow-ups

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -84,6 +84,10 @@ report=$(printf '%s\n' "$output" | sed -n '/^\[SWARM_CI_JSON\]$/,/^\[\/SWARM_CI_
 Startup and evaluation run under an overall deadline (`--timeout-ms`, default
 300000; supported range 1–300000). SIGINT/SIGTERM abort the run (exit 2) and
 run registered cleanup exactly once; the run journal is capped at 200 events.
+The `run_started` journal event intentionally has no `detail`/directory field;
+cancellation/deadline/error diagnostics redact the evaluated directory from
+their bounded detail and journal-tail text. The former 600000ms example is no
+longer accepted: callers must use a value in the supported 1–300000ms range.
 Note that POSIX-style self-signalling is unreliable on Windows (Git Bash in
 particular), so treat signal-driven exit 2 there as best-effort; the
 `--timeout-ms` deadline is the portable bound. A SIGKILL or a host crash cannot be cleaned in-process. Any residue is confined to the OS temporary directory, where the operating system can reclaim it.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -10,7 +10,7 @@ LLMs, and never writes to the repo.
 ```bash
 bunx opencode-swarm ci                 # Markdown report + [SWARM_CI_JSON] block
 bunx opencode-swarm ci --json          # machine block only
-bunx opencode-swarm ci --timeout-ms 600000
+bunx opencode-swarm ci --timeout-ms 300000
 # equivalent inside OpenCode: /swarm ci ... ; registry form: bunx opencode-swarm run ci ...
 ```
 
@@ -70,8 +70,9 @@ report=$(printf '%s\n' "$output" | sed -n '/^\[SWARM_CI_JSON\]$/,/^\[\/SWARM_CI_
 - The evaluated repo is never modified: file-backed reads are pure, and
   DB-mediated reads (gate profile, plan-critic snapshots — which open the
   SQLite store and would create WAL sidecars) run against a bounded, discarded
-  temp **shadow copy** of `.swarm/`. If the shadow exceeds 512 MiB, those rows
-  are reported as errors instead of copying unbounded data.
+  temp **shadow copy** of `.swarm/`. The incremental shadow copy is bounded by
+  both 512 MiB of copied bytes and 100000 filesystem entries. If the shadow exceeds 512 MiB or 100000 entries, those rows are reported as errors instead
+  of copying unbounded data.
 - No gate can be satisfied or bypassed from this path — it only reads and
   reports. The live enforcement points (delegation gate, reviewer/test gates at
   task completion) are unchanged.
@@ -81,11 +82,11 @@ report=$(printf '%s\n' "$output" | sed -n '/^\[SWARM_CI_JSON\]$/,/^\[\/SWARM_CI_
 ## Bounds
 
 Startup and evaluation run under an overall deadline (`--timeout-ms`, default
-300000). SIGINT/SIGTERM abort the run (exit 2) and run registered cleanup
-exactly once; the run journal is capped at 200 events. Note that POSIX-style
-self-signalling is unreliable on Windows (Git Bash in particular), so treat
-signal-driven exit 2 there as best-effort; the `--timeout-ms` deadline is the
-portable bound.
+300000; supported range 1–300000). SIGINT/SIGTERM abort the run (exit 2) and
+run registered cleanup exactly once; the run journal is capped at 200 events.
+Note that POSIX-style self-signalling is unreliable on Windows (Git Bash in
+particular), so treat signal-driven exit 2 there as best-effort; the
+`--timeout-ms` deadline is the portable bound. A SIGKILL or a host crash cannot be cleaned in-process. Any residue is confined to the OS temporary directory, where the operating system can reclaim it.
 
 ## Related
 

--- a/docs/releases/pending/2633-ci-runtime-hardening.md
+++ b/docs/releases/pending/2633-ci-runtime-hardening.md
@@ -3,3 +3,9 @@
 - Bounds advisory CI deadlines and shadow/journal resources, keeps diagnostics
   free of evaluated-directory paths, and documents unavoidable process-death
   cleanup residue.
+- `run_started` journal entries omit the evaluated directory, and Windows
+  signal-driven cancellation remains best-effort; the timeout remains the
+  portable cancellation bound. Legacy flat-retrospective evidence reads stay
+  migration-free and do not rewrite the evaluated repository.
+- The documented `600000` ms timeout example is no longer compatible with the
+  supported `1`–`300000` ms range; callers using the former value must lower it.

--- a/docs/releases/pending/2633-ci-runtime-hardening.md
+++ b/docs/releases/pending/2633-ci-runtime-hardening.md
@@ -1,0 +1,5 @@
+# Advisory CI runtime hardening
+
+- Bounds advisory CI deadlines and shadow/journal resources, keeps diagnostics
+  free of evaluated-directory paths, and documents unavoidable process-death
+  cleanup residue.

--- a/scripts/drift-check-docs-claims.ts
+++ b/scripts/drift-check-docs-claims.ts
@@ -10,6 +10,12 @@ import {
 	TOMBSTONE_MIN_AGE_MS,
 } from '../src/background/pending-delegations';
 import { MAX_RECOVERY_LEDGER_BYTES } from '../src/background/delegation-health';
+import { DEFAULT_CI_DEADLINE_MS } from '../src/commands/ci';
+import {
+	MAX_SHADOW_COPY_BYTES,
+	MAX_SHADOW_COPY_ENTRIES,
+} from '../src/ci/evaluate';
+import { MAX_CI_JOURNAL_EVENTS } from '../src/ci/runtime';
 
 type DriftSeverity = 'error' | 'warning' | 'notice';
 
@@ -116,6 +122,34 @@ const DOCS_NUMERIC_CLAIMS = [
 		regex: /scaled to surface size up to the (\d+)-lane cap/,
 		expected: MAX_LANES,
 		sourceName: 'MAX_LANES',
+	},
+	{
+		file: 'docs/ci.md',
+		label: 'advisory CI timeout example',
+		regex: /opencode-swarm ci --timeout-ms (\d+)/,
+		expected: DEFAULT_CI_DEADLINE_MS,
+		sourceName: 'DEFAULT_CI_DEADLINE_MS',
+	},
+	{
+		file: 'docs/ci.md',
+		label: 'advisory CI shadow-copy byte cap',
+		regex: /shadow exceeds (\d+) MiB/i,
+		expected: MAX_SHADOW_COPY_BYTES / (1024 * 1024),
+		sourceName: 'MAX_SHADOW_COPY_BYTES',
+	},
+	{
+		file: 'docs/ci.md',
+		label: 'advisory CI shadow-copy entry cap',
+		regex: /shadow exceeds \d+ MiB or (\d+) entries/i,
+		expected: MAX_SHADOW_COPY_ENTRIES,
+		sourceName: 'MAX_SHADOW_COPY_ENTRIES',
+	},
+	{
+		file: 'docs/ci.md',
+		label: 'advisory CI journal event cap',
+		regex: /journal is capped at (\d+) events/i,
+		expected: MAX_CI_JOURNAL_EVENTS,
+		sourceName: 'MAX_CI_JOURNAL_EVENTS',
 	},
 ] as const satisfies readonly DocsNumericClaim[];
 

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -3526,7 +3526,7 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		],
 		writerCitations: [
 			'src/config/project-init.ts:25 writeSwarmConfigExampleIfNew (first-run .swarm/config.example.json write incl. $schema ref; errors non-fatal)',
-			'src/cli/index.ts:289 saveJson — CLI-managed global/plugin config saves (outside .swarm)',
+			'src/cli/index.ts:290 saveJson — CLI-managed global/plugin config saves (outside .swarm)',
 		],
 		readerCitations: ['config loader; CLI loadJson (:269)'],
 		schemaVersion: 'config schema',

--- a/src/ci/evaluate.ts
+++ b/src/ci/evaluate.ts
@@ -28,6 +28,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { closeProjectDb } from '../db/project-db.js';
 import {
 	DEFAULT_QA_GATES,
 	getEffectiveGates,
@@ -40,6 +41,7 @@ import {
 } from '../gate-evidence.js';
 import { isPlanCriticApproved } from '../hooks/delegation-gate.js';
 import { loadPlanJsonOnly } from '../plan/manager.js';
+import { invalidateCachedArtifact } from '../utils/swarm-artifact-cache.js';
 import {
 	CI_QUALITY_THRESHOLDS,
 	computeEvidenceQualitySummary,
@@ -195,6 +197,10 @@ function copyFileBounded(
 			copiedBytes += bytesRead;
 		}
 	} finally {
+		// This helper writes a transient OS-temp path through an open descriptor.
+		// Invalidate explicitly so the scanner and read-your-own-write contract do
+		// not depend on the copy target remaining below the evaluated project root.
+		invalidateCachedArtifact(destination);
 		if (destinationFd !== undefined) {
 			try {
 				fs.closeSync(destinationFd);
@@ -289,7 +295,11 @@ function createShadowCopy(
 			const rel = path.relative(directory, src);
 			const dest = path.join(shadowRoot, rel);
 			fs.mkdirSync(path.dirname(dest), { recursive: true });
-			const copied = copyFileBounded(src, dest, maxBytes - copiedBytes);
+			const copied = _internals.copyFileBounded(
+				src,
+				dest,
+				maxBytes - copiedBytes,
+			);
 			if (copied === null) {
 				removeShadowRoot(shadowRoot);
 				return null;
@@ -351,9 +361,23 @@ export async function evaluateAdvisoryCi(
 	const journal = options.journal ?? (() => {});
 	const externalRegisterCleanup = options.registerCleanup;
 	let directShadowCleanup: (() => void) | undefined;
+	const directShadowCleanups: Array<() => void> = [];
 	const registerCleanup = (fn: () => void) => {
 		if (externalRegisterCleanup) externalRegisterCleanup(fn);
-		else directShadowCleanup = fn;
+		else {
+			directShadowCleanups.push(fn);
+			directShadowCleanup ??= () => {
+				for (const cleanup of directShadowCleanups.splice(0)) {
+					try {
+						cleanup();
+					} catch {
+						// Direct callers have no runtime cleanup supervisor; one failed
+						// best-effort cleanup must not hide the evaluation result or
+						// prevent later callbacks from running.
+					}
+				}
+			};
+		}
 	};
 	const gates: AdvisoryCiGateRow[] = [];
 	const tasks: AdvisoryCiReport['tasks'] = [];
@@ -433,11 +457,25 @@ export async function evaluateAdvisoryCi(
 		shadowDir = null;
 	}
 	if (shadowDir) {
-		const cleanupShadow = () => removeShadowRoot(shadowDir as string);
+		const cleanupShadow = () => {
+			try {
+				closeProjectDb(shadowDir as string);
+			} finally {
+				// SQLite must release WAL/SHM handles before the temp tree is
+				// removed (especially on Windows). Removal remains best-effort
+				// even if the cached DB is already closed or unavailable.
+				removeShadowRoot(shadowDir as string);
+			}
+		};
 		try {
 			registerCleanup(cleanupShadow);
 		} catch (error) {
-			removeShadowRoot(shadowDir);
+			try {
+				cleanupShadow();
+			} catch {
+				// Preserve the cleanup-registration failure; the shadow root has
+				// still received a best-effort removal attempt above.
+			}
 			throw error;
 		}
 	}

--- a/src/ci/evaluate.ts
+++ b/src/ci/evaluate.ts
@@ -57,6 +57,9 @@ export const TERMINAL_SUCCESS_STATES = ['complete', 'closed'] as const;
  * rather than copying unbounded data into a temp dir. */
 export const MAX_SHADOW_COPY_BYTES = 512 * 1024 * 1024;
 
+/** Maximum number of filesystem entries examined by one shadow-copy census. */
+export const MAX_SHADOW_COPY_ENTRIES = 100_000;
+
 export type AdvisoryCiGateStatus =
 	| 'pass'
 	| 'fail'
@@ -148,43 +151,163 @@ function countStatuses(rows: AdvisoryCiGateRow[]): AdvisoryCiReport['counts'] {
 	return counts;
 }
 
+function removeShadowRoot(shadowRoot: string): void {
+	try {
+		fs.rmSync(shadowRoot, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup; the OS reclaims the temp directory eventually.
+	}
+}
+
+const SHADOW_COPY_CHUNK_BYTES = 64 * 1024;
+
+function copyFileBounded(
+	source: string,
+	destination: string,
+	remainingBytes: number,
+): number | null {
+	let sourceFd: number | undefined;
+	let destinationFd: number | undefined;
+	let copiedBytes = 0;
+	try {
+		sourceFd = fs.openSync(source, 'r');
+		destinationFd = fs.openSync(destination, 'w');
+		const buffer = Buffer.allocUnsafe(
+			Math.min(SHADOW_COPY_CHUNK_BYTES, remainingBytes + 1),
+		);
+		while (true) {
+			const bytesRead = fs.readSync(sourceFd, buffer, 0, buffer.length, null);
+			if (bytesRead === 0) return copiedBytes;
+			if (bytesRead > remainingBytes - copiedBytes) return null;
+			let written = 0;
+			while (written < bytesRead) {
+				const bytesWritten = fs.writeSync(
+					destinationFd,
+					buffer,
+					written,
+					bytesRead - written,
+				);
+				if (bytesWritten <= 0) {
+					throw new Error('shadow-copy write made no progress');
+				}
+				written += bytesWritten;
+			}
+			copiedBytes += bytesRead;
+		}
+	} finally {
+		if (destinationFd !== undefined) {
+			try {
+				fs.closeSync(destinationFd);
+			} catch {
+				// Preserve the original copy error, if any.
+			}
+		}
+		if (sourceFd !== undefined) {
+			try {
+				fs.closeSync(sourceFd);
+			} catch {
+				// Preserve the original copy error, if any.
+			}
+		}
+	}
+}
+
+function isClosedDirectoryError(error: unknown): boolean {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		(error as { code?: unknown }).code === 'ERR_DIR_CLOSED'
+	);
+}
+
 /** Copy `.swarm/` into a fresh temp dir for DB-mediated reads. Returns null
  * when `.swarm` is absent or exceeds the copy budget. */
-function createShadowCopy(directory: string): string | null {
+function createShadowCopy(
+	directory: string,
+	maxBytes = MAX_SHADOW_COPY_BYTES,
+): string | null {
 	const swarmDir = path.join(directory, '.swarm');
 	if (!fs.existsSync(swarmDir)) return null;
 	let total = 0;
-	const files: Array<{ src: string; dest: string }> = [];
+	let entriesSeen = 0;
+	const files: string[] = [];
+	let budgetExceeded = false;
 	const walk = (dir: string) => {
-		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-			const src = path.join(dir, entry.name);
-			if (entry.isDirectory()) {
-				walk(src);
-				continue;
+		let directoryHandle: fs.Dir | undefined;
+		let traversalError: unknown;
+		let closeError: unknown;
+		try {
+			directoryHandle = fs.opendirSync(dir);
+			while (true) {
+				const entry = directoryHandle.readSync();
+				if (entry === null) break;
+				entriesSeen++;
+				if (entriesSeen > MAX_SHADOW_COPY_ENTRIES) {
+					budgetExceeded = true;
+					break;
+				}
+				const src = path.join(dir, entry.name);
+				if (entry.isDirectory()) {
+					walk(src);
+					if (budgetExceeded) break;
+					continue;
+				}
+				if (!entry.isFile()) continue;
+				const size = fs.statSync(src).size;
+				total += size;
+				if (total > maxBytes) {
+					budgetExceeded = true;
+					break;
+				}
+				files.push(src);
 			}
-			if (!entry.isFile()) continue;
-			const size = fs.statSync(src).size;
-			total += size;
-			if (total > MAX_SHADOW_COPY_BYTES) return;
-			files.push({
-				src,
-				dest: path.join(path.dirname(src), path.basename(src)),
-			});
+		} catch (error) {
+			traversalError = error;
+			throw error;
+		} finally {
+			if (directoryHandle !== undefined) {
+				try {
+					directoryHandle.closeSync();
+				} catch (error) {
+					if (!isClosedDirectoryError(error) && traversalError === undefined) {
+						closeError = error;
+					}
+				}
+			}
 		}
+		if (closeError !== undefined) throw closeError;
 	};
 	walk(swarmDir);
-	if (total > MAX_SHADOW_COPY_BYTES) return null;
+	if (budgetExceeded) return null;
 	const shadowRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-ci-shadow-'));
-	const shadowSwarm = path.join(shadowRoot, '.swarm');
-	fs.mkdirSync(shadowSwarm, { recursive: true });
-	for (const { src } of files) {
-		const rel = path.relative(directory, src);
-		const dest = path.join(shadowRoot, rel);
-		fs.mkdirSync(path.dirname(dest), { recursive: true });
-		fs.copyFileSync(src, dest);
+	try {
+		const shadowSwarm = path.join(shadowRoot, '.swarm');
+		fs.mkdirSync(shadowSwarm, { recursive: true });
+		let copiedBytes = 0;
+		for (const src of files) {
+			const rel = path.relative(directory, src);
+			const dest = path.join(shadowRoot, rel);
+			fs.mkdirSync(path.dirname(dest), { recursive: true });
+			const copied = copyFileBounded(src, dest, maxBytes - copiedBytes);
+			if (copied === null) {
+				removeShadowRoot(shadowRoot);
+				return null;
+			}
+			copiedBytes += copied;
+		}
+		return shadowRoot;
+	} catch (error) {
+		removeShadowRoot(shadowRoot);
+		throw error;
 	}
-	return shadowRoot;
 }
+
+export const _internals = {
+	computeEvidenceQualitySummary,
+	copyFileBounded,
+	createShadowCopy,
+};
 
 /** Gates whose only durable record lives in live plugin state; advisory CI
  * reports them instead of fabricating a pass. */
@@ -226,7 +349,12 @@ export async function evaluateAdvisoryCi(
 ): Promise<AdvisoryCiReport> {
 	const { directory, tty } = options;
 	const journal = options.journal ?? (() => {});
-	const registerCleanup = options.registerCleanup ?? (() => {});
+	const externalRegisterCleanup = options.registerCleanup;
+	let directShadowCleanup: (() => void) | undefined;
+	const registerCleanup = (fn: () => void) => {
+		if (externalRegisterCleanup) externalRegisterCleanup(fn);
+		else directShadowCleanup = fn;
+	};
 	const gates: AdvisoryCiGateRow[] = [];
 	const tasks: AdvisoryCiReport['tasks'] = [];
 
@@ -305,115 +433,130 @@ export async function evaluateAdvisoryCi(
 		shadowDir = null;
 	}
 	if (shadowDir) {
-		registerCleanup(() => {
-			try {
-				fs.rmSync(shadowDir as string, { recursive: true, force: true });
-			} catch {
-				// Best-effort temp cleanup; the OS reclaims tmpdirs.
-			}
-		});
-	}
-
-	// --- effective gate set (R2: default fallback, honest reporting) -------
-	const identity = {
-		swarm: planLike.swarm ?? 'local',
-		title: planLike.title ?? '',
-	};
-	let effectiveGates: QaGates = { ...DEFAULT_QA_GATES };
-	let gateProfile: 'default' | 'profile' = 'default';
-	if (shadowDir) {
-		const lookup = getProfileLookupForIdentity(shadowDir, identity);
-		if (lookup && 'profile' in lookup && lookup.profile) {
-			effectiveGates = getEffectiveGates(lookup.profile, {});
-			gateProfile = 'profile';
-		}
-	}
-	journal('gate_profile', gateProfile);
-
-	gates.push({ name: 'plan', status: 'pass' });
-
-	// --- plan-critic gate (critic_pre_plan) --------------------------------
-	if (effectiveGates.critic_pre_plan) {
-		if (shadowDir) {
-			const approved = await isPlanCriticApproved(shadowDir);
-			gates.push({
-				name: 'plan_critic',
-				status: approved ? 'pass' : 'fail',
-				detail: approved
-					? 'plan-critic APPROVED snapshot matches the current plan structure'
-					: 'no plan_critic_gate APPROVED snapshot matching the current plan (critic_pre_plan is enabled)',
-			});
-		} else {
-			gates.push({
-				name: 'plan_critic',
-				status: 'error',
-				detail:
-					'ledger snapshot read unavailable: durable state exceeds the shadow-copy budget',
-			});
-		}
-	}
-
-	// --- per-task gates (tri-state evidence, terminal workflow) ------------
-	for (const task of planTasks) {
+		const cleanupShadow = () => removeShadowRoot(shadowDir as string);
 		try {
-			const state = await readTaskEvidenceState(directory, task.id);
-			if (state.kind === 'ok') {
-				const evidence = state.evidence;
-				const required = [...evidence.required_gates];
-				const satisfiedKeys = Object.keys(evidence.gates ?? {});
-				const missing = required.filter((g) => !satisfiedKeys.includes(g));
-				const workflowState = evidence.workflow?.state;
-				const terminal = TERMINAL_SUCCESS_STATES.includes(
-					workflowState as (typeof TERMINAL_SUCCESS_STATES)[number],
-				);
-				const satisfied = missing.length === 0 && terminal;
-				tasks.push({
-					task_id: task.id,
-					evidence_state: 'valid',
-					required_gates: required,
-					missing_gates: missing,
-					workflow_state: workflowState,
-					satisfied,
-				});
+			registerCleanup(cleanupShadow);
+		} catch (error) {
+			removeShadowRoot(shadowDir);
+			throw error;
+		}
+	}
+
+	try {
+		// --- effective gate set (R2: default fallback, honest reporting) -------
+		const identity = {
+			swarm: planLike.swarm ?? 'local',
+			title: planLike.title ?? '',
+		};
+		let effectiveGates: QaGates = { ...DEFAULT_QA_GATES };
+		let gateProfile: 'default' | 'profile' = 'default';
+		if (shadowDir) {
+			const lookup = getProfileLookupForIdentity(shadowDir, identity);
+			if (lookup && 'profile' in lookup && lookup.profile) {
+				effectiveGates = getEffectiveGates(lookup.profile, {});
+				gateProfile = 'profile';
+			}
+		}
+		journal('gate_profile', gateProfile);
+
+		gates.push({ name: 'plan', status: 'pass' });
+
+		// --- plan-critic gate (critic_pre_plan) --------------------------------
+		if (effectiveGates.critic_pre_plan) {
+			if (shadowDir) {
+				const approved = await isPlanCriticApproved(shadowDir);
 				gates.push({
-					name: `task ${task.id} gates`,
-					status: satisfied ? 'pass' : 'fail',
-					detail: satisfied
-						? `all required gates satisfied; workflow ${workflowState}`
-						: missing.length > 0
-							? `missing gate evidence: ${missing.join(', ')}${terminal ? '' : `; workflow state ${workflowState} is not terminal`}`
-							: `workflow state ${workflowState} is not a terminal-success state`,
-				});
-			} else if (state.kind === 'missing') {
-				const required = deriveRequiredGates('coder');
-				tasks.push({
-					task_id: task.id,
-					evidence_state: 'missing',
-					required_gates: required,
-					missing_gates: [...required],
-					satisfied: false,
-				});
-				gates.push({
-					name: `task ${task.id} gates`,
-					status: 'no_data',
-					detail: 'no durable task-gate evidence recorded',
-				});
-			} else if (state.kind === 'unparseable') {
-				const required = deriveRequiredGates('coder');
-				tasks.push({
-					task_id: task.id,
-					evidence_state: 'corrupt',
-					required_gates: required,
-					missing_gates: [...required],
-					satisfied: false,
-				});
-				gates.push({
-					name: `task ${task.id} gates`,
-					status: 'corrupt',
-					detail:
-						'task-gate evidence exists but cannot be parsed (#2470 tri-state)',
+					name: 'plan_critic',
+					status: approved ? 'pass' : 'fail',
+					detail: approved
+						? 'plan-critic APPROVED snapshot matches the current plan structure'
+						: 'no plan_critic_gate APPROVED snapshot matching the current plan (critic_pre_plan is enabled)',
 				});
 			} else {
+				gates.push({
+					name: 'plan_critic',
+					status: 'error',
+					detail:
+						'ledger snapshot read unavailable: durable state exceeds the shadow-copy budget',
+				});
+			}
+		}
+
+		// --- per-task gates (tri-state evidence, terminal workflow) ------------
+		for (const task of planTasks) {
+			try {
+				const state = await readTaskEvidenceState(directory, task.id);
+				if (state.kind === 'ok') {
+					const evidence = state.evidence;
+					const required = [...evidence.required_gates];
+					const satisfiedKeys = Object.keys(evidence.gates ?? {});
+					const missing = required.filter((g) => !satisfiedKeys.includes(g));
+					const workflowState = evidence.workflow?.state;
+					const terminal = TERMINAL_SUCCESS_STATES.includes(
+						workflowState as (typeof TERMINAL_SUCCESS_STATES)[number],
+					);
+					const satisfied = missing.length === 0 && terminal;
+					tasks.push({
+						task_id: task.id,
+						evidence_state: 'valid',
+						required_gates: required,
+						missing_gates: missing,
+						workflow_state: workflowState,
+						satisfied,
+					});
+					gates.push({
+						name: `task ${task.id} gates`,
+						status: satisfied ? 'pass' : 'fail',
+						detail: satisfied
+							? `all required gates satisfied; workflow ${workflowState}`
+							: missing.length > 0
+								? `missing gate evidence: ${missing.join(', ')}${terminal ? '' : `; workflow state ${workflowState} is not terminal`}`
+								: `workflow state ${workflowState} is not a terminal-success state`,
+					});
+				} else if (state.kind === 'missing') {
+					const required = deriveRequiredGates('coder');
+					tasks.push({
+						task_id: task.id,
+						evidence_state: 'missing',
+						required_gates: required,
+						missing_gates: [...required],
+						satisfied: false,
+					});
+					gates.push({
+						name: `task ${task.id} gates`,
+						status: 'no_data',
+						detail: 'no durable task-gate evidence recorded',
+					});
+				} else if (state.kind === 'unparseable') {
+					const required = deriveRequiredGates('coder');
+					tasks.push({
+						task_id: task.id,
+						evidence_state: 'corrupt',
+						required_gates: required,
+						missing_gates: [...required],
+						satisfied: false,
+					});
+					gates.push({
+						name: `task ${task.id} gates`,
+						status: 'corrupt',
+						detail:
+							'task-gate evidence exists but cannot be parsed (#2470 tri-state)',
+					});
+				} else {
+					tasks.push({
+						task_id: task.id,
+						evidence_state: 'error',
+						required_gates: deriveRequiredGates('coder'),
+						missing_gates: deriveRequiredGates('coder'),
+						satisfied: false,
+					});
+					gates.push({
+						name: `task ${task.id} gates`,
+						status: 'error',
+						detail: `evidence reader returned unexpected state ${JSON.stringify((state as { kind?: string }).kind)}`,
+					});
+				}
+			} catch (error) {
 				tasks.push({
 					task_id: task.id,
 					evidence_state: 'error',
@@ -424,103 +567,94 @@ export async function evaluateAdvisoryCi(
 				gates.push({
 					name: `task ${task.id} gates`,
 					status: 'error',
-					detail: `evidence reader returned unexpected state ${JSON.stringify((state as { kind?: string }).kind)}`,
+					detail: error instanceof Error ? error.message : String(error),
 				});
 			}
-		} catch (error) {
-			tasks.push({
-				task_id: task.id,
-				evidence_state: 'error',
-				required_gates: deriveRequiredGates('coder'),
-				missing_gates: deriveRequiredGates('coder'),
-				satisfied: false,
-			});
+		}
+
+		// --- evidence-quality thresholds (shared with benchmark) ---------------
+		const summary = await _internals.computeEvidenceQualitySummary(directory);
+		const q = summary.qualityMetrics;
+		const qualityRows: Array<[string, boolean | null, number | null, string]> =
+			[
+				[
+					'review_pass_rate',
+					summary.reviewPassRate === null
+						? null
+						: summary.reviewPassRate >= CI_QUALITY_THRESHOLDS.review_pass_rate,
+					summary.reviewPassRate,
+					`>= ${CI_QUALITY_THRESHOLDS.review_pass_rate}% over ${summary.totalReviews} reviews`,
+				],
+				[
+					'test_pass_rate',
+					summary.testPassRate === null
+						? null
+						: summary.testPassRate >= CI_QUALITY_THRESHOLDS.test_pass_rate,
+					summary.testPassRate,
+					`>= ${CI_QUALITY_THRESHOLDS.test_pass_rate}% over ${summary.testsPassed + summary.testsFailed} tests`,
+				],
+				[
+					'quality_budget.complexity_delta',
+					q.hasEvidence
+						? q.complexityDelta <= CI_QUALITY_THRESHOLDS.max_complexity_delta
+						: null,
+					q.hasEvidence ? q.complexityDelta : null,
+					`<= ${CI_QUALITY_THRESHOLDS.max_complexity_delta}`,
+				],
+				[
+					'quality_budget.public_api_delta',
+					q.hasEvidence
+						? q.publicApiDelta <= CI_QUALITY_THRESHOLDS.max_public_api_delta
+						: null,
+					q.hasEvidence ? q.publicApiDelta : null,
+					`<= ${CI_QUALITY_THRESHOLDS.max_public_api_delta}`,
+				],
+				[
+					'quality_budget.duplication_ratio',
+					q.hasEvidence
+						? q.duplicationRatio <= CI_QUALITY_THRESHOLDS.max_duplication_ratio
+						: null,
+					q.hasEvidence ? q.duplicationRatio : null,
+					`<= ${CI_QUALITY_THRESHOLDS.max_duplication_ratio}%`,
+				],
+				[
+					'quality_budget.test_to_code_ratio',
+					q.hasEvidence
+						? q.testToCodeRatio >= CI_QUALITY_THRESHOLDS.min_test_to_code_ratio
+						: null,
+					q.hasEvidence ? q.testToCodeRatio : null,
+					`>= ${CI_QUALITY_THRESHOLDS.min_test_to_code_ratio}%`,
+				],
+			];
+		for (const [name, passed, value, threshold] of qualityRows) {
 			gates.push({
-				name: `task ${task.id} gates`,
-				status: 'error',
-				detail: error instanceof Error ? error.message : String(error),
+				name,
+				status: passed === null ? 'no_data' : passed ? 'pass' : 'fail',
+				detail:
+					passed === null
+						? `no evidence data (${threshold}); not a pass`
+						: `value ${value} ${threshold}`,
 			});
 		}
-	}
 
-	// --- evidence-quality thresholds (shared with benchmark) ---------------
-	const summary = await computeEvidenceQualitySummary(directory);
-	const q = summary.qualityMetrics;
-	const qualityRows: Array<[string, boolean | null, number | null, string]> = [
-		[
-			'review_pass_rate',
-			summary.reviewPassRate === null
-				? null
-				: summary.reviewPassRate >= CI_QUALITY_THRESHOLDS.review_pass_rate,
-			summary.reviewPassRate,
-			`>= ${CI_QUALITY_THRESHOLDS.review_pass_rate}% over ${summary.totalReviews} reviews`,
-		],
-		[
-			'test_pass_rate',
-			summary.testPassRate === null
-				? null
-				: summary.testPassRate >= CI_QUALITY_THRESHOLDS.test_pass_rate,
-			summary.testPassRate,
-			`>= ${CI_QUALITY_THRESHOLDS.test_pass_rate}% over ${summary.testsPassed + summary.testsFailed} tests`,
-		],
-		[
-			'quality_budget.complexity_delta',
-			q.hasEvidence
-				? q.complexityDelta <= CI_QUALITY_THRESHOLDS.max_complexity_delta
-				: null,
-			q.hasEvidence ? q.complexityDelta : null,
-			`<= ${CI_QUALITY_THRESHOLDS.max_complexity_delta}`,
-		],
-		[
-			'quality_budget.public_api_delta',
-			q.hasEvidence
-				? q.publicApiDelta <= CI_QUALITY_THRESHOLDS.max_public_api_delta
-				: null,
-			q.hasEvidence ? q.publicApiDelta : null,
-			`<= ${CI_QUALITY_THRESHOLDS.max_public_api_delta}`,
-		],
-		[
-			'quality_budget.duplication_ratio',
-			q.hasEvidence
-				? q.duplicationRatio <= CI_QUALITY_THRESHOLDS.max_duplication_ratio
-				: null,
-			q.hasEvidence ? q.duplicationRatio : null,
-			`<= ${CI_QUALITY_THRESHOLDS.max_duplication_ratio}%`,
-		],
-		[
-			'quality_budget.test_to_code_ratio',
-			q.hasEvidence
-				? q.testToCodeRatio >= CI_QUALITY_THRESHOLDS.min_test_to_code_ratio
-				: null,
-			q.hasEvidence ? q.testToCodeRatio : null,
-			`>= ${CI_QUALITY_THRESHOLDS.min_test_to_code_ratio}%`,
-		],
-	];
-	for (const [name, passed, value, threshold] of qualityRows) {
-		gates.push({
-			name,
-			status: passed === null ? 'no_data' : passed ? 'pass' : 'fail',
-			detail:
-				passed === null
-					? `no evidence data (${threshold}); not a pass`
-					: `value ${value} ${threshold}`,
+		const report = finishReport({
+			gates,
+			tasks,
+			planMeta: {
+				present: true,
+				title: planLike.title,
+				swarm: planLike.swarm,
+				task_count: planTasks.length,
+			},
+			tty,
+			exit_reason: 'gate_violations',
+			effectiveGates,
+			gateProfile,
 		});
+		return report;
+	} finally {
+		directShadowCleanup?.();
 	}
-
-	return finishReport({
-		gates,
-		tasks,
-		planMeta: {
-			present: true,
-			title: planLike.title,
-			swarm: planLike.swarm,
-			task_count: planTasks.length,
-		},
-		tty,
-		exit_reason: 'gate_violations',
-		effectiveGates,
-		gateProfile,
-	});
 }
 
 function finishReport(args: {

--- a/src/ci/index.ts
+++ b/src/ci/index.ts
@@ -15,11 +15,9 @@ export {
 	type AdvisoryCiTaskEntry,
 	type EvaluateAdvisoryCiOptions,
 	evaluateAdvisoryCi,
-	MAX_SHADOW_COPY_BYTES,
 	TERMINAL_SUCCESS_STATES,
 } from './evaluate.js';
 export {
-	CI_QUALITY_THRESHOLDS,
 	computeEvidenceQualitySummary,
 	type EvidenceQualitySummary,
 } from './quality-checks.js';
@@ -27,15 +25,11 @@ export {
 	renderFullReport,
 	renderJsonBlock,
 	renderMarkdownReport,
-	SWARM_CI_JSON_CLOSE,
-	SWARM_CI_JSON_OPEN,
 } from './report.js';
 export {
 	type CiEvaluateContext,
-	type CiRunEvent,
 	type CiRunOutcome,
 	type CiRunResult,
 	type CiRuntimeOptions,
-	MAX_CI_JOURNAL_EVENTS,
 	runAdvisoryCiRuntime,
 } from './runtime.js';

--- a/src/ci/runtime.ts
+++ b/src/ci/runtime.ts
@@ -31,6 +31,8 @@ import type { AdvisoryCiReport } from './evaluate.js';
  * line — so 200 covers large plans while still bounding memory. Mirrors the
  * named-cap pattern of MAX_PENDING_ADVISORIES (src/utils/advisory-queue.ts). */
 export const MAX_CI_JOURNAL_EVENTS = 200;
+const DEFAULT_CI_DEADLINE_MS = 300_000;
+const MAX_CI_DEADLINE_MS = 300_000;
 
 /** Terminal outcome vocabulary for an advisory CI run. */
 export type CiRunOutcome =
@@ -40,7 +42,7 @@ export type CiRunOutcome =
 	| 'deadline'
 	| 'error';
 
-export interface CiRunEvent {
+interface CiRunEvent {
 	seq: number;
 	type: string;
 	detail?: string;
@@ -50,8 +52,8 @@ export interface CiRunEvent {
 export interface CiEvaluateContext {
 	/** Append a bounded journal event. */
 	journal: (type: string, detail?: string) => void;
-	/** Register a cleanup callback; all callbacks run exactly once in the
-	 * runtime's finally block (even on cancel/deadline/error). */
+	/** Register a cleanup callback; callbacks run exactly once during or after
+	 * the runtime's cleanup drain (even on cancel/deadline/error). */
 	registerCleanup: (fn: () => void) => void;
 	/** Trips when the caller aborts (SIGINT/SIGTERM at the CLI layer). */
 	signal: AbortSignal;
@@ -62,7 +64,7 @@ export interface CiEvaluateContext {
 
 export interface CiRuntimeOptions {
 	directory: string;
-	/** Overall deadline for the whole run. Default 300s; clamps to >=1ms. */
+	/** Overall deadline for the whole run. Default 300s; clamps to 1..300s. */
 	deadlineMs?: number;
 	/** Caller-owned abort source (CLI wires SIGINT/SIGTERM). */
 	signal?: AbortSignal;
@@ -115,19 +117,42 @@ async function settle<T>(promise: Promise<T>): Promise<Settled<T>> {
  *
  * Bounds: every stage is raced against both the caller's abort signal and
  * the overall deadline; the journal is capped; cleanup callbacks run exactly
- * once in `finally`. The evaluation callback receives the context above and
- * must not outlive the runtime (cleanup disposes its resources).
+ * once during or after the cleanup drain. Losing evaluation work may settle
+ * after the runtime outcome; late cleanup registration runs immediately.
  */
 export async function runAdvisoryCiRuntime(
 	options: CiRuntimeOptions,
 ): Promise<CiRunResult> {
-	const deadlineMs = Math.max(1, options.deadlineMs ?? 300_000);
+	const requestedDeadlineMs = options.deadlineMs ?? DEFAULT_CI_DEADLINE_MS;
+	// Direct callers bypass the CLI parser, so keep the runtime bounded even
+	// when they pass Infinity, NaN, or an out-of-range finite value.
+	const deadlineMs = Number.isFinite(requestedDeadlineMs)
+		? Math.min(MAX_CI_DEADLINE_MS, Math.max(1, requestedDeadlineMs))
+		: requestedDeadlineMs > 0
+			? MAX_CI_DEADLINE_MS
+			: 1;
 	const startedAt = Date.now();
 	const events: CiRunEvent[] = [];
 	let journalTruncated = 0;
 	let seq = 0;
 	const cleanups: Array<() => void> = [];
-	let cleanupsRan = false;
+	let cleanupDrainStarted = false;
+	const activeCleanups = new Set<() => void>();
+
+	const invokeCleanup = (fn: () => void) => {
+		// A pathological callback that registers itself must not recurse forever;
+		// distinct callbacks registered during cleanup still run immediately.
+		if (activeCleanups.has(fn)) return;
+		activeCleanups.add(fn);
+		try {
+			fn();
+		} catch {
+			// Cleanup is best-effort; a failing callback must not block the
+			// remaining ones or the outcome.
+		} finally {
+			activeCleanups.delete(fn);
+		}
+	};
 
 	const journal = (type: string, detail?: string) => {
 		seq++;
@@ -140,19 +165,20 @@ export async function runAdvisoryCiRuntime(
 	};
 
 	const registerCleanup = (fn: () => void) => {
+		if (cleanupDrainStarted) {
+			// Losing evaluation work can register after the runtime has settled.
+			// Run that callback now rather than appending to a closed drain.
+			invokeCleanup(fn);
+			return;
+		}
 		cleanups.push(fn);
 	};
 
 	const runCleanups = () => {
-		if (cleanupsRan) return;
-		cleanupsRan = true;
+		if (cleanupDrainStarted) return;
+		cleanupDrainStarted = true;
 		for (const fn of cleanups) {
-			try {
-				fn();
-			} catch {
-				// Cleanup is best-effort; a failing callback must not block the
-				// remaining ones or the outcome.
-			}
+			invokeCleanup(fn);
 		}
 	};
 
@@ -171,7 +197,7 @@ export async function runAdvisoryCiRuntime(
 	let cancelPromise: Promise<never> | undefined;
 
 	try {
-		journal('run_started', options.directory);
+		journal('run_started');
 
 		// One stage: the whole evaluation. A finer-grained stage split adds
 		// racing overhead without changing the outcome vocabulary; per-stage

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import packageJson from '../../package.json' with { type: 'json' };
 import { formatCommandNotFound } from '../commands/command-dispatch.js';
 import {
 	COMMAND_REGISTRY,
+	handleHelpCommand,
 	isCommandFailure,
 	resolveCommand,
 	VALID_COMMANDS,
@@ -926,11 +927,36 @@ Examples:
 `);
 }
 
+async function printCommandHelp(command: string): Promise<void> {
+	const text = await handleHelpCommand({
+		directory: process.cwd(),
+		args: [command],
+		sessionID: '',
+		agents: {},
+		source: 'cli',
+		packageRoot: PACKAGE_ROOT,
+	});
+	console.log(text);
+}
+
 async function main(): Promise<void> {
 	const args = process.argv.slice(2);
 
 	if (args.includes('-v') || args.includes('--version')) {
 		console.log(`opencode-swarm ${version}`);
+		process.exit(0);
+	}
+
+	const isHelpFlag = (arg: string | undefined): boolean =>
+		arg === '-h' || arg === '--help';
+	if (
+		(args.length === 2 && args[0] === 'ci' && isHelpFlag(args[1])) ||
+		(args.length === 3 &&
+			args[0] === 'run' &&
+			args[1] === 'ci' &&
+			isHelpFlag(args[2]))
+	) {
+		await printCommandHelp('ci');
 		process.exit(0);
 	}
 

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -16,6 +16,7 @@
  * consumes no stdin.
  */
 
+import * as path from 'node:path';
 import {
 	type AdvisoryCiReport,
 	evaluateAdvisoryCi,
@@ -30,6 +31,7 @@ export const DEFAULT_CI_DEADLINE_MS = 300_000;
 
 const MIN_CI_DEADLINE_MS = 1;
 const MAX_CI_DEADLINE_MS = DEFAULT_CI_DEADLINE_MS;
+const INVALID_TIMEOUT_MESSAGE = `Invalid --timeout-ms value: expected a positive finite number from ${MIN_CI_DEADLINE_MS} through ${MAX_CI_DEADLINE_MS} milliseconds.`;
 
 export interface CiSignalCancellation {
 	/** The handler invoked on SIGINT/SIGTERM; exported for unit testing the
@@ -76,9 +78,7 @@ function parseTimeoutMs(args: string[]): number {
 	if (index === -1) return DEFAULT_CI_DEADLINE_MS;
 	const raw = args[index + 1];
 	if (raw === undefined || raw.startsWith('--')) {
-		throw new Error(
-			'Invalid --timeout-ms value: expected a positive number of milliseconds.',
-		);
+		throw new Error(INVALID_TIMEOUT_MESSAGE);
 	}
 	const parsed = Number(raw);
 	if (
@@ -86,9 +86,7 @@ function parseTimeoutMs(args: string[]): number {
 		parsed < MIN_CI_DEADLINE_MS ||
 		parsed > MAX_CI_DEADLINE_MS
 	) {
-		throw new Error(
-			`Invalid --timeout-ms value: expected a positive finite number from ${MIN_CI_DEADLINE_MS} through ${MAX_CI_DEADLINE_MS} milliseconds.`,
-		);
+		throw new Error(INVALID_TIMEOUT_MESSAGE);
 	}
 	return parsed;
 }
@@ -101,6 +99,30 @@ function validateNoUnknownFlags(args: string[]): void {
 			throw new Error(`Unknown flag: ${arg}`);
 		}
 	}
+}
+
+function redactDirectory(value: string, directory: string): string {
+	if (directory.length === 0 || value.length === 0) return value;
+
+	// Diagnostics can contain a path rendered by a different layer. Match the
+	// native, normalized, and alternate-separator forms; Windows paths are also
+	// case-insensitive. Sorting longest-first avoids a shorter parent variant
+	// consuming the prefix of a more specific form.
+	const variants = new Set<string>();
+	for (const variant of [directory, path.normalize(directory)]) {
+		variants.add(variant);
+		variants.add(variant.replaceAll('\\', '/'));
+		variants.add(variant.replaceAll('/', '\\'));
+	}
+	const escaped = [...variants]
+		.filter((variant) => variant.length > 0)
+		.sort((a, b) => b.length - a.length)
+		.map((variant) => variant.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+	if (escaped.length === 0) return value;
+	return value.replace(
+		new RegExp(escaped.join('|'), process.platform === 'win32' ? 'gi' : 'g'),
+		'[evaluated-directory]',
+	);
 }
 
 export async function handleCiCommand(
@@ -148,17 +170,17 @@ export async function handleCiCommand(
 		// machine block carries the full report shape with neutral evaluation
 		// fields. One `version: 1` schema for every exit code keeps the
 		// #2498 consumer contract branch-independent.
-		const redactDirectory = (value: string): string =>
-			ctx.directory.length > 0
-				? value.split(ctx.directory).join('[evaluated-directory]')
-				: value;
 		const tail = result.journal
 			.slice(-5)
 			.map(
-				(e) => `${e.type}${e.detail ? `: ${redactDirectory(e.detail)}` : ''}`,
+				(e) =>
+					`${e.type}${e.detail ? `: ${redactDirectory(e.detail, ctx.directory)}` : ''}`,
 			)
 			.join('; ');
-		const detail = redactDirectory(result.detail ?? result.outcome);
+		const detail = redactDirectory(
+			result.detail ?? result.outcome,
+			ctx.directory,
+		);
 		// 'pass'/'violations' returned above, so only the abort outcomes reach
 		// this diagnostic branch.
 		const diagnosticReason =

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -28,6 +28,9 @@ import type { CommandContext, CommandFailure } from './registry.js';
 
 export const DEFAULT_CI_DEADLINE_MS = 300_000;
 
+const MIN_CI_DEADLINE_MS = 1;
+const MAX_CI_DEADLINE_MS = DEFAULT_CI_DEADLINE_MS;
+
 export interface CiSignalCancellation {
 	/** The handler invoked on SIGINT/SIGTERM; exported for unit testing the
 	 * wiring without relying on platform signal delivery. */
@@ -78,9 +81,13 @@ function parseTimeoutMs(args: string[]): number {
 		);
 	}
 	const parsed = Number(raw);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
+	if (
+		!Number.isFinite(parsed) ||
+		parsed < MIN_CI_DEADLINE_MS ||
+		parsed > MAX_CI_DEADLINE_MS
+	) {
 		throw new Error(
-			'Invalid --timeout-ms value: expected a positive number of milliseconds.',
+			`Invalid --timeout-ms value: expected a positive finite number from ${MIN_CI_DEADLINE_MS} through ${MAX_CI_DEADLINE_MS} milliseconds.`,
 		);
 	}
 	return parsed;
@@ -141,11 +148,17 @@ export async function handleCiCommand(
 		// machine block carries the full report shape with neutral evaluation
 		// fields. One `version: 1` schema for every exit code keeps the
 		// #2498 consumer contract branch-independent.
+		const redactDirectory = (value: string): string =>
+			ctx.directory.length > 0
+				? value.split(ctx.directory).join('[evaluated-directory]')
+				: value;
 		const tail = result.journal
 			.slice(-5)
-			.map((e) => `${e.type}${e.detail ? `: ${e.detail}` : ''}`)
+			.map(
+				(e) => `${e.type}${e.detail ? `: ${redactDirectory(e.detail)}` : ''}`,
+			)
 			.join('; ');
-		const detail = result.detail ?? result.outcome;
+		const detail = redactDirectory(result.detail ?? result.outcome);
 		// 'pass'/'violations' returned above, so only the abort outcomes reach
 		// this diagnostic branch.
 		const diagnosticReason =

--- a/tests/helpers/swarm-write-cache-scan.ts
+++ b/tests/helpers/swarm-write-cache-scan.ts
@@ -3353,18 +3353,4 @@ export const EVIDENCE_WRITE_BLIND_SPOTS: readonly EvidenceWriteBlindSpot[] = [
 			'plan.json.rebuild.<time>.<rand> temp file that is renamed onto ' +
 			'plan.json, and that rename IS governed by RULE R.',
 	},
-	{
-		file: 'src/ci/evaluate.ts',
-		rule: 'C',
-		target: 'dest',
-		status: 'not-an-evidence-artifact',
-		reason:
-			'Issue #2497: createShadowCopy() copies .swarm state files into an OS ' +
-			'temporary directory created with fs.mkdtempSync(path.join(os.tmpdir(), ' +
-			"'swarm-ci-shadow-')) so the advisory CI run can evaluate a snapshot " +
-			'without touching the evaluated repo. The `dest` operand is ' +
-			'path.join(shadowRoot, rel), and shadowRoot comes from mkdtempSync, so ' +
-			'the path folds to null — but the target is always OUTSIDE the project ' +
-			'.swarm/evidence/ tree (same shape as cost-accounting.ts|C|snap).',
-	},
 ];

--- a/tests/unit/ci/evaluate-resource-bounds.test.ts
+++ b/tests/unit/ci/evaluate-resource-bounds.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, spyOn, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals,
+	MAX_SHADOW_COPY_ENTRIES,
+} from '../../../src/ci/evaluate.js';
+import { makeFixtureDir } from './_fixtures.js';
+
+function fakeFileDirent(name: string): fs.Dirent {
+	return {
+		name,
+		isBlockDevice: () => false,
+		isCharacterDevice: () => false,
+		isDirectory: () => false,
+		isFIFO: () => false,
+		isFile: () => true,
+		isSocket: () => false,
+		isSymbolicLink: () => false,
+	} as fs.Dirent;
+}
+
+describe('advisory CI shadow-copy resource bounds', () => {
+	test('source growth is detected before any over-budget bytes are written', () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-growth-bound-');
+		const source = path.join(dir, '.swarm', 'growth.bin');
+		fs.mkdirSync(path.dirname(source), { recursive: true });
+		fs.writeFileSync(source, 'xxxx');
+		const realStat = fs.statSync.bind(fs);
+		const realRead = fs.readSync.bind(fs);
+		const realMkdtemp = fs.mkdtempSync.bind(fs);
+		let shadowRoot: string | undefined;
+		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
+			filePath: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			const stat = realStat(filePath as any, rest[0] as any);
+			return path.resolve(String(filePath)) === path.resolve(source)
+				? { ...stat, size: 1 }
+				: stat;
+		}) as unknown as typeof fs.statSync);
+		const readSpy = spyOn(fs, 'readSync').mockImplementation(((
+			fd: number,
+			buffer: NodeJS.ArrayBufferView,
+			offset: number,
+			length: number,
+			position: number | null,
+		) => realRead(fd, buffer, offset, length, position)) as typeof fs.readSync);
+		const writeSpy = spyOn(fs, 'writeSync');
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(((
+			prefix: string,
+			...rest: unknown[]
+		) => {
+			shadowRoot = realMkdtemp(prefix, ...(rest as any));
+			return shadowRoot;
+		}) as unknown as typeof fs.mkdtempSync);
+		try {
+			const result = _internals.createShadowCopy(dir, 3);
+			expect(result).toBeNull();
+			expect(readSpy.mock.calls[0]?.[3]).toBe(4);
+			expect(writeSpy).not.toHaveBeenCalled();
+			expect(shadowRoot).toBeDefined();
+			expect(fs.existsSync(shadowRoot as string)).toBe(false);
+		} finally {
+			mkdtempSpy.mockRestore();
+			writeSpy.mockRestore();
+			readSpy.mockRestore();
+			statSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('entry bound stops before the sibling without allocating or copying', () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-entry-bound-');
+		const swarmDir = path.join(dir, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		const sibling = 'zz-sibling';
+		const entries = Array.from(
+			{ length: MAX_SHADOW_COPY_ENTRIES },
+			(_, index) => fakeFileDirent(`entry-${String(index).padStart(6, '0')}`),
+		);
+		entries.push(fakeFileDirent('bound-trigger'));
+		entries.push(fakeFileDirent(sibling));
+		const realStat = fs.statSync.bind(fs);
+		const seenStats: string[] = [];
+		const readNames: string[] = [];
+		let closeCount = 0;
+		const fakeDirectory = {
+			readSync: () => {
+				const entry = entries[readNames.length] ?? null;
+				if (entry !== null) readNames.push(entry.name);
+				return entry;
+			},
+			closeSync: () => {
+				closeCount++;
+			},
+		} as unknown as fs.Dir;
+		const realOpendir = fs.opendirSync.bind(fs);
+		const opendirSpy = spyOn(fs, 'opendirSync').mockImplementation(((
+			directory: fs.PathLike,
+		) =>
+			path.resolve(String(directory)) === path.resolve(swarmDir)
+				? fakeDirectory
+				: realOpendir(directory as any)) as unknown as typeof fs.opendirSync);
+		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
+			filePath: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			const resolved = path.resolve(String(filePath));
+			seenStats.push(resolved);
+			if (resolved === path.resolve(sibling)) {
+				throw new Error('sibling must not be examined');
+			}
+			if (resolved.startsWith(path.resolve(swarmDir) + path.sep)) {
+				return { size: 0 } as fs.Stats;
+			}
+			return realStat(filePath as any, rest[0] as any);
+		}) as unknown as typeof fs.statSync);
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(() => {
+			throw new Error('entry-bound census must not allocate a shadow root');
+		});
+		const openSpy = spyOn(fs, 'openSync').mockImplementation(() => {
+			throw new Error('entry-bound census must not open a file');
+		});
+		try {
+			const result = _internals.createShadowCopy(dir);
+			expect(result).toBeNull();
+			expect(seenStats).toHaveLength(MAX_SHADOW_COPY_ENTRIES);
+			expect(readNames).toHaveLength(MAX_SHADOW_COPY_ENTRIES + 1);
+			expect(readNames).toContain('bound-trigger');
+			expect(readNames).not.toContain(sibling);
+			expect(closeCount).toBe(1);
+			expect(mkdtempSpy).not.toHaveBeenCalled();
+			expect(openSpy).not.toHaveBeenCalled();
+		} finally {
+			openSpy.mockRestore();
+			mkdtempSpy.mockRestore();
+			statSpy.mockRestore();
+			opendirSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/ci/evaluate-resource-bounds.test.ts
+++ b/tests/unit/ci/evaluate-resource-bounds.test.ts
@@ -21,6 +21,96 @@ function fakeFileDirent(name: string): fs.Dirent {
 }
 
 describe('advisory CI shadow-copy resource bounds', () => {
+	test('copyFileBounded copies a complete file within the byte budget', () => {
+		const dir = makeFixtureDir('swarm-ci-copy-bounded-success-');
+		const source = path.join(dir, 'source.bin');
+		const destination = path.join(dir, 'destination.bin');
+		const content = 'bounded shadow copy';
+		fs.writeFileSync(source, content);
+		try {
+			const copied = _internals.copyFileBounded(source, destination, 1024);
+			expect(copied).toBe(Buffer.byteLength(content));
+			expect(fs.readFileSync(destination, 'utf8')).toBe(content);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('copyFileBounded rejects a read that exceeds the remaining budget', () => {
+		const dir = makeFixtureDir('swarm-ci-copy-bounded-budget-');
+		const source = path.join(dir, 'source.bin');
+		const destination = path.join(dir, 'destination.bin');
+		fs.writeFileSync(source, '1234');
+		try {
+			const copied = _internals.copyFileBounded(source, destination, 3);
+			expect(copied).toBeNull();
+			expect(fs.readFileSync(destination)).toHaveLength(0);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('copyFileBounded fails closed when a write makes no progress', () => {
+		const dir = makeFixtureDir('swarm-ci-copy-bounded-stall-');
+		const source = path.join(dir, 'source.bin');
+		const destination = path.join(dir, 'destination.bin');
+		fs.writeFileSync(source, '1234');
+		const writeSpy = spyOn(fs, 'writeSync').mockImplementation(
+			(() => 0) as unknown as typeof fs.writeSync,
+		);
+		try {
+			expect(() =>
+				_internals.copyFileBounded(source, destination, 1024),
+			).toThrow('shadow-copy write made no progress');
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			writeSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('ERR_DIR_CLOSED during directory cleanup is ignored', () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-dir-closed-');
+		const swarmDir = path.join(dir, '.swarm');
+		fs.mkdirSync(swarmDir, { recursive: true });
+		let readCount = 0;
+		let closeCount = 0;
+		const fakeDirectory = {
+			readSync: () => {
+				readCount++;
+				return null;
+			},
+			closeSync: () => {
+				closeCount++;
+				const error = new Error(
+					'directory was closed concurrently',
+				) as Error & {
+					code?: string;
+				};
+				error.code = 'ERR_DIR_CLOSED';
+				throw error;
+			},
+		} as unknown as fs.Dir;
+		const realOpendir = fs.opendirSync.bind(fs);
+		const opendirSpy = spyOn(fs, 'opendirSync').mockImplementation(
+			(directory: fs.PathLike) =>
+				path.resolve(String(directory)) === path.resolve(swarmDir)
+					? fakeDirectory
+					: realOpendir(directory as any),
+		) as unknown as typeof fs.opendirSync;
+		let shadowRoot: string | null = null;
+		try {
+			shadowRoot = _internals.createShadowCopy(dir, 0);
+			expect(shadowRoot).not.toBeNull();
+			expect(readCount).toBe(1);
+			expect(closeCount).toBe(1);
+		} finally {
+			opendirSpy.mockRestore();
+			if (shadowRoot) fs.rmSync(shadowRoot, { recursive: true, force: true });
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	test('source growth is detected before any over-budget bytes are written', () => {
 		const dir = makeFixtureDir('swarm-ci-shadow-growth-bound-');
 		const source = path.join(dir, '.swarm', 'growth.bin');

--- a/tests/unit/ci/evaluate-shadow-copy-acceptance.test.ts
+++ b/tests/unit/ci/evaluate-shadow-copy-acceptance.test.ts
@@ -1,0 +1,241 @@
+/** Acceptance checks for issue #2633 shadow-copy behavior. */
+
+import { describe, expect, spyOn, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	evaluateAdvisoryCi,
+	MAX_SHADOW_COPY_BYTES,
+} from '../../../src/ci/evaluate.js';
+import { makeFixtureDir, writePlan } from './_fixtures.js';
+
+function overflowFixture(prefix: string) {
+	const dir = makeFixtureDir(prefix);
+	writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+	const nested = path.join(dir, '.swarm', '00-overflow');
+	fs.mkdirSync(nested, { recursive: true });
+	const overflowFile = path.join(nested, 'payload.bin');
+	const siblingFile = path.join(dir, '.swarm', '99-sibling.bin');
+	fs.writeFileSync(overflowFile, 'x');
+	fs.writeFileSync(siblingFile, 'x');
+	return { dir, overflowFile, siblingFile };
+}
+
+function fakeSymlinkDirent(name: string): fs.Dirent {
+	return {
+		name,
+		isBlockDevice: () => false,
+		isCharacterDevice: () => false,
+		isDirectory: () => false,
+		isFIFO: () => false,
+		isFile: () => false,
+		isSocket: () => false,
+		isSymbolicLink: () => true,
+	} as fs.Dirent;
+}
+
+describe('advisory CI shadow-copy acceptance checks', () => {
+	test('AC2 — budget overflow stops the complete traversal', async () => {
+		const fixture = overflowFixture('swarm-ci-ac2-');
+		const seenStats: string[] = [];
+		const realReaddir = fs.readdirSync.bind(fs);
+		const realStat = fs.statSync.bind(fs);
+		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
+			directory: fs.PathLike,
+			options?: unknown,
+		) =>
+			[...(realReaddir(directory as any, options as any) as fs.Dirent[])].sort(
+				(a, b) => a.name.localeCompare(b.name),
+			)) as unknown as typeof fs.readdirSync);
+		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
+			filePath: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			const resolved = path.resolve(String(filePath));
+			seenStats.push(resolved);
+			const stat = realStat(filePath as any, rest[0] as any);
+			return resolved === path.resolve(fixture.overflowFile)
+				? { ...stat, size: MAX_SHADOW_COPY_BYTES + 1 }
+				: stat;
+		}) as unknown as typeof fs.statSync);
+		try {
+			await evaluateAdvisoryCi({ directory: fixture.dir, tty: false });
+			// Before the fix, return only unwound the overflowing recursion frame;
+			// the parent then stat'ed this sibling.
+			expect(seenStats).not.toContain(path.resolve(fixture.siblingFile));
+		} finally {
+			readdirSpy.mockRestore();
+			statSpy.mockRestore();
+			fs.rmSync(fixture.dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('AC3 — budget overflow reports an honest error without a large fixture', async () => {
+		const fixture = overflowFixture('swarm-ci-ac3-');
+		const realReaddir = fs.readdirSync.bind(fs);
+		const realStat = fs.statSync.bind(fs);
+		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
+			directory: fs.PathLike,
+			options?: unknown,
+		) =>
+			[...(realReaddir(directory as any, options as any) as fs.Dirent[])].sort(
+				(a, b) => a.name.localeCompare(b.name),
+			)) as unknown as typeof fs.readdirSync);
+		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
+			filePath: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			const stat = realStat(filePath as any, rest[0] as any);
+			return path.resolve(String(filePath)) ===
+				path.resolve(fixture.overflowFile)
+				? { ...stat, size: MAX_SHADOW_COPY_BYTES + 1 }
+				: stat;
+		}) as unknown as typeof fs.statSync);
+		try {
+			const report = await evaluateAdvisoryCi({
+				directory: fixture.dir,
+				tty: false,
+			});
+			const planCritic = report.gates.find(
+				(gate) => gate.name === 'plan_critic',
+			);
+			expect(planCritic?.status).toBe('error');
+			expect(planCritic?.detail).toContain('shadow-copy budget');
+			expect(report.verdict).toBe('fail');
+		} finally {
+			readdirSpy.mockRestore();
+			statSpy.mockRestore();
+			fs.rmSync(fixture.dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('AC12 — file and directory symlink entries are skipped', async () => {
+		const dir = makeFixtureDir('swarm-ci-ac12-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		const swarmDir = path.join(dir, '.swarm');
+		const linkedFile = path.join(swarmDir, 'linked-file-target');
+		const linkedDirectory = path.join(swarmDir, 'linked-directory-target');
+		const realReaddir = fs.readdirSync.bind(fs);
+		const realStat = fs.statSync.bind(fs);
+		const realCopy = fs.copyFileSync.bind(fs);
+		const seenStats: string[] = [];
+		const copiedSources: string[] = [];
+		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
+			directory: fs.PathLike,
+			options?: unknown,
+		) => {
+			const entries = realReaddir(
+				directory as any,
+				options as any,
+			) as fs.Dirent[];
+			return path.resolve(String(directory)) === path.resolve(swarmDir)
+				? [
+						...entries,
+						fakeSymlinkDirent('linked-directory'),
+						fakeSymlinkDirent('linked-file'),
+					]
+				: entries;
+		}) as unknown as typeof fs.readdirSync);
+		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
+			filePath: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			seenStats.push(path.resolve(String(filePath)));
+			return realStat(filePath as any, rest[0] as any);
+		}) as unknown as typeof fs.statSync);
+		const copySpy = spyOn(fs, 'copyFileSync').mockImplementation(((
+			source: fs.PathLike,
+			destination: fs.PathLike,
+			...rest: unknown[]
+		) => {
+			copiedSources.push(path.resolve(String(source)));
+			return realCopy(source as any, destination as any, ...(rest as any));
+		}) as unknown as typeof fs.copyFileSync);
+		const cleanups: Array<() => void> = [];
+		try {
+			await evaluateAdvisoryCi({
+				directory: dir,
+				tty: false,
+				registerCleanup: (cleanup) => cleanups.push(cleanup),
+			});
+			expect(seenStats).not.toContain(path.resolve(linkedFile));
+			expect(seenStats).not.toContain(path.resolve(linkedDirectory));
+			expect(copiedSources).not.toContain(path.resolve(linkedFile));
+			expect(copiedSources).not.toContain(path.resolve(linkedDirectory));
+		} finally {
+			for (const cleanup of cleanups) cleanup();
+			copySpy.mockRestore();
+			statSpy.mockRestore();
+			readdirSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('AC17 — obsolete dest field is removed from the file list', () => {
+		const source = fs.readFileSync(
+			path.join(import.meta.dir, '..', '..', '..', 'src', 'ci', 'evaluate.ts'),
+			'utf8',
+		);
+		// The pre-fix implementation retained this unused field.
+		expect(source).not.toContain(
+			'const files: Array<{ src: string; dest: string }>',
+		);
+	});
+
+	test('AC17 — copied files still land below a swarm-ci-shadow root', async () => {
+		const dir = makeFixtureDir('swarm-ci-ac17-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		fs.writeFileSync(path.join(dir, '.swarm', 'payload.txt'), 'payload');
+		const destinations: string[] = [];
+		const realOpen = fs.openSync.bind(fs);
+		const openSpy = spyOn(fs, 'openSync').mockImplementation(((
+			filePath: fs.PathLike,
+			flags: string | number,
+			...rest: unknown[]
+		) => {
+			if (flags === 'w') destinations.push(path.resolve(String(filePath)));
+			return realOpen(filePath as any, flags as any, ...(rest as any));
+		}) as unknown as typeof fs.openSync);
+		const cleanups: Array<() => void> = [];
+		try {
+			await evaluateAdvisoryCi({
+				directory: dir,
+				tty: false,
+				registerCleanup: (cleanup) => cleanups.push(cleanup),
+			});
+			expect(destinations.length).toBeGreaterThan(0);
+			for (const destination of destinations) {
+				const shadowRoot = path.dirname(path.dirname(destination));
+				expect(path.basename(shadowRoot)).toMatch(/^swarm-ci-shadow-/);
+				expect(path.basename(path.dirname(destination))).toBe('.swarm');
+			}
+		} finally {
+			for (const cleanup of cleanups) cleanup();
+			openSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('AC13 — evaluation preserves snapshot file mtime and mode', async () => {
+		const dir = makeFixtureDir('swarm-ci-ac13-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		const planPath = path.join(dir, '.swarm', 'plan.json');
+		const before = fs.statSync(planPath);
+		const cleanups: Array<() => void> = [];
+		try {
+			await evaluateAdvisoryCi({
+				directory: dir,
+				tty: false,
+				registerCleanup: (cleanup) => cleanups.push(cleanup),
+			});
+			const after = fs.statSync(planPath);
+			expect(after.mtimeMs).toBe(before.mtimeMs);
+			expect(after.mode).toBe(before.mode);
+			// atime is intentionally not asserted: access-time updates vary by
+			// filesystem mount and host policy, even for read-only evaluation.
+		} finally {
+			for (const cleanup of cleanups) cleanup();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+});

--- a/tests/unit/ci/evaluate-shadow-copy-acceptance.test.ts
+++ b/tests/unit/ci/evaluate-shadow-copy-acceptance.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, spyOn, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+	_internals,
 	evaluateAdvisoryCi,
 	MAX_SHADOW_COPY_BYTES,
 } from '../../../src/ci/evaluate.js';
@@ -34,19 +35,75 @@ function fakeSymlinkDirent(name: string): fs.Dirent {
 	} as fs.Dirent;
 }
 
+function fakeFileDirent(name: string): fs.Dirent {
+	return {
+		name,
+		isBlockDevice: () => false,
+		isCharacterDevice: () => false,
+		isDirectory: () => false,
+		isFIFO: () => false,
+		isFile: () => true,
+		isSocket: () => false,
+		isSymbolicLink: () => false,
+	} as fs.Dirent;
+}
+
+function fakeDirectory(
+	entries: fs.Dirent[],
+	onRead?: (entry: fs.Dirent) => void,
+	onClose?: () => void,
+): fs.Dir {
+	let index = 0;
+	return {
+		readSync: () => {
+			const entry = entries[index++] ?? null;
+			if (entry !== null) onRead?.(entry);
+			return entry;
+		},
+		closeSync: () => onClose?.(),
+	} as unknown as fs.Dir;
+}
+
 describe('advisory CI shadow-copy acceptance checks', () => {
 	test('AC2 — budget overflow stops the complete traversal', async () => {
 		const fixture = overflowFixture('swarm-ci-ac2-');
 		const seenStats: string[] = [];
-		const realReaddir = fs.readdirSync.bind(fs);
+		const rootReadNames: string[] = [];
+		const nestedReadNames: string[] = [];
+		let closeCount = 0;
+		const rootHandle = fakeDirectory(
+			[
+				{
+					...fakeFileDirent('00-overflow'),
+					isDirectory: () => true,
+				} as fs.Dirent,
+				fakeFileDirent('99-sibling.bin'),
+			],
+			(entry) => rootReadNames.push(entry.name),
+			() => closeCount++,
+		);
+		const nestedHandle = fakeDirectory(
+			[fakeFileDirent('payload.bin')],
+			(entry) => nestedReadNames.push(entry.name),
+			() => closeCount++,
+		);
 		const realStat = fs.statSync.bind(fs);
-		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
-			directory: fs.PathLike,
-			options?: unknown,
-		) =>
-			[...(realReaddir(directory as any, options as any) as fs.Dirent[])].sort(
-				(a, b) => a.name.localeCompare(b.name),
-			)) as unknown as typeof fs.readdirSync);
+		const realOpendir = fs.opendirSync.bind(fs);
+		const opendirSpy = spyOn(fs, 'opendirSync').mockImplementation(
+			(directory: fs.PathLike) => {
+				const resolved = path.resolve(String(directory));
+				if (resolved === path.resolve(path.join(fixture.dir, '.swarm'))) {
+					return rootHandle;
+				}
+				if (
+					resolved ===
+					path.resolve(path.join(fixture.dir, '.swarm', '00-overflow'))
+				) {
+					return nestedHandle;
+				}
+				return realOpendir(directory as any);
+			},
+		) as unknown as typeof fs.opendirSync;
 		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
 			filePath: fs.PathLike,
 			...rest: unknown[]
@@ -62,25 +119,22 @@ describe('advisory CI shadow-copy acceptance checks', () => {
 			await evaluateAdvisoryCi({ directory: fixture.dir, tty: false });
 			// Before the fix, return only unwound the overflowing recursion frame;
 			// the parent then stat'ed this sibling.
+			expect(seenStats).toContain(path.resolve(fixture.overflowFile));
 			expect(seenStats).not.toContain(path.resolve(fixture.siblingFile));
+			expect(rootReadNames).toEqual(['00-overflow']);
+			expect(nestedReadNames).toEqual(['payload.bin']);
+			expect(closeCount).toBe(2);
+			expect(opendirSpy).toHaveBeenCalledTimes(2);
 		} finally {
-			readdirSpy.mockRestore();
 			statSpy.mockRestore();
+			opendirSpy.mockRestore();
 			fs.rmSync(fixture.dir, { recursive: true, force: true });
 		}
 	}, 10000);
 
 	test('AC3 — budget overflow reports an honest error without a large fixture', async () => {
 		const fixture = overflowFixture('swarm-ci-ac3-');
-		const realReaddir = fs.readdirSync.bind(fs);
 		const realStat = fs.statSync.bind(fs);
-		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
-			directory: fs.PathLike,
-			options?: unknown,
-		) =>
-			[...(realReaddir(directory as any, options as any) as fs.Dirent[])].sort(
-				(a, b) => a.name.localeCompare(b.name),
-			)) as unknown as typeof fs.readdirSync);
 		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
 			filePath: fs.PathLike,
 			...rest: unknown[]
@@ -103,7 +157,6 @@ describe('advisory CI shadow-copy acceptance checks', () => {
 			expect(planCritic?.detail).toContain('shadow-copy budget');
 			expect(report.verdict).toBe('fail');
 		} finally {
-			readdirSpy.mockRestore();
 			statSpy.mockRestore();
 			fs.rmSync(fixture.dir, { recursive: true, force: true });
 		}
@@ -115,27 +168,27 @@ describe('advisory CI shadow-copy acceptance checks', () => {
 		const swarmDir = path.join(dir, '.swarm');
 		const linkedFile = path.join(swarmDir, 'linked-file-target');
 		const linkedDirectory = path.join(swarmDir, 'linked-directory-target');
-		const realReaddir = fs.readdirSync.bind(fs);
 		const realStat = fs.statSync.bind(fs);
-		const realCopy = fs.copyFileSync.bind(fs);
 		const seenStats: string[] = [];
 		const copiedSources: string[] = [];
-		const readdirSpy = spyOn(fs, 'readdirSync').mockImplementation(((
-			directory: fs.PathLike,
-			options?: unknown,
-		) => {
-			const entries = realReaddir(
-				directory as any,
-				options as any,
-			) as fs.Dirent[];
-			return path.resolve(String(directory)) === path.resolve(swarmDir)
-				? [
-						...entries,
-						fakeSymlinkDirent('linked-directory'),
-						fakeSymlinkDirent('linked-file'),
-					]
-				: entries;
-		}) as unknown as typeof fs.readdirSync);
+		const readNames: string[] = [];
+		let closeCount = 0;
+		const rootHandle = fakeDirectory(
+			[
+				fakeFileDirent('plan.json'),
+				fakeSymlinkDirent(path.basename(linkedDirectory)),
+				fakeSymlinkDirent(path.basename(linkedFile)),
+			],
+			(entry) => readNames.push(entry.name),
+			() => closeCount++,
+		);
+		const realOpendir = fs.opendirSync.bind(fs);
+		const opendirSpy = spyOn(fs, 'opendirSync').mockImplementation(
+			(directory: fs.PathLike) =>
+				path.resolve(String(directory)) === path.resolve(swarmDir)
+					? rootHandle
+					: realOpendir(directory as any),
+		) as unknown as typeof fs.opendirSync;
 		const statSpy = spyOn(fs, 'statSync').mockImplementation(((
 			filePath: fs.PathLike,
 			...rest: unknown[]
@@ -143,14 +196,11 @@ describe('advisory CI shadow-copy acceptance checks', () => {
 			seenStats.push(path.resolve(String(filePath)));
 			return realStat(filePath as any, rest[0] as any);
 		}) as unknown as typeof fs.statSync);
-		const copySpy = spyOn(fs, 'copyFileSync').mockImplementation(((
-			source: fs.PathLike,
-			destination: fs.PathLike,
-			...rest: unknown[]
-		) => {
-			copiedSources.push(path.resolve(String(source)));
-			return realCopy(source as any, destination as any, ...(rest as any));
-		}) as unknown as typeof fs.copyFileSync);
+		const originalCopy = _internals.copyFileBounded;
+		_internals.copyFileBounded = (source, destination, remainingBytes) => {
+			copiedSources.push(path.resolve(source));
+			return originalCopy(source, destination, remainingBytes);
+		};
 		const cleanups: Array<() => void> = [];
 		try {
 			await evaluateAdvisoryCi({
@@ -162,11 +212,20 @@ describe('advisory CI shadow-copy acceptance checks', () => {
 			expect(seenStats).not.toContain(path.resolve(linkedDirectory));
 			expect(copiedSources).not.toContain(path.resolve(linkedFile));
 			expect(copiedSources).not.toContain(path.resolve(linkedDirectory));
+			expect(readNames).toEqual([
+				'plan.json',
+				path.basename(linkedDirectory),
+				path.basename(linkedFile),
+			]);
+			expect(seenStats).toContain(path.resolve(swarmDir, 'plan.json'));
+			expect(copiedSources).toEqual([path.resolve(swarmDir, 'plan.json')]);
+			expect(closeCount).toBe(1);
+			expect(opendirSpy).toHaveBeenCalledTimes(1);
 		} finally {
 			for (const cleanup of cleanups) cleanup();
-			copySpy.mockRestore();
+			_internals.copyFileBounded = originalCopy;
 			statSpy.mockRestore();
-			readdirSpy.mockRestore();
+			opendirSpy.mockRestore();
 			fs.rmSync(dir, { recursive: true, force: true });
 		}
 	}, 10000);

--- a/tests/unit/ci/evaluate.test.ts
+++ b/tests/unit/ci/evaluate.test.ts
@@ -8,11 +8,12 @@
  * plan_missing / plan_corrupt / no_tasks exit reasons.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+	_internals,
 	evaluateAdvisoryCi,
 	MAX_SHADOW_COPY_BYTES,
 	TERMINAL_SUCCESS_STATES,
@@ -232,6 +233,120 @@ describe('evaluateAdvisoryCi', () => {
 		const after = snapshotTree(dir);
 		expect(after).toEqual(before);
 	});
+
+	test('direct evaluation removes its shadow copy after success', async () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-cleanup-success-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		let shadowRoot: string | undefined;
+		const realMkdtemp = fs.mkdtempSync.bind(fs);
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(((
+			prefix: string,
+			...rest: unknown[]
+		) => {
+			const root = realMkdtemp(prefix, ...(rest as any));
+			if (prefix.includes('swarm-ci-shadow-')) shadowRoot = root;
+			return root;
+		}) as unknown as typeof fs.mkdtempSync);
+		try {
+			await evaluateAdvisoryCi({ directory: dir, tty: false });
+			expect(shadowRoot).toBeDefined();
+			expect(fs.existsSync(shadowRoot as string)).toBe(false);
+		} finally {
+			mkdtempSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('partial shadow-copy failure removes the allocated root', async () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-cleanup-partial-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		let shadowRoot: string | undefined;
+		const realMkdtemp = fs.mkdtempSync.bind(fs);
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(((
+			prefix: string,
+			...rest: unknown[]
+		) => {
+			const root = realMkdtemp(prefix, ...(rest as any));
+			if (prefix.includes('swarm-ci-shadow-')) shadowRoot = root;
+			return root;
+		}) as unknown as typeof fs.mkdtempSync);
+		const readSpy = spyOn(fs, 'readSync').mockImplementation((() => {
+			throw new Error('injected shadow-copy failure');
+		}) as unknown as typeof fs.readSync);
+		try {
+			const report = await evaluateAdvisoryCi({ directory: dir, tty: false });
+			expect(
+				report.gates.find((gate) => gate.name === 'plan_critic')?.status,
+			).toBe('error');
+			expect(shadowRoot).toBeDefined();
+			expect(fs.existsSync(shadowRoot as string)).toBe(false);
+		} finally {
+			readSpy.mockRestore();
+			mkdtempSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('direct evaluation removes its shadow copy when downstream evaluation throws', async () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-cleanup-downstream-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		let shadowRoot: string | undefined;
+		const realMkdtemp = fs.mkdtempSync.bind(fs);
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(((
+			prefix: string,
+			...rest: unknown[]
+		) => {
+			const root = realMkdtemp(prefix, ...(rest as any));
+			if (prefix.includes('swarm-ci-shadow-')) shadowRoot = root;
+			return root;
+		}) as unknown as typeof fs.mkdtempSync);
+		const originalSummary = _internals.computeEvidenceQualitySummary;
+		_internals.computeEvidenceQualitySummary = async () => {
+			throw new Error('injected downstream evaluation failure');
+		};
+		try {
+			await expect(
+				evaluateAdvisoryCi({ directory: dir, tty: false }),
+			).rejects.toThrow('injected downstream evaluation failure');
+			expect(shadowRoot).toBeDefined();
+			expect(fs.existsSync(shadowRoot as string)).toBe(false);
+		} finally {
+			_internals.computeEvidenceQualitySummary = originalSummary;
+			mkdtempSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
+
+	test('cleanup-registration failure removes its shadow copy before rethrowing', async () => {
+		const dir = makeFixtureDir('swarm-ci-shadow-cleanup-registration-');
+		writePlan(dir, [{ id: '1.1', status: 'pending' }]);
+		let shadowRoot: string | undefined;
+		const realMkdtemp = fs.mkdtempSync.bind(fs);
+		const mkdtempSpy = spyOn(fs, 'mkdtempSync').mockImplementation(((
+			prefix: string,
+			...rest: unknown[]
+		) => {
+			const root = realMkdtemp(prefix, ...(rest as any));
+			if (prefix.includes('swarm-ci-shadow-')) shadowRoot = root;
+			return root;
+		}) as unknown as typeof fs.mkdtempSync);
+		try {
+			await expect(
+				evaluateAdvisoryCi({
+					directory: dir,
+					tty: false,
+					registerCleanup: () => {
+						throw new Error('injected cleanup-registration failure');
+					},
+				}),
+			).rejects.toThrow('injected cleanup-registration failure');
+			expect(shadowRoot).toBeDefined();
+			expect(fs.existsSync(shadowRoot as string)).toBe(false);
+		} finally {
+			mkdtempSpy.mockRestore();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 10000);
 });
 
 function snapshotTree(root: string): Array<[string, string]> {

--- a/tests/unit/ci/runtime-acceptance-2633.test.ts
+++ b/tests/unit/ci/runtime-acceptance-2633.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Focused pre-fix acceptance checks for issue #2633: runtime cleanup
+ * lifecycle, deadline edge handling, and concurrent-run isolation.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AdvisoryCiReport } from '../../../src/ci/evaluate.js';
+import { runAdvisoryCiRuntime } from '../../../src/ci/runtime.js';
+
+function report(verdict: 'pass' | 'fail'): AdvisoryCiReport {
+	return {
+		version: 1,
+		verdict,
+		exit_reason: verdict === 'pass' ? 'all_gates_passed' : 'gate_violations',
+		gates: [{ name: 'fixture', status: verdict === 'pass' ? 'pass' : 'fail' }],
+		tasks: [],
+		plan: { present: true, task_count: 0 },
+		environment: { mode: 'advisory', tty: false, host: 'none' },
+		gate_profile: 'default',
+		effective_gates: {
+			reviewer: true,
+			test_engineer: true,
+			council_mode: false,
+			sme_enabled: true,
+			critic_pre_plan: true,
+			hallucination_guard: false,
+			sast_enabled: true,
+			mutation_test: false,
+			phase_council: false,
+			drift_check: true,
+			final_council: false,
+		},
+		not_evaluated: [],
+		not_evaluable: [],
+		counts:
+			verdict === 'pass'
+				? { pass: 1, fail: 0, no_data: 0, corrupt: 0, error: 0 }
+				: { pass: 0, fail: 1, no_data: 0, corrupt: 0, error: 0 },
+	};
+}
+
+function deferred<T = void>(): {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+} {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('issue #2633 runtime acceptance checks', () => {
+	test('AC1: late cleanup registration is drained exactly once', async () => {
+		const lateCleanup = deferred<void>();
+		let beforeSettlement = 0;
+		let afterSettlement = 0;
+
+		const result = await runAdvisoryCiRuntime({
+			directory: 'ci-ac1-fixture',
+			deadlineMs: 5_000,
+			evaluate: async (ctx) => {
+				ctx.registerCleanup(() => {
+					beforeSettlement++;
+				});
+				// The late callback is registered after the evaluation promise has
+				// settled, matching a shadow-copy creator that resumes after the
+				// runtime's race winner has entered finally.
+				return Promise.resolve(report('pass')).finally(() => {
+					setTimeout(() => {
+						ctx.registerCleanup(() => {
+							afterSettlement++;
+						});
+						lateCleanup.resolve();
+					}, 0);
+				});
+			},
+		});
+
+		expect(result.outcome).toBe('pass');
+		expect(beforeSettlement).toBe(1);
+		expect(result.cleanupRan).toBe(true);
+		await lateCleanup.promise;
+		expect(afterSettlement).toBe(1);
+	});
+
+	test('AC11: deadline checks retain timer-tick margin and normalize edge inputs', async () => {
+		// 100ms leaves ample room above the ~15.6ms Windows timer tick while
+		// remaining short enough that a broken deadline cannot stall this test.
+		const result = await runAdvisoryCiRuntime({
+			directory: 'ci-ac11-fixture',
+			deadlineMs: 100,
+			evaluate: () => new Promise<AdvisoryCiReport>(() => {}),
+		});
+		expect(result.outcome).toBe('deadline');
+
+		const remaining = async (deadlineMs: number) => {
+			let observed = Number.NaN;
+			await runAdvisoryCiRuntime({
+				directory: 'ci-ac11-edge',
+				deadlineMs,
+				evaluate: async (ctx) => {
+					observed = ctx.remainingMs();
+					return report('pass');
+				},
+			});
+			return observed;
+		};
+
+		const [zero, negative, infinite] = await Promise.all([
+			remaining(0),
+			remaining(-1),
+			remaining(Number.POSITIVE_INFINITY),
+		]);
+		expect(zero).toBeGreaterThanOrEqual(0);
+		expect(zero).toBeLessThanOrEqual(1);
+		expect(negative).toBeGreaterThanOrEqual(0);
+		expect(negative).toBeLessThanOrEqual(1);
+		expect(Number.isFinite(infinite)).toBe(true);
+	});
+
+	test('AC13: concurrent runtimes keep outcomes, journals, and cleanup isolated', async () => {
+		const firstStarted = deferred<void>();
+		const releaseFirst = deferred<void>();
+		let firstCleanups = 0;
+		let secondCleanups = 0;
+
+		const firstPromise = runAdvisoryCiRuntime({
+			directory: 'ci-ac13-first',
+			deadlineMs: 5_000,
+			evaluate: async (ctx) => {
+				ctx.registerCleanup(() => {
+					firstCleanups++;
+				});
+				ctx.journal('first_only');
+				firstStarted.resolve();
+				await releaseFirst.promise;
+				return report('pass');
+			},
+		});
+		await firstStarted.promise;
+
+		const second = await runAdvisoryCiRuntime({
+			directory: 'ci-ac13-second',
+			deadlineMs: 5_000,
+			evaluate: async (ctx) => {
+				ctx.registerCleanup(() => {
+					secondCleanups++;
+				});
+				ctx.journal('second_only');
+				return report('fail');
+			},
+		});
+		releaseFirst.resolve();
+		const first = await firstPromise;
+
+		expect(first.outcome).toBe('pass');
+		expect(second.outcome).toBe('violations');
+		expect(firstCleanups).toBe(1);
+		expect(secondCleanups).toBe(1);
+		expect(first.journal.some((event) => event.type === 'first_only')).toBe(
+			true,
+		);
+		expect(first.journal.some((event) => event.type === 'second_only')).toBe(
+			false,
+		);
+		expect(second.journal.some((event) => event.type === 'second_only')).toBe(
+			true,
+		);
+		expect(second.journal.some((event) => event.type === 'first_only')).toBe(
+			false,
+		);
+	});
+});

--- a/tests/unit/ci/runtime-bounds.test.ts
+++ b/tests/unit/ci/runtime-bounds.test.ts
@@ -15,7 +15,7 @@
  * per-test budget can always preempt it; the deadline uses short
  * millisecond budgets and the assertions are outcome-based, not
  * wall-clock-based, to stay deterministic across CI platforms (Windows
- * timer tick ~15.6ms — deadlines here are >= 50ms).
+ * timer tick ~15.6ms — deadlines here are >= 100ms).
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -66,7 +66,7 @@ describe('runAdvisoryCiRuntime bounds', () => {
 	test('deadline cuts a hung evaluation stage and reports the deadline outcome', async () => {
 		const result = await runAdvisoryCiRuntime({
 			directory: 'C:\\definitely\\not\\used',
-			deadlineMs: 60,
+			deadlineMs: 100,
 			evaluate: () =>
 				// Timer-backed hang: the runtime deadline must win the race.
 				new Promise<AdvisoryCiReport>(() => {}),
@@ -76,6 +76,35 @@ describe('runAdvisoryCiRuntime bounds', () => {
 		expect(result.journal.some((e) => e.type === 'run_deadline')).toBe(true);
 		expect(result.cleanupRan).toBe(true);
 	}, 5000);
+
+	test('direct runtime deadlines normalize to the supported finite range', async () => {
+		const realDateNow = Date.now;
+		Date.now = () => 1_000_000;
+		try {
+			const observe = async (deadlineMs: number) => {
+				let remaining = Number.NaN;
+				const result = await runAdvisoryCiRuntime({
+					directory: 'ci-deadline-normalization',
+					deadlineMs,
+					evaluate: async (ctx) => {
+						remaining = ctx.remainingMs();
+						return minimalReport('pass');
+					},
+				});
+				expect(result.outcome).toBe('pass');
+				return remaining;
+			};
+
+			expect(await observe(0)).toBe(1);
+			expect(await observe(-1)).toBe(1);
+			expect(await observe(Number.NaN)).toBe(1);
+			expect(await observe(Number.POSITIVE_INFINITY)).toBe(300_000);
+			expect(await observe(300_000)).toBe(300_000);
+			expect(await observe(300_001)).toBe(300_000);
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
 
 	test('abort mid-run produces a cancelled outcome and runs cleanup exactly once', async () => {
 		const controller = new AbortController();
@@ -195,4 +224,51 @@ describe('runAdvisoryCiRuntime bounds', () => {
 		// A failing callback is skipped; the remaining ones still run.
 		expect(cleanups).toBe(2);
 	}, 5000);
+
+	test('late cleanup remains best-effort and handles self-registration safely', async () => {
+		let beforeThrowing = 0;
+		let beforeNormal = 0;
+		let lateThrowing = 0;
+		let lateNormal = 0;
+		let registerLate!: (fn: () => void) => void;
+
+		const result = await runAdvisoryCiRuntime({
+			directory: 'ci-late-cleanup',
+			deadlineMs: 5_000,
+			evaluate: async (ctx) => {
+				registerLate = ctx.registerCleanup;
+				ctx.registerCleanup(() => {
+					beforeThrowing++;
+					throw new Error('pre-settlement cleanup failure');
+				});
+				ctx.registerCleanup(() => {
+					beforeNormal++;
+				});
+				return minimalReport('pass');
+			},
+		});
+
+		let selfRuns = 0;
+		let selfRegistering!: () => void;
+		selfRegistering = () => {
+			selfRuns++;
+			registerLate(selfRegistering);
+		};
+		registerLate(() => {
+			lateThrowing++;
+			throw new Error('late cleanup failure');
+		});
+		registerLate(selfRegistering);
+		registerLate(() => {
+			lateNormal++;
+		});
+
+		expect(result.outcome).toBe('pass');
+		expect(result.cleanupRan).toBe(true);
+		expect(beforeThrowing).toBe(1);
+		expect(beforeNormal).toBe(1);
+		expect(lateThrowing).toBe(1);
+		expect(selfRuns).toBe(1);
+		expect(lateNormal).toBe(1);
+	});
 });

--- a/tests/unit/commands/ci-acceptance-2633.test.ts
+++ b/tests/unit/commands/ci-acceptance-2633.test.ts
@@ -10,7 +10,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import {
 	_internals,
@@ -22,6 +21,9 @@ import {
 	isCommandFailure,
 } from '../../../src/commands/registry.js';
 import { DEFAULT_QA_GATES } from '../../../src/db/qa-gate-profile.js';
+import {
+	canonicalTmpDir as canonicalProjectTempRoot,
+} from '../../helpers/tmpdir.js';
 
 function makeContext(directory: string, args: string[] = []): CommandContext {
 	return {
@@ -91,7 +93,7 @@ describe('issue #2633 CLI acceptance checks', () => {
 
 		await expect(
 			handleCiCommand(
-				makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac4-over-limit'), [
+				makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-over-limit'), [
 					'--timeout-ms',
 					String(DEFAULT_CI_DEADLINE_MS + 1),
 				]),
@@ -114,7 +116,7 @@ describe('issue #2633 CLI acceptance checks', () => {
 		};
 
 		await handleCiCommand(
-			makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac4-forward'), [
+			makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-forward'), [
 				'--timeout-ms',
 				'1234.5',
 			]),
@@ -133,7 +135,7 @@ describe('issue #2633 CLI acceptance checks', () => {
 		});
 
 		const result = await handleCiCommand(
-			makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac6-json'), ['--json']),
+			makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac6-json'), ['--json']),
 		);
 		expect(isCommandFailure(result)).toBe(true);
 		if (!isCommandFailure(result)) return;
@@ -164,7 +166,7 @@ describe('issue #2633 CLI acceptance checks', () => {
 
 	test('AC9: cancellation/deadline diagnostics do not echo the absolute evaluated path', async () => {
 		const directory = path.resolve(
-			os.tmpdir(),
+			canonicalProjectTempRoot(),
 			'swarm-ci-ac9-directory-with-sensitive-name',
 		);
 		_internals.runAdvisoryCiRuntime = async () => ({
@@ -315,7 +317,7 @@ if (red.length === 0) process.exit(1);
 	test('AC13: unknown flags retain the exact diagnostic contract', async () => {
 		await expect(
 			handleCiCommand(
-				makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac13'), ['--wat']),
+				makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac13'), ['--wat']),
 			),
 		).rejects.toThrow('Unknown flag: --wat');
 	});

--- a/tests/unit/commands/ci-acceptance-2633.test.ts
+++ b/tests/unit/commands/ci-acceptance-2633.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Issue #2633 acceptance checks for the CLI/report/help contracts.
+ *
+ * These checks are intentionally authored against the current pre-fix tree:
+ * AC4, AC8, AC9, AC14, AC15, and AC16 are expected to fail until their
+ * corresponding contracts are implemented. AC5, AC6, and AC13 preserve
+ * behavior that already works on the pre-fix tree.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+	_internals,
+	DEFAULT_CI_DEADLINE_MS,
+	handleCiCommand,
+} from '../../../src/commands/ci.js';
+import {
+	type CommandContext,
+	isCommandFailure,
+} from '../../../src/commands/registry.js';
+import { DEFAULT_QA_GATES } from '../../../src/db/qa-gate-profile.js';
+
+function makeContext(directory: string, args: string[] = []): CommandContext {
+	return {
+		directory,
+		args,
+		sessionID: '',
+		agents: {},
+		source: 'cli',
+	};
+}
+
+function makeViolationReport() {
+	return {
+		version: 1 as const,
+		verdict: 'fail' as const,
+		exit_reason: 'gate_violations' as const,
+		gates: [
+			{
+				name: 'plan',
+				status: 'fail' as const,
+				detail: 'synthetic violation',
+			},
+		],
+		tasks: [],
+		plan: { present: false, task_count: 0 },
+		environment: {
+			mode: 'advisory' as const,
+			tty: false,
+			host: 'none' as const,
+		},
+		gate_profile: 'default' as const,
+		effective_gates: { ...DEFAULT_QA_GATES },
+		not_evaluated: [],
+		not_evaluable: [],
+		counts: { pass: 0, fail: 1, no_data: 0, corrupt: 0, error: 0 },
+	};
+}
+
+function parseJsonBlock(text: string): Record<string, unknown> {
+	const open = '[SWARM_CI_JSON]';
+	const close = '[/SWARM_CI_JSON]';
+	const start = text.indexOf(open);
+	const end = text.indexOf(close);
+	expect(start).toBeGreaterThanOrEqual(0);
+	expect(end).toBeGreaterThan(start);
+	expect(text.slice(0, start)).toBe('');
+	expect(text.slice(end + close.length).trim()).toBe('');
+	return JSON.parse(text.slice(start + open.length, end)) as Record<
+		string,
+		unknown
+	>;
+}
+
+describe('issue #2633 CLI acceptance checks', () => {
+	const realRuntime = _internals.runAdvisoryCiRuntime;
+
+	afterEach(() => {
+		_internals.runAdvisoryCiRuntime = realRuntime;
+	});
+
+	test('AC4: rejects a finite timeout above the supported maximum', async () => {
+		let runtimeCalls = 0;
+		_internals.runAdvisoryCiRuntime = async () => {
+			runtimeCalls++;
+			throw new Error('runtime must not be entered for invalid timeout');
+		};
+
+		await expect(
+			handleCiCommand(
+				makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac4-over-limit'), [
+					'--timeout-ms',
+					String(DEFAULT_CI_DEADLINE_MS + 1),
+				]),
+			),
+		).rejects.toThrow(/--timeout-ms/);
+		expect(runtimeCalls).toBe(0);
+	});
+
+	test('AC4: forwards a normal finite timeout unchanged to the runtime', async () => {
+		let capturedDeadline: number | undefined;
+		_internals.runAdvisoryCiRuntime = async (options) => {
+			capturedDeadline = options.deadlineMs;
+			return {
+				outcome: 'deadline',
+				journal: [],
+				journalTruncated: 0,
+				cleanupRan: true,
+				detail: 'synthetic deadline',
+			};
+		};
+
+		await handleCiCommand(
+			makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac4-forward'), [
+				'--timeout-ms',
+				'1234.5',
+			]),
+		);
+		expect(capturedDeadline).toBe(1234.5);
+	});
+
+	test('AC6: violations --json emits only the marker-bounded report and exit 1', async () => {
+		const report = makeViolationReport();
+		_internals.runAdvisoryCiRuntime = async () => ({
+			outcome: 'violations',
+			report,
+			journal: [],
+			journalTruncated: 0,
+			cleanupRan: true,
+		});
+
+		const result = await handleCiCommand(
+			makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac6-json'), ['--json']),
+		);
+		expect(isCommandFailure(result)).toBe(true);
+		if (!isCommandFailure(result)) return;
+		expect(result.exitCode).toBe(1);
+		expect(parseJsonBlock(result.text)).toEqual(report);
+		expect(result.text).not.toContain('## Swarm CI Advisory Report');
+	});
+
+	test('AC5: a real top-level ci --json argv reaches dispatch and exit status', () => {
+		const repoRoot = path.resolve(import.meta.dir, '../../..');
+		const child = spawnSync(
+			process.execPath,
+			[path.join(repoRoot, 'src', 'cli', 'index.ts'), 'ci', '--json'],
+			{
+				cwd: repoRoot,
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: 15_000,
+			},
+		);
+		const output = `${child.stdout ?? ''}${child.stderr ?? ''}`;
+		// The checkout has no guaranteed passing plan fixture. This pins the
+		// real argv path, machine report, and honest violation exit code.
+		expect(child.status).toBe(1);
+		expect(output).toContain('[SWARM_CI_JSON]');
+		expect(output).toContain('[/SWARM_CI_JSON]');
+	});
+
+	test('AC9: cancellation/deadline diagnostics do not echo the absolute evaluated path', async () => {
+		const directory = path.resolve(
+			os.tmpdir(),
+			'swarm-ci-ac9-directory-with-sensitive-name',
+		);
+		_internals.runAdvisoryCiRuntime = async () => ({
+			outcome: 'deadline',
+			journal: [{ seq: 1, type: 'run_started', detail: directory }],
+			journalTruncated: 0,
+			cleanupRan: true,
+			detail: `deadline while evaluating ${directory}`,
+		});
+
+		const result = await handleCiCommand(makeContext(directory));
+		expect(isCommandFailure(result)).toBe(true);
+		if (!isCommandFailure(result)) return;
+		expect(result.text).not.toContain(directory);
+	});
+
+	test('AC14: ci --help and run ci --help provide command-specific help', () => {
+		const repoRoot = path.resolve(import.meta.dir, '../../..');
+		const runCli = (args: string[]) =>
+			spawnSync(
+				process.execPath,
+				[path.join(repoRoot, 'src/cli/index.ts'), ...args],
+				{
+					cwd: repoRoot,
+					encoding: 'utf8',
+					input: undefined,
+					stdio: ['ignore', 'pipe', 'pipe'],
+					timeout: 15_000,
+				},
+			);
+
+		for (const args of [
+			['ci', '--help'],
+			['run', 'ci', '--help'],
+		]) {
+			const child = runCli(args);
+			const output = `${child.stdout ?? ''}${child.stderr ?? ''}`;
+			expect(child.status).toBe(0);
+			expect(output).toContain('Advisory headless CI');
+			expect(output).toContain('--timeout-ms');
+			expect(output).toContain('--json');
+		}
+
+		const globalHelp = runCli(['--help']);
+		expect(globalHelp.status).toBe(0);
+		expect(`${globalHelp.stdout ?? ''}${globalHelp.stderr ?? ''}`).toContain(
+			'Usage: bunx opencode-swarm [command] [OPTIONS]',
+		);
+	});
+
+	test('AC15: docs numeric claims stay bound to the owning source constants', () => {
+		const sourceRoot = path.resolve(import.meta.dir, '../../..');
+		const ciSource = fs.readFileSync(
+			path.join(sourceRoot, 'src', 'commands', 'ci.ts'),
+			'utf8',
+		);
+		const evaluateSource = fs.readFileSync(
+			path.join(sourceRoot, 'src', 'ci', 'evaluate.ts'),
+			'utf8',
+		);
+		const runtimeSource = fs.readFileSync(
+			path.join(sourceRoot, 'src', 'ci', 'runtime.ts'),
+			'utf8',
+		);
+		const docs = fs.readFileSync(
+			path.join(sourceRoot, 'docs', 'ci.md'),
+			'utf8',
+		);
+		const driftCheck = fs.readFileSync(
+			path.join(sourceRoot, 'scripts', 'drift-check-docs-claims.ts'),
+			'utf8',
+		);
+
+		expect(ciSource).toMatch(/DEFAULT_CI_DEADLINE_MS\s*=\s*300_000/);
+		expect(evaluateSource).toMatch(
+			/MAX_SHADOW_COPY_BYTES\s*=\s*512\s*\*\s*1024\s*\*\s*1024/,
+		);
+		expect(runtimeSource).toMatch(
+			/(?:journal|JOURNAL)[^\n]{0,120}(?:200|MAX_JOURNAL)/i,
+		);
+		expect(docs).toContain('300000');
+		expect(docs).toContain('512 MiB');
+		expect(docs).toContain('200 events');
+		for (const sourceName of [
+			'DEFAULT_CI_DEADLINE_MS',
+			'MAX_SHADOW_COPY_BYTES',
+			'MAX_CI_JOURNAL_EVENTS',
+		]) {
+			expect(driftCheck).toContain(`sourceName: '${sourceName}'`);
+		}
+		expect(evaluateSource).toMatch(/MAX_SHADOW_COPY_ENTRIES\s*=\s*100_000/);
+		expect(docs).toContain('100000 entries');
+		expect(driftCheck).toContain("sourceName: 'MAX_SHADOW_COPY_ENTRIES'");
+
+		const mutation = `
+const fs = require('node:fs');
+const path = require('node:path');
+const original = fs.readFileSync;
+fs.readFileSync = function(file, ...args) {
+  const value = original.call(this, file, ...args);
+  return path.resolve(String(file)) === path.resolve('docs/ci.md')
+    ? value.replace('100000 entries', '100001 entries')
+    : value;
+};
+const { detectDocsClaimDrift } = await import('./scripts/drift-check-docs-claims.ts');
+const findings = detectDocsClaimDrift(process.cwd());
+const red = findings.filter((finding) =>
+  finding.file === 'docs/ci.md' && finding.message.includes('MAX_SHADOW_COPY_ENTRIES'));
+console.log(JSON.stringify(red));
+fs.readFileSync = original;
+if (red.length === 0) process.exit(1);
+`;
+		const driftMutation = spawnSync(
+			process.execPath,
+			['--smol', '-e', mutation],
+			{
+				cwd: sourceRoot,
+				encoding: 'utf8',
+				input: undefined,
+				stdio: ['ignore', 'pipe', 'pipe'],
+				timeout: 15_000,
+			},
+		);
+		expect(driftMutation.status).toBe(0);
+		expect(
+			`${driftMutation.stdout ?? ''}${driftMutation.stderr ?? ''}`,
+		).toContain('100001');
+	});
+
+	test('AC8: the CI barrel omits implementation-only constants and event internals', () => {
+		const sourceRoot = path.resolve(import.meta.dir, '../../..');
+		const barrel = fs.readFileSync(
+			path.join(sourceRoot, 'src', 'ci', 'index.ts'),
+			'utf8',
+		);
+		for (const internalName of [
+			'MAX_SHADOW_COPY_BYTES',
+			'CI_QUALITY_THRESHOLDS',
+			'SWARM_CI_JSON_OPEN',
+			'SWARM_CI_JSON_CLOSE',
+			'CiRunEvent',
+			'MAX_CI_JOURNAL_EVENTS',
+		]) {
+			expect(barrel).not.toContain(internalName);
+		}
+	});
+
+	test('AC13: unknown flags retain the exact diagnostic contract', async () => {
+		await expect(
+			handleCiCommand(
+				makeContext(path.resolve(os.tmpdir(), 'swarm-ci-ac13'), ['--wat']),
+			),
+		).rejects.toThrow('Unknown flag: --wat');
+	});
+
+	test('AC16: docs disclose uncatchable process-death shadow residue', () => {
+		const sourceRoot = path.resolve(import.meta.dir, '../../..');
+		const docs = fs.readFileSync(
+			path.join(sourceRoot, 'docs', 'ci.md'),
+			'utf8',
+		);
+		expect(docs).toMatch(/(?:SIGKILL|host crash)/i);
+		expect(docs).toMatch(/cannot be cleaned in-process/i);
+		expect(docs).toMatch(
+			/(?:OS temporary directory|operating system.*reclaim)/i,
+		);
+	});
+});

--- a/tests/unit/commands/ci-acceptance-2633.test.ts
+++ b/tests/unit/commands/ci-acceptance-2633.test.ts
@@ -21,9 +21,7 @@ import {
 	isCommandFailure,
 } from '../../../src/commands/registry.js';
 import { DEFAULT_QA_GATES } from '../../../src/db/qa-gate-profile.js';
-import {
-	canonicalTmpDir as canonicalProjectTempRoot,
-} from '../../helpers/tmpdir.js';
+import { canonicalTmpDir as canonicalProjectTempRoot } from '../../helpers/tmpdir.js';
 
 function makeContext(directory: string, args: string[] = []): CommandContext {
 	return {
@@ -93,10 +91,10 @@ describe('issue #2633 CLI acceptance checks', () => {
 
 		await expect(
 			handleCiCommand(
-				makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-over-limit'), [
-					'--timeout-ms',
-					String(DEFAULT_CI_DEADLINE_MS + 1),
-				]),
+				makeContext(
+					path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-over-limit'),
+					['--timeout-ms', String(DEFAULT_CI_DEADLINE_MS + 1)],
+				),
 			),
 		).rejects.toThrow(/--timeout-ms/);
 		expect(runtimeCalls).toBe(0);
@@ -116,10 +114,10 @@ describe('issue #2633 CLI acceptance checks', () => {
 		};
 
 		await handleCiCommand(
-			makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-forward'), [
-				'--timeout-ms',
-				'1234.5',
-			]),
+			makeContext(
+				path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac4-forward'),
+				['--timeout-ms', '1234.5'],
+			),
 		);
 		expect(capturedDeadline).toBe(1234.5);
 	});
@@ -135,7 +133,10 @@ describe('issue #2633 CLI acceptance checks', () => {
 		});
 
 		const result = await handleCiCommand(
-			makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac6-json'), ['--json']),
+			makeContext(
+				path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac6-json'),
+				['--json'],
+			),
 		);
 		expect(isCommandFailure(result)).toBe(true);
 		if (!isCommandFailure(result)) return;
@@ -317,7 +318,9 @@ if (red.length === 0) process.exit(1);
 	test('AC13: unknown flags retain the exact diagnostic contract', async () => {
 		await expect(
 			handleCiCommand(
-				makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac13'), ['--wat']),
+				makeContext(path.resolve(canonicalProjectTempRoot(), 'swarm-ci-ac13'), [
+					'--wat',
+				]),
 			),
 		).rejects.toThrow('Unknown flag: --wat');
 	});

--- a/tests/unit/commands/ci.test.ts
+++ b/tests/unit/commands/ci.test.ts
@@ -76,6 +76,34 @@ describe('swarm ci argument validation', () => {
 		).rejects.toThrow(/--timeout-ms/);
 	});
 
+	test('all invalid --timeout-ms forms share one validation diagnostic (PR-TIMEOUT-MSG)', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-timeout-message-');
+		const invalidArgs = [
+			['--timeout-ms'],
+			['--timeout-ms', '--json'],
+			['--timeout-ms', 'banana'],
+			['--timeout-ms', '0'],
+			['--timeout-ms', '-5'],
+			['--timeout-ms', 'Infinity'],
+			['--timeout-ms', String(300_001)],
+		];
+		const messages: string[] = [];
+		for (const args of invalidArgs) {
+			try {
+				await handleCiCommand(ctx(dir, args));
+				messages.push('command unexpectedly succeeded');
+			} catch (error) {
+				messages.push(error instanceof Error ? error.message : String(error));
+			}
+		}
+
+		const expected =
+			'Invalid --timeout-ms value: expected a positive finite number from 1 through 300000 milliseconds.';
+		// The missing-value branch and Number() validation branch must expose the
+		// same stable diagnostic, rather than subtly different caller guidance.
+		expect(messages).toEqual(invalidArgs.map(() => expected));
+	});
+
 	test('unknown flag throws before the runtime is entered', async () => {
 		const dir = makeFixtureDir('swarm-ci-cmd-unknown-');
 		await expect(handleCiCommand(ctx(dir, ['--turbo']))).rejects.toThrow(
@@ -235,4 +263,25 @@ describe('swarm ci diagnostic branch (exit 2/3)', () => {
 		const parsed = parseDiagnosticBlock(result.text);
 		expect(parsed.exit_reason).toBe('cancelled');
 	}, 15000);
+
+	test('diagnostics redact an alternate-separator directory form (PR-REDACTION)', async () => {
+		const dir = makeFixtureDir('swarm-ci-cmd-redaction-');
+		const alternateDirectory = dir.replaceAll(
+			path.sep,
+			path.sep === '/' ? '\\' : '/',
+		);
+		_internals.runAdvisoryCiRuntime = async () => ({
+			outcome: 'deadline' as const,
+			journal: [{ seq: 1, type: 'run_started', detail: alternateDirectory }],
+			journalTruncated: 0,
+			cleanupRan: true,
+			detail: `deadline while evaluating ${alternateDirectory}`,
+		});
+
+		const result = await handleCiCommand(ctx(dir));
+		expect(isCommandFailure(result)).toBe(true);
+		if (!isCommandFailure(result)) return;
+		expect(result.text).not.toContain(alternateDirectory);
+		expect(result.text).toContain('[evaluated-directory]');
+	});
 });

--- a/tests/unit/scripts/drift-check-docs-claims.test.ts
+++ b/tests/unit/scripts/drift-check-docs-claims.test.ts
@@ -2,6 +2,12 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { detectDocsClaimDrift } from '../../../scripts/drift-check.ts';
+import {
+	MAX_SHADOW_COPY_BYTES,
+	MAX_SHADOW_COPY_ENTRIES,
+} from '../../../src/ci/evaluate';
+import { MAX_CI_JOURNAL_EVENTS } from '../../../src/ci/runtime';
+import { DEFAULT_CI_DEADLINE_MS } from '../../../src/commands/ci';
 import { QA_GATE_PIPELINE_STEP_COUNT } from '../../../src/config/qa-gate-pipeline';
 import { MAX_LANES } from '../../../src/tools/dispatch-lanes';
 import { canonicalMkdtemp } from '../../helpers/tmpdir';
@@ -54,6 +60,13 @@ const QA_GATE_CLAIM_FILES: Record<string, string> = {
 	'docs/swarm-briefing.md': `After every task a ${QA_GATE_PIPELINE_STEP_COUNT}-step QA gate verifies quality.\n\n## Pipeline (${QA_GATE_PIPELINE_STEP_COUNT} Steps)\n`,
 };
 
+const CI_CLAIM_FILES: Record<string, string> = {
+	'docs/ci.md':
+		`bunx opencode-swarm ci --timeout-ms ${DEFAULT_CI_DEADLINE_MS}\n` +
+		`If the shadow exceeds ${MAX_SHADOW_COPY_BYTES / (1024 * 1024)} MiB or ${MAX_SHADOW_COPY_ENTRIES} entries, it is rejected.\n` +
+		`The run journal is capped at ${MAX_CI_JOURNAL_EVENTS} events.\n`,
+};
+
 /** Writes every file the docs-claim detector pins, with optional overrides. */
 function writeDocsClaimFixture(
 	root: string,
@@ -62,6 +75,7 @@ function writeDocsClaimFixture(
 	const files = {
 		...QA_GATE_CLAIM_FILES,
 		...LANE_CAP_CLAIM_FILES,
+		...CI_CLAIM_FILES,
 		...overrides,
 	};
 	for (const [relative, contents] of Object.entries(files)) {
@@ -99,6 +113,7 @@ describe('drift-check: docs numeric claim detection', () => {
 		const { ['docs/planning.md']: _omitted, ...rest } = {
 			...QA_GATE_CLAIM_FILES,
 			...LANE_CAP_CLAIM_FILES,
+			...CI_CLAIM_FILES,
 		};
 		for (const [relative, contents] of Object.entries(rest)) {
 			writeFile(root, relative, contents);


### PR DESCRIPTION
Closes #2633

## Summary

- Harden CI advisory runtime follow-ups so late cleanup registrations execute immediately after drain without extending the bounded lifecycle.
- Bound shadow-copy work with cumulative byte/entry limits, chunked I/O, explicit descriptor and directory-handle cleanup, and privacy-preserving diagnostics.
- Close cached shadow SQLite handles before temporary-root removal, make bounded-copy writes visible to the cache scanner, and repair acceptance tests to use production seams.
- Normalize CI deadlines and diagnostics, redact alternate path spellings, and align docs/release notes and drift fixtures with the supported contract.

## Feedback closure

- TEST-001 / F3-AC2 / F3-AC12: replaced obsolete `readdirSync`/`copyFileSync` spies with deterministic `opendirSync`/`readSync` and `_internals.copyFileBounded` seams; assertions now cover traversal order, budget stop, and symlink skipping.
- F1 / CI-001 / BODY-001: added the `docs/ci.md` drift fixture and refreshed this test evidence for the current head.
- F2: added explicit post-write cache invalidation and removed the stale blind-spot registry exception.
- CORR-2633-DB-CLEANUP / PR-CLEANUP: close the cached shadow DB before best-effort root removal; direct fallback cleanup now drains all callbacks safely.
- F4 / PR-TIMEOUT-MSG / PR-REDACTION / CUBIC-O008: unified timeout diagnostics, documented the 1–300000ms ceiling and former 600000ms example, redacted native and alternate separators, and documented the `run_started` payload contract.
- CUBIC-CLOSED-DIR / CUBIC-COPY-UNIT: added focused coverage for `ERR_DIR_CLOSED`, complete/budgeted/stalled bounded copies.
- COPILOT-RUNTIME / CUBIC-SIGNAL: focused runtime and package smoke receipts are included below; Windows signal delivery remains documented as best-effort.
- CONFLICT-001 / STALE-001 / DIST-001: current head is conflict-free, stale prior-head comments are not treated as current findings, and generated `dist/` remains uncommitted.

## Invariant audit

- 1 (plugin init): not touched — `node scripts/repro-704.mjs` passed; no plugin initialization path changed.
- 2 (runtime portability): touched — `bun run build` and Node ESM import of `dist/index.js` passed; no `bun:` runtime resolution was added.
- 3 (subprocesses): not touched — no production subprocess call sites changed; `bun run check:bare-spawn` passed.
- 4 (.swarm containment): touched — shadow copies remain OS-temp only and cleanup is explicit; focused CI evaluation tests passed.
- 5 (plan durability): not touched — no plan ledger, projection, or checkpoint code changed.
- 6 (test_runner safety): touched — validation used bounded shell commands and explicit test files; no broad OpenCode `test_runner` scope was used.
- 7 (test writing): touched — new `bun:test` coverage uses `_internals` seams and stays below the 500-line cap; focused CI suites passed.
- 8 (session state): not touched — no session-keyed state changed.
- 9 (guardrails/retry): not touched — no guardrail, retry, or circuit-breaker behavior changed.
- 10 (chat/system msg): not touched — no chat hook or message-shape code changed.
- 11 (tool registration): not touched — no tool metadata, manifest, or agent-map entry changed; drift/invariant checks passed.
- 12 (release/cache): touched — pending release fragment updated, cache invalidation is explicit, and elevated package smoke passed.

## Test plan

- `bun --smol test tests/unit/ci --timeout 30000` — 57 passed, 0 failed across 9 files.
- Focused changed-file suites — shadow acceptance 6/6, resource bounds 6/6, commands/ci 15/15, docs-claim 15/15, write-cache scanner 25/25, CLI acceptance 10/10, runtime acceptance 3/3.
- `bun run typecheck` — passed.
- `bun run build` and `node --input-type=module -e "await import('./dist/index.js'); console.log('dist import OK')"` — passed.
- Changed-file Biome check — passed. Repository `bun run lint:ci` still reports only pre-existing unused-import errors in `src/hooks/guardrails/tool-before.ts`; no changed-file lint errors.
- Invariant/ratchet checks and `bun run drift:check --enforce --no-report` — passed (pre-existing warnings noted by the scripts).
- `bun run package:smoke` — passed on the elevated Windows retry after the sandboxed npm-cache attempt hit `EPERM`.
- The local full unit loop was stopped after reproducing the pre-existing Windows `EBUSY` cleanup failure in unchanged `src/hooks/incremental-verify.test.ts`; the remote matrix below is authoritative.

No migration required.
