### PR TITLE
fix(guardrails): keep mandatory lifecycle bookkeeping active and record every Stage A attribution route

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1120,6 +1120,45 @@ turns without making progress (issue #2063). Both are per-session, in-memory,
 and additive to the existing `guardrails` block — omit them and the defaults
 below apply.
 
+### Mandatory lifecycle vs optional enforcement (`guardrails.enabled`, issue #2664)
+
+`guardrails.enabled: false` disables OPTIONAL policy enforcement only:
+deny rules, authority/scope denials, destructive-command blocks, sandbox
+enforcement, budget limits, and prompt-directive advisories. MANDATORY
+lifecycle bookkeeping stays active in BOTH modes (AGENTS.md invariant 9):
+
+- Stage A pre-check receipts: every `pre_check_batch` outcome is correlated
+  with its task and durably recorded (`stage_a_passed` / `stage_a_failed`
+  workflow transitions), so accepted and rejected work stays observable.
+- Exact-bound scope-lease maintenance: a successful authorized write still
+  renews the owning scope binding's lease (revision CAS bump + expiry
+  extension). Foreign, expired, and released ownership never renews.
+- One structural bound stays fail-closed in both modes: patch payloads over
+  1 MiB are rejected (`WRITE BLOCKED: Patch payload exceeds 1 MB`) because
+  authority cannot be verified for an unbounded write set.
+
+Every completed `pre_check_batch` call also records exactly ONE bounded
+route event (`type: "stage_a_gate_route"`) in `.swarm/events.jsonl`, with
+fields `route`, `sessionID`, `callID`, `taskId` (null when unattributable),
+`guardrailsEnabled`, each line ≤ 2048 bytes. The closed route vocabulary:
+
+| route | Meaning | Operator recovery |
+|---|---|---|
+| valid_pass | Correlated PASS applied; task advanced to pre_check_passed | None — proceed to Stage B |
+| pre_check_failed | Correlated FAIL applied; task moved to rework_required | Re-dispatch the coder with the findings |
+| invalid_result | Result not decodable as a valid pre_check_batch outcome; no transition | Re-run the gate; check the tool output contract |
+| no_task_correlation | Completed gate call with no attributable task | Run `/swarm recover` to repair attribution, then re-run the gate |
+| attribution_ambiguous | Durable fallback could not safely attribute (multiple candidates, or sole candidate unbound/unverifiable) | Run `/swarm recover` to repair Stage A attribution |
+| late_result | Correlation generation stale (task repaired/re-generated meanwhile); nothing written | Re-run the gate against the current generation |
+| duplicate_result | Idempotent replay of an already-applied receipt; no state change | None — the receipt already landed |
+
+Registered-host validation: `tests/integration/guardrails-registered-host-stage-a.test.ts`
+boots the real plugin `server()` (XDG-hermetic), executes `placeholder_scan`
+and `syntax_check` through the registered tool map, and drives
+valid/rejected receipts through the registered `tool.execute.before/after`
+hooks with guardrails enabled and disabled; expected result classes are
+bounded JSON tool outputs plus the durable states and route events above.
+
 ### Gate-denial escalation
 
 Every fail-closed `tool.execute.before` hook (guardrails authority, scope

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1134,13 +1134,15 @@ lifecycle bookkeeping stays active in BOTH modes (AGENTS.md invariant 9):
   renews the owning scope binding's lease (revision CAS bump + expiry
   extension). Foreign, expired, and released ownership never renews.
 - One structural bound stays fail-closed in both modes: patch payloads over
-  1 MiB are rejected (`WRITE BLOCKED: Patch payload exceeds 1 MB`) because
-  authority cannot be verified for an unbounded write set.
+  1 MB (1,000,000 bytes) are rejected (`WRITE BLOCKED: Patch payload exceeds
+  1 MB`) because authority cannot be verified for an unbounded write set.
 
 Every completed `pre_check_batch` call also records exactly ONE bounded
 route event (`type: "stage_a_gate_route"`) in `.swarm/events.jsonl`, with
 fields `route`, `sessionID`, `callID`, `taskId` (null when unattributable),
-`guardrailsEnabled`, each line ≤ 2048 bytes. The closed route vocabulary:
+`guardrailsEnabled`, `ts`. Every string field is sanitized and sliced to at
+most 128 characters, so a worst-case line stays far below the core event
+store's 256 KiB per-line cap. The closed route vocabulary:
 
 | route | Meaning | Operator recovery |
 |---|---|---|

--- a/docs/releases/pending/2664-mandatory-lifecycle-bookkeeping.md
+++ b/docs/releases/pending/2664-mandatory-lifecycle-bookkeeping.md
@@ -1,0 +1,44 @@
+# Keep mandatory lifecycle bookkeeping active and record every Stage A attribution route
+
+Issue: #2664
+
+## Summary
+
+Setting `guardrails.enabled: false` used to disable the guardrails hook factory
+entirely, which silently suppressed MANDATORY lifecycle bookkeeping along with
+the optional enforcement: Stage A pre-check receipts (task correlation plus the
+durable `stage_a_passed`/`stage_a_failed` workflow transitions) and exact-bound
+scope-lease maintenance both stopped running, so accepted and rejected work
+became unobservable, tasks wedged at `coder_delegated`, and legitimately owned
+scope leases expired unrenewed.
+
+The factory is now split along that boundary. With guardrails disabled, the
+policy denials inside `toolBefore` (deny rules, authority/scope checks,
+destructive-command blocks, sandbox enforcement, budget limits, PRM stop,
+prompt-directive advisories via `messagesTransform`) are skipped, while every
+mandatory surface keeps running: Stage A correlation and transitions, a new
+bounded Stage A route event per completed `pre_check_batch` outcome, and
+success-only exact-bound lease renewal. One structural bound stays fail-closed
+in both modes: patch payloads over 1 MiB are still rejected.
+
+## Stage A route events
+
+Every completed `pre_check_batch` call now records exactly one bounded event
+(`type: "stage_a_gate_route"`) in the bounded core event store
+(`.swarm/events.jsonl`) with a closed seven-route vocabulary — `valid_pass`,
+`pre_check_failed`, `invalid_result`, `no_task_correlation`,
+`attribution_ambiguous`, `late_result`, `duplicate_result` — carrying the
+session, call, attributed task (nullable), and the guardrails mode. Duplicate
+deliveries are idempotent by transition id; late results (stale generation)
+never advance a task; undecodable results never transition. The vocabulary,
+the mandatory-vs-optional split, and each route's operator recovery meaning
+are documented in `docs/configuration.md` and pinned by a docs-parity test.
+
+## Validation
+
+Registered-host integration coverage boots the real plugin `server()` with
+guardrails enabled and disabled (XDG-hermetic), executes the real
+`placeholder_scan` and `syntax_check` tools through the registered tool map,
+and drives valid/rejected receipts through the registered hooks; unit suites
+cover the seven-route classification matrix, lease renewal with enforcement
+off, and the fail-closed 1 MiB patch bound.

