### PR TITLE
fix(subprocess): bound the remaining unbounded probe sites (#2674)

### DIFF
--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -565,6 +565,16 @@ try {
 - `grep -n "bunSpawn\\|spawn(\\|spawnSync(" src/<changed>/*.ts` — every match has `timeout`, `stdin: 'ignore'` (unless intentionally interactive), `cwd` or `git -C <directory>`, and a `kill()` in the cleanup path.
 - A test mocks the spawn function (via the file-scoped `_internals` seam, not `mock.module`) to never resolve and asserts the call returns within bounded time.
 
+**Bounded caller contract for the #2674 probe sites:**
+
+| Caller (function) | timeout | stdin / stdio | cwd | output bound | cleanup (kill) |
+| --- | --- | --- | --- | --- | --- |
+| `getGitRemoteUrl` — `src/knowledge/identity.ts` (`execFileSync` via `_internals`) | `GIT_REMOTE_URL_TIMEOUT_MS` = 1 500 ms | `stdio: ['ignore', 'pipe', 'ignore']` — stdin ignored | explicit `cwd: directory` | execFileSync default buffer (1 MiB); the remote URL is tiny | OS kill at timeout (sync probe; the catch path falls back to "no remote") |
+| `checkGitRepository` — `src/services/diagnose-service.ts` (`execFileSync` via `_internals`) | `GIT_REPOSITORY_CHECK_TIMEOUT_MS` = 3 000 ms | `stdio: 'ignore'` — output is discarded, so stdout/stderr are ignored too | explicit `cwd: directory` | none retained (ignored) | OS kill at timeout (sync probe; the catch path yields the failing health row) |
+| `getGitChurn` — `src/tools/complexity-hotspots.ts` (`bunSpawn` via `_internals`) | `GIT_CHURN_TIMEOUT_MS` = 2 000 ms, passed to `bunSpawn` AND raced caller-side | `stdin: 'ignore'` | explicit `cwd: directory` | `maxBuffer` default 5 MiB (bunSpawn overflow controller kills the child past the bound) | `finally { clearTimeout; proc.kill(); }` on every exit path — mirrors `resolveCurrentGitHeadAsync` in `src/tools/pr-workflow-status.ts` |
+
+A slow-but-legitimate churn run now fails closed at the 2 s bound with an error naming the bound instead of hanging the tool; the two sync probes degrade to their existing fallback paths on timeout. `deriveProjectHash` (same file as `getGitRemoteUrl`) was already compliant and is deliberately untouched.
+
 ### 4. Working directory and `.swarm/` containment
 
 **Anti-pattern:**

--- a/docs/releases/pending/2674-subprocess-lifetime-gaps.md
+++ b/docs/releases/pending/2674-subprocess-lifetime-gaps.md
@@ -1,0 +1,51 @@
+# Close remaining subprocess lifetime gaps at three probe sites (#2674)
+
+## What
+
+Three production subprocess callers gained the full bounded, killable caller
+contract required by AGENTS.md invariant 3:
+
+- `src/knowledge/identity.ts` — `getGitRemoteUrl` (the legacy
+  `writeProjectIdentity` path) now runs `git remote get-url` through a
+  file-scoped `_internals.execFileSync` seam with `stdin` ignored
+  (`stdio: ['ignore', 'pipe', 'ignore']`) and an explicit 1 500 ms timeout,
+  matching its already-compliant sibling `deriveProjectHash`.
+- `src/services/diagnose-service.ts` — `checkGitRepository` (the
+  `/swarm diagnose` git probe) runs `git rev-parse --git-dir` through the
+  module's extended `_internals` seam with all-ignored stdio (its output was
+  already discarded) and an explicit 3 000 ms timeout.
+- `src/tools/complexity-hotspots.ts` — `getGitChurn` now passes
+  `stdin: 'ignore'` and `timeout: 2 000` to `bunSpawn`, races the read against
+  the same 2 000 ms bound caller-side, and kills the owned child in a
+  `finally` on every exit path (mirroring `resolveCurrentGitHeadAsync` in
+  `pr-workflow-status.ts`). A hung child can no longer leave the tool's await
+  pending forever.
+- `docs/engineering-invariants.md` gained the caller-contract table
+  (timeout / stdin-stdio / cwd / output bound / cleanup) for the three
+  functions.
+
+Tests: a new tracked contract test pins the options and the hung-child
+settle+kill bound at all three sites through the `_internals` seams; the one
+`diagnose-git-repository.test.ts` assertion that pinned the old unbounded
+options shape was updated to the bounded shape.
+
+## Why
+
+Issue #2674 (Workstream A, PR 11 of 12): a caller that leaves stdin open,
+fails to consume output, or ignores cancellation can hang the host even when
+the higher-level await has a timeout. All three sites predated the bounded
+spawn contract: two synchronous probes had no timeout at all (an unbounded
+event-loop block on a hung child), and the churn analysis had no timeout, no
+ignored stdin, and no kill-in-finally — reproduced live with a hung child
+still pending after 2.5 s with zero kill calls.
+
+## Migration
+
+No public API changes; the `_internals` additions and the exported
+`GIT_REPOSITORY_CHECK_TIMEOUT_MS` constant are additive. One behavior
+tightening, deliberate: a churn run that exceeds the new 2 s bound now fails
+closed with an error naming the bound (surfaced through the tool's existing
+`analysis failed:` error JSON) instead of eventually completing; the two sync
+probes degrade to their existing fallback paths on timeout (no remote /
+failing health row). `deriveProjectHash` was already compliant and is
+untouched.

--- a/scripts/retention-registry.data.ts
+++ b/scripts/retention-registry.data.ts
@@ -2499,7 +2499,7 @@ export const RETENTION_REGISTRY: readonly RetentionRow[] = [
 		],
 		writerCitations: [
 			'src/hooks/hive-transaction.ts:165 transactHiveStore — single cross-process lock spanning read/validate/cap/staged-appends/atomic-persist (:206-316)',
-			'src/knowledge/identity.ts:176 writeProjectIdentity — platform config identity.json',
+			'src/knowledge/identity.ts:205 writeProjectIdentity — platform config identity.json',
 			'src/knowledge/family-migration.ts — staged directory migration writes',
 		],
 		readerCitations: ['readKnowledge over hive paths (inside transactHiveStore); knowledge-events hive readers'],

--- a/src/knowledge/identity.ts
+++ b/src/knowledge/identity.ts
@@ -125,17 +125,46 @@ async function getSwarmVersion(directory?: string): Promise<string> {
 }
 
 /**
+ * Test/inspection seam for the git subprocess this module runs (#2674).
+ *
+ * `Reflect.apply` reads the namespace binding at CALL time (not at module
+ * init), so both `mock.module('node:child_process', ...)` and direct
+ * `_internals.execFileSync` replacement are observed by production code, with
+ * the receiver forwarded unchanged. The wrapper owns no options of its own —
+ * every real call site in this file passes the bounded options object.
+ * Restore in `afterEach` when replacing this seam (AGENTS.md §7 convention).
+ */
+export const _internals = {
+	execFileSync: (
+		...args: Parameters<typeof child_process.execFileSync>
+	): ReturnType<typeof child_process.execFileSync> =>
+		Reflect.apply(
+			child_process.execFileSync,
+			child_process,
+			args,
+		) as ReturnType<typeof child_process.execFileSync>,
+};
+
+/**
+ * Bounded git-remote probe budget (#2674) — matches the compliant sibling
+ * `deriveProjectHash` so both probes in this file share one budget class.
+ */
+const GIT_REMOTE_URL_TIMEOUT_MS = 1_500;
+
+/**
  * Get git remote URL for a directory
  */
 function getGitRemoteUrl(directory: string): string | undefined {
 	try {
 		const gitExecutable = resolveGitExecutable();
-		const remoteUrl = child_process
+		const remoteUrl = _internals
 			.execFileSync(gitExecutable, ['remote', 'get-url', 'origin'], {
 				cwd: directory,
 				encoding: 'utf-8',
-				stdio: ['pipe', 'pipe', 'ignore'],
+				stdio: ['ignore', 'pipe', 'ignore'],
+				timeout: GIT_REMOTE_URL_TIMEOUT_MS,
 			})
+			.toString()
 			.trim();
 		return remoteUrl;
 	} catch {

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,4 +1,13 @@
 /** Knowledge system exports for opencode-swarm. */
 
 export * from './cohort-identity.js';
-export * from './identity.js';
+// Explicit (not `export *`) because identity.ts also exports a file-scoped
+// `_internals` DI seam that would collide with cohort-identity's at this
+// barrel. The seam stays importable from './identity.js' directly.
+export {
+	deriveProjectHash,
+	readProjectIdentity,
+	resolveIdentityPath,
+	writeProjectIdentity,
+} from './identity.js';
+export type { ProjectIdentity } from './identity.js';

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,6 +1,7 @@
 /** Knowledge system exports for opencode-swarm. */
 
 export * from './cohort-identity.js';
+export type { ProjectIdentity } from './identity.js';
 // Explicit (not `export *`) because identity.ts also exports a file-scoped
 // `_internals` DI seam that would collide with cohort-identity's at this
 // barrel. The seam stays importable from './identity.js' directly.
@@ -10,4 +11,3 @@ export {
 	resolveIdentityPath,
 	writeProjectIdentity,
 } from './identity.js';
-export type { ProjectIdentity } from './identity.js';

--- a/src/services/diagnose-service.ts
+++ b/src/services/diagnose-service.ts
@@ -53,7 +53,30 @@ const REQUIRED_CACHE_GRAMMAR_ASSETS = [
 export const _internals = {
 	detectSandboxCapability: () => sandboxCapabilityProbe.detect(),
 	getSandboxExecutor: getExecutor,
+	// #2674: subprocess seam for checkGitRepository. `Reflect.apply` reads the
+	// namespace binding at CALL time (not at module init) so
+	// `mock.module('node:child_process')` and direct seam replacement are both
+	// observed, with the receiver forwarded unchanged; the wrapper owns no
+	// options of its own — the real call site passes the bounded options.
+	// Restore in afterEach when replacing (AGENTS.md §7 convention).
+	execFileSync: (
+		...args: Parameters<typeof child_process.execFileSync>
+	): ReturnType<typeof child_process.execFileSync> =>
+		Reflect.apply(
+			child_process.execFileSync,
+			child_process,
+			args,
+		) as ReturnType<typeof child_process.execFileSync>,
 };
+
+/**
+ * Bounded git rev-parse probe budget (#2674) — the same budget class
+ * `src/tools/diff.ts` uses for its `fileExistsInRef` git probe. The probe's
+ * output is discarded, so all three stdio slots are ignored and the bound is
+ * purely a lifetime guarantee. Exported for the contract test that pins the
+ * exact budget.
+ */
+export const GIT_REPOSITORY_CHECK_TIMEOUT_MS = 3_000;
 
 /**
  * A single health check result.
@@ -458,9 +481,10 @@ async function checkGitRepository(directory: string): Promise<HealthCheck> {
 			};
 		}
 		const gitExecutable = await resolveGitExecutableAsync();
-		child_process.execFileSync(gitExecutable, ['rev-parse', '--git-dir'], {
+		_internals.execFileSync(gitExecutable, ['rev-parse', '--git-dir'], {
 			cwd: directory,
-			stdio: 'pipe',
+			stdio: 'ignore',
+			timeout: GIT_REPOSITORY_CHECK_TIMEOUT_MS,
 		});
 		return {
 			name: 'Git Repository',

--- a/src/tools/complexity-hotspots.ts
+++ b/src/tools/complexity-hotspots.ts
@@ -208,10 +208,13 @@ async function getGitChurn(
 				GIT_CHURN_TIMEOUT_MS,
 			);
 		});
-		const [stdout] = await Promise.race([
-			Promise.all([proc.stdout.text(), proc.exited]),
-			boundedRead,
-		]);
+		const churnRead = Promise.all([proc.stdout.text(), proc.exited]);
+		const [stdout] = await Promise.race([churnRead, boundedRead]);
+		// When the bound wins the race, the loser keeps running: stdout.text()
+		// can still reject later (BunCompatOutputLimitError past maxBuffer).
+		// Swallow that here — the bounded path already reports the timeout —
+		// so the abandoned promise can never surface as an unhandled rejection.
+		churnRead.catch(() => {});
 
 		// A spawn failure (process never started — e.g. missing git binary or a
 		// cwd that no longer exists) means the churn data is unproven, not empty.

--- a/src/tools/complexity-hotspots.ts
+++ b/src/tools/complexity-hotspots.ts
@@ -156,6 +156,17 @@ export const _internals: {
 } = { bunSpawn, resolveGitExecutable };
 
 // ============ Git Churn Analysis ============
+
+/**
+ * Bounded churn-analysis budget (#2674). bunSpawn's own `timeout` option kills
+ * the child at this bound; the caller-side race below enforces the same bound
+ * even when the spawn implementation ignores the option, and the `finally`
+ * guarantees the owned child is killed on every exit path. Slow-but-legit
+ * churn runs now fail closed with an error naming this bound instead of
+ * hanging the tool.
+ */
+const GIT_CHURN_TIMEOUT_MS = 2_000;
+
 async function getGitChurn(
 	days: number,
 	directory: string,
@@ -173,65 +184,100 @@ async function getGitChurn(
 		{
 			stdout: 'pipe',
 			stderr: 'pipe',
+			stdin: 'ignore',
 			cwd: directory,
+			timeout: GIT_CHURN_TIMEOUT_MS,
 		},
 	);
 
-	// Read stdout concurrently with process exit to avoid pipe deadlock.
-	// git log output can be very large for repos with extensive history.
-	const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+	// Bounded await + kill-in-finally (#2674) — the finally-kill shape mirrors
+	// `resolveCurrentGitHeadAsync` in src/tools/pr-workflow-status.ts. Read
+	// stdout concurrently with process exit to avoid pipe deadlock (git log
+	// output can be very large for repos with extensive history), and race
+	// both against the caller-side bound so a hung child cannot defeat it.
+	let boundTimer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const boundedRead = new Promise<never>((_, reject) => {
+			boundTimer = setTimeout(
+				() =>
+					reject(
+						new Error(
+							`git churn analysis timed out after ${GIT_CHURN_TIMEOUT_MS}ms`,
+						),
+					),
+				GIT_CHURN_TIMEOUT_MS,
+			);
+		});
+		const [stdout] = await Promise.race([
+			Promise.all([proc.stdout.text(), proc.exited]),
+			boundedRead,
+		]);
 
-	// A spawn failure (process never started — e.g. missing git binary or a
-	// cwd that no longer exists) means the churn data is unproven, not empty.
-	// `analyzeHotspots` drives its entire file iteration off this map, so
-	// silently continuing here previously produced a false "ran fine, found
-	// nothing" success once the Bun spawn path stopped throwing on process-
-	// creation failure (#2236 Sweep A, FIX 1). Throwing preserves the loud
-	// `error: 'analysis failed: ...'` behavior the tool already surfaces via
-	// the try/catch in `execute`.
-	//
-	// Deliberately scoped to `spawnError` only, NOT a general non-zero-exit
-	// check: `git log` legitimately exits non-zero with empty (not erroring)
-	// output on a repo with no commits yet (exit 128, verified empirically),
-	// and treating every non-zero exit as a hard failure would turn that
-	// benign case into a false error. This mirrors FIX 2's scoping in
-	// `pkg-audit.ts`'s `runCargoAudit`.
-	if (proc.spawnError) {
-		throw new Error(`git churn analysis failed: ${proc.spawnError.message}`);
-	}
-
-	// Split on CRLF for cross-platform handling
-	const lines = stdout.split(/\r?\n/);
-
-	for (const line of lines) {
-		// Normalize path separators: \ to /
-		const normalizedPath = line.replace(/\\/g, '/');
-
-		// Skip empty lines
-		if (!normalizedPath || normalizedPath.trim() === '') {
-			continue;
+		// A spawn failure (process never started — e.g. missing git binary or a
+		// cwd that no longer exists) means the churn data is unproven, not empty.
+		// `analyzeHotspots` drives its entire file iteration off this map, so
+		// silently continuing here previously produced a false "ran fine, found
+		// nothing" success once the Bun spawn path stopped throwing on process-
+		// creation failure (#2236 Sweep A, FIX 1). Throwing preserves the loud
+		// `error: 'analysis failed: ...'` behavior the tool already surfaces via
+		// the try/catch in `execute`.
+		//
+		// Deliberately scoped to `spawnError` only, NOT a general non-zero-exit
+		// check: `git log` legitimately exits non-zero with empty (not erroring)
+		// output on a repo with no commits yet (exit 128, verified empirically),
+		// and treating every non-zero exit as a hard failure would turn that
+		// benign case into a false error. This mirrors FIX 2's scoping in
+		// `pkg-audit.ts`'s `runCargoAudit`.
+		if (proc.spawnError) {
+			throw new Error(`git churn analysis failed: ${proc.spawnError.message}`);
 		}
 
-		// Skip files in excluded directories
-		if (
-			normalizedPath.includes('node_modules') ||
-			normalizedPath.includes('/.git/') ||
-			normalizedPath.includes('/dist/') ||
-			normalizedPath.includes('/build/') ||
-			normalizedPath.includes('__tests__')
-		) {
-			continue;
-		}
+		// Split on CRLF for cross-platform handling
+		const lines = stdout.split(/\r?\n/);
 
-		// Skip test files
-		if (
-			normalizedPath.includes('.test.') ||
-			normalizedPath.includes('.spec.')
-		) {
-			continue;
-		}
+		for (const line of lines) {
+			// Normalize path separators: \ to /
+			const normalizedPath = line.replace(/\\/g, '/');
 
-		churnMap.set(normalizedPath, (churnMap.get(normalizedPath) || 0) + 1);
+			// Skip empty lines
+			if (!normalizedPath || normalizedPath.trim() === '') {
+				continue;
+			}
+
+			// Skip files in excluded directories
+			if (
+				normalizedPath.includes('node_modules') ||
+				normalizedPath.includes('/.git/') ||
+				normalizedPath.includes('/dist/') ||
+				normalizedPath.includes('/build/') ||
+				normalizedPath.includes('__tests__')
+			) {
+				continue;
+			}
+
+			// Skip test files
+			if (
+				normalizedPath.includes('.test.') ||
+				normalizedPath.includes('.spec.')
+			) {
+				continue;
+			}
+
+			churnMap.set(normalizedPath, (churnMap.get(normalizedPath) || 0) + 1);
+		}
+	} finally {
+		// Clear the race timer so a completed read leaves no dangling timer,
+		// then best-effort-kill the owned child on EVERY exit path. kill() is
+		// idempotent on an already-exited child (bun-compat contract), so the
+		// post-success call is harmless; the try/catch follows the invariant-3
+		// required pattern so a kill-unavailable subprocess object cannot turn
+		// cleanup into a new failure.
+		if (boundTimer !== undefined) clearTimeout(boundTimer);
+		try {
+			proc.kill();
+		} catch {
+			/* already exited or kill unavailable */
+		}
 	}
 
 	return churnMap;

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -145,7 +145,7 @@ export const SWARM_TEMP_GRAMMARS: readonly SwarmTempGrammar[] = [
 			'src/hooks/review-receipt.ts:609',
 			'src/hooks/review-receipt.ts:675',
 			'src/hooks/review-receipt.ts:894',
-			'src/knowledge/identity.ts:209',
+			'src/knowledge/identity.ts:238',
 			'src/evidence/phase-participation.ts (pre-#2035; migrated-to=src/evidence/phase-participation.ts:atomicWriteBytes)',
 			'src/turbo/lean/integration.ts:428',
 			'src/turbo/lean/reviewer.ts:403',

--- a/tests/unit/scripts/check-bare-executable-spawn.test.ts
+++ b/tests/unit/scripts/check-bare-executable-spawn.test.ts
@@ -97,9 +97,9 @@ describe('scanSourceForBareSpawn — form 1 (shell-string callees: exec/execSync
 	 * `execSync`/`exec` take a SHELL COMMAND STRING, not an argv[0] — the
 	 * literal `'git'` string-equality check used for `spawnSync`-style
 	 * callees never matches `'git remote get-url origin'`. This is the exact
-	 * shape of the real sites this gate previously missed:
-	 * `src/knowledge/identity.ts:68`/`:131`,
-	 * `src/services/diagnose-service.ts:387` (issue #2236 follow-up).
+	 * shape of the real sites this gate previously missed (issue #2236
+	 * follow-up): `getGitRemoteUrl` in src/knowledge/identity.ts and
+	 * `checkGitRepository` in src/services/diagnose-service.ts.
 	 */
 	test('child_process.execSync("git remote get-url origin", opts) is flagged on the command string\'s first token', () => {
 		const v = scanSourceForBareSpawn(

--- a/tests/unit/services/diagnose-git-repository.test.ts
+++ b/tests/unit/services/diagnose-git-repository.test.ts
@@ -11,7 +11,10 @@ import { readSwarmFileAsync } from '../../../src/hooks/utils.js';
 // Import mocked modules
 import { loadPlanJsonOnly } from '../../../src/plan/manager.js';
 import { readEffectiveSpecSync } from '../../../src/sdd/effective-spec.js';
-import { getDiagnoseData } from '../../../src/services/diagnose-service.js';
+import {
+	GIT_REPOSITORY_CHECK_TIMEOUT_MS,
+	getDiagnoseData,
+} from '../../../src/services/diagnose-service.js';
 import { __seedGitExecutableForTests } from '../../../src/utils/git-executable.js';
 
 // This file holds `checkGitRepository`-related coverage extracted from
@@ -204,7 +207,8 @@ describe('DiagnoseService Adversarial Security Tests', () => {
 
 			// Verify git was invoked in array-argv form (never through a shell
 			// string), so the malicious swarm ID has no shell-metacharacter
-			// interpretation surface at all.
+			// interpretation surface at all. #2674: the probe is also bounded —
+			// ignored stdio (output is discarded) and an explicit timeout.
 			expect(mockExecSync).not.toHaveBeenCalled();
 			expect(mockExecFileSync).toHaveBeenCalledTimes(1);
 			expect(mockExecFileSync).toHaveBeenCalledWith(
@@ -212,7 +216,8 @@ describe('DiagnoseService Adversarial Security Tests', () => {
 				['rev-parse', '--git-dir'],
 				{
 					cwd: testDirectory,
-					stdio: 'pipe',
+					stdio: 'ignore',
+					timeout: GIT_REPOSITORY_CHECK_TIMEOUT_MS,
 				},
 			);
 		});

--- a/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
+++ b/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
@@ -274,9 +274,12 @@ describe('subprocess lifetime bounds — regression: unbounded probes (#2674)', 
 			})) as typeof hotspotsInternals.bunSpawn;
 
 			try {
-				const started = Date.now();
+				// performance.now (monotonic, wall-clock-independent) is the
+				// sanctioned timer for elapsed-duration assertions; a frozen
+				// Date clock would zero the measurement.
+				const started = performance.now();
 				const result = await complexity_hotspots.execute({}, makeContext(dir));
-				const elapsedMs = Date.now() - started;
+				const elapsedMs = performance.now() - started;
 				const parsed = JSON.parse(result);
 				// Pre-fix behavior (the bug): the await stayed pending forever
 				// with zero kills. Post-fix: a bounded settle with kill evidence

--- a/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
+++ b/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ToolContext } from '@opencode-ai/plugin';
 import {
+	deriveProjectHash,
 	_internals as identityInternals,
 	writeProjectIdentity,
 } from '../../../src/knowledge/identity';
@@ -291,6 +292,40 @@ describe('subprocess lifetime bounds — regression: unbounded probes (#2674)', 
 			} finally {
 				hotspotsInternals.bunSpawn = original;
 			}
+		});
+	});
+
+	describe('deriveProjectHash (compliant sibling — regression guard, PRR-004)', () => {
+		it('falls back to the path hash when the directory has no git remote (timeout/failure contract preserved)', () => {
+			__seedGitExecutableForTests('git');
+			const dir = canonicalMkdtemp('swarm-2674-dph-');
+			tempDirs.push(dir);
+			// A bare temp dir has no origin remote, so the 1500ms-bounded git
+			// probe throws and the catch path hashes the absolute path.
+			const hash = deriveProjectHash(dir);
+			expect(hash).toMatch(/^[0-9a-f]{12}$/);
+		});
+
+		it('is deterministic per directory and distinct across directories', () => {
+			__seedGitExecutableForTests('git');
+			const dirA = canonicalMkdtemp('swarm-2674-dph-a-');
+			const dirB = canonicalMkdtemp('swarm-2674-dph-b-');
+			tempDirs.push(dirA, dirB);
+			expect(deriveProjectHash(dirA)).toBe(deriveProjectHash(dirA));
+			expect(deriveProjectHash(dirA)).not.toBe(deriveProjectHash(dirB));
+		});
+
+		it('still returns a bounded fallback hash for a nonexistent directory', () => {
+			__seedGitExecutableForTests('git');
+			const missing = path.join(
+				os.tmpdir(),
+				`swarm-2674-dph-missing-${process.pid}`,
+			);
+			// execFileSync with a nonexistent cwd throws immediately — the
+			// catch must fall back to hashing the resolved absolute path, not
+			// propagate the failure.
+			const hash = deriveProjectHash(missing);
+			expect(hash).toMatch(/^[0-9a-f]{12}$/);
 		});
 	});
 });

--- a/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
+++ b/tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ToolContext } from '@opencode-ai/plugin';
+import {
+	_internals as identityInternals,
+	writeProjectIdentity,
+} from '../../../src/knowledge/identity';
+import {
+	_internals as diagnoseInternals,
+	GIT_REPOSITORY_CHECK_TIMEOUT_MS,
+	getDiagnoseData,
+} from '../../../src/services/diagnose-service';
+import {
+	complexity_hotspots,
+	_internals as hotspotsInternals,
+} from '../../../src/tools/complexity-hotspots';
+import { __seedGitExecutableForTests } from '../../../src/utils/git-executable';
+import { canonicalMkdtemp } from '../../helpers/tmpdir.js';
+
+/**
+ * #2674 — bounded-subprocess caller contract for the three probe sites:
+ * `getGitRemoteUrl` (identity.ts), `checkGitRepository` (diagnose-service.ts),
+ * and `getGitChurn` (complexity-hotspots.ts).
+ *
+ * Everything routes through the file-scoped `_internals` seams (no
+ * `mock.module`), per AGENTS.md §7 and the gitignore-warning-bounded.test.ts
+ * precedent. The seams are restored in afterEach; hotspots assertions mirror
+ * the frozen acceptance checks in the issue trace.
+ */
+
+function stdinIgnored(opts: Record<string, unknown>): boolean {
+	if (opts.stdin === 'ignore') return true;
+	if (opts.stdio === 'ignore') return true;
+	return Array.isArray(opts.stdio) && opts.stdio[0] === 'ignore';
+}
+
+function timeoutOk(opts: Record<string, unknown>): boolean {
+	return typeof opts.timeout === 'number' && (opts.timeout as number) > 0;
+}
+
+describe('subprocess lifetime bounds — regression: unbounded probes (#2674)', () => {
+	const tempDirs: string[] = [];
+	const savedEnv: Record<string, string | undefined> = {
+		HOME: process.env.HOME,
+		LOCALAPPDATA: process.env.LOCALAPPDATA,
+		APPDATA: process.env.APPDATA,
+		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+		XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+	};
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+		for (const [key, value] of Object.entries(savedEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	describe('identity.ts getGitRemoteUrl (via writeProjectIdentity)', () => {
+		it('git remote probe passes positive timeout and ignored stdin through the seam', async () => {
+			__seedGitExecutableForTests('git');
+			const calls: {
+				args: string[];
+				opts: Record<string, unknown>;
+			}[] = [];
+			const original = identityInternals.execFileSync;
+			identityInternals.execFileSync = ((
+				_cmd: string,
+				args: string[],
+				opts?: Record<string, unknown>,
+			) => {
+				calls.push({ args, opts: opts ?? {} });
+				return 'https://example.com/repo.git';
+			}) as typeof identityInternals.execFileSync;
+
+			const redirect = canonicalMkdtemp('swarm-2674-id-cfg-');
+			tempDirs.push(redirect);
+			const projectDir = canonicalMkdtemp('swarm-2674-id-proj-');
+			tempDirs.push(projectDir);
+			if (process.platform === 'win32') {
+				process.env.LOCALAPPDATA = redirect;
+				process.env.APPDATA = redirect;
+			} else {
+				process.env.HOME = redirect;
+				process.env.XDG_CONFIG_HOME = path.join(redirect, '.config');
+				process.env.XDG_DATA_HOME = path.join(redirect, '.local/share');
+			}
+
+			try {
+				const identity = await writeProjectIdentity(
+					projectDir,
+					'2674contract',
+					'proj-2674',
+				);
+				const remoteCall = calls.find((call) => call.args.includes('remote'));
+				expect(remoteCall).toBeDefined();
+				expect(timeoutOk(remoteCall?.opts ?? {})).toBe(true);
+				expect(stdinIgnored(remoteCall?.opts ?? {})).toBe(true);
+				expect(remoteCall?.opts.cwd).toBe(projectDir);
+				expect(identity.repoUrl).toBe('https://example.com/repo.git');
+			} finally {
+				identityInternals.execFileSync = original;
+			}
+		});
+
+		it('a timed-out or failing remote probe degrades to repoUrl undefined (existing fallback preserved)', async () => {
+			__seedGitExecutableForTests('git');
+			const original = identityInternals.execFileSync;
+			identityInternals.execFileSync = ((
+				_cmd: string,
+				_args: string[],
+				opts?: Record<string, unknown>,
+			) => {
+				// Simulate Node's timeout kill: the probe throws, the catch path
+				// must fall back to "no remote".
+				throw new Error(
+					`spawn ETIMEDOUT after ${(opts as { timeout?: number })?.timeout ?? 0}ms`,
+				);
+			}) as typeof identityInternals.execFileSync;
+
+			const redirect = canonicalMkdtemp('swarm-2674-id-to-');
+			tempDirs.push(redirect);
+			const projectDir = canonicalMkdtemp('swarm-2674-id-top-');
+			tempDirs.push(projectDir);
+			if (process.platform === 'win32') {
+				process.env.LOCALAPPDATA = redirect;
+				process.env.APPDATA = redirect;
+			} else {
+				process.env.HOME = redirect;
+				process.env.XDG_CONFIG_HOME = path.join(redirect, '.config');
+				process.env.XDG_DATA_HOME = path.join(redirect, '.local/share');
+			}
+
+			try {
+				const identity = await writeProjectIdentity(
+					projectDir,
+					'2674timeout',
+					'proj-2674-t',
+				);
+				expect(identity.repoUrl).toBeUndefined();
+			} finally {
+				identityInternals.execFileSync = original;
+			}
+		});
+	});
+
+	describe('diagnose-service.ts checkGitRepository (via getDiagnoseData)', () => {
+		it('rev-parse probe passes positive timeout and all-ignored stdio through the seam', async () => {
+			__seedGitExecutableForTests('git');
+			const calls: {
+				args: string[];
+				opts: Record<string, unknown>;
+			}[] = [];
+			const originalExec = diagnoseInternals.execFileSync;
+			const originalSandbox = diagnoseInternals.detectSandboxCapability;
+			const originalExecutor = diagnoseInternals.getSandboxExecutor;
+			diagnoseInternals.execFileSync = ((
+				_cmd: string,
+				args: string[],
+				opts?: Record<string, unknown>,
+			) => {
+				calls.push({ args, opts: opts ?? {} });
+				return '.git';
+			}) as typeof diagnoseInternals.execFileSync;
+			diagnoseInternals.detectSandboxCapability = () =>
+				({ supported: false }) as never;
+			diagnoseInternals.getSandboxExecutor = () =>
+				undefined as unknown as ReturnType<
+					typeof diagnoseInternals.getSandboxExecutor
+				>;
+
+			const projectDir = canonicalMkdtemp('swarm-2674-diag-');
+			tempDirs.push(projectDir);
+
+			try {
+				const result = await getDiagnoseData(projectDir);
+				const revParse = calls.find((call) => call.args.includes('rev-parse'));
+				expect(revParse).toBeDefined();
+				expect(revParse?.opts.cwd).toBe(projectDir);
+				expect(revParse?.opts.stdio).toBe('ignore');
+				expect(revParse?.opts.timeout).toBe(GIT_REPOSITORY_CHECK_TIMEOUT_MS);
+				// The health check itself still completes.
+				expect(Array.isArray(result.checks)).toBe(true);
+			} finally {
+				diagnoseInternals.execFileSync = originalExec;
+				diagnoseInternals.detectSandboxCapability = originalSandbox;
+				diagnoseInternals.getSandboxExecutor = originalExecutor;
+			}
+		});
+	});
+
+	describe('complexity-hotspots.ts getGitChurn', () => {
+		function makeContext(directory: string): ToolContext {
+			return {
+				sessionID: 'test-session',
+				messageID: 'test-message',
+				agent: 'test-agent',
+				directory,
+				worktree: directory,
+				abort: new AbortController().signal,
+				metadata: () => ({}),
+				ask: async () => undefined,
+			} as ToolContext;
+		}
+
+		it('bunSpawn options carry positive timeout and stdin ignore; kill() runs on success', async () => {
+			__seedGitExecutableForTests('git');
+			const dir = canonicalMkdtemp('swarm-2674-churn-opts-');
+			tempDirs.push(dir);
+			const original = hotspotsInternals.bunSpawn;
+			let killCalls = 0;
+			const seen: { opts: Record<string, unknown> }[] = [];
+			hotspotsInternals.bunSpawn = ((_cmd: string[], opts?: unknown) => {
+				seen.push({ opts: (opts ?? {}) as Record<string, unknown> });
+				return {
+					stdout: { text: async () => 'src/a.ts\n' },
+					stderr: { text: async () => '' },
+					exited: Promise.resolve(0),
+					exitCode: 0,
+					spawnError: null,
+					kill() {
+						killCalls += 1;
+					},
+				};
+			}) as typeof hotspotsInternals.bunSpawn;
+
+			try {
+				const parsed = JSON.parse(
+					await complexity_hotspots.execute({}, makeContext(dir)),
+				);
+				expect(seen.length).toBeGreaterThan(0);
+				const opts = seen[0].opts;
+				expect(timeoutOk(opts)).toBe(true);
+				expect(opts.stdin).toBe('ignore');
+				expect(opts.cwd).toBe(dir);
+				// finally-kill runs even on the success path (best-effort,
+				// idempotent on an already-exited child).
+				expect(killCalls).toBeGreaterThan(0);
+				expect(parsed.error).toBeUndefined();
+			} finally {
+				hotspotsInternals.bunSpawn = original;
+			}
+		});
+
+		it('hung child settles within the bound with kill evidence and a typed timeout error', async () => {
+			__seedGitExecutableForTests('git');
+			const dir = canonicalMkdtemp('swarm-2674-churn-hung-');
+			tempDirs.push(dir);
+			const original = hotspotsInternals.bunSpawn;
+			let killCalls = 0;
+			let releaseExited: (code: number) => void = () => {};
+			let releaseStdout: (text: string) => void = () => {};
+			const exited = new Promise<number>((resolve) => {
+				releaseExited = resolve;
+			});
+			const stdoutText = new Promise<string>((resolve) => {
+				releaseStdout = resolve;
+			});
+			hotspotsInternals.bunSpawn = (() => ({
+				stdout: { text: () => stdoutText },
+				stderr: { text: async () => '' },
+				exited,
+				exitCode: null,
+				spawnError: null,
+				kill() {
+					killCalls += 1;
+					releaseExited(1);
+					releaseStdout('');
+				},
+			})) as typeof hotspotsInternals.bunSpawn;
+
+			try {
+				const started = Date.now();
+				const result = await complexity_hotspots.execute({}, makeContext(dir));
+				const elapsedMs = Date.now() - started;
+				const parsed = JSON.parse(result);
+				// Pre-fix behavior (the bug): the await stayed pending forever
+				// with zero kills. Post-fix: a bounded settle with kill evidence
+				// and the loud timeout error naming the bound.
+				expect(elapsedMs).toBeLessThan(4_000);
+				expect(killCalls).toBeGreaterThan(0);
+				expect(parsed.error).toContain('analysis failed');
+				expect(parsed.error).toContain('timed out after');
+			} finally {
+				hotspotsInternals.bunSpawn = original;
+			}
+		});
+	});
+});


### PR DESCRIPTION
Closes #2674

PR head: 90614571151f92312ba5bc3a28e51d4cc20d1093

## Summary

Closes #2674 (Workstream A, PR 11 of 12). The three remaining unbounded subprocess callers - `getGitRemoteUrl` (src/knowledge/identity.ts), `checkGitRepository` (src/services/diagnose-service.ts), and `getGitChurn` (src/tools/complexity-hotspots.ts) - now carry the full bounded caller contract (AGENTS.md invariant 3): explicit cwd, ignored stdin, positive timeouts (1.5s/3s/2s), bounded/ignored output, and best-effort kill-in-finally with a caller-side race at the async site. A hung child is proven to settle inside the bound with kill evidence (base: still pending after 2.5s, zero kills; head: settled 2002ms, 1 kill). Engineering docs gained the caller-contract table; a release fragment ships with the PR.

## Invariant audit

- 1 (plugin init): not touched — none of the three callers is on the init path (caller map in trace 03); no init-path code changed.
- 2 (runtime portability): touched — no new spawn mechanism (node:child_process execFileSync + existing bunSpawn only); `bun run typecheck` exit 0; both runtimes share the same options contract; existing Node/Bun bunSpawn fallback unchanged.
- 3 (subprocesses): touched — the fix itself: explicit cwd, stdin ignore, positive timeouts (1.5s/3s/2s), bounded/ignored output, kill-in-finally on the async path; frozen C1/C2 prove it.
- 4 (.swarm containment): not touched — no runtime-state paths changed.
- 5 (plan durability): not touched — no plan schema/ledger paths.
- 6 (test_runner safety): not touched.
- 7 (test writing): touched — new 293-line bun:test file using only `_internals` seams (no `mock.module`), canonicalMkdtemp tmpdirs, env restored in afterEach; one defect-pinning assertion updated in diagnose-git-repository.test.ts; `bun run check:test-file-cap` 0 violations.
- 8 (session state): not touched.
- 9 (guardrails/retry): not touched.
- 10 (chat/system msg): not touched.
- 11 (tool registration): not touched — no tool/metadata/manifest changes (`complexity_hotspots` registration untouched).
- 12 (release/cache): touched — pending fragment docs/releases/pending/2674-subprocess-lifetime-gaps.md; version files untouched.


## Root Cause

Three production subprocess callers predated the bounded caller contract (AGENTS.md invariant 3): `src/knowledge/identity.ts` `getGitRemoteUrl` ran `execFileSync` with piped stdin and NO timeout (unbounded event-loop block on a hung child); `src/services/diagnose-service.ts` `checkGitRepository` (reached by `/swarm diagnose`) had the same shape; `src/tools/complexity-hotspots.ts` `getGitChurn` spawned `git log` via `bunSpawn` with no timeout option, no `stdin: 'ignore'`, and no kill-in-finally — reproduced live at base with the tool await still pending after 2.5 s and zero kill calls.

## Fix

- identity.ts: new lazy `_internals.execFileSync` seam; the probe now passes `stdio: ['ignore','pipe','ignore']` + `timeout: GIT_REMOTE_URL_TIMEOUT_MS` (1 500 ms, matching the compliant sibling `deriveProjectHash`, which is untouched).
- diagnose-service.ts: `_internals` gains `execFileSync`; the rev-parse probe passes `stdio: 'ignore'` (output was already discarded) + `timeout: GIT_REPOSITORY_CHECK_TIMEOUT_MS` (3 000 ms, exported for the contract test).
- complexity-hotspots.ts: `getGitChurn` passes `stdin: 'ignore'` + `timeout: GIT_CHURN_TIMEOUT_MS` (2 000 ms), races the read against the same bound caller-side, and best-effort-kills the child in a `finally` on every exit path (the invariant-3 documented `try { proc.kill(); } catch {}` shape, mirroring `resolveCurrentGitHeadAsync` in `pr-workflow-status.ts`).
- `src/knowledge/index.ts`: explicit re-exports from identity.ts (the new file-scoped `_internals` would collide with cohort-identity's at the `export *` barrel).
- docs/engineering-invariants.md: caller-contract table (timeout / stdin-stdio / cwd / output / cleanup) for the three functions; release fragment `docs/releases/pending/2674-subprocess-lifetime-gaps.md`.

## Recurrence Prevention (defect class)

- Defect class: a subprocess spawn site in src/ missing any of {explicit cwd or git -C, ignored stdin, positive timeout (option/constant/caller race), bounded/ignored output, kill-in-finally on the async path}.
- Sweep result: repo-wide generalization of the frozen scanner over 978 src files -> 41 hits, dispositioned 1:1 in the trace (08a): 20 bounded via named/computed options constants, 9 spawn-implementation/forwarding/JSDoc internals, 12 bounded by caller-side Promise.race+kill (pre-existing residual stdin hardening noted for pkg-audit 7 + build-check 1 sites — outside this issue's named scope per its non-goals), 0 genuinely unbounded remain.
- Guardrail: frozen acceptance check C1 (source-contract scan over the three files, fail-closed on caller deletion) demonstrated RED at base (3 violations) and GREEN at fix; behavioral pinning in the tracked regression test; mutation probes A/B/C show single-property removals flip the checks.

## Test plan

- Regression test: `bun --smol test tests/unit/tools/subprocess-lifetime-bounds-2674.test.ts` -> 5 pass / 0 fail (options contracts at all three sites, hung-child settle+kill, timeout fallbacks).
- Impacted suites (per-file isolation): complexity-hotspots 43/0, -cwd 19/0, -spawn-failure 2/0, identity 8/0, diagnose-git-repository 4/0, diagnose-service 27/0, diagnose-service.adversarial 20/0, adversarial subprocess-injection.timeout 4/0.
- Lint/type: `bun run typecheck` -> exit 0; `biome check --write` on touched files -> formatted; `bun run check:test-file-cap` -> 0 violations.
- Frozen acceptance checks: all 7 PASS at head via repro-check (C1-C3 RED-to-GREEN, C4-C5 ERROR-to-GREEN, C6-C7 GREEN-to-GREEN), verify-checkpoint 5/5 OK.
- Deferred-work scan: `scan-deferred.sh origin/main` -> clean.
- Pre-existing (reproduced at base in a probe worktree, unrelated): diagnose-settlement-check Windows-local teardown failure; bundled-run cross-file pollution of the estimateComplexity block.

## Regression Protection

- New tracked test asserts the exact options (timeout value via exported constant, stdio[0]/stdin ignore, cwd) AND the behavioral bound (hung child settles with kill evidence and a typed timeout error).
- Negative/boundary: timeout-throw fallback (repoUrl undefined; failing health row), EOF + >1 MiB output settle, benign exit-128 carve-out and #2236 spawnError loudness preserved (C6).
- Tautology probes: removing the churn timeout / flipping identity stdio / dropping the finally-kill each flip the corresponding check or test to its failure sentinel (probes A/B/C, independently repeated by the implementation reviewer).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 all bounded-subprocess sites in the three files carry positive timeout + ignored stdin | Frozen C1: base RED (3 sentinel violations) -> head GREEN ("all 4 bounded-subprocess call site(s)"), repro/C1.*.log |
| AC2 hung child, EOF, output volume bounded with kill evidence at the churn caller | Frozen C2: base "outcome=still-pending elapsedMs=2514 killCalls=0" -> head "settled 2002ms killCalls=1"; EOF/volume green |
| AC3 caller-contract doc table for the three functions | Frozen C3 RED-to-GREEN; table at docs/engineering-invariants.md:568-576 |
| AC4 identity seam observable + bounded through writeProjectIdentity | Frozen C4 ERROR-to-GREEN + mutation probe A (timeout removal fails it) |
| AC5 diagnose seam observable + bounded through getDiagnoseData | Frozen C5 ERROR-to-GREEN + mutation probe B |
| AC6 #2236 spawn-failure contract preserved | Frozen C6 GREEN-to-GREEN (2/2) |
| AC7 repo-wide adversarial timeout ratchet preserved | Frozen C7 GREEN-to-GREEN (4/4) |


## Risk and Rollback

- Risk level: medium-low — the one behavior tightening is deliberate: churn runs exceeding the new 2 s bound now fail closed with an error naming the bound instead of eventually completing (documented in the fragment's Migration section and the invariants table); the two sync probes degrade to their existing fallback paths on timeout.
- Rollback: single revert of commit 157dbea64aaa5987023f9ee7c7a09d11d5747d73.
- Residual risk: large cold-FS repos may hit the 2 s churn bound (operator-readable error); pre-existing stdin residuals at pkg-audit/build-check sites are tracked in the trace sweep, outside this issue's scope.

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.
