### PR TITLE
[liveproof-2585] docs(getting-started): link diagnose health-check reference

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,6 +77,8 @@ You should see a health check report like:
 **Result**: ✅ All checks passed
 ```
 
+A full reference for every diagnostic check lives in [Configuration](configuration.md).
+
 If you see ❌ failures, fix them before proceeding. Also check:
 
 ```bash


### PR DESCRIPTION
Benign live-proof target for issue #2585 Phase C (AC11). Self-owned, doc-only, intended to be CLOSED unmerged after its review run is recorded.

Adds a pointer from the Getting Started diagnose step to a fuller reference for the health-check report.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