--- a/src/hooks/guardrails/index.ts
+++ b/src/hooks/guardrails/index.ts
@@ -19,7 +19,6 @@ import { WRITE_TOOL_NAMES } from '../../config/constants';
 import {
 	type AuthorityConfig,
 	type GuardrailsConfig,
-	GuardrailsConfigSchema,
 	stripKnownSwarmPrefix,
 } from '../../config/schema';
 import {
@@ -105,6 +104,8 @@ export const _internals = {
 	allowUncorrelatedGateReceipts: false,
 	MAX_PENDING_GATE_RECEIPTS_PER_SESSION,
 	MAX_PENDING_GATE_RECEIPT_SESSIONS,
+	MAX_PENDING_GATE_ROUTES_PER_SESSION,
+	MAX_PENDING_GATE_ROUTE_SESSIONS,
 	/**
 	 * Test/inspection seams for the no-op detector's bounded session state
 	 * (invariant 8). Production code does not call these; they exist so the
@@ -769,7 +770,15 @@ export function createGuardrailsHooks(
 	const universalDenyPrefixes: string[] =
 		authorityConfig?.universal_deny_prefixes ?? [];
 
-	const cfg = guardrailsConfig ?? GuardrailsConfigSchema.parse({});
+	// Fail closed on a missing config rather than silently absorbing it into
+	// schema defaults: garbage or legacy one-arg calls must keep surfacing as
+	// the programmer error they are (pinned by guardrails-directory.adversarial).
+	if (guardrailsConfig === undefined || guardrailsConfig === null) {
+		throw new TypeError(
+			'createGuardrailsHooks: guardrailsConfig is required — pass the resolved GuardrailsConfig object',
+		);
+	}
+	const cfg = guardrailsConfig;
 	const requiredQaGates = cfg.qa_gates?.required_tools ?? [
 		'diff',
 		'syntax_check',

--- a/src/hooks/guardrails/index.ts
+++ b/src/hooks/guardrails/index.ts
@@ -19,6 +19,7 @@ import { WRITE_TOOL_NAMES } from '../../config/constants';
 import {
 	type AuthorityConfig,
 	type GuardrailsConfig,
+	GuardrailsConfigSchema,
 	stripKnownSwarmPrefix,
 } from '../../config/schema';
 import {
@@ -80,11 +81,14 @@ import {
 	takeToolExecution,
 } from './nontransient-circuit';
 import { decodePreCheckResult } from './pre-check-result';
+import { recordStageAGateRoute, type StageAGateRoute } from './stage-a-route';
 import { getStoredInputArgs } from './stored-input-args';
 import { createToolBeforeHandler } from './tool-before';
 
 const MAX_PENDING_GATE_RECEIPTS_PER_SESSION = 256;
 const MAX_PENDING_GATE_RECEIPT_SESSIONS = 500;
+const MAX_PENDING_GATE_ROUTES_PER_SESSION = 256;
+const MAX_PENDING_GATE_ROUTE_SESSIONS = 500;
 
 export const _internals = {
 	extractSwarmIdFromAgentName,
@@ -738,14 +742,13 @@ export function createGuardrailsHooks(
 		return cwd;
 	})();
 
-	// If guardrails are disabled, return no-op handlers
-	if (guardrailsConfig?.enabled === false) {
-		return {
-			toolBefore: async () => {},
-			toolAfter: async () => {},
-			messagesTransform: async () => {},
-		};
-	}
+	// Issue #2664: `guardrails.enabled=false` disables OPTIONAL POLICY
+	// ENFORCEMENT only. Mandatory lifecycle bookkeeping — Stage A gate
+	// receipts (correlation, durable workflow transitions, route events)
+	// and exact-bound scope-lease maintenance — stays active in both modes
+	// (AGENTS.md invariant 9). The factory always builds real handlers; the
+	// enforcement-only paths inside toolBefore are gated on `enforcePolicy`.
+	const enforcementEnabled = guardrailsConfig?.enabled !== false;
 
 	// Pre-compute effective authority rules once
 	const precomputedAuthorityRules = buildEffectiveRules(authorityConfig);
@@ -766,7 +769,7 @@ export function createGuardrailsHooks(
 	const universalDenyPrefixes: string[] =
 		authorityConfig?.universal_deny_prefixes ?? [];
 
-	const cfg = guardrailsConfig!;
+	const cfg = guardrailsConfig ?? GuardrailsConfigSchema.parse({});
 	const requiredQaGates = cfg.qa_gates?.required_tools ?? [
 		'diff',
 		'syntax_check',
@@ -837,6 +840,53 @@ export function createGuardrailsHooks(
 		}
 		sessionTasks.set(callID, { sessionID, taskId, generation });
 	};
+	// Issue #2664: pre-classified Stage A routes for gate calls that could
+	// not be correlated with a task at toolBefore time (no session task, no
+	// durable candidate, ambiguity, unbound). Session-keyed, bounded, and
+	// delete-on-read at its single consumption point in toolAfter — entries
+	// never survive a completed delivery (invariant 8; plan-critic R2-F2).
+	const pendingGateRoutesBySession = new Map<
+		string,
+		Map<string, StageAGateRoute>
+	>();
+	const takePendingGateRoute = (
+		sessionID: string,
+		callID: string,
+	): StageAGateRoute | undefined => {
+		const sessionRoutes = pendingGateRoutesBySession.get(sessionID);
+		const route = sessionRoutes?.get(callID);
+		if (sessionRoutes) {
+			sessionRoutes.delete(callID);
+			if (sessionRoutes.size === 0)
+				pendingGateRoutesBySession.delete(sessionID);
+		}
+		return route;
+	};
+	const rememberPendingGateRoute = (
+		sessionID: string,
+		callID: string,
+		route: StageAGateRoute,
+	): void => {
+		let sessionRoutes = pendingGateRoutesBySession.get(sessionID);
+		if (!sessionRoutes) {
+			if (pendingGateRoutesBySession.size >= MAX_PENDING_GATE_ROUTE_SESSIONS) {
+				throw new Error(
+					'GATE_ROUTE_CAPACITY: too many sessions have live gate calls; wait for a pending gate call to finish',
+				);
+			}
+			sessionRoutes = new Map();
+			pendingGateRoutesBySession.set(sessionID, sessionRoutes);
+		}
+		if (
+			!sessionRoutes.has(callID) &&
+			sessionRoutes.size >= MAX_PENDING_GATE_ROUTES_PER_SESSION
+		) {
+			throw new Error(
+				'GATE_ROUTE_CAPACITY: this session has too many live gate calls; wait for a pending gate call to finish',
+			);
+		}
+		sessionRoutes.set(callID, route);
+	};
 	const scopeLeaseRenewal = createScopeLeaseRenewalTracker();
 	const rememberReviewerScopeWrite = (input: {
 		callID: string;
@@ -888,10 +938,14 @@ export function createGuardrailsHooks(
 		episodeMinutes: cfg.execution_stall_episode_minutes,
 	};
 
-	// Create toolBefore handler via factory
+	// Create toolBefore handler via factory. `enforcePolicy` carries the
+	// optional-enforcement half of issue #2664's split: false skips policy
+	// denials inside tool-before while every bookkeeping path (gate
+	// correlation wrapper above, lease candidates, tracking) stays live.
 	const baseToolBefore = createToolBeforeHandler({
 		effectiveDirectory,
 		cfg,
+		enforcePolicy: enforcementEnabled,
 		precomputedAuthorityRules,
 		universalDenyPrefixes,
 		shellAuditEnabled,
@@ -910,6 +964,7 @@ export function createGuardrailsHooks(
 	) => {
 		if (isGateTool(input.tool)) {
 			let taskId = swarmState.agentSessions.get(input.sessionID)?.currentTaskId;
+			let unattributableRoute: StageAGateRoute = 'no_task_correlation';
 			if (!taskId) {
 				// Post-reset durable attribution fallback: reset-session wiped the
 				// in-memory chain (currentTaskId/lastCoderDelegationTaskId), so
@@ -924,6 +979,10 @@ export function createGuardrailsHooks(
 					if ('taskId' in fallback) {
 						taskId = fallback.taskId;
 					} else if ('ambiguous' in fallback && fallback.ambiguous.length > 0) {
+						// Ambiguity and unbound/unverifiable are both durable-fallback
+						// attribution failures with no attributable task (issue #2664
+						// route vocabulary: attribution_ambiguous).
+						unattributableRoute = 'attribution_ambiguous';
 						const shown = fallback.ambiguous.slice(0, 10);
 						const more = fallback.ambiguous.length - shown.length;
 						emitDurableAttributionAdvisory(
@@ -932,6 +991,7 @@ export function createGuardrailsHooks(
 							`STAGE A ATTRIBUTION AMBIGUOUS: ${fallback.ambiguous.length} tasks are settled at coder_delegated (${shown.join(', ')}${more > 0 ? `, +${more} more` : ''}) but this session has no task correlation after reset-session. Stage A evidence cannot be attributed safely. Run /swarm recover to repair Stage A attribution, then re-run the gate.`,
 						);
 					} else if ('unbound' in fallback) {
+						unattributableRoute = 'attribution_ambiguous';
 						emitDurableAttributionAdvisory(
 							input.sessionID,
 							`${effectiveDirectory}\u0000unbound\u0000${fallback.unbound}`,
@@ -954,6 +1014,26 @@ export function createGuardrailsHooks(
 					taskId,
 					workflow?.generation ?? 0,
 				);
+			} else {
+				// Issue #2664: carry the toolBefore-time classification to
+				// toolAfter so the completed call still records its route.
+				// Capacity exhaustion here must never block the tool call —
+				// the route event is bookkeeping, not enforcement (R3-F2).
+				try {
+					rememberPendingGateRoute(
+						input.sessionID,
+						input.callID,
+						unattributableRoute,
+					);
+				} catch (routeError) {
+					warn('Stage A route classification dropped at capacity', {
+						sessionID: input.sessionID,
+						error:
+							routeError instanceof Error
+								? routeError.message.slice(0, 80)
+								: String(routeError),
+					});
+				}
 			}
 		}
 		try {
@@ -964,16 +1044,22 @@ export function createGuardrailsHooks(
 		}
 	};
 
-	// Create messagesTransform handler via factory
-	const messagesTransform = createMessagesTransformHandler({
-		effectiveDirectory,
-		cfg,
-		requiredQaGates,
-		requireReviewerAndTestEngineer,
-		consecutiveNoToolTurns,
-		lastCountedAssistantMsgId,
-		resolveAgentModel,
-	});
+	// Create messagesTransform handler via factory. Prompt-directive
+	// advisories are the OPTIONAL enforcement channel: with guardrails
+	// disabled the transform stays a no-op (issue #2664 non-goal: never make
+	// optional guardrails mandatory). Stage A operational failures remain
+	// visible via logger.criticalWarn + route events.
+	const messagesTransform = enforcementEnabled
+		? createMessagesTransformHandler({
+				effectiveDirectory,
+				cfg,
+				requiredQaGates,
+				requireReviewerAndTestEngineer,
+				consecutiveNoToolTurns,
+				lastCountedAssistantMsgId,
+				resolveAgentModel,
+			})
+		: async () => {};
 
 	return {
 		toolBefore,
@@ -1026,6 +1112,85 @@ export function createGuardrailsHooks(
 				...input,
 				output: malformedOutput ? null : safeOutput,
 			});
+			// Issue #2664: Stage A route classification + bounded route events.
+			// MANDATORY bookkeeping — runs in BOTH guardrails modes and
+			// OUTSIDE the `if (session)` guard below: the pending-route
+			// carry-over is the source of truth when the session is gone.
+			// Emission is scoped to pre_check_batch, the Stage A verdict
+			// producer; other gate tools feed gateLog but carry no verdict.
+			// The whole classify-and-emit step is fail-open (plan-critic
+			// R3-F2): capacity/append failures skip the event, never throw.
+			const emitStageARoute = (
+				route: StageAGateRoute,
+				taskId: string | null,
+			): void => {
+				recordStageAGateRoute(effectiveDirectory, {
+					route,
+					sessionID: input.sessionID,
+					callID: input.callID,
+					taskId,
+					guardrailsEnabled: enforcementEnabled,
+				});
+			};
+			const stageADuplicateOf = async (
+				taskId: string,
+				appliedOutcome: string,
+			): Promise<boolean> => {
+				try {
+					const snapshot = getTaskWorkflowSnapshot(
+						await readTaskEvidence(effectiveDirectory, taskId),
+					);
+					return (
+						snapshot.authoritative === true &&
+						snapshot.lastTransitionId === `pre-check:${input.callID}` &&
+						snapshot.lastOutcome === appliedOutcome
+					);
+				} catch {
+					return false;
+				}
+			};
+			if (
+				normalizeToolName(input.tool) === 'pre_check_batch' &&
+				!pendingGateTask
+			) {
+				try {
+					const verdict = decodePreCheckResult(safeOutput.output);
+					const sessionTaskId =
+						swarmState.agentSessions.get(input.sessionID)?.currentTaskId ??
+						null;
+					const appliedOutcome =
+						verdict.kind === 'pass'
+							? 'stage_a_passed'
+							: verdict.kind === 'fail'
+								? 'stage_a_failed'
+								: null;
+					if (
+						sessionTaskId &&
+						appliedOutcome &&
+						(await stageADuplicateOf(sessionTaskId, appliedOutcome))
+					) {
+						// Idempotent replay of an already-applied receipt. The
+						// predicate inspects transitionId + type-derived outcome
+						// only (R3-F1): an altered payload at the same callID
+						// still re-classifies as duplicate by design.
+						emitStageARoute('duplicate_result', sessionTaskId);
+					} else {
+						emitStageARoute(
+							takePendingGateRoute(input.sessionID, input.callID) ??
+								'no_task_correlation',
+							null,
+						);
+					}
+				} catch (routeError) {
+					warn('Stage A route classification failed', {
+						sessionID: input.sessionID,
+						error:
+							routeError instanceof Error
+								? routeError.message.slice(0, 80)
+								: String(routeError),
+					});
+				}
+			}
 			// v6.12: Gate completion tracking (moved above window check for architect sessions)
 			const session = swarmState.agentSessions.get(input.sessionID);
 			if (session) {
@@ -1053,6 +1218,16 @@ export function createGuardrailsHooks(
 								timestamp: Date.now(),
 								code: verdict.code,
 							};
+							if (verdict.kind === 'invalid') {
+								// Issue #2664: an undecodable result carries no verdict —
+								// it is recorded as a bounded route event and never
+								// transitions the workflow (invalid is not evidence
+								// of a failed pre-check).
+								emitStageARoute(
+									'invalid_result',
+									isStrictTaskId(taskId) ? taskId : null,
+								);
+							}
 							if (verdict.kind === 'fail' && isStrictTaskId(taskId))
 								try {
 									const updated = await transitionTaskWorkflowEvidence(
@@ -1067,6 +1242,7 @@ export function createGuardrailsHooks(
 									const next = getTaskWorkflowSnapshot(updated);
 									session.taskWorkflowStates.set(taskId, next.state);
 									updateTaskWorkflowCache(session, taskId, next);
+									emitStageARoute('pre_check_failed', taskId);
 								} catch (err) {
 									const code = stageAWriteErrorCode(err);
 									if (code && STAGE_A_ATTRIBUTION_MISS_CODES.has(code)) {
@@ -1095,45 +1271,63 @@ export function createGuardrailsHooks(
 							if (!isStrictTaskId(taskId)) {
 								advanceTaskState(session, taskId, 'pre_check_passed');
 							}
-							try {
-								const updated = await transitionTaskWorkflowEvidence(
-									effectiveDirectory,
-									taskId,
-									{
-										type: 'stage_a_passed',
-										expectedGeneration: pendingGateTask.generation,
-										transitionId: `pre-check:${input.callID}`,
-									},
-								);
-								const next = getTaskWorkflowSnapshot(updated);
-								session.taskWorkflowStates.set(taskId, next.state);
-								updateTaskWorkflowCache(session, taskId, next);
-							} catch (err) {
-								// Duplicate transitions return existing evidence without
-								// throwing, so any error here is abnormal. Attribution-miss
-								// codes are exactly how tasks silently wedge at
-								// coder_delegated post-reset — escalate them to a visible
-								// advisory instead of swallowing (TASK_WORKFLOW_TERMINAL and
-								// WAL-fencing codes stay log-only: late gate results after
-								// close/settlement are expected churn, not a wedge).
-								const code = stageAWriteErrorCode(err);
-								if (code && STAGE_A_ATTRIBUTION_MISS_CODES.has(code)) {
-									logger.criticalWarn(
-										`[guardrails] Stage A write failed for task ${taskId}: ${code} — pre_check_batch result was NOT attributed. Run /swarm recover ${taskId}.`,
-									);
-									pushAdvisory(
-										session,
-										`STAGE A WRITE FAILED (${code}) for task ${taskId}: pre_check_batch passed but the workflow transition was rejected, so Stage B dispatches will be denied with TASK_WORKFLOW_STAGE_A_REQUIRED. Run /swarm recover ${taskId} to repair attribution.`,
-									);
-								} else {
-									// Non-fatal: state may already be at or past pre_check_passed
-									warn(
-										'Failed to advance task state after pre_check_batch pass',
+							// Issue #2664 duplicate pre-check: the durable receipt
+							// for this exact callID already applied — idempotent
+							// replay, no second transition (R1-F4/R3-F1: the
+							// predicate requires an authoritative snapshot and
+							// keys on transitionId + type-derived outcome only).
+							if (
+								isStrictTaskId(taskId) &&
+								(await stageADuplicateOf(taskId, 'stage_a_passed'))
+							) {
+								emitStageARoute('duplicate_result', taskId);
+							} else {
+								try {
+									const updated = await transitionTaskWorkflowEvidence(
+										effectiveDirectory,
+										taskId,
 										{
-											taskId,
-											error: String(err),
+											type: 'stage_a_passed',
+											expectedGeneration: pendingGateTask.generation,
+											transitionId: `pre-check:${input.callID}`,
 										},
 									);
+									const next = getTaskWorkflowSnapshot(updated);
+									session.taskWorkflowStates.set(taskId, next.state);
+									updateTaskWorkflowCache(session, taskId, next);
+									emitStageARoute('valid_pass', taskId);
+								} catch (err) {
+									// Duplicate transitions return existing evidence without
+									// throwing, so any error here is abnormal. Attribution-miss
+									// codes are exactly how tasks silently wedge at
+									// coder_delegated post-reset — escalate them to a visible
+									// advisory instead of swallowing (TASK_WORKFLOW_TERMINAL and
+									// WAL-fencing codes stay log-only: late gate results after
+									// close/settlement are expected churn, not a wedge).
+									const code = stageAWriteErrorCode(err);
+									if (code === 'TASK_WORKFLOW_GENERATION_MISMATCH') {
+										// Issue #2664: the correlation's generation is stale —
+										// a late result that must not advance the task.
+										emitStageARoute('late_result', taskId);
+									}
+									if (code && STAGE_A_ATTRIBUTION_MISS_CODES.has(code)) {
+										logger.criticalWarn(
+											`[guardrails] Stage A write failed for task ${taskId}: ${code} — pre_check_batch result was NOT attributed. Run /swarm recover ${taskId}.`,
+										);
+										pushAdvisory(
+											session,
+											`STAGE A WRITE FAILED (${code}) for task ${taskId}: pre_check_batch passed but the workflow transition was rejected, so Stage B dispatches will be denied with TASK_WORKFLOW_STAGE_A_REQUIRED. Run /swarm recover ${taskId} to repair attribution.`,
+										);
+									} else {
+										// Non-fatal: state may already be at or past pre_check_passed
+										warn(
+											'Failed to advance task state after pre_check_batch pass',
+											{
+												taskId,
+												error: String(err),
+											},
+										);
+									}
 								}
 							}
 						}

--- a/src/hooks/guardrails/stage-a-route.ts
+++ b/src/hooks/guardrails/stage-a-route.ts
@@ -1,0 +1,102 @@
+import { appendCoreEventSync } from '../../events/core-events.js';
+import { warn } from '../../utils/logger.js';
+
+/**
+ * Stage A attribution route events (issue #2664).
+ *
+ * MANDATORY lifecycle bookkeeping: every completed gate-tool call outcome is
+ * recorded as ONE bounded event in the core event store, in BOTH guardrails
+ * modes. Optional enforcement (`guardrails.enabled=false`) removes policy
+ * denials only — it never suppresses these receipts.
+ *
+ * Bounded by construction: route is a member of the closed vocabulary, IDs
+ * are sanitized and sliced, and the serialized line stays far under both the
+ * frozen 2048-byte contract bound and the store's 256 KiB maxLineBytes, so
+ * the store's typed CORE_EVENT_LINE_TOO_LARGE / CORE_EVENT_LOCKED failures
+ * are practically unreachable. The catch exists so a locked-store storm can
+ * never turn a logged route event into a thrown exception inside the
+ * lifecycle hook (plan-critic R1-F1).
+ */
+
+export type StageAGateRoute =
+	| 'valid_pass'
+	| 'pre_check_failed'
+	| 'invalid_result'
+	| 'no_task_correlation'
+	| 'attribution_ambiguous'
+	| 'late_result'
+	| 'duplicate_result';
+
+export const STAGE_A_ROUTES: readonly StageAGateRoute[] = [
+	'valid_pass',
+	'pre_check_failed',
+	'invalid_result',
+	'no_task_correlation',
+	'attribution_ambiguous',
+	'late_result',
+	'duplicate_result',
+] as const;
+
+export const STAGE_A_ROUTE_EVENT_TYPE = 'stage_a_gate_route';
+
+/** Sanitize an identifier for event emission: printable, bounded. */
+function boundedId(value: string | null | undefined): string | null {
+	if (typeof value !== 'string') return null;
+	const cleaned = value.replace(/[\r\n\t]/g, '_').trim();
+	if (cleaned === '') return null;
+	return cleaned.slice(0, 128);
+}
+
+export interface StageAGateRouteEventInput {
+	route: StageAGateRoute;
+	sessionID: string;
+	callID: string;
+	/** Attributed task, or null when no single task is attributable. */
+	taskId: string | null;
+	guardrailsEnabled: boolean;
+}
+
+function buildEvent(input: StageAGateRouteEventInput): Record<string, unknown> {
+	return {
+		type: STAGE_A_ROUTE_EVENT_TYPE,
+		route: input.route,
+		sessionID: boundedId(input.sessionID),
+		callID: boundedId(input.callID),
+		taskId: boundedId(input.taskId),
+		guardrailsEnabled: input.guardrailsEnabled === true,
+		ts: new Date().toISOString(),
+	};
+}
+
+/**
+ * Record one Stage A route event. Fail-open for the hook: append failures
+ * (typed CORE_EVENT_LOCKED / CORE_EVENT_LINE_TOO_LARGE) are logged warn-only
+ * and never propagate into the lifecycle path. The exactly-one-event
+ * contract holds under a healthy store; the warn line is the disclosure for
+ * the exceptional window.
+ */
+export function recordStageAGateRoute(
+	directory: string,
+	input: StageAGateRouteEventInput,
+): void {
+	if (!STAGE_A_ROUTES.includes(input.route)) {
+		warn('Stage A route event rejected: route outside closed vocabulary', {
+			route: String(input.route),
+		});
+		return;
+	}
+	try {
+		appendCoreEventSync(directory, buildEvent(input));
+	} catch (error) {
+		warn('Stage A route event append failed', {
+			code: error instanceof Error ? error.message.slice(0, 80) : String(error),
+			route: input.route,
+		});
+	}
+}
+
+export const _internals = {
+	buildEvent,
+	boundedId,
+	append: appendCoreEventSync,
+};

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -361,14 +361,20 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		}
 	}
 
