### PR TITLE
[liveproof-2585] docs(modes): expand Turbo when-to-use guidance and lane evidence layout

### DIFF
--- a/docs/modes.md
+++ b/docs/modes.md
@@ -26,7 +26,7 @@ Skips Stage B (reviewer + test_engineer) for low-risk tasks. The task still goes
 
 This list is enforced at `src/tools/update-task-status.ts:98-109`. You cannot turn it off.
 
-**When to use:** rapid iteration on non-critical code — UI tweaks, documentation, internal refactors.
+**When to use:** rapid iteration on non-critical code — UI tweaks, documentation, internal refactors. Turbo trades automated gate coverage for speed — the syntax, placeholder, and SAST checks are all skipped alongside Stage B.
 
 **Toggle:**
 
@@ -445,7 +445,7 @@ Lean Turbo is controlled via `/swarm turbo lean`:
 
 ### Evidence and Phase Reviewer/Critic Requirements
 
-Lane evidence is written to `.swarm/evidence/{phase}/lean-turbo/` per lane:
+Lane evidence is written to `.swarm/evidence/{phase}/lean-turbo/` per lane (one directory per phase under `.swarm/evidence/lean-turbo/`):
 - Each lane writes its own evidence file (`lane-{n}.json`)
 - Contains task IDs, assigned files, lane status, and completion state
 


### PR DESCRIPTION
Benign live-proof target for issue #2585 Phase C (AC11). Self-owned, doc-only, intended to be CLOSED unmerged after its review run is recorded.

Expands the Turbo when-to-use note with what it skips, and clarifies where lane evidence lands.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

