### PR TITLE
fix(dispatch): refuse unregistered lane agents at dispatch time (issue #2614)

### DIFF
--- a/docs/releases/pending/2614-refuse-unregistered-lane-agents.md
+++ b/docs/releases/pending/2614-refuse-unregistered-lane-agents.md
@@ -1,0 +1,18 @@
+# Refuse unregistered lane agents at dispatch time (issue #2614)
+
+## What
+
+- `dispatch_lanes_async` / `dispatch_lanes` now refuse a lane whose `agent` is not a registered generated agent name when the host's generated-name registry is non-empty (multi-swarm hosts that register only prefixed agents). The rejection is a typed `rejected` lane row whose error names the requested agent and lists the registered names, bounded to the first 8 plus ", and N more".
+- Bare canonical roles (e.g. `explorer`) remain valid on legacy/default configurations whose registry registers them, and on hosts with an empty registry (the documented legacy launch shape).
+- `startAsyncLanePrompt` carries the same registry-aware refusal as defense-in-depth for direct callers: when the registry proves the agent unregistered and no swarm agent entry or model resolves, the lane settles a typed launch error through the exactly-once terminal path instead of launching a `promptAsync` the host cannot run.
+- The `dispatch_lanes_async` tool description now states the `agent` contract: each lane agent must be a registered generated agent name; bare canonical roles are refused on multi-swarm hosts that do not register them.
+
+## Why
+
+On the PR #2609 review run (2026-09-06), the built-in `build` agent dispatched 12 `swarm-pr-review:base` lanes with the bare name `explorer` on a multi-swarm host that registers only prefixed agents. `validateLaneAgent` accepted the name (`getCanonicalAgentRole` resolves bare canonical roles before consulting the generated-name registry), the lane launched `promptAsync` with no model, the host accepted and then died in its background fiber (`Die(UnknownError)`), and all 12 lanes stayed `pending` for 41–52 minutes with zero output until the operator cancelled — `complete_pr_workflow(INCOMPLETE)` was refused for lacking a typed terminal failure. The dispatch-time refusal makes this entire failure class unreachable: the caller now receives an immediate, actionable rejection instead of a silent hang.
+
+## Notes
+
+- The existing caller-prefix guard (`does not match caller swarm prefix`) is unchanged and now has direct test coverage.
+- New regression suite: `tests/unit/tools/dispatch-lanes-unregistered-agent-refusal.test.ts` (7 tests: refusal + bounded name list, legacy acceptance, mixed-registry acceptance, caller-prefix guard, async row refusal, deep-gate direct refusal).
+- Sibling sites that resolve agent names without registry membership (council identity, curator matching, full-auto policy, execution-stall classification) were enumerated in the issue trace; they are out of this change's dispatch path and remain tracked for a follow-up sweep.

--- a/src/tools/dispatch-lanes.ts
+++ b/src/tools/dispatch-lanes.ts
@@ -3549,6 +3549,35 @@ async function startAsyncLanePrompt(args: {
 			? args.lane.agent.slice(0, args.lane.agent.length - baseRole.length - 1)
 			: undefined;
 	const swarmAgents = getSwarmAgents(swarmID);
+	// Issue #2614 defense-in-depth: when the generated-name registry proves the
+	// lane agent is NOT registered (non-empty registry, no member match) and the
+	// swarm agent map has no resolvable entry or model, refuse instead of
+	// launching a lane the host cannot run. validateLaneAgent rejects this
+	// shape first on every launchAsyncLane path; this gate protects direct
+	// callers. The empty-registry (legacy/unconfigured) shape must NOT fire —
+	// bare-role launches without a swarm map are the documented legacy path.
+	const lanePrimaryModel = swarmAgents?.[baseRole]?.model;
+	const laneFallbackModels = swarmAgents?.[baseRole]?.fallback_models ?? [];
+	const registry = _internals.getGeneratedAgentNames();
+	const registryProvesUnregistered =
+		registry.length > 0 &&
+		!registry.some(
+			(name) => name.toLowerCase() === args.lane.agent.toLowerCase(),
+		);
+	if (
+		registryProvesUnregistered &&
+		!swarmAgents?.[baseRole] &&
+		!lanePrimaryModel &&
+		laneFallbackModels.length === 0
+	) {
+		await appendAsyncLaneLaunchError(
+			args.directory,
+			args.session,
+			args.sessionId,
+			`Lane "${args.lane.id}" agent "${args.lane.agent}" resolves no registered swarm agent and no model; refusing to launch a lane the host cannot run`,
+		);
+		return;
+	}
 	let promptResult: { data?: unknown; error?: unknown };
 	try {
 		const dispatched = await dispatchWithModelFallback({
@@ -4787,6 +4816,30 @@ function validateLaneAgent(
 			role,
 			error: `Agent role "${role}" is not allowed for read-only lane dispatch`,
 		};
+	}
+
+	// Issue #2614: a bare canonical role (e.g. "explorer") resolves as a known
+	// role before the generated-name registry is consulted, so on multi-swarm
+	// hosts that register only prefixed agents the lane would launch against an
+	// agent the host does not have. Refuse at dispatch time with the registered
+	// names so the caller can self-correct; never auto-prefix (ambiguous).
+	if (generatedAgentNames.length > 0) {
+		const normalized = agent.toLowerCase();
+		const registered = generatedAgentNames.find(
+			(name) => name.toLowerCase() === normalized,
+		);
+		if (!registered) {
+			const shown = generatedAgentNames.slice(0, 8).join(', ');
+			const overflow =
+				generatedAgentNames.length > 8
+					? `, and ${generatedAgentNames.length - 8} more`
+					: '';
+			return {
+				ok: false,
+				role,
+				error: `Agent "${agent}" is not registered on this host. Registered generated agent names: ${shown}${overflow}. Use a registered name (bare canonical roles are only valid when the host registers them).`,
+			};
+		}
 	}
 
 	const callerPrefix = context.callerAgent

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -892,7 +892,7 @@ export const TOOL_METADATA = {
 	},
 	dispatch_lanes_async: {
 		description:
-			'launch read-only advisory lanes non-blockingly and return a batch id plus lane session handles immediately so you can keep working; launch_timeout_ms is only a promptAsync acceptance budget, not a lane runtime timeout; poll incrementally with collect_lane_results (wait omitted or false) while doing independent investigation, or join with wait: true when you need all results',
+			'launch read-only advisory lanes non-blockingly and return a batch id plus lane session handles immediately; each lane agent must be a registered generated agent name (unregistered bare roles are refused on multi-swarm hosts); launch_timeout_ms is only a promptAsync acceptance budget, not a lane runtime timeout; poll incrementally with collect_lane_results (wait omitted), or join with wait: true for all results',
 		agents: ['architect'],
 	},
 	collect_lane_results: {

--- a/tests/unit/tools/dispatch-lanes-unregistered-agent-refusal.test.ts
+++ b/tests/unit/tools/dispatch-lanes-unregistered-agent-refusal.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Issue #2614 — refuse unregistered lane agents at dispatch time.
+ *
+ * A bare canonical role (e.g. `explorer`) dispatched on a multi-swarm host
+ * whose registry contains only prefixed names was accepted by
+ * `validateLaneAgent` (the exact-canonical-role match in `getCanonicalAgentRole`
+ * resolves before the registry membership check), forwarded to
+ * `session.promptAsync` with no model, and the host died in its background
+ * fiber (PR #2609: 12 lanes pending 41–52 min, `Die(UnknownError)`).
+ *
+ * Refusal contract:
+ *  - non-empty registry + lane agent not a member (case-insensitive) → typed
+ *    `rejected` dispatch row naming the agent and the registered names
+ *    (bounded to the first 8 + ", and N more")
+ *  - legacy bare-name registries (and empty registries) still accept bare
+ *    roles — that launch shape is the documented legacy path
+ *  - the caller-prefix guard is unchanged
+ *  - `startAsyncLanePrompt` carries the same registry-aware refusal as
+ *    defense-in-depth for direct callers (validateLaneAgent rejects first on
+ *    every launchAsyncLane path)
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from 'bun:test';
+import fs from 'node:fs';
+import {
+	findByCorrelationIdDetailed,
+	recordPendingDelegation,
+} from '../../../src/background/pending-delegations.js';
+import {
+	_internals,
+	_test_exports,
+	executeDispatchLanes,
+	executeDispatchLanesAsync,
+	type SessionOps,
+} from '../../../src/tools/dispatch-lanes.js';
+import { canonicalMkdtemp } from '../../../tests/helpers/tmpdir.js';
+
+const originalInternals = { ..._internals };
+
+// Workaround for Bun #32056 (mirror of dispatch-lanes.test.ts): on Windows, a
+// pending promise that leaves the event loop idle prevents bun's per-test
+// --timeout from firing. A 1s keepalive interval keeps the loop awake.
+let _keepalive: ReturnType<typeof setInterval> | undefined;
+beforeAll(() => {
+	_keepalive = setInterval(() => {}, 1000);
+});
+afterAll(() => {
+	if (_keepalive) clearInterval(_keepalive);
+});
+
+afterEach(() => {
+	Object.assign(_internals, originalInternals);
+});
+
+function makeTempDir(): string {
+	return canonicalMkdtemp('dispatch-lanes-2614-');
+}
+
+function stubSyncOps() {
+	const promptBodies: Array<{ agent: string; model?: unknown }> = [];
+	let createCalls = 0;
+	let promptCalls = 0;
+	const ops: SessionOps = {
+		create: async () => {
+			createCalls += 1;
+			return { data: { id: 'session-2614' }, error: undefined };
+		},
+		prompt: async (input: { body: { agent: string; model?: unknown } }) => {
+			promptCalls += 1;
+			promptBodies.push(input.body);
+			return {
+				data: {
+					parts: [{ type: 'text' as const, text: `ok ${input.body.agent}` }],
+				},
+				error: undefined,
+			};
+		},
+		delete: async () => undefined,
+	};
+	return {
+		ops,
+		promptBodies,
+		createCalls: () => createCalls,
+		promptCalls: () => promptCalls,
+	};
+}
+
+function stubAsyncOps(promptAsyncAgents: string[]) {
+	const ops = {
+		create: async () => ({ data: { id: 'session-2614a' }, error: undefined }),
+		promptAsync: async (input: { body: { agent: string } }) => {
+			promptAsyncAgents.push(input.body.agent);
+			return { data: {}, error: undefined };
+		},
+		delete: async () => undefined,
+	} as never as SessionOps;
+	return { ops };
+}
+
+describe('issue #2614 — unregistered lane agents are refused at dispatch time', () => {
+	test('bare "explorer" + prefixed-only registry + prefix-less caller is rejected with agent and registered names', async () => {
+		const directory = makeTempDir();
+		const { ops, createCalls, promptCalls } = stubSyncOps();
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'mega_architect',
+			'mega_explorer',
+			'paid_explorer',
+		];
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'bare', agent: 'explorer', prompt: 'probe' }] },
+			directory,
+			{ callerAgent: 'build' },
+		);
+
+		const lane = result.lane_results[0];
+		expect(lane?.status).toBe('rejected');
+		expect(lane?.error ?? '').toContain('explorer');
+		expect(lane?.error ?? '').toContain('mega_explorer');
+		// A rejected lane never reaches the host.
+		expect(createCalls()).toBe(0);
+		expect(promptCalls()).toBe(0);
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('refusal list is bounded: first 8 registered names then ", and N more"', async () => {
+		const directory = makeTempDir();
+		const { ops } = stubSyncOps();
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			's01_explorer',
+			's02_explorer',
+			's03_explorer',
+			's04_explorer',
+			's05_explorer',
+			's06_explorer',
+			's07_explorer',
+			's08_explorer',
+			's09_explorer',
+			's10_explorer',
+		];
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'bare', agent: 'explorer', prompt: 'probe' }] },
+			directory,
+			{ callerAgent: 'build' },
+		);
+
+		const error = result.lane_results[0]?.error ?? '';
+		expect(error).toContain('s08_explorer');
+		expect(error).toContain(', and 2 more');
+		expect(error).not.toContain('s09_explorer');
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('legacy bare-name registry still accepts bare "explorer" (model path unchanged)', async () => {
+		const directory = makeTempDir();
+		const { ops, promptBodies } = stubSyncOps();
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'architect',
+			'explorer',
+			'reviewer',
+		];
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'legacy', agent: 'explorer', prompt: 'probe' }] },
+			directory,
+			{ callerAgent: 'build' },
+		);
+
+		expect(result.lane_results[0]).toEqual(
+			expect.objectContaining({ status: 'completed', output: 'ok explorer' }),
+		);
+		expect(promptBodies[0]?.agent).toBe('explorer');
+		expect('model' in (promptBodies[0] ?? {})).toBe(false);
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('mixed bare+prefixed registry accepts the registered bare role', async () => {
+		const directory = makeTempDir();
+		const { ops } = stubSyncOps();
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => ['explorer', 'mega_explorer'];
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'mixed', agent: 'explorer', prompt: 'probe' }] },
+			directory,
+			{ callerAgent: 'build' },
+		);
+
+		expect(result.lane_results[0]?.status).toBe('completed');
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('caller-prefix guard still rejects cross-swarm dispatch with its specific message', async () => {
+		const directory = makeTempDir();
+		const { ops, createCalls } = stubSyncOps();
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'mega_architect',
+			'mega_reviewer',
+			'paid_reviewer',
+		];
+
+		const result = await executeDispatchLanes(
+			{ lanes: [{ id: 'cross', agent: 'paid_reviewer', prompt: 'cross' }] },
+			directory,
+			{ callerAgent: 'mega_architect' },
+		);
+
+		const lane = result.lane_results[0];
+		expect(lane?.status).toBe('rejected');
+		expect(lane?.error ?? '').toContain('does not match caller swarm prefix');
+		expect(createCalls()).toBe(0);
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('async: unregistered bare role is rejected at the dispatch row and never reaches promptAsync', async () => {
+		const directory = makeTempDir();
+		const promptAsyncAgents: string[] = [];
+		const { ops } = stubAsyncOps(promptAsyncAgents);
+		_internals.getSessionOps = () => ops;
+		_internals.getGeneratedAgentNames = () => [
+			'mega_architect',
+			'mega_reviewer',
+			'paid_reviewer',
+		];
+
+		const dispatch = await executeDispatchLanesAsync(
+			{
+				batch_id: 'batch-2614-async',
+				lanes: [{ id: 'probe', agent: 'reviewer', prompt: 'p' }],
+			},
+			directory,
+			{ callerAgent: 'build' },
+		);
+
+		expect(dispatch.lane_results[0]?.status).toBe('rejected');
+		expect(promptAsyncAgents).toHaveLength(0);
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+
+	test('deep gate: startAsyncLanePrompt refuses a provably-unregistered agent before promptAsync', async () => {
+		const directory = makeTempDir();
+		let promptAsyncCalled = false;
+		const ops = {
+			create: async () => ({
+				data: { id: 'session-2614-deep' },
+				error: undefined,
+			}),
+			promptAsync: async () => {
+				promptAsyncCalled = true;
+				return { data: {}, error: undefined };
+			},
+			delete: async () => undefined,
+		} as never as SessionOps;
+		_internals.getGeneratedAgentNames = () => [
+			'mega_architect',
+			'mega_explorer',
+		];
+		// Seed a pending record so the refusal settles through the exactly-once
+		// terminal claim with a typed result (the no-record bare-transition
+		// fallback leaves no findByCorrelationIdDetailed-readable record).
+		await recordPendingDelegation(directory, {
+			correlationId: 'session-2614-deep',
+			jobId: null,
+			subagentSessionId: 'session-2614-deep',
+			parentSessionId: 'parent-2614-deep',
+			callID: 'call-2614-deep',
+			normalizedAgent: 'explorer',
+			swarmPrefixedAgent: 'mega_explorer',
+			planTaskId: null,
+			evidenceTaskId: null,
+			mode: 'swarm-pr-review:base',
+		});
+
+		await _test_exports.startAsyncLanePrompt({
+			session: ops,
+			directory,
+			sessionId: 'session-2614-deep',
+			lane: { id: 'lane-deep', agent: 'explorer', prompt: 'probe' } as never,
+			timeoutMs: 5_000,
+		});
+
+		expect(promptAsyncCalled).toBe(false);
+		const read = findByCorrelationIdDetailed(directory, 'session-2614-deep');
+		expect(read.status).not.toBe('uncertain');
+		const settled = read.value;
+		expect(settled).toBeDefined();
+		expect(settled?.status).toBe('error');
+		const terminalError = String(
+			settled?.terminalResult?.result.error ?? settled?.result?.error ?? '',
+		);
+		expect(terminalError).toContain('refusing to launch');
+		fs.rmSync(directory, { recursive: true, force: true });
+	});
+});


### PR DESCRIPTION
Closes #2614

## Summary

`dispatch_lanes_async` / `dispatch_lanes` accepted a lane whose `agent` was a bare canonical role (e.g. `explorer`) even on multi-swarm hosts that register only prefixed agents: `getCanonicalAgentRole` resolves bare canonical roles before consulting the generated-name registry, so `validateLaneAgent` never learned the name was unregistered. The lane then launched `promptAsync` with no model and the host died in its background fiber — the PR #2609 incident (12 lanes pending 41–52 min, `Die(UnknownError)`, `complete_pr_workflow(INCOMPLETE)` refused for lacking a typed failure).

- `validateLaneAgent` now enforces case-insensitive registry membership when the registry is non-empty, rejecting with a typed `rejected` row whose error names the agent and lists the registered names (bounded to the first 8 + ", and N more"); the refusal fires before the caller-prefix guard, which is unchanged.
- Legacy shapes are preserved: bare-name registries (and empty registries) still accept bare roles — that launch shape is the documented legacy path.
- `startAsyncLanePrompt` carries the same registry-aware refusal as defense-in-depth for direct callers, settling a typed launch error through the existing exactly-once terminal path instead of an unrunnable `promptAsync`.
- The `dispatch_lanes_async` tool description now states the contract: each lane agent must be a registered generated agent name; bare canonical roles are refused on multi-swarm hosts that do not register them.
- Release fragment: `docs/releases/pending/2614-refuse-unregistered-lane-agents.md`.

## Invariant audit

- 1 (plugin init): not touched — no init-path changes; refusal runs at dispatch time only.
- 2 (runtime portability): not touched — no new imports, no bundle-surface change (`node --input-type=module` import of dist not required; no package/exports change).
- 3 (subprocesses): not touched — no new spawns.
- 4 (.swarm containment): not touched — refusal uses the existing delegation store paths.
- 5 (plan durability): not touched.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — new `bun:test` file (306 lines, under the 500 cap), no `mock.module`, `_internals` seam set directly and restored in `afterEach`, `canonicalMkdtemp` temp dirs, no raw clock. `bun run check:test-file-cap`, `check:test-clock`, `check:mock-cleanup` surfaces all pass.
- 8 (session state): not touched — no new module-level state.
- 9 (guardrails/retry): not touched — circuit/classification behavior unchanged; refusal happens before session creation (sync) / before dispatch (async).
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched (description only) — `TOOL_METADATA` entry edited; no tool/handler/agent-map additions; `/swarm doctor tools` surface derives from the same metadata.
- 12 (release/cache): touched — pending release fragment added; no version/changelog hand edits.

## Test plan

New regression suite `tests/unit/tools/dispatch-lanes-unregistered-agent-refusal.test.ts` (7 tests): refusal + bounded name list, legacy bare-name acceptance, mixed bare+prefixed registry acceptance, caller-prefix guard pin, async row refusal, and a direct deep-gate probe (seeded pending record; strict `status === 'error'` + `'refusing to launch'` assertion).

- Regression suite: `bun --smol test tests/unit/tools/dispatch-lanes-unregistered-agent-refusal.test.ts --timeout 120000` → 7 pass / 0 fail
- Impacted suites: all 72 `tests/unit/tools/dispatch-lanes*.test.ts` files run individually → 72/72 pass, 0 fail (incl. `dispatch-lanes.test.ts` 69/0); independent reviewer and final critic each re-ran the sweep
- Quality gates: biome (3 touched files) clean; typecheck zero errors in touched files (2 pre-existing `src/mcp/server.ts` errors confirmed on clean base); `bun run check:registry-citations` all passed (85 baseline); `bun test tests/unit/utils/atomic-write-ratchet.test.ts` 7/0; `check:test-file-cap`, `check:test-clock` pass
- Falsifiability: revert-probe — neutralizing the membership check (`&& false` mutation) flips exactly the 3 row-level tests RED while the deep-gate test stays GREEN (independent predicate), restore verified clean (`git status` empty, zero mutation residue)
- Deferred-work scan: `.opencode/skills/issue-tracer/scripts/scan-deferred.sh` → clean
- Issue-tracer trace: full protocol at `.agents/issue-traces/2614-refuse-unregistered-lane-agents/` (independent check author; plan critic Round 1 NEEDS_REVISION → 5 revisions → Round 2 APPROVE; implementation reviewer Round 1 NEEDS_REVISION → both revisions landed → Round 2 APPROVE; final critic APPROVE at head `0ce179c3b81b207b9d46f706daefc9a62cde5e1f` with independent re-execution)

### Acceptance Criteria -> Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC1 bare role + prefixed-only registry + prefix-less caller rejected with agent + registered names | Trace check C1 RED at base (`repro/C1.base.log`) → GREEN at head; committed tests 1–2 |
| AC2 legacy bare-name registry still accepts bare roles (model path unchanged) | C2 PRESERVING GREEN/GREEN; committed test 3 (asserts no `model` key in prompt body) |
| AC3 caller-prefix guard directly tested | C3 PRESERVING; committed test 5 pins `does not match caller swarm prefix` |
| AC4 no launch without registered agent or resolvable model | C4 (amended, manifest AMEND/CHECK_WRONG with fresh RED/GREEN replay — the empty-registry shape is the documented legacy path) + committed tests 6–7 incl. strict deep-gate assertion |
| AC5 tool description states the contract | C6 NEW-SURFACE GREEN; `src/tools/tool-metadata.ts` description now contains "registered generated agent name" |
| AC6 release fragment | `docs/releases/pending/2614-refuse-unregistered-lane-agents.md` in diff |

### Waivers (or none)

None.

### Merge status

PR head: 0ce179c3b81b207b9d46f706daefc9a62cde5e1f

Merge approval is recorded separately in the trace (`10b-merge-approval.md`) per the issue-tracer human-enforced merge gate.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