-	function resolveDeclaredScope(sessionID: string): string[] | null {
+	function resolveDeclaredScope(
+		sessionID: string,
+		observing = false,
+	): string[] | null {
 		const session = swarmState.agentSessions.get(sessionID);
 		if (!session?.currentTaskId) {
 			return session?.declaredCoderScope?.length
 				? [...session.declaredCoderScope]
 				: null;
 		}
-		return resolveActiveScopeBinding(sessionID)?.files ?? null;
+		const binding = observing
+			? resolveActiveScopeBindingObserving(sessionID)
+			: resolveActiveScopeBinding(sessionID);
+		return binding?.files ?? null;
 	}
 
 	/**
@@ -1075,10 +1081,15 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 
 		if (!analysis.hasWrites || analysis.writes.length === 0) return;
 
-		const declaredScope = resolveDeclaredScope(sessionID);
+		const declaredScope = resolveDeclaredScope(sessionID, !enforce);
 
 		const shellWriteAgent = swarmState.activeAgent.get(sessionID);
 		if (!shellWriteAgent) {
+			if (enforce) {
+				throw new Error(
+					`WRITE BLOCKED: No active agent registered for session "${sessionID}". Agent identity must be established (e.g. via a chat message or Task delegation) before shell writes can be authorized.`,
+				);
+			}
 			// Observe mode cannot determine coder identity without an agent;
 			// lease bookkeeping needs it, so there is nothing to observe.
 			return;
@@ -1418,7 +1429,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			return;
 		}
 
-		const declaredPaths = resolveDeclaredScope(sessionID);
+		const declaredPaths = resolveDeclaredScope(sessionID, !enforcePolicy);
 		if (!declaredPaths || declaredPaths.length === 0) {
 			recordOutcome({
 				finalCommandHash: originalCommandHash,
@@ -2486,7 +2497,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			);
 		} catch (err) {
 			const toolArgs = output.args as Record<string, unknown> | undefined;
-			const declaredScope = resolveDeclaredScope(input.sessionID);
+			// Diagnostics for an in-flight denial must never throw their own
+			// binding diagnostics over the original error: observing mode.
+			const declaredScope = resolveDeclaredScope(input.sessionID, true);
 			const declaredScopeText =
 				declaredScope != null && declaredScope.length > 0
 					? declaredScope.join(', ')
@@ -2638,6 +2651,11 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			) {
 				structuralPatch = (patchArgs.cmd as unknown[])[1] as string;
 			}
+			if (structuralPatch === undefined && typeof patchArgs?.cmd === 'string') {
+				// Mirrors write-target-resolver: a plain-string cmd is a patch
+				// payload shape, not an argv array.
+				structuralPatch = patchArgs.cmd;
+			}
 			if ((structuralPatch ?? '').length > 1_000_000) {
 				throw new Error(
 					'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
@@ -2705,12 +2723,14 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 						`WRITE BLOCKED: No active agent registered for session "${input.sessionID}". Call startAgentSession before issuing write tool calls.`,
 					);
 				}
-				// lstat: block writes through symlinks
+				// lstat: block writes through symlinks. The decision is RECORDED in
+				// both modes (observe-mode audit stays active per issue #2664); only
+				// the denial itself is enforcement-gated.
 				const lstatBlock = checkWriteTargetForSymlink(
 					targetPath,
 					writeDirectory,
 				);
-				if (lstatBlock && enforcePolicy) {
+				if (lstatBlock) {
 					void appendGuardrailDecision(
 						{
 							type: 'file_write',
@@ -2721,7 +2741,10 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 							path: targetPath,
 							reason: lstatBlock,
 							resolvedScope: (() => {
-								const scope = resolveDeclaredScope(input.sessionID);
+								const scope = resolveDeclaredScope(
+									input.sessionID,
+									!enforcePolicy,
+								);
 								return scope != null && scope.length > 0
 									? scope.join(', ')
 									: '';
@@ -2732,7 +2755,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 							enabled: shellAuditEnabled,
 						},
 					);
-					throw new Error(lstatBlock);
+					if (enforcePolicy) {
+						throw new Error(lstatBlock);
+					}
 				}
 
 				// Per-agent authority check
@@ -2757,7 +2782,6 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					},
 				);
 				if (!authorityCheck.allowed) {
-					if (!enforcePolicy) continue;
 					const evidenceEventID =
 						authorityCheck.layer === 'protected-path'
 							? recordFullAutoSevereEvidenceEvent({
@@ -2788,6 +2812,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 							enabled: shellAuditEnabled,
 						},
 					);
+					if (!enforcePolicy) {
+						continue;
+					}
 					throw new Error(
 						`WRITE BLOCKED: Agent "${agentName}" is not authorised to write "${targetPath}". Reason: ${authorityCheck.reason}${evidenceEventID ? ` Evidence event: ${evidenceEventID}.` : ''}`,
 					);

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -148,6 +148,16 @@ export interface ToolBeforeContext {
 	}) => void;
 	/** Snapshot an exact authorized write for success-only lease renewal. */
 	rememberScopeLeaseCandidate?: (input: ScopeLeaseCandidateInput) => void;
+	/**
+	 * Issue #2664: whether OPTIONAL policy enforcement is active. When false
+	 * (guardrails.enabled=false), every policy denial below is skipped while
+	 * all mandatory lifecycle bookkeeping (gate correlation in the wrapper,
+	 * lease candidates, modified-file/reviewer-scope tracking) keeps running.
+	 * Defaults to true — direct unit callers are unchanged. Structural
+	 * fail-closed bounds (the 1 MiB patch-payload guard) stay active in both
+	 * modes.
+	 */
+	enforcePolicy?: boolean;
 }
 
 // Shared helper functions extracted to helpers.ts (task 1.4 / FR-005)
@@ -237,6 +247,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		rememberReviewerScopeWrite,
 		rememberScopeLeaseCandidate,
 	} = ctx;
+	// Issue #2664: optional-enforcement gate. Bookkeeping below is mandatory
+	// and runs regardless of this flag.
+	const enforcePolicy = ctx.enforcePolicy !== false;
 
 	// Issue #2236 F6a item 3: propagate the resolved macOS sandbox activation
 	// gate to the sandbox executor factory. Must run here, synchronously, at
@@ -333,6 +346,19 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			session.declaredCoderScope = [...binding.files];
 		}
 		return binding;
+	}
+
+	// Issue #2664: observe-only variant for mandatory lease bookkeeping when
+	// optional enforcement is disabled. Converts the resolver's diagnostic
+	// throw (SCOPE_BINDING_*/STALE/EXPIRED) into a null so observe-mode call
+	// sites simply find no binding — the throwing resolver above is UNCHANGED
+	// and remains the only resolver enforcement call sites use.
+	function resolveActiveScopeBindingObserving(sessionID: string) {
+		try {
+			return resolveActiveScopeBinding(sessionID);
+		} catch {
+			return null;
+		}
 	}
 
 	function resolveDeclaredScope(sessionID: string): string[] | null {
@@ -967,7 +993,11 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		tool: string,
 		args: unknown,
 		commandOverride?: string,
+		options?: { enforce?: boolean },
 	): void {
+		// Issue #2664 observe mode: skip every denial below, keep the
+		// reviewer-scope routing and lease-candidate bookkeeping.
+		const enforce = options?.enforce !== false;
 		if (tool !== 'bash' && tool !== 'shell') return;
 		const session = swarmState.agentSessions.get(sessionID);
 
@@ -998,7 +1028,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 
 		const interactiveShellType =
 			shellType === 'unix' || shellType === 'bash' ? 'posix' : shellType;
-		if (detectInteractiveSession(command, interactiveShellType)) {
+		if (enforce && detectInteractiveSession(command, interactiveShellType)) {
 			throw new Error(
 				`BLOCKED: interactive/session tool detected — rejecting for safety`,
 			);
@@ -1014,7 +1044,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		// Fail-closed parse gate runs on the ORIGINAL command so a genuinely
 		// malformed command (e.g. an unclosed quote) is still rejected for safety.
 		const primaryAnalysis = detect(command);
-		if (primaryAnalysis.parseError) {
+		if (enforce && primaryAnalysis.parseError) {
 			throw new Error(
 				`BLOCKED: bash write detection failed to parse command — rejecting for safety`,
 			);
@@ -1037,7 +1067,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 
 		// A wrapped command whose unwrapped inner form fails to parse is also
 		// rejected for safety.
-		if (analysis.parseError) {
+		if (enforce && analysis.parseError) {
 			throw new Error(
 				`BLOCKED: bash write detection failed to parse command — rejecting for safety`,
 			);
@@ -1049,9 +1079,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 
 		const shellWriteAgent = swarmState.activeAgent.get(sessionID);
 		if (!shellWriteAgent) {
-			throw new Error(
-				`WRITE BLOCKED: No active agent registered for session "${sessionID}". Call startAgentSession before issuing shell write operations.`,
-			);
+			// Observe mode cannot determine coder identity without an agent;
+			// lease bookkeeping needs it, so there is nothing to observe.
+			return;
 		}
 
 		const shellWriteRole = stripKnownSwarmPrefix(shellWriteAgent).toLowerCase();
@@ -1064,7 +1094,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		const isImmutableNonWriter =
 			shellRoleCapability === 'read-only' ||
 			shellRoleCapability === 'dedicated-tool-only';
-		if (isCoder && (!declaredScope || declaredScope.length === 0)) {
+		if (enforce && isCoder && (!declaredScope || declaredScope.length === 0)) {
 			throw new Error(
 				`SCOPE_NOT_DECLARED: ${shellWriteAgent} cannot perform shell writes without an active Task-correlated scope binding. ACTION[architect]: call declare_scope with the exact workspace-relative paths and replace_existing=true, then dispatch a new Task call.`,
 			);
@@ -1102,7 +1132,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					// phantom marker instead of hard-blocking the whole command.
 					continue;
 				}
-				if (write.original.category === 'interpreter_eval') {
+				if (enforce && write.original.category === 'interpreter_eval') {
 					// Inline code (`python -c`, `node -e`, …) can write to arbitrary
 					// files whose targets are not statically knowable, so it cannot be
 					// verified against the declared scope. This stays fail-closed (it is
@@ -1115,15 +1145,22 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				}
 				// A concrete redirect/builtin target that resolved to null because it
 				// uses a shell variable or command substitution ($VAR, $(cmd)) —
-				// genuinely unverifiable, so keep failing closed.
-				throw new Error(
-					`BLOCKED: bash/shell write to a dynamic path target${
-						write.original.path ? ` "${write.original.path}"` : ''
-					} that cannot be statically resolved (shell variable or command substitution) — rejecting for safety.`,
-				);
+				// genuinely unverifiable, so keep failing closed. Observe mode
+				// skips this write target; the aggregate lease candidate below
+				// is not remembered (targets must be provable, issue #2664).
+				if (enforce) {
+					throw new Error(
+						`BLOCKED: bash/shell write to a dynamic path target${
+							write.original.path ? ` "${write.original.path}"` : ''
+						} that cannot be statically resolved (shell variable or command substitution) — rejecting for safety.`,
+					);
+				}
+				// Observe mode: an unprovable target cannot participate in
+				// exact-bound lease bookkeeping — skip it (issue #2664).
+				continue;
 			}
 
-			if (noScopeLenient && universalDenyPrefixes.length > 0) {
+			if (enforce && noScopeLenient && universalDenyPrefixes.length > 0) {
 				for (const prefix of universalDenyPrefixes) {
 					if (
 						matchesAuthorityDenyPrefix(
@@ -1155,7 +1192,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					verifierConfigPaths: authorityConfig?.verifier_config_paths,
 				},
 			);
-			if (!authorityCheck.allowed) {
+			if (enforce && !authorityCheck.allowed) {
 				const evidenceEventID =
 					authorityCheck.layer === 'protected-path'
 						? recordFullAutoSevereEvidenceEvent({
@@ -1171,6 +1208,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			}
 
 			if (
+				enforce &&
 				declaredScope &&
 				declaredScope.length > 0 &&
 				!isInDeclaredScope(write.resolvedPath, declaredScope, shellDirectory)
@@ -1186,7 +1224,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				);
 			}
 			if (isCoder && session?.currentTaskId) {
-				const writeBinding = resolveActiveScopeBinding(sessionID);
+				const writeBinding = enforce
+					? resolveActiveScopeBinding(sessionID)
+					: resolveActiveScopeBindingObserving(sessionID);
 				if (
 					writeBinding?.activation === 'active' &&
 					writeBinding.parentOwnerSessionId &&
@@ -1217,7 +1257,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			}
 		}
 		if (isCoder && session?.currentTaskId) {
-			const binding = resolveActiveScopeBinding(sessionID);
+			const binding = enforce
+				? resolveActiveScopeBinding(sessionID)
+				: resolveActiveScopeBindingObserving(sessionID);
 			if (binding) {
 				rememberScopeLeaseCandidate?.({
 					callID,
@@ -2293,10 +2335,12 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		input: { tool: string; sessionID: string; callID: string },
 		output: { args: unknown },
 	): Promise<void> => {
-		assertNonTransientCircuitAllowsTool(input.sessionID, {
-			tool: input.tool,
-			args: output.args,
-		});
+		if (enforcePolicy) {
+			assertNonTransientCircuitAllowsTool(input.sessionID, {
+				tool: input.tool,
+				args: output.args,
+			});
+		}
 		// Establish the lazy fallback invocation before recording this tool's
 		// before/after correlation. Beginning it later would clear the command we
 		// just stored, losing whether a parser error came from the sandbox wrapper.
@@ -2346,10 +2390,14 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		handleDelegatedWriteTracking(input.sessionID, input.tool, output.args);
 
 		// v6.29: Loop detection for Task tool delegations
-		handleLoopDetection(input.sessionID, input.tool, output.args);
+		if (enforcePolicy) {
+			handleLoopDetection(input.sessionID, input.tool, output.args);
+		}
 
 		// Block full test suite execution without file argument
-		handleTestSuiteBlocking(input.tool, output.args);
+		if (enforcePolicy) {
+			handleTestSuiteBlocking(input.tool, output.args);
+		}
 
 		const rawShellCommand = (() => {
 			const bashArgs = output.args as Record<string, unknown> | undefined;
@@ -2384,11 +2432,15 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		}
 
 		// Interpreter gating
-		handleInterpreterGating(input.sessionID, input.tool);
+		if (enforcePolicy) {
+			handleInterpreterGating(input.sessionID, input.tool);
+		}
 
 		// Block destructive shell commands
 		try {
-			checkDestructiveCommand(input.sessionID, input.tool, output.args);
+			if (enforcePolicy) {
+				checkDestructiveCommand(input.sessionID, input.tool, output.args);
+			}
 		} catch (err) {
 			const destructiveCategory =
 				err instanceof DestructiveCommandBlockedError
@@ -2420,7 +2472,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			throw err;
 		}
 
-		// Shell write scope enforcement
+		// Shell write scope enforcement. Issue #2664: ALWAYS runs — the
+		// observe half (reviewer-scope routing + lease candidate) is mandatory
+		// bookkeeping; only the denials inside are enforcement-gated.
 		try {
 			checkShellWriteScope(
 				input.sessionID,
@@ -2428,6 +2482,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				input.tool,
 				output.args,
 				rawShellCommand,
+				{ enforce: enforcePolicy },
 			);
 		} catch (err) {
 			const toolArgs = output.args as Record<string, unknown> | undefined;
@@ -2519,23 +2574,49 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			input.tool,
 			rawShellCommand,
 		);
-		await applySandboxExecution(
-			input.sessionID,
-			input.callID,
-			input.tool,
-			output.args,
-			agentNameForSandbox,
-			rawShellCommand,
-			shellAuditEnabled,
-		);
+		if (enforcePolicy) {
+			await applySandboxExecution(
+				input.sessionID,
+				input.callID,
+				input.tool,
+				output.args,
+				agentNameForSandbox,
+				rawShellCommand,
+				shellAuditEnabled,
+			);
+		}
 
 		// Issue #853 Layer B: structural spec-drift block
-		enforceSpecDriftGate(effectiveDirectory, input.tool);
+		if (enforcePolicy) {
+			enforceSpecDriftGate(effectiveDirectory, input.tool);
+		}
 
 		// Preserve architect plan/config protection even when a malformed payload
 		// cannot be fully resolved for the universal guard pass below.
-		if (isArchitect(input.sessionID) && isWriteTool(input.tool)) {
+		if (
+			enforcePolicy &&
+			isArchitect(input.sessionID) &&
+			isWriteTool(input.tool)
+		) {
 			handlePlanAndScopeProtection(input.sessionID, input.tool, output.args);
+		}
+
+		// Issue #2664: the patch-payload size bound is STRUCTURAL, not policy —
+		// authority/observation cannot be verified over an unbounded write set,
+		// so it fails closed in BOTH modes (independent of enforcePolicy above,
+		// which only gates the architect-scoped plan/config checks).
+		if (
+			(input.tool === 'apply_patch' ||
+				input.tool === 'swarm_apply_patch' ||
+				input.tool === 'patch') &&
+			typeof (output.args as Record<string, unknown> | undefined)?.patch ===
+				'string' &&
+			((output.args as Record<string, unknown>).patch as string).length >
+				1_000_000
+		) {
+			throw new Error(
+				'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
+			);
 		}
 
 		// Issue #1875: resolve the complete write set once, before any authority,
@@ -2559,13 +2640,19 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				// Universal deny, containment, and lstat checks cannot be proven when
 				// the complete write set is unknown. This is unsafe for every role,
 				// including architect; plan/config guards remain additional checks.
-				throw new Error(`WRITE TARGET UNVERIFIABLE: ${resolution.reason}`);
+				// Issue #2664: with enforcement off the write proceeds, but exact
+				// lease maintenance still requires provable targets — no candidate.
+				if (enforcePolicy) {
+					throw new Error(`WRITE TARGET UNVERIFIABLE: ${resolution.reason}`);
+				}
 			} else {
 				resolvedFileTargets = resolution.paths;
 			}
 			const writeBinding =
 				session?.currentTaskId && isCoder
-					? resolveActiveScopeBinding(input.sessionID)
+					? enforcePolicy
+						? resolveActiveScopeBinding(input.sessionID)
+						: resolveActiveScopeBindingObserving(input.sessionID)
 					: null;
 			if (writeBinding) {
 				rememberScopeLeaseCandidate?.({
@@ -2587,6 +2674,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 			for (const targetPath of resolvedFileTargets ?? []) {
 				const agentName = swarmState.activeAgent.get(input.sessionID);
 				if (!agentName) {
+					if (!enforcePolicy) continue;
 					throw new Error(
 						`WRITE BLOCKED: No active agent registered for session "${input.sessionID}". Call startAgentSession before issuing write tool calls.`,
 					);
@@ -2596,7 +2684,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					targetPath,
 					writeDirectory,
 				);
-				if (lstatBlock) {
+				if (lstatBlock && enforcePolicy) {
 					void appendGuardrailDecision(
 						{
 							type: 'file_write',
@@ -2624,7 +2712,9 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				// Per-agent authority check
 				const writeBinding =
 					session?.currentTaskId && isCoder
-						? resolveActiveScopeBinding(input.sessionID)
+						? enforcePolicy
+							? resolveActiveScopeBinding(input.sessionID)
+							: resolveActiveScopeBindingObserving(input.sessionID)
 						: null;
 				const writeDeclaredScope = writeBinding?.files ?? null;
 
@@ -2641,6 +2731,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 					},
 				);
 				if (!authorityCheck.allowed) {
+					if (!enforcePolicy) continue;
 					const evidenceEventID =
 						authorityCheck.layer === 'protected-path'
 							? recordFullAutoSevereEvidenceEvent({
@@ -2773,13 +2864,15 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 				output.args,
 			);
 
-			await checkGateLimits({
-				sessionID: input.sessionID,
-				window,
-				agentConfig,
-				elapsedMinutes,
-				repetitionCount,
-			});
+			if (enforcePolicy) {
+				await checkGateLimits({
+					sessionID: input.sessionID,
+					window,
+					agentConfig,
+					elapsedMinutes,
+					repetitionCount,
+				});
+			}
 		}
 
 		// (2) v6.29 / issue #2063 C2+C3: PRM hard stop — DENY once.
@@ -2796,7 +2889,7 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		// proceeds. The stop is a directive to report progress, not a permanent
 		// wedge — and `EscalationTracker` re-arms both tokens on any further
 		// detection at count >= 3, so a session that ignores it is stopped again.
-		{
+		if (enforcePolicy) {
 			const prmSession = swarmState.agentSessions.get(input.sessionID);
 			if (prmSession?.prmHardStopPending) {
 				prmSession.prmHardStopPending = false;

--- a/src/hooks/guardrails/tool-before.ts
+++ b/src/hooks/guardrails/tool-before.ts
@@ -2604,19 +2604,45 @@ export function createToolBeforeHandler(ctx: ToolBeforeContext) {
 		// Issue #2664: the patch-payload size bound is STRUCTURAL, not policy —
 		// authority/observation cannot be verified over an unbounded write set,
 		// so it fails closed in BOTH modes (independent of enforcePolicy above,
-		// which only gates the architect-scoped plan/config checks).
+		// which only gates the architect-scoped plan/config checks). Resolves
+		// the payload with the same legacy precedence as extractPatchTargetPaths
+		// (input > patch > diff > aliases > cmd[1]) so every recognized field
+		// carries the bound, not just args.patch (implementation-review MINOR 4).
 		if (
-			(input.tool === 'apply_patch' ||
-				input.tool === 'swarm_apply_patch' ||
-				input.tool === 'patch') &&
-			typeof (output.args as Record<string, unknown> | undefined)?.patch ===
-				'string' &&
-			((output.args as Record<string, unknown>).patch as string).length >
-				1_000_000
+			input.tool === 'apply_patch' ||
+			input.tool === 'swarm_apply_patch' ||
+			input.tool === 'patch'
 		) {
-			throw new Error(
-				'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
-			);
+			const patchArgs = output.args as Record<string, unknown> | undefined;
+			let structuralPatch: string | undefined =
+				typeof patchArgs?.input === 'string'
+					? patchArgs.input
+					: typeof patchArgs?.patch === 'string'
+						? patchArgs.patch
+						: typeof patchArgs?.diff === 'string'
+							? patchArgs.diff
+							: undefined;
+			if (structuralPatch === undefined) {
+				for (const key of PATCH_PAYLOAD_KEYS) {
+					const value = patchArgs?.[key];
+					if (typeof value === 'string') {
+						structuralPatch = value;
+						break;
+					}
+				}
+			}
+			if (
+				structuralPatch === undefined &&
+				Array.isArray(patchArgs?.cmd) &&
+				typeof (patchArgs.cmd as unknown[])[1] === 'string'
+			) {
+				structuralPatch = (patchArgs.cmd as unknown[])[1] as string;
+			}
+			if ((structuralPatch ?? '').length > 1_000_000) {
+				throw new Error(
+					'WRITE BLOCKED: Patch payload exceeds 1 MB — authority cannot be verified for all modified paths. Split into smaller patches.',
+				);
+			}
 		}
 
 		// Issue #1875: resolve the complete write set once, before any authority,

--- a/tests/integration/guardrails-registered-host-stage-a.test.ts
+++ b/tests/integration/guardrails-registered-host-stage-a.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Issue #2664 — registered-host integration: boots the real plugin
+ * `server()`, executes real scan tools (`placeholder_scan`, `syntax_check`)
+ * through the REGISTERED tool map, and drives pre_check_batch receipts
+ * through the REGISTERED tool.execute.before/after hooks — with guardrails
+ * enabled AND disabled (XDG_CONFIG_HOME hermetic so a developer's user-level
+ * config cannot re-enable guardrails behind the project file).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readCoreEvents } from '../../src/events/core-events';
+import {
+	getTaskWorkflowSnapshot,
+	readTaskEvidence,
+	transitionTaskWorkflowEvidence,
+} from '../../src/gate-evidence';
+import OpenCodeSwarmPlugin from '../../src/index';
+import { ensureAgentSession, resetSwarmState } from '../../src/state';
+import { resetTelemetryForTesting } from '../../src/telemetry';
+import { canonicalMkdtemp } from '../helpers/tmpdir';
+
+const PASS_PAYLOAD = JSON.stringify({
+	gates_passed: true,
+	total_duration_ms: 1,
+	batch_status: 'completed',
+	lint: { ran: true, duration_ms: 1 },
+	secretscan: {
+		ran: true,
+		duration_ms: 1,
+		result: {
+			count: 0,
+			findings: [],
+			files_scanned: 5,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		},
+	},
+	sast_scan: { ran: true, duration_ms: 1, result: { verdict: 'pass' } },
+	quality_budget: { ran: false, duration_ms: 0 },
+});
+
+const FAIL_PAYLOAD = JSON.stringify({
+	gates_passed: false,
+	total_duration_ms: 1,
+	batch_status: 'completed',
+	lint: { ran: true, duration_ms: 1 },
+	secretscan: { ran: false, duration_ms: 0 },
+	sast_scan: { ran: false, duration_ms: 0 },
+	quality_budget: { ran: false, duration_ms: 0 },
+});
+
+interface Host {
+	hooks: Record<string, (input: unknown, output: unknown) => Promise<void>>;
+	tool: Record<
+		string,
+		{ execute: (args: unknown, ctx: unknown) => Promise<unknown> }
+	>;
+}
+
+let hermeticConfigHome: string;
+let prevXdg: string | undefined;
+let directory: string;
+
+async function bootHost(guardrailsEnabled: boolean): Promise<Host> {
+	const opencodeDir = path.join(directory, '.opencode');
+	fs.mkdirSync(opencodeDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(opencodeDir, 'opencode-swarm.json'),
+		JSON.stringify({
+			version_check: false,
+			knowledge: { enabled: true, hive_enabled: false },
+			guardrails: { enabled: guardrailsEnabled },
+		}),
+	);
+	const ctx = {
+		client: {},
+		project: {},
+		directory,
+		worktree: directory,
+		serverUrl: new URL('http://localhost:3000'),
+		$: {},
+	};
+	// server() returns the hook map at TOP level (the knowledge-real-host
+	// helper wraps this same object as { hooks: result, tool: result.tool }).
+	const result = (await (
+		OpenCodeSwarmPlugin as unknown as {
+			server: (c: unknown) => Promise<Record<string, unknown>>;
+		}
+	).server(ctx)) as unknown as Host;
+	return {
+		hooks: result as unknown as Host['hooks'],
+		tool: (result as unknown as { tool: Host['tool'] }).tool ?? {},
+	};
+}
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('swarm-host-stage-a-');
+	resetSwarmState();
+	resetTelemetryForTesting();
+	hermeticConfigHome = canonicalMkdtemp('swarm-host-xdg-');
+	prevXdg = process.env.XDG_CONFIG_HOME;
+	process.env.XDG_CONFIG_HOME = hermeticConfigHome;
+});
+
+afterEach(() => {
+	if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+	else process.env.XDG_CONFIG_HOME = prevXdg;
+	resetSwarmState();
+	resetTelemetryForTesting();
+	for (const dir of [directory, hermeticConfigHome]) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5 });
+		} catch {
+			/* held handles on Windows; disposable */
+		}
+	}
+});
+
+function routeEvents(): Array<Record<string, unknown>> {
+	const events: Array<Record<string, unknown>> = [];
+	for (const line of readCoreEvents(directory).text.split('\n')) {
+		if (!line.includes('stage_a_gate_route')) continue;
+		try {
+			events.push(JSON.parse(line) as Record<string, unknown>);
+		} catch {
+			/* manifest line */
+		}
+	}
+	return events;
+}
+
+describe('registered host — Stage A receipts with guardrails on and off', () => {
+	for (const enabled of [true, false]) {
+		test(`real scan tools + valid/rejected receipts (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+			fs.writeFileSync(
+				path.join(directory, 'src', 'sample.ts'),
+				'export function f() {\n  return 1;\n}\n',
+			);
+			const host = await bootHost(enabled);
+
+			// Real scan tools through the REGISTERED tool map — bounded JSON.
+			const scan = (await host.tool.placeholder_scan?.execute(
+				{ files: ['src/sample.ts'] },
+				{},
+			)) as unknown;
+			expect(scan).toBeDefined();
+			expect(Buffer.byteLength(JSON.stringify(scan), 'utf8')).toBeLessThan(
+				65_536,
+			);
+			const syntax = (await host.tool.syntax_check?.execute(
+				{ files: ['src/sample.ts'] },
+				{},
+			)) as unknown;
+			expect(syntax).toBeDefined();
+
+			// Valid receipt: pre_check_batch PASS through REGISTERED hooks.
+			await transitionTaskWorkflowEvidence(directory, '1.1', {
+				type: 'accepted_mutation',
+				agentType: 'coder',
+				expectedGeneration: 0,
+				transitionId: 'coder:setup-1.1',
+			});
+			resetSwarmState();
+			const session = ensureAgentSession('architect');
+			session.currentTaskId = '1.1';
+			await host.hooks['tool.execute.before'](
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'rp1' },
+				{ args: {} },
+			);
+			await host.hooks['tool.execute.after'](
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'rp1' },
+				{ title: '', output: PASS_PAYLOAD, metadata: null },
+			);
+			expect(
+				getTaskWorkflowSnapshot(await readTaskEvidence(directory, '1.1')).state,
+			).toBe('pre_check_passed');
+
+			// Rejected receipt: FAIL lands rework_required in BOTH modes.
+			await transitionTaskWorkflowEvidence(directory, '1.2', {
+				type: 'accepted_mutation',
+				agentType: 'coder',
+				expectedGeneration: 0,
+				transitionId: 'coder:setup-1.2',
+			});
+			resetSwarmState();
+			const session2 = ensureAgentSession('architect');
+			session2.currentTaskId = '1.2';
+			await host.hooks['tool.execute.before'](
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'rp2' },
+				{ args: {} },
+			);
+			await host.hooks['tool.execute.after'](
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'rp2' },
+				{ title: '', output: FAIL_PAYLOAD, metadata: null },
+			);
+			expect(
+				getTaskWorkflowSnapshot(await readTaskEvidence(directory, '1.2')).state,
+			).toBe('rework_required');
+
+			// Route events recorded with the correct mode flag.
+			const events = routeEvents();
+			const routes = events.map((e) => e.route);
+			expect(routes).toContain('valid_pass');
+			expect(routes).toContain('pre_check_failed');
+			for (const event of events) {
+				expect(event.guardrailsEnabled).toBe(enabled);
+			}
+		}, 120_000);
+	}
+});

--- a/tests/unit/hooks/guardrails-disabled-lifecycle.test.ts
+++ b/tests/unit/hooks/guardrails-disabled-lifecycle.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Issue #2664 — with guardrails.enabled=false the OPTIONAL policy denials
+ * are inert while MANDATORY lifecycle bookkeeping stays active: Stage A
+ * receipts land, lease candidates are remembered, and the structural
+ * 1 MiB patch-payload bound still fails closed in BOTH modes.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Plan } from '../../../src/config/plan-schema';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import {
+	getTaskWorkflowSnapshot,
+	readTaskEvidence,
+	transitionTaskWorkflowEvidence,
+} from '../../../src/gate-evidence';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import {
+	clearScopeBindings,
+	createScopeBinding,
+} from '../../../src/scope/scope-binding';
+import {
+	claimScopeBindingForChildDurably,
+	persistAndRegisterScopeBinding,
+	resolveAuthorizedScopeBinding,
+} from '../../../src/scope/scope-persistence';
+import {
+	getAgentSession,
+	resetSwarmState as resetState,
+	resetSwarmState,
+	startAgentSession,
+} from '../../../src/state';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const PASS_PAYLOAD = JSON.stringify({
+	gates_passed: true,
+	total_duration_ms: 1,
+	batch_status: 'completed',
+	lint: { ran: true, duration_ms: 1 },
+	secretscan: {
+		ran: true,
+		duration_ms: 1,
+		result: {
+			count: 0,
+			findings: [],
+			files_scanned: 5,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		},
+	},
+	sast_scan: { ran: true, duration_ms: 1, result: { verdict: 'pass' } },
+	quality_budget: { ran: false, duration_ms: 0 },
+});
+
+function config(enabled: boolean): GuardrailsConfig {
+	return {
+		enabled,
+		max_tool_calls: 1,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+	};
+}
+
+let directory: string;
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('swarm-disabled-lifecycle-');
+	fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+	resetState();
+});
+
+afterEach(() => {
+	resetState();
+	clearScopeBindings();
+	fs.rmSync(directory, { recursive: true, force: true, maxRetries: 5 });
+});
+
+describe('guardrails disabled — mandatory lifecycle, inert policy', () => {
+	test('Stage A receipt lands with guardrails off (task reaches pre_check_passed)', async () => {
+		await transitionTaskWorkflowEvidence(directory, '1.1', {
+			type: 'accepted_mutation',
+			agentType: 'coder',
+			expectedGeneration: 0,
+			transitionId: 'coder:setup-1.1',
+		});
+		resetState();
+		const { ensureAgentSession } = await import('../../../src/state');
+		const session = ensureAgentSession('architect');
+		session.currentTaskId = '1.1';
+		const hooks = createGuardrailsHooks(directory, config(false));
+		await hooks.toolBefore(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c1' },
+			{ args: {} },
+		);
+		await hooks.toolAfter(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c1' },
+			{ title: '', output: PASS_PAYLOAD, metadata: null },
+		);
+		const snapshot = getTaskWorkflowSnapshot(
+			await readTaskEvidence(directory, '1.1'),
+		);
+		expect(snapshot.state).toBe('pre_check_passed');
+	});
+
+	test('policy battery is inert with guardrails off (no denial throws)', async () => {
+		const hooks = createGuardrailsHooks(directory, config(false));
+		// Destructive-pattern shell command.
+		await hooks.toolBefore(
+			{ tool: 'bash', sessionID: 's', callID: 'p1' },
+			{ args: { command: 'rm -rf /tmp/whatever' } },
+		);
+		// Full test-suite invocation without a file argument.
+		await hooks.toolBefore(
+			{ tool: 'bash', sessionID: 's', callID: 'p2' },
+			{ args: { command: 'bun test' } },
+		);
+		// Interpreter command (bash tool is always interpreter-gated shape).
+		await hooks.toolBefore(
+			{ tool: 'bash', sessionID: 's', callID: 'p3' },
+			{ args: { command: 'echo ok' } },
+		);
+	});
+
+	test('policy battery still denies with guardrails on (control)', async () => {
+		const hooks = createGuardrailsHooks(directory, config(true));
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'bash', sessionID: 's', callID: 'p1' },
+				{ args: { command: 'rm -rf /tmp/whatever' } },
+			),
+		).rejects.toThrow();
+	});
+
+	test('structural 1 MiB patch-payload bound still fails closed with guardrails off', async () => {
+		const hooks = createGuardrailsHooks(directory, config(false));
+		const hugePatch = `*** Begin Patch\n${'x'.repeat(1_100_000)}\n*** End Patch\n`;
+		await expect(
+			hooks.toolBefore(
+				{ tool: 'apply_patch', sessionID: 's', callID: 'big' },
+				{ args: { patch: hugePatch } },
+			),
+		).rejects.toThrow(/Patch payload exceeds 1 MB/);
+	});
+
+	test('lease maintenance active with guardrails off (revision CAS bump)', async () => {
+		const plan: Plan = {
+			schema_version: '1.0.0',
+			title: 'lease',
+			swarm: 'test',
+			current_phase: 1,
+			phases: [
+				{
+					id: 1,
+					name: 'Implementation',
+					status: 'in_progress',
+					tasks: [
+						{
+							id: '1.1',
+							phase: 1,
+							status: 'pending',
+							size: 'small',
+							description: 'renew',
+							depends: [],
+							files_touched: ['src/a.ts'],
+						},
+					],
+				},
+			],
+		};
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'plan.json'),
+			JSON.stringify(plan),
+		);
+		const pending = createScopeBinding({
+			directory,
+			plan,
+			taskId: '1.1',
+			files: ['src/a.ts'],
+			ownerSessionId: 'architect-session',
+			ownerMessageId: 'task-call',
+			dispatchCallId: 'task-call',
+			activation: 'pending_child',
+			source: 'plan',
+		});
+		expect(pending).not.toBeNull();
+		const published = await persistAndRegisterScopeBinding(directory, pending!);
+		expect(published.ok).toBe(true);
+		const claimed = await claimScopeBindingForChildDurably({
+			directory,
+			parentSessionId: 'architect-session',
+			childSessionId: 'coder-session',
+			dispatchCallId: 'task-call',
+		});
+		expect(claimed.ok).toBe(true);
+		const before = claimed.value.claimed;
+		startAgentSession('coder-session', 'coder', directory);
+		const session = getAgentSession('coder-session');
+		expect(session).not.toBeNull();
+		session!.currentTaskId = '1.1';
+		session!.declaredCoderScope = ['src/a.ts'];
+		const file = path.join(directory, 'src', 'a.ts');
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, 'before');
+		const hooks = createGuardrailsHooks(directory, config(false));
+		await hooks.toolBefore(
+			{ tool: 'write', sessionID: 'coder-session', callID: 'w1' },
+			{ args: { path: 'src/a.ts', content: 'after' } },
+		);
+		fs.writeFileSync(file, 'after');
+		await hooks.toolAfter(
+			{ tool: 'write', sessionID: 'coder-session', callID: 'w1' },
+			{ title: '', output: 'Wrote file successfully.', metadata: null },
+		);
+		const refreshed = resolveAuthorizedScopeBinding({
+			directory,
+			taskId: '1.1',
+			activeSessionId: 'coder-session',
+		});
+		expect(refreshed).not.toBeNull();
+		expect(refreshed!.revision).toBe(before.revision + 1);
+		expect(refreshed!.expiresAt).toBeGreaterThanOrEqual(before.expiresAt);
+	});
+});

--- a/tests/unit/hooks/guardrails-disabled.test.ts
+++ b/tests/unit/hooks/guardrails-disabled.test.ts
@@ -7,7 +7,7 @@ import { GuardrailsConfigSchema } from '../../../src/config/schema';
 import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
 
 describe('guardrails disabled — end-to-end', () => {
-	it('config file with guardrails.enabled:false → createGuardrailsHooks → toolBefore is a noop', async () => {
+	it('config file with guardrails.enabled:false → createGuardrailsHooks → policy denials skipped, handlers still resolve (issue #2664)', async () => {
 		// Write a temp config file with guardrails: { enabled: false }
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-test-'));
 		const originalXDG = process.env.XDG_CONFIG_HOME;
@@ -37,22 +37,32 @@ describe('guardrails disabled — end-to-end', () => {
 				);
 				expect(guardrailsConfig.enabled).toBe(false);
 
-				// Create guardrails hooks — should return noops
-				const hooks = createGuardrailsHooks(guardrailsConfig);
+				// Create guardrails hooks — issue #2664: handlers are REAL, not
+				// no-ops; only the optional policy denials are inert. A shell
+				// command that would be policy-blocked with guardrails on
+				// (destruction-pattern prefix, no registered agent) must pass
+				// through without throwing, and both hook halves must resolve.
+				const hooks = createGuardrailsHooks(projectDir, guardrailsConfig);
 
-				// toolBefore should be a noop (returns undefined, doesn't throw)
 				const result = await hooks.toolBefore(
 					{ tool: 'bash', sessionID: 'test-session', callID: 'call-1' },
 					{ args: { command: 'echo hello' } },
 				);
 				expect(result).toBeUndefined();
 
-				// toolAfter should also be a noop
 				const afterResult = await hooks.toolAfter(
 					{ tool: 'bash', sessionID: 'test-session', callID: 'call-1' },
 					{ title: 'bash', output: 'hello', metadata: {} },
 				);
 				expect(afterResult).toBeUndefined();
+
+				// Optional enforcement is inert: a destructive-pattern shell
+				// command (no file argument — also the test-suite-block shape)
+				// must NOT throw with guardrails disabled.
+				await hooks.toolBefore(
+					{ tool: 'bash', sessionID: 'test-session', callID: 'call-2' },
+					{ args: { command: 'rm -rf /tmp/does-not-matter' } },
+				);
 			} finally {
 				fs.rmSync(projectDir, { recursive: true, force: true });
 			}

--- a/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
+++ b/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
@@ -235,14 +235,44 @@ describe('stage-a-route-events', () => {
 		});
 
 		test(`non-authoritative evidence never classifies as duplicate (guardrails ${enabled ? 'on' : 'off'})`, async () => {
-			// No durable evidence at all + no pending correlation + a session
-			// whose currentTaskId points at a task that was never settled: the
-			// duplicate predicate must fail closed (authoritative===true is a
-			// precondition) instead of misclassifying.
-			await drive(enabled, 'c-nonauth', PASS_PAYLOAD, 'none');
+			// Production-shaped evidence whose workflow metadata is made
+			// NON-authoritative (schema !== 'exact-task-v1') while its
+			// lastTransitionId equals this call's pre-check receipt.
+			// Without the authoritative precondition this exact shape
+			// misclassifies the replay as duplicate_result (the R1-F4
+			// fail-open window); the precondition fails it closed.
+			await settle('1.1');
+			const evidencePath = path.join(
+				directory,
+				'.swarm',
+				'evidence',
+				'1.1.json',
+			);
+			const evidence = JSON.parse(fs.readFileSync(evidencePath, 'utf8')) as {
+				workflow: Record<string, unknown>;
+			};
+			evidence.workflow = {
+				...evidence.workflow,
+				schema: 'legacy-v0',
+				lastTransitionId: 'pre-check:c-nonauth',
+				lastOutcome: 'stage_a_passed',
+			};
+			fs.writeFileSync(evidencePath, JSON.stringify(evidence));
+			const session = ensureAgentSession('architect');
+			session.currentTaskId = '1.1';
+			const hooks = createGuardrailsHooks(directory, config(enabled));
+			await hooks.toolAfter(
+				{
+					tool: 'pre_check_batch',
+					sessionID: 'architect',
+					callID: 'c-nonauth',
+				},
+				{ title: '', output: PASS_PAYLOAD, metadata: null },
+			);
 			const events = routeEvents(directory);
 			expect(events).toHaveLength(1);
 			expect(events[0]?.route).toBe('no_task_correlation');
+			expect(events[0]?.taskId).toBeNull();
 		});
 	}
 

--- a/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
+++ b/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Issue #2664 — Stage A attribution route events: unit coverage for route
+ * classification and receipt shape through createGuardrailsHooks, in BOTH
+ * guardrails modes. The route events are one bounded line per completed
+ * pre_check_batch outcome in the core event store
+ * (`type: "stage_a_gate_route"`), fields
+ * route/sessionID/callID/taskId/guardrailsEnabled.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { GuardrailsConfig } from '../../../src/config/schema';
+import { readCoreEvents } from '../../../src/events/core-events';
+import {
+	getTaskWorkflowSnapshot,
+	readTaskEvidence,
+	transitionTaskWorkflowEvidence,
+} from '../../../src/gate-evidence';
+import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import {
+	STAGE_A_ROUTE_EVENT_TYPE,
+	STAGE_A_ROUTES,
+} from '../../../src/hooks/guardrails/stage-a-route';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const PASS_PAYLOAD = JSON.stringify({
+	gates_passed: true,
+	total_duration_ms: 1,
+	batch_status: 'completed',
+	lint: { ran: true, duration_ms: 1 },
+	secretscan: {
+		ran: true,
+		duration_ms: 1,
+		result: {
+			count: 0,
+			findings: [],
+			files_scanned: 5,
+			incomplete_files: 0,
+			incomplete_paths: [],
+		},
+	},
+	sast_scan: { ran: true, duration_ms: 1, result: { verdict: 'pass' } },
+	quality_budget: { ran: false, duration_ms: 0 },
+});
+
+function config(enabled: boolean): GuardrailsConfig {
+	return {
+		enabled,
+		max_tool_calls: 200,
+		max_duration_minutes: 30,
+		idle_timeout_minutes: 60,
+		max_repetitions: 10,
+		max_consecutive_errors: 5,
+		warning_threshold: 0.75,
+	};
+}
+
+interface RouteEvent {
+	route: string;
+	sessionID: unknown;
+	callID: unknown;
+	taskId: unknown;
+	guardrailsEnabled: unknown;
+}
+
+function routeEvents(directory: string): RouteEvent[] {
+	const read = readCoreEvents(directory);
+	const events: RouteEvent[] = [];
+	for (const line of read.text.split('\n')) {
+		if (!line.trim()) continue;
+		try {
+			const parsed = JSON.parse(line) as Record<string, unknown>;
+			if (parsed.type === STAGE_A_ROUTE_EVENT_TYPE) {
+				events.push(parsed as unknown as RouteEvent);
+			}
+		} catch {
+			// skip non-JSON manifest line
+		}
+	}
+	return events;
+}
+
+let directory: string;
+
+beforeEach(() => {
+	directory = canonicalMkdtemp('swarm-route-events-');
+	fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
+	resetSwarmState();
+});
+
+afterEach(() => {
+	resetSwarmState();
+	fs.rmSync(directory, { recursive: true, force: true, maxRetries: 5 });
+});
+
+async function settle(taskId: string): Promise<void> {
+	await transitionTaskWorkflowEvidence(directory, taskId, {
+		type: 'accepted_mutation',
+		agentType: 'coder',
+		expectedGeneration: 0,
+		transitionId: `coder:setup-${taskId}`,
+	});
+}
+
+async function drive(
+	enabled: boolean,
+	callID: string,
+	payload: unknown,
+	setup: 'correlated' | 'none',
+): Promise<void> {
+	if (setup === 'correlated') {
+		await settle('1.1');
+	}
+	const session = ensureAgentSession('architect');
+	if (setup === 'correlated') session.currentTaskId = '1.1';
+	const hooks = createGuardrailsHooks(directory, config(enabled));
+	await hooks.toolBefore(
+		{ tool: 'pre_check_batch', sessionID: 'architect', callID },
+		{ args: {} },
+	);
+	await hooks.toolAfter(
+		{ tool: 'pre_check_batch', sessionID: 'architect', callID },
+		{ title: '', output: payload, metadata: null },
+	);
+}
+
+describe('stage-a-route-events', () => {
+	test('vocabulary is closed with exactly the seven frozen routes', () => {
+		expect([...STAGE_A_ROUTES].sort()).toEqual([
+			'attribution_ambiguous',
+			'duplicate_result',
+			'invalid_result',
+			'late_result',
+			'no_task_correlation',
+			'pre_check_failed',
+			'valid_pass',
+		]);
+	});
+
+	for (const enabled of [true, false]) {
+		test(`valid pass receipt: route=valid_pass taskId set (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			await drive(enabled, 'c-pass', PASS_PAYLOAD, 'correlated');
+			const snapshot = getTaskWorkflowSnapshot(
+				await readTaskEvidence(directory, '1.1'),
+			);
+			expect(snapshot.state).toBe('pre_check_passed');
+			const events = routeEvents(directory);
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({
+				route: 'valid_pass',
+				sessionID: 'architect',
+				callID: 'c-pass',
+				taskId: '1.1',
+				guardrailsEnabled: enabled,
+			});
+		});
+
+		test(`invalid result: no transition, route=invalid_result (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			await drive(
+				enabled,
+				'c-invalid',
+				'definitely not json {{{',
+				'correlated',
+			);
+			const snapshot = getTaskWorkflowSnapshot(
+				await readTaskEvidence(directory, '1.1'),
+			);
+			expect(snapshot.state).toBe('coder_delegated');
+			const events = routeEvents(directory);
+			expect(events).toHaveLength(1);
+			expect(events[0]?.route).toBe('invalid_result');
+			expect(events[0]?.taskId).toBe('1.1');
+		});
+
+		test(`no task correlation: bounded, no advance (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			await drive(enabled, 'c-nocorr', PASS_PAYLOAD, 'none');
+			const events = routeEvents(directory);
+			expect(events).toHaveLength(1);
+			expect(events[0]?.route).toBe('no_task_correlation');
+			expect(events[0]?.taskId).toBeNull();
+			expect(events[0]?.guardrailsEnabled).toBe(enabled);
+		});
+
+		test(`duplicate replay is idempotent: valid_pass then duplicate_result, state frozen (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			await drive(enabled, 'c-dup', PASS_PAYLOAD, 'correlated');
+			// Second delivery of the SAME callID after the pending receipt was
+			// consumed: the durable pre-check:<callID> receipt already applied.
+			const hooks = createGuardrailsHooks(directory, config(enabled));
+			await hooks.toolAfter(
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c-dup' },
+				{ title: '', output: PASS_PAYLOAD, metadata: null },
+			);
+			const snapshot = getTaskWorkflowSnapshot(
+				await readTaskEvidence(directory, '1.1'),
+			);
+			expect(snapshot.state).toBe('pre_check_passed');
+			expect(snapshot.generation).toBe(1);
+			const events = routeEvents(directory);
+			expect(events.map((e) => e.route)).toEqual([
+				'valid_pass',
+				'duplicate_result',
+			]);
+		});
+
+		test(`late result: generation mismatch never advances (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			await settle('1.1');
+			const session = ensureAgentSession('architect');
+			session.currentTaskId = '1.1';
+			const hooks = createGuardrailsHooks(directory, config(enabled));
+			await hooks.toolBefore(
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c-late' },
+				{ args: {} },
+			);
+			// Task repaired before the gate result arrives: generation bumps,
+			// the pending correlation is now stale.
+			await transitionTaskWorkflowEvidence(directory, '1.1', {
+				type: 'repair_idle',
+				expectedGeneration: 1,
+				transitionId: 'repair:gen-bump',
+			});
+			await hooks.toolAfter(
+				{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c-late' },
+				{ title: '', output: PASS_PAYLOAD, metadata: null },
+			);
+			const snapshot = getTaskWorkflowSnapshot(
+				await readTaskEvidence(directory, '1.1'),
+			);
+			expect(snapshot.state).toBe('idle');
+			expect(snapshot.generation).toBe(2);
+			const events = routeEvents(directory);
+			expect(events).toHaveLength(1);
+			expect(events[0]?.route).toBe('late_result');
+			expect(events[0]?.taskId).toBe('1.1');
+		});
+
+		test(`non-authoritative evidence never classifies as duplicate (guardrails ${enabled ? 'on' : 'off'})`, async () => {
+			// No durable evidence at all + no pending correlation + a session
+			// whose currentTaskId points at a task that was never settled: the
+			// duplicate predicate must fail closed (authoritative===true is a
+			// precondition) instead of misclassifying.
+			await drive(enabled, 'c-nonauth', PASS_PAYLOAD, 'none');
+			const events = routeEvents(directory);
+			expect(events).toHaveLength(1);
+			expect(events[0]?.route).toBe('no_task_correlation');
+		});
+	}
+
+	test('unbound durable fallback classifies as attribution_ambiguous (guardrails off)', async () => {
+		// Sole durable candidate whose declared files do not match the scan.
+		await settle('1.1');
+		const walDir = path.join(directory, '.swarm', 'coder-settlements');
+		fs.mkdirSync(walDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(walDir, '1.1.json'),
+			JSON.stringify({
+				version: 1,
+				state: 'COMMITTED',
+				taskId: '1.1',
+				transitionId: 'coder:test-1.1',
+				actor: 'test',
+				processId: process.pid,
+				runtimeId: '00000000-0000-4000-8000-000000000000',
+				expectedGeneration: 1,
+				context: {
+					baseline: {
+						directory,
+						gitHead: null,
+						dirtyHash: null,
+						prHeadSha: null,
+						scope: null,
+						changedFiles: [],
+					},
+					declaredFiles: ['src/a.ts'],
+				},
+				accepted: true,
+				recordedAt: '2026-01-01T00:00:00.000Z',
+			}),
+		);
+		resetSwarmState();
+		ensureAgentSession('architect');
+		const hooks = createGuardrailsHooks(directory, config(false));
+		await hooks.toolBefore(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c-unbound' },
+			{ args: { files: ['README.md'] } },
+		);
+		await hooks.toolAfter(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'c-unbound' },
+			{ title: '', output: PASS_PAYLOAD, metadata: null },
+		);
+		const snapshot = getTaskWorkflowSnapshot(
+			await readTaskEvidence(directory, '1.1'),
+		);
+		expect(snapshot.state).toBe('coder_delegated');
+		const events = routeEvents(directory);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.route).toBe('attribution_ambiguous');
+		expect(events[0]?.taskId).toBeNull();
+	});
+
+	test('event lines stay within the 2048-byte contract bound', async () => {
+		await drive(false, 'c-bounded'.padEnd(120, 'x'), PASS_PAYLOAD, 'none');
+		const read = readCoreEvents(directory);
+		for (const line of read.text.split('\n')) {
+			if (line.includes(STAGE_A_ROUTE_EVENT_TYPE)) {
+				expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(2048);
+			}
+		}
+	});
+});

--- a/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
+++ b/tests/unit/hooks/guardrails-stage-a-route-events.test.ts
@@ -16,7 +16,10 @@ import {
 	readTaskEvidence,
 	transitionTaskWorkflowEvidence,
 } from '../../../src/gate-evidence';
-import { createGuardrailsHooks } from '../../../src/hooks/guardrails';
+import {
+	_internals,
+	createGuardrailsHooks,
+} from '../../../src/hooks/guardrails';
 import {
 	STAGE_A_ROUTE_EVENT_TYPE,
 	STAGE_A_ROUTES,
@@ -336,5 +339,59 @@ describe('stage-a-route-events', () => {
 				expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(2048);
 			}
 		}
+	});
+
+	test('pending-route capacity bounds are pinned via _internals', () => {
+		expect(_internals.MAX_PENDING_GATE_ROUTES_PER_SESSION).toBe(256);
+		expect(_internals.MAX_PENDING_GATE_ROUTE_SESSIONS).toBe(500);
+	});
+
+	test('per-session pending-route overflow is bounded and never throws', async () => {
+		resetSwarmState();
+		ensureAgentSession('architect');
+		const hooks = createGuardrailsHooks(directory, config(false));
+		// Exceed the 256-per-session bound with unresolved toolBefore calls;
+		// the capacity throw must be caught warn-only at the remember site.
+		for (let i = 0; i < 260; i++) {
+			await hooks.toolBefore(
+				{
+					tool: 'pre_check_batch',
+					sessionID: 'architect',
+					callID: `c-overflow-${i}`,
+				},
+				{ args: {} },
+			);
+		}
+		// The lifecycle path stays fully functional after overflow.
+		await hooks.toolAfter(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'after' },
+			{ title: '', output: PASS_PAYLOAD, metadata: null },
+		);
+		const events = routeEvents(directory);
+		expect(events.length).toBeGreaterThanOrEqual(1);
+	});
+
+	test('cross-session pending-route overflow is bounded and never throws', async () => {
+		for (let i = 0; i < 503; i++) {
+			const sessionID = `cap-session-${i}`;
+			ensureAgentSession(sessionID);
+			const hooks = createGuardrailsHooks(directory, config(false));
+			await hooks.toolBefore(
+				{ tool: 'pre_check_batch', sessionID, callID: `cs-${i}` },
+				{ args: {} },
+			);
+		}
+		resetSwarmState();
+		ensureAgentSession('architect');
+		const hooks = createGuardrailsHooks(directory, config(false));
+		await hooks.toolBefore(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'cs-final' },
+			{ args: {} },
+		);
+		await hooks.toolAfter(
+			{ tool: 'pre_check_batch', sessionID: 'architect', callID: 'cs-final' },
+			{ title: '', output: PASS_PAYLOAD, metadata: null },
+		);
+		expect(routeEvents(directory).length).toBeGreaterThanOrEqual(1);
 	});
 });

--- a/tests/unit/hooks/guardrails-stage-a-route-vocabulary-docs.test.ts
+++ b/tests/unit/hooks/guardrails-stage-a-route-vocabulary-docs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #2664 — deterministic set-equality between the code's closed Stage A
+ * route vocabulary (STAGE_A_ROUTES) and the documented route table in
+ * docs/configuration.md. Adding/removing a route without updating the docs
+ * (or vice versa) fails here.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { STAGE_A_ROUTES } from '../../../src/hooks/guardrails/stage-a-route';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '..', '..', '..');
+const DOC = path.join(REPO_ROOT, 'docs', 'configuration.md');
+
+function documentedRoutes(): Set<string> {
+	expect(fs.existsSync(DOC)).toBe(true);
+	const text = fs.readFileSync(DOC, 'utf8');
+	const routes = new Set<string>();
+	for (const route of STAGE_A_ROUTES) {
+		// Each documented route appears as a table row `| <route> |`.
+		if (new RegExp(`\\|\\s*${route}\\s*\\|`).test(text)) routes.add(route);
+	}
+	// Inverse: no documented route row outside the code vocabulary.
+	for (const match of text.matchAll(/\|\s*([a-z_]+)\s*\|\s*[A-Z]/g)) {
+		const candidate = match[1];
+		if ((STAGE_A_ROUTES as readonly string[]).includes(candidate)) continue;
+		// Any other snake_case row token immediately followed by a capital
+		// letter (the description column) that looks like a route is drift.
+		if (
+			/^(valid_pass|pre_check_failed|invalid_result|no_task_correlation|attribution_ambiguous|late_result|duplicate_result)/.test(
+				candidate,
+			)
+		) {
+			throw new Error(`Undocumented-code route row found: ${candidate}`);
+		}
+	}
+	return routes;
+}
+
+describe('stage-a-route vocabulary docs parity', () => {
+	test('every STAGE_A_ROUTES member is documented in docs/configuration.md (set equality)', () => {
+		const documented = documentedRoutes();
+		for (const route of STAGE_A_ROUTES) {
+			expect(documented.has(route)).toBe(true);
+		}
+		expect(documented.size).toBe(STAGE_A_ROUTES.length);
+	});
+});


### PR DESCRIPTION
Closes #2664

## Summary

**Root cause.** `createGuardrailsHooks` returned a no-op hook object when `guardrails.enabled === false` (the early return formerly at `src/hooks/guardrails/index.ts:741-748`). That branch suppressed not just optional *enforcement* but also mandatory *lifecycle bookkeeping*: Stage A receipts (toolBefore callID→task correlation plus the `stage_a_passed`/`stage_a_failed` workflow transitions) and exact-bound scope-lease maintenance (`scopeLeaseRenewal` remember/consume → `refreshScopeBindingLease`). With guardrails disabled, a valid `pre_check_batch` result was silently dropped (task stuck in `coder_delegated`), unattributable/late/duplicate gate results left no audit trail, and a successful in-scope coder write stopped renewing its scope binding's lease.

**Fix — enforcement is now gated separately from bookkeeping:**

- `src/hooks/guardrails/index.ts` — removed the no-op early return; `enforcementEnabled` flows to the handlers as `enforcePolicy` while correlation, transitions, and lease maintenance always run. A session-keyed `pendingGateRoutesBySession` map (bounded 500 sessions × 256 entries, delete-on-read) carries toolBefore correlation to toolAfter.
- `src/hooks/guardrails/stage-a-route.ts` (new) — `recordStageAGateRoute` appends one bounded `stage_a_gate_route` event per completed `pre_check_batch` outcome to `.swarm/events.jsonl` through the sanctioned `appendCoreEventSync` seam, with a closed 7-route vocabulary (`valid_pass`, `pre_check_failed`, `invalid_result`, `no_task_correlation`, `attribution_ambiguous`, `late_result`, `duplicate_result`), IDs ≤128 chars, line ≤2 KiB, warn-only on append failure. Every Stage A attribution route is now recorded in both guardrails modes.
- `src/hooks/guardrails/tool-before.ts` — every policy *denial* site is gated on `enforcePolicy` (loop detection, destructive commands, scope violations, authority, gate limits, …) while mandatory bookkeeping (file-modification recording, reviewer-scope writes, lease candidates) stays unconditional; an observing resolver feeds lease maintenance in observe mode without widening enforcement; the structural patch-payload bound (>1 MiB → `WRITE BLOCKED`) resolves across the full `PATCH_PAYLOAD_KEYS` set with legacy precedence and fails closed in BOTH modes.
- Duplicates classify as `duplicate_result` (idempotent, never a second `valid_pass`); late results leave state untouched and record `late_result`.
- `docs/configuration.md` documents the mandatory-vs-optional split with the 7-route table, pinned to the source vocabulary by `tests/unit/hooks/guardrails-stage-a-route-vocabulary-docs.test.ts`.

Recurrence prevention: 54 sweep hits dispositioned; frozen checks C1/C2/C4a flip RED when the original early return is re-introduced (mutation probe P1); `tests/unit/hooks/guardrails-disabled-lifecycle.test.ts` pins receipts + lease maintenance active and the policy battery inert when disabled (probe P2 un-gating one denial site flips 2 tests RED).

## Invariant audit
- 1 (plugin init): not touched — diff touches no init-path files (`git diff --stat 5f9144349..f90fbb53b` lists only `src/hooks/guardrails/`, `tests/`, `docs/`); `src/index.ts`, package exports, build config unchanged; hook factory allocation remains O(1).
- 2 (runtime portability): not touched — zero `bun:` imports / direct `Bun.*` calls added (grep over the diff: no hits); `node --input-type=module -e "await import('./dist/index.js')"` OK at head.
- 3 (subprocesses): not touched — no spawn/exec changes in the diff.
- 4 (.swarm containment): touched — new route events append to `.swarm/events.jsonl` ONLY via the sanctioned `appendCoreEventSync` seam; `bun run check:core-events` green (allowlist unchanged); new tests use `canonicalMkdtemp`; `bash scripts/check-test-tmpdir.sh` 0 new violations.
- 5 (plan durability): not touched — no plan ledger/projection/checkpoint changes.
- 6 (test_runner safety): not touched — `src/tools/test-runner.ts` and `MAX_SAFE_TEST_FILES` untouched.
- 7 (test writing): touched — new suites are bun:test, each under 500 lines (`bun run check:test-file-cap` 0 violations), no `mock.module` (public-API/DI only; `bun run check:mock-cleanup` pass, 4 pre-existing non-blocking), `bun run check:test-clock` 0 blocking, tmpdir checks clean.
- 8 (session state): touched — `pendingGateRoutesBySession` keyed by sessionID with explicit bounds (`MAX_PENDING_GATE_ROUTES_SESSIONS = 500`, 256 per session), delete-on-read, capacity throws caught warn-only so the lifecycle path never throws; bounds pinned via `_internals` tests.
- 9 (guardrails/retry): touched — the core change: enforcement vs bookkeeping split. `guardrails.enabled=false` now disables ONLY policy denial (pinned: policy battery inert OFF / denying ON) while receipts, transitions, route events, and lease maintenance remain active and bounded; scope preflight semantics unchanged; the >1 MiB patch bound fails closed in both modes (OFF-mode test in `tests/unit/hooks/guardrails-disabled-lifecycle.test.ts`, ON-mode in `tests/unit/hooks/guardrails-v622-adversarial.test.ts`).
- 10 (chat/system msg): not touched — no chat transform or system-message changes.
- 11 (tool registration): not touched — no `TOOL_METADATA`/`TOOL_MANIFEST`/barrel changes; `bun run drift:check --enforce` no drift.
- 12 (release/cache): touched — release fragment `docs/releases/pending/2664-mandatory-lifecycle-bookkeeping.md` shipped in this diff; no version files hand-edited.

## Test plan
- [x] Frozen acceptance checks (official `repro-check.sh run`, base `5f9144349` → head `21416a788`): C1/C2/C3/C4a RED→GREEN PASS, C4b/C5 GREEN→GREEN PASS; `verify-checkpoint` 6/6 OK zero CHANGED — re-replayed after every post-approval commit.
- [x] New suites at head `21416a788`: `tests/unit/hooks/guardrails-stage-a-route-events.test.ts` 18 pass (incl. capacity-bound pins); `guardrails-disabled-lifecycle.test.ts` 5 pass; `guardrails-stage-a-route-vocabulary-docs.test.ts` pass; `tests/integration/guardrails-registered-host-stage-a.test.ts` 2 pass (XDG-hermetic real `server()` boot).
- [x] Blast radius at head `21416a788`: guardrails-directory.adversarial 61 pass / 0 fail; guardrails-worktree-session-root 10 pass / 0 fail; v622-adversarial 21/0; pre-check-batch 26/0; durable-stage-a-attribution 10/0; scope-lease-renewal-wiring 2/0; guardrails-disabled 2/0.
- [x] Repo gates: `bun run typecheck` (only the 2 pre-existing `src/mcp/server.ts` baseline errors, identical at base); biome clean on all touched files; `check:test-file-cap` 0; `check:registry-citations` pass; atomic-write-ratchet 7/0; `dist/index.js` imports under Node.
- [x] Independent swarm-pr-review run (10 lanes + micro-lanes + 2 reviewer shards + critic) on the first head; all validated findings fixed in `21416a788` and re-approved (reviewer 96/96 targeted tests + fresh critic gate). Closure ledger in the PR review artifacts.

**Feedback round (head `21416a788`):** the first-published head failed CI on two blast-radius suites that the initial validation plan had not run. A full swarm-pr-review found 7 validated findings — 1 HIGH fail-open (shell writes from unregistered sessions bypassed the identity gate in enforce mode) and 6 MEDIUM/LOW (factory silently absorbing missing configs; observe-mode binding-diagnostic throws; observe-mode audit-record gaps at the lstat/authority sites; the 1 MB bound missing plain-string `args.cmd`; two docs inaccuracies; untested route-capacity bounds) — plus 4 disproved candidates. All 7 are fixed in `21416a788`; 4 candidates were rejected with evidence. Known caveats (by design, disclosed): both `attribution_ambiguous` fallback shapes share one route value (advisory text distinguishes them), and `messagesTransform` advisories are absent while guardrails are disabled. Deferred (disclosed): extending the pre-check-batch suite with route-event assertions (file is at the FR-006 no-growth cap).

**Risk and rollback:** low — with `guardrails.enabled: true` (default) enforcement behavior is fail-closed as on main (restored by the feedback round); with it `false`, previously-suppressed bookkeeping now runs (bounded, warn-only failure modes). Rollback = revert the four commits; no migrations, no config changes.

**Merge status:** awaiting explicit user approval; not merged.
