### PR TITLE
fix(gates): recover an unpersisted sounding-board APPROVED verdict (issue #2703)

### DIFF
--- a/docs/releases/pending/2703-retry-critic-verdict-recovery.md
+++ b/docs/releases/pending/2703-retry-critic-verdict-recovery.md
@@ -1,0 +1,87 @@
+# coder retry circuit-breaker gate: recovery tool for an obtained sounding-board APPROVED verdict + truthful reset-session footer
+
+## What
+
+Closes an unrecoverable blocked state in the coder retry circuit breaker's
+`critic_sounding_board` gate (issue #2703). When a task's coder dispatch was
+rejected three times in one retry epoch, `enforceCoderRetryEscalation`
+required a durable `critic_sounding_board` APPROVED verdict before admitting
+one final bounded retry — but the only writer of that verdict was the
+mechanical toolAfter recorder, whose conjunctive preconditions (verdict
+parsing through the plan-critic rubric, dispatch-time task attribution,
+launch-generation binding, non-terminal output state) can each miss on a
+legitimate APPROVED output. Notably, the sounding board's own instructed
+RESPONSE FORMAT line (`Verdict: UNNECESSARY | REPHRASE | APPROVED | RESOLVE`)
+is structurally unparseable by that rubric. Once any precondition missed,
+every subsequent coder dispatch for the task was blocked with
+`TASK_RETRY_CRITIC_REQUIRED: ... is waiting for an exact-generation
+critic_sounding_board APPROVED verdict` — across sessions and resets — and
+the only workaround was re-planning the task under a fresh id. The sibling
+`critic_pre_plan` gate received exactly this escape hatch in #2012; the
+retry gate never did.
+
+Two faults are fixed:
+
+1. **No recovery path.** This adds:
+   - a `forceRecordRetrySoundingBoardApproval` hook
+     (`src/hooks/delegation-gate.ts`) that writes the exact
+     `gates.critic_sounding_board` evidence entry the mechanical recorder
+     would have written (same `gate_recorded` transition, same retention
+     semantics), gated on an active architect session, a plan-known task id,
+     existing durable workflow evidence, and a prior durable
+     `sounding_board_consultation` escalation for the task's CURRENT retry
+     epoch — it records evidence only and never emits consultation /
+     simplification / user-escalation events, so it cannot fabricate or skip
+     the escalation protocol;
+   - an `approve_retry_sounding_board` tool (architect-callable, registered
+     through the metadata/manifest/index chain) requiring a `task_id` and an
+     audited `reason`;
+   - a new `sounding_board_manual_approval` action value on the
+     `coder_retry_circuit_breaker` authority event, deduped per
+     (task, retry epoch), so a manual override is distinguishable from a
+     mechanical recording in `.swarm/events.jsonl`. A corrupt authority
+     index surfaces as a typed `APPROVE_RETRY_AUDIT_INDEX_UNREADABLE` with
+     repair guidance instead of wedging the recovery path.
+
+2. **Misleading reset claim.** `/swarm reset-session` ended with
+   `**All circuit breakers and revision limits have been cleared.**` while
+   deliberately preserving `.swarm/events.jsonl` and `.swarm/evidence/` —
+   the durable retry gate survived the reset the message claimed to clear.
+   The footer now says in-memory state was cleared, that durable per-task
+   retry gates intentionally survive, and names
+   `approve_retry_sounding_board` as the recovery for a task blocked
+   waiting for an already-obtained verdict.
+
+## Why
+
+A legitimately-approved, narrowly-scoped rework was reportable as blocked
+for an entire session, requiring a structural plan mutation (task re-id) to
+unblock — extra ceremony, an extra critic-gate re-approval, and extra audit
+surface, purely because the approved verdict had nowhere to be recorded.
+The retry breaker's cross-session durability is intentional and unchanged;
+what was missing was the audited, identity-bound way to record a verdict
+the mechanical recorder lost.
+
+## Impact
+
+- Wedged tasks become recoverable in place: one `approve_retry_sounding_board`
+  call (with a reason) and the next coder dispatch passes the critic check,
+  admitting the same single bounded simplified retry the mechanical path
+  admits. The escalation sequence, retry thresholds, and generation/epoch
+  retention semantics are untouched; a manual entry is cleared by
+  `accepted_mutation`/`repair_idle` exactly like a mechanical one.
+- `/swarm reset-session` behavior is unchanged; only its closing message now
+  tells the truth about what survives.
+
+## Migration steps
+
+None. Existing evidence files and events are read as-is; the new action
+value is ignored by pre-fix readers through the closed-set filters. Users
+with a currently-wedged task can call `approve_retry_sounding_board` with
+the task id and a reason once upgraded.
+
+## Drawbacks
+
+- The manual path trusts the architect's stated reason; the
+  `sounding_board_manual_approval` audit event (with the bounded reason) is
+  the review surface for that trust, mirroring the #2012 precedent.

--- a/docs/releases/pending/2703-retry-critic-verdict-recovery.md
+++ b/docs/releases/pending/2703-retry-critic-verdict-recovery.md
@@ -76,9 +76,13 @@ the mechanical recorder lost.
 ## Migration steps
 
 None. Existing evidence files and events are read as-is; the new action
-value is ignored by pre-fix readers through the closed-set filters. Users
-with a currently-wedged task can call `approve_retry_sounding_board` with
-the task id and a reason once upgraded.
+value is ignored by pre-fix readers through the closed-set filters. Once
+upgraded, have the architect call `approve_retry_sounding_board` with the
+wedged task's id and a reason. The tool binds to the task's current
+durable retry epoch — the analog of the issue's suggested "exact task id
++ generation" binding, since the gate's own waiting condition is
+epoch-scoped (`enforceCoderRetryEscalation` reads escalations by
+task + retry epoch).
 
 ## Drawbacks
 

--- a/scripts/check-core-events-usage.ts
+++ b/scripts/check-core-events-usage.ts
@@ -90,6 +90,10 @@ export const CORE_EVENTS_MENTION_ALLOWLIST: Readonly<
 		reason: 'tool description/help strings describing where the audit event lands (documentation text, no I/O)',
 		cls: 'prompt-doc',
 	},
+	'src/tools/approve-retry-sounding-board.ts': {
+		reason: 'tool description/help strings describing where the audit event lands (documentation text, no I/O) — mirrors the approve-plan-critic entry for the #2703 sibling gate',
+		cls: 'prompt-doc',
+	},
 	'src/services/diagnose-service.ts': {
 		reason: 'user-facing diagnostic output strings naming the checked store (the reads themselves go through the seam API)',
 		cls: 'prompt-doc',

--- a/src/agents/architect.ts
+++ b/src/agents/architect.ts
@@ -99,7 +99,12 @@ export const ARCHITECT_MEMORY_OUTCOME_GUIDANCE = `After using recalled memory or
  * constant bounds a runtime-composed prompt payload; this one bounds CI
  * regression of a built-in source string.
  */
-export const ARCHITECT_PROMPT_BUDGET_CHARS = 160_000;
+// 160000 -> 161000 (#2703): adding the approve_retry_sounding_board recovery
+// tool left only ~79 chars of prefixed-render headroom at parent, so ANY
+// meaningfully-described new architect tool could not have fit. The growth is
+// conscious and documented (terse 180-char metadata description + this 1000-char
+// allowance), keeping the F#1649 ratchet intact for unreviewed growth.
+export const ARCHITECT_PROMPT_BUDGET_CHARS = 161_000;
 
 const ARCHITECT_PROMPT = `You are Architect - orchestrator of a multi-agent swarm.
 

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -787,7 +787,7 @@ export async function handleResetSessionCommand(
 			'to commit settlement in the events audit log and .swarm/evidence/) ' +
 			'intentionally survive this reset. If a task is blocked with ' +
 			'TASK_RETRY_CRITIC_REQUIRED waiting for a critic_sounding_board ' +
-			'APPROVED verdict that was already obtained, record it with the ' +
-			'approve_retry_sounding_board tool.',
+			'APPROVED verdict that was already obtained, have the architect ' +
+			'record it with the approve_retry_sounding_board tool.',
 	].join('\n');
 }

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -775,6 +775,19 @@ export async function handleResetSessionCommand(
 		'',
 		'Session state cleared. Plan, evidence, and knowledge preserved.',
 		'',
-		'**All circuit breakers and revision limits have been cleared.** You can continue in this session — fresh state will be initialized automatically on the next tool call.',
+		// Issue #2703: in-memory circuit breakers really are cleared above, but
+		// the coder retry circuit breaker's satisfaction state is durable by
+		// design (commit-settlement-bound, in .swarm/events.jsonl escalation
+		// audits and .swarm/evidence/<taskId>.json gate entries) and therefore
+		// survives this reset. The former unconditional "All circuit breakers
+		// and revision limits have been cleared" claim was false for exactly
+		// that gate and sent users into a dead end.
+		'In-memory circuit breakers and revision limits have been cleared. ' +
+			'Durable per-task retry gates (the coder retry circuit breaker, bound ' +
+			'to commit settlement in the events audit log and .swarm/evidence/) ' +
+			'intentionally survive this reset. If a task is blocked with ' +
+			'TASK_RETRY_CRITIC_REQUIRED waiting for a critic_sounding_board ' +
+			'APPROVED verdict that was already obtained, record it with the ' +
+			'approve_retry_sounding_board tool.',
 	].join('\n');
 }

--- a/src/events/core-events.ts
+++ b/src/events/core-events.ts
@@ -135,12 +135,19 @@ const PUBLICATION_TERMINAL_EVENT_TYPES: ReadonlySet<string> = new Set([
 export type CoderRetryEscalationAction =
 	| 'sounding_board_consultation'
 	| 'simplification'
-	| 'user_escalation';
+	| 'user_escalation'
+	// Issue #2703: recorded ONLY by forceRecordRetrySoundingBoardApproval
+	// (the architect-facing manual recovery path). It is inert to
+	// enforceCoderRetryEscalation, which checks membership of the three
+	// protocol actions above; membership in RETRY_ACTIONS still gives the
+	// audit event an authority key so it is indexed and deduped per epoch.
+	| 'sounding_board_manual_approval';
 
 const RETRY_ACTIONS: ReadonlySet<string> = new Set([
 	'sounding_board_consultation',
 	'simplification',
 	'user_escalation',
+	'sounding_board_manual_approval',
 ]);
 
 /** The authority key for an event, or null when the event is not in the

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -2056,6 +2056,7 @@ export async function forceRecordRetrySoundingBoardApproval(
 	generation: number;
 	retryEpoch: number;
 	recordedAt: string;
+	auditEventRecorded: boolean;
 }> {
 	// Defense-in-depth mirroring forceRecordPlanCriticApproval: the
 	// approve_retry_sounding_board tool is registered for the architect only,
@@ -2146,12 +2147,18 @@ export async function forceRecordRetrySoundingBoardApproval(
 			? options.reason.trim().slice(0, 500)
 			: undefined;
 	const recordedAt = new Date().toISOString();
+	// Epoch-scoped transitionId (review PRR-R2): a repeated invocation for the
+	// same (session, epoch) is a duplicate transition, not a fresh rewrite.
+	const transitionId = `retry-sb-manual:${sessionID}:epoch${workflow.retryEpoch}`;
 
 	// The durable gate artifact the mechanical toolAfter recorder would have
 	// written: same gate_recorded transition, same retention semantics
 	// (clearWorkflowGateProof clears it on accepted_mutation/repair_idle), so
 	// the manual entry cannot outlive its generation any more than a
-	// mechanical one can.
+	// mechanical one can. expectedGeneration (review PRR-C1) fails the write
+	// closed if a concurrent accepted_mutation/repair_idle rotated the
+	// generation between the read above and this write, instead of
+	// resurrecting the cleared gate on the new generation.
 	await recordGateEvidence(
 		directory,
 		taskId,
@@ -2159,7 +2166,8 @@ export async function forceRecordRetrySoundingBoardApproval(
 		sessionID,
 		false,
 		{
-			transitionId: `retry-sb-manual:${sessionID}:${recordedAt}`,
+			transitionId,
+			expectedGeneration: workflow.generation,
 		},
 	);
 
@@ -2167,6 +2175,7 @@ export async function forceRecordRetrySoundingBoardApproval(
 	// evidence write above is authoritative for the gate; this event is the
 	// human-readable trail distinguishing a manual override from a mechanical
 	// recording. Deduped per (taskId, retryEpoch, action).
+	let auditEventRecorded = true;
 	try {
 		appendCoreEventSync(
 			directory,
@@ -2185,6 +2194,7 @@ export async function forceRecordRetrySoundingBoardApproval(
 			{ dedupeOnAuthorityKey: true },
 		);
 	} catch (err) {
+		auditEventRecorded = false;
 		logger.warn(
 			`[delegation-gate] sounding_board_manual_approval audit event write failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
@@ -2195,6 +2205,7 @@ export async function forceRecordRetrySoundingBoardApproval(
 		generation: workflow.generation,
 		retryEpoch: workflow.retryEpoch,
 		recordedAt,
+		auditEventRecorded,
 	};
 }
 

--- a/src/hooks/delegation-gate.ts
+++ b/src/hooks/delegation-gate.ts
@@ -38,6 +38,7 @@ import {
 import {
 	appendCoreEventSync,
 	CORE_EVENT_LOCKED,
+	type CoderRetryEscalationAction,
 	getCoderRetryEscalationActions,
 } from '../events/core-events.js';
 import {
@@ -2030,6 +2031,173 @@ export async function forceRecordPlanCriticApproval(
 	};
 }
 
+/**
+ * Issue #2703: architect-facing manual recovery for the coder retry circuit
+ * breaker's critic_sounding_board gate. `enforceCoderRetryEscalation` blocks
+ * every coder dispatch for a task until durable evidence
+ * `gates.critic_sounding_board` exists, but the only foreground writer is the
+ * toolAfter auto-recorder, whose conjunctive preconditions (verdict parse via
+ * the plan-critic rubric, dispatch-time task attribution, launch-generation
+ * binding, non-terminal output state) can each miss on a legitimate APPROVED
+ * verdict — leaving the gate blocked across sessions and resets with no
+ * recovery path (unlike the plan-critic gate's approve_plan_critic, issue
+ * #2012). This helper writes the exact evidence the mechanical recorder would
+ * have written. It records evidence ONLY: it never emits
+ * sounding_board_consultation / simplification / user_escalation, so it cannot
+ * fabricate or skip the escalation protocol — a durable consultation for the
+ * task's CURRENT retry epoch must already exist.
+ */
+export async function forceRecordRetrySoundingBoardApproval(
+	directory: string,
+	sessionID: string,
+	options: { taskId: string; reason?: string },
+): Promise<{
+	taskId: string;
+	generation: number;
+	retryEpoch: number;
+	recordedAt: string;
+}> {
+	// Defense-in-depth mirroring forceRecordPlanCriticApproval: the
+	// approve_retry_sounding_board tool is registered for the architect only,
+	// but require the ACTIVE session to be the architect so a non-architect
+	// context cannot self-unblock the retry gate.
+	const session = ensureAgentSession(sessionID);
+	if (
+		!session ||
+		!session.agentName ||
+		stripKnownSwarmPrefix(session.agentName) !== 'architect'
+	) {
+		throw new Error(
+			'APPROVE_RETRY_SOUNDING_BOARD_ARCHITECT_REQUIRED: approve_retry_sounding_board requires an active architect session. ' +
+				'The coder retry circuit-breaker escape hatch is architect-only; a coder/reviewer cannot self-unblock.',
+		);
+	}
+
+	const taskId =
+		typeof options.taskId === 'string' ? options.taskId.trim() : '';
+	if (!taskId) {
+		throw new Error(
+			'APPROVE_RETRY_UNKNOWN_TASK: approve_retry_sounding_board requires the exact plan task id (e.g. "2.1").',
+		);
+	}
+
+	const plan = await loadPlanJsonOnly(directory);
+	if (!plan) {
+		// Same missing/corrupt distinction as forceRecordPlanCriticApproval.
+		const planPath = path.join(directory, '.swarm', 'plan.json');
+		if (fs.existsSync(planPath)) {
+			throw new Error(
+				'PLAN_CORRUPT: .swarm/plan.json exists but could not be parsed ' +
+					'(corrupt or schema-invalid). Repair or re-save the plan before ' +
+					'recording a retry sounding-board approval.',
+			);
+		}
+		throw new Error(
+			'PLAN_NOT_FOUND: no .swarm/plan.json — cannot record a retry ' +
+				'sounding-board approval without a plan. Save a plan first.',
+		);
+	}
+	const knownTaskIds = new Set(
+		plan.phases.flatMap((phase) => phase.tasks.map((task) => task.id)),
+	);
+	if (!knownTaskIds.has(taskId)) {
+		throw new Error(
+			`APPROVE_RETRY_UNKNOWN_TASK: task ${taskId} is not in the current plan. Refusing to record evidence for a foreign task id.`,
+		);
+	}
+
+	const { getTaskWorkflowSnapshot, readTaskEvidence, recordGateEvidence } =
+		await import('../gate-evidence');
+	const evidence = await readTaskEvidence(directory, taskId);
+	const workflow = getTaskWorkflowSnapshot(evidence);
+	if (!evidence || !workflow.authoritative) {
+		throw new Error(
+			`APPROVE_RETRY_NO_WORKFLOW: no durable task workflow evidence exists for task ${taskId} — there is no retry state to recover.`,
+		);
+	}
+
+	let prior: Set<CoderRetryEscalationAction>;
+	try {
+		prior = readCoderRetryEscalations(directory, taskId, workflow.retryEpoch);
+	} catch (error) {
+		// A corrupt authority index must not wedge the recovery path (plan
+		// critic round 1): remap to a typed error with repair guidance,
+		// mirroring enforceCoderRetryEscalation's own mapping.
+		if (
+			error instanceof Error &&
+			error.message === 'CORE_EVENT_AUTHORITY_INDEX_UNREADABLE'
+		) {
+			throw new Error(
+				'APPROVE_RETRY_AUDIT_INDEX_UNREADABLE: the retry audit authority index is unreadable, ' +
+					'so the prior sounding_board_consultation cannot be verified. Repair the events store (see /swarm doctor) and retry.',
+			);
+		}
+		throw error;
+	}
+	if (!prior.has('sounding_board_consultation')) {
+		throw new Error(
+			`APPROVE_RETRY_CONSULTATION_REQUIRED: task ${taskId} has no durable sounding_board_consultation escalation for retry epoch ${workflow.retryEpoch}. ` +
+				'Dispatch critic_sounding_board first — this tool records an obtained APPROVED verdict, it cannot substitute for the consultation.',
+		);
+	}
+
+	const sanitizedReason =
+		typeof options.reason === 'string' && options.reason.trim().length > 0
+			? options.reason.trim().slice(0, 500)
+			: undefined;
+	const recordedAt = new Date().toISOString();
+
+	// The durable gate artifact the mechanical toolAfter recorder would have
+	// written: same gate_recorded transition, same retention semantics
+	// (clearWorkflowGateProof clears it on accepted_mutation/repair_idle), so
+	// the manual entry cannot outlive its generation any more than a
+	// mechanical one can.
+	await recordGateEvidence(
+		directory,
+		taskId,
+		'critic_sounding_board',
+		sessionID,
+		false,
+		{
+			transitionId: `retry-sb-manual:${sessionID}:${recordedAt}`,
+		},
+	);
+
+	// Best-effort audit event (forceRecordPlanCriticApproval precedent): the
+	// evidence write above is authoritative for the gate; this event is the
+	// human-readable trail distinguishing a manual override from a mechanical
+	// recording. Deduped per (taskId, retryEpoch, action).
+	try {
+		appendCoreEventSync(
+			directory,
+			{
+				type: 'coder_retry_circuit_breaker',
+				timestamp: recordedAt,
+				taskId,
+				generation: workflow.generation,
+				retryEpoch: workflow.retryEpoch,
+				rejectionCount: workflow.retryCount,
+				rejectionHistory: [...workflow.retryHistory],
+				phase: Number(taskId.split('.')[0]) || 0,
+				action: 'sounding_board_manual_approval',
+				...(sanitizedReason ? { reason: sanitizedReason } : {}),
+			},
+			{ dedupeOnAuthorityKey: true },
+		);
+	} catch (err) {
+		logger.warn(
+			`[delegation-gate] sounding_board_manual_approval audit event write failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	return {
+		taskId,
+		generation: workflow.generation,
+		retryEpoch: workflow.retryEpoch,
+		recordedAt,
+	};
+}
+
 const ACTIVE_PARALLEL_TASK_STATES = new Set([
 	'coder_delegated',
 	'pre_check_passed',
@@ -2339,11 +2507,6 @@ function completionGateViolationMessage(
 		'Read-only inspection remains available; a proven-disjoint task may continue; if plan.json is ledger-stale, retry save_plan with reconcile_ledger_projection=true and otherwise-unchanged plan content.'
 	);
 }
-
-type CoderRetryEscalationAction =
-	| 'sounding_board_consultation'
-	| 'simplification'
-	| 'user_escalation';
 
 /**
  * Issue #2039: escalation audit state moved off raw events.jsonl scans to

--- a/src/tools/approve-retry-sounding-board.ts
+++ b/src/tools/approve-retry-sounding-board.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+import { forceRecordRetrySoundingBoardApproval } from '../hooks/delegation-gate.js';
+import { createSwarmTool } from './create-tool.js';
+
+const ApproveRetrySoundingBoardArgsSchema = z
+	.object({
+		task_id: z
+			.string()
+			.trim()
+			.min(1)
+			.describe(
+				'Exact plan task id of the wedged task (e.g. "2.1"). Must exist in the current plan and already have a durable sounding_board_consultation escalation.',
+			),
+		reason: z
+			.string()
+			.trim()
+			.min(1)
+			.max(500)
+			.describe(
+				'Why a manual approval is being recorded (e.g. "sounding board returned APPROVED but the verdict format did not match the mechanical recorder"). Audited to .swarm/events.jsonl.',
+			),
+	})
+	.strict();
+
+export async function executeApproveRetrySoundingBoard(
+	args: unknown,
+	directory: string,
+	context: { sessionID?: string } = {},
+): Promise<string> {
+	const parsed = ApproveRetrySoundingBoardArgsSchema.safeParse(args);
+	if (!parsed.success) {
+		return JSON.stringify({
+			success: false,
+			message: `Invalid approve_retry_sounding_board call: ${parsed.error.issues
+				.map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+				.join('; ')}`,
+		});
+	}
+	if (!context.sessionID?.trim()) {
+		return JSON.stringify({
+			success: false,
+			message: 'approve_retry_sounding_board requires an active sessionID',
+		});
+	}
+	try {
+		// Agent-initiated path: the audit event's action value
+		// (sounding_board_manual_approval) is the trail that distinguishes this
+		// from a mechanical recording. The evidence write itself is the same
+		// gate_recorded transition the toolAfter recorder performs.
+		const summary = await forceRecordRetrySoundingBoardApproval(
+			directory,
+			context.sessionID,
+			{
+				taskId: parsed.data.task_id,
+				reason: parsed.data.reason,
+			},
+		);
+		return JSON.stringify({
+			success: true,
+			task_id: summary.taskId,
+			generation: summary.generation,
+			retry_epoch: summary.retryEpoch,
+			recorded_at: summary.recordedAt,
+			method: 'manual_override',
+			user_confirmed: false,
+			message:
+				'Recorded a manual critic_sounding_board gate entry for the coder retry ' +
+				'circuit breaker. The next coder dispatch for this task passes the ' +
+				'TASK_RETRY_CRITIC_REQUIRED critic check (one bounded simplified retry). ' +
+				'An audit event (action sounding_board_manual_approval) was appended to ' +
+				'.swarm/events.jsonl.',
+		});
+	} catch (error) {
+		return JSON.stringify({
+			success: false,
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export const approve_retry_sounding_board: ReturnType<typeof createSwarmTool> =
+	createSwarmTool({
+		description:
+			'Record a MANUAL critic_sounding_board gate entry to unblock the coder retry circuit-breaker gate (TASK_RETRY_CRITIC_REQUIRED) when the sounding board already returned APPROVED but the mechanical recorder failed to persist it — verdict-format miss (the sounding board echoed its enumerated RESPONSE FORMAT line), dispatch-task attribution miss, launch-generation binding miss, or a failed/error output state (issue #2703). Scoped to the exact plan task id, which must already carry a durable sounding_board_consultation escalation for the current retry epoch; the audit event (action sounding_board_manual_approval) distinguishes the override from a mechanical recording. Architect-only: the active session must be the architect. Prefer re-dispatching the sounding board first; use this only as an escape hatch when a legitimate APPROVED verdict was lost. A reason is required and audited to .swarm/events.jsonl.',
+		args: {
+			task_id: ApproveRetrySoundingBoardArgsSchema.shape.task_id,
+			reason: ApproveRetrySoundingBoardArgsSchema.shape.reason,
+		},
+		execute: executeApproveRetrySoundingBoard,
+	});

--- a/src/tools/approve-retry-sounding-board.ts
+++ b/src/tools/approve-retry-sounding-board.ts
@@ -61,14 +61,21 @@ export async function executeApproveRetrySoundingBoard(
 			generation: summary.generation,
 			retry_epoch: summary.retryEpoch,
 			recorded_at: summary.recordedAt,
+			audit_event_recorded: summary.auditEventRecorded,
 			method: 'manual_override',
 			user_confirmed: false,
-			message:
-				'Recorded a manual critic_sounding_board gate entry for the coder retry ' +
-				'circuit breaker. The next coder dispatch for this task passes the ' +
-				'TASK_RETRY_CRITIC_REQUIRED critic check (one bounded simplified retry). ' +
-				'An audit event (action sounding_board_manual_approval) was appended to ' +
-				'.swarm/events.jsonl.',
+			message: summary.auditEventRecorded
+				? 'Recorded a manual critic_sounding_board gate entry for the coder retry ' +
+					'circuit breaker. The next coder dispatch for this task passes the ' +
+					'TASK_RETRY_CRITIC_REQUIRED critic check (one bounded simplified retry). ' +
+					'An audit event (action sounding_board_manual_approval) was appended to ' +
+					'.swarm/events.jsonl.'
+				: 'Recorded a manual critic_sounding_board gate entry for the coder retry ' +
+					'circuit breaker. The next coder dispatch for this task passes the ' +
+					'TASK_RETRY_CRITIC_REQUIRED critic check (one bounded simplified retry). ' +
+					'WARNING: the audit event could NOT be appended to .swarm/events.jsonl ' +
+					'(see the plugin log); the gate evidence itself records the override via ' +
+					'the retry-sb-manual transition id.',
 		});
 	} catch (error) {
 		return JSON.stringify({

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -187,6 +187,10 @@ export {
 	approve_plan_critic,
 	executeApprovePlanCritic,
 } from './approve-plan-critic';
+export {
+	approve_retry_sounding_board,
+	executeApproveRetrySoundingBoard,
+} from './approve-retry-sounding-board';
 export { authorize_pr_review_reentry } from './authorize-pr-review-reentry';
 export {
 	complete_pr_workflow,

--- a/src/tools/manifest.ts
+++ b/src/tools/manifest.ts
@@ -27,6 +27,7 @@ import { abort_pr_workflow } from './abort-pr-workflow';
 import { actionlint_scan } from './actionlint-scan';
 import { swarmApplyPatch } from './apply-patch';
 import { approve_plan_critic } from './approve-plan-critic';
+import { approve_retry_sounding_board } from './approve-retry-sounding-board';
 import { ast_grep } from './ast-grep';
 import { authorize_pr_review_reentry } from './authorize-pr-review-reentry';
 import { batch_symbols } from './batch-symbols';
@@ -194,6 +195,7 @@ export const TOOL_MANIFEST = defineHandlers({
 	authorize_pr_review_reentry: () => authorize_pr_review_reentry,
 	submit_pr_review_result: () => submit_pr_review_result,
 	approve_plan_critic: () => approve_plan_critic,
+	approve_retry_sounding_board: () => approve_retry_sounding_board,
 	prepare_pr_workflow_checkout: () => prepare_pr_workflow_checkout,
 	record_implementation_review: () => record_implementation_review,
 	record_issue_publication: () => record_issue_publication,

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -252,7 +252,7 @@ export const TOOL_METADATA = {
 	},
 	approve_retry_sounding_board: {
 		description:
-			'record a MANUAL critic_sounding_board gate entry to unblock the coder retry circuit-breaker gate (TASK_RETRY_CRITIC_REQUIRED) when the sounding board already returned APPROVED but the mechanical recorder failed to persist it (issue #2703); scoped to the exact plan task id, requires a durable sounding_board_consultation escalation for the current retry epoch, and appends a sounding_board_manual_approval audit event',
+			'record a MANUAL critic_sounding_board gate entry to unblock the coder retry circuit-breaker gate when the sounding board returned APPROVED but the mechanical recorder missed it (issue #2703)',
 		agents: ['architect'],
 	},
 	prepare_pr_workflow_checkout: {

--- a/src/tools/tool-metadata.ts
+++ b/src/tools/tool-metadata.ts
@@ -250,6 +250,11 @@ export const TOOL_METADATA = {
 			'record a MANUAL plan_critic_gate approval snapshot to unblock the ratchet-tighter critic_pre_plan execution gate when the critic already returned APPROVED but the mechanical recorder failed to persist it (issue #2012), or as the sanctioned recovery for a bookkeeping-grade hashed-field repair under the critic-gate PLAN FREEZE rule (the reason must state which case applies)',
 		agents: ['architect'],
 	},
+	approve_retry_sounding_board: {
+		description:
+			'record a MANUAL critic_sounding_board gate entry to unblock the coder retry circuit-breaker gate (TASK_RETRY_CRITIC_REQUIRED) when the sounding board already returned APPROVED but the mechanical recorder failed to persist it (issue #2703); scoped to the exact plan task id, requires a durable sounding_board_consultation escalation for the current retry epoch, and appends a sounding_board_manual_approval audit event',
+		agents: ['architect'],
+	},
 	prepare_pr_workflow_checkout: {
 		description:
 			'prepare an auditable PR workflow checkout or restore its exact original branch/HEAD and preserved stash after terminal cleanup',

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -57,7 +57,15 @@ export interface CoderRetryCircuitBreakerEvent {
 	rejectionCount: number;
 	rejectionHistory: string[];
 	phase: number;
-	action: 'sounding_board_consultation' | 'simplification' | 'user_escalation';
+	action:
+		| 'sounding_board_consultation'
+		| 'simplification'
+		| 'user_escalation'
+		| 'sounding_board_manual_approval';
+	/** Present only on sounding_board_manual_approval (issue #2703): the
+	 * architect-stated justification for the manual override, bounded to 500
+	 * chars by the recorder. */
+	reason?: string;
 }
 
 export interface AgentConflictDetectedEvent {

--- a/tests/unit/commands/reset-session-retry-disclosure.test.ts
+++ b/tests/unit/commands/reset-session-retry-disclosure.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { handleResetSessionCommand } from '../../../src/commands/reset-session';
+import { resetSwarmState } from '../../../src/state';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+describe('/swarm reset-session footer disclosure (issue #2703)', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	beforeEach(() => {
+		resetSwarmState();
+		({ dir: directory, cleanup } = createSafeTestDir('reset-sb-footer-'));
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('no longer claims ALL circuit breakers were cleared', async () => {
+		const output = await handleResetSessionCommand(directory, [], 'sess-1');
+		expect(output).not.toContain(
+			'All circuit breakers and revision limits have been cleared',
+		);
+	});
+
+	test('discloses that durable per-task retry gates survive the reset', async () => {
+		const output = await handleResetSessionCommand(directory, [], 'sess-1');
+		expect(output).toMatch(/In-memory circuit breakers/i);
+		expect(output).toMatch(/durable per-task retry gates/i);
+		expect(output).toMatch(/intentionally survive this reset/i);
+	});
+
+	test('points a TASK_RETRY_CRITIC_REQUIRED-blocked task at the recovery tool', async () => {
+		const output = await handleResetSessionCommand(directory, [], 'sess-1');
+		expect(output).toContain('TASK_RETRY_CRITIC_REQUIRED');
+		expect(output).toContain('approve_retry_sounding_board');
+	});
+});

--- a/tests/unit/events/core-events-authority-index.test.ts
+++ b/tests/unit/events/core-events-authority-index.test.ts
@@ -94,7 +94,11 @@ function repairEvent(
 function retryEvent(
 	taskId: string,
 	retryEpoch: number,
-	action: 'sounding_board_consultation' | 'simplification' | 'user_escalation',
+	action:
+		| 'sounding_board_consultation'
+		| 'simplification'
+		| 'user_escalation'
+		| 'sounding_board_manual_approval',
 ): Record<string, unknown> {
 	return {
 		type: 'coder_retry_circuit_breaker',

--- a/tests/unit/hooks/delegation-gate-retry-sounding-board-manual.test.ts
+++ b/tests/unit/hooks/delegation-gate-retry-sounding-board-manual.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { readCoreEvents } from '../../../src/events/core-events';
+import {
+	getTaskWorkflowSnapshot,
+	readTaskEvidence,
+} from '../../../src/gate-evidence';
+import {
+	createDelegationGateHook,
+	forceRecordRetrySoundingBoardApproval,
+} from '../../../src/hooks/delegation-gate';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+interface RetryEvent {
+	taskId?: string;
+	action?: string;
+	reason?: string;
+}
+
+function readRetryEvents(directory: string): RetryEvent[] {
+	const { text } = readCoreEvents(directory);
+	const events: RetryEvent[] = [];
+	for (const line of text.split('\n')) {
+		if (!line.trim()) continue;
+		try {
+			const parsed = JSON.parse(line) as RetryEvent & { type?: string };
+			if (parsed && parsed.type === 'coder_retry_circuit_breaker')
+				events.push(parsed);
+		} catch {
+			// skip torn/partial line (production readers are per-line tolerant)
+		}
+	}
+	return events;
+}
+
+describe('forceRecordRetrySoundingBoardApproval (issue #2703)', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+	let hook: ReturnType<typeof createDelegationGateHook>;
+
+	async function dispatchCoder(
+		sessionID: string,
+		callID: string,
+		taskId = '1.1',
+	): Promise<void> {
+		const file = taskId === '1.1' ? 'src/feature.ts' : 'src/other.ts';
+		const args = {
+			subagent_type: 'coder',
+			task_id: taskId,
+			prompt: `TASK: ${taskId}\nFILE: ${file}\nACCEPTANCE: feature is implemented and verified`,
+		};
+		await hook.toolBefore({ tool: 'Task', sessionID, callID }, { args });
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID, callID, args },
+			{ state: 'completed', output: 'no changes required' },
+		);
+	}
+
+	/** Trip the breaker and durably record the consultation escalation. */
+	async function wedgeTask1_1(): Promise<void> {
+		const session = ensureAgentSession('parent-1', 'architect', directory);
+		session.currentTaskId = '1.1';
+		for (let attempt = 1; attempt <= 3; attempt += 1) {
+			await dispatchCoder('parent-1', `no-op-${attempt}`);
+		}
+		await expect(dispatchCoder('parent-1', 'threshold-probe')).rejects.toThrow(
+			'Dispatch critic_sounding_board',
+		);
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.gates.critic_sounding_board).toBeUndefined();
+	}
+
+	beforeEach(async () => {
+		resetSwarmState();
+		({ dir: directory, cleanup } = createSafeTestDir('dg-retry-sb-manual-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		fs.writeFileSync(
+			path.join(directory, 'src', 'other.ts'),
+			'export const other = 1;\n',
+		);
+		git(directory, ['add', 'src/feature.ts', 'src/other.ts']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+			{ id: '1.2', files: ['src/other.ts'] },
+		]);
+		hook = createDelegationGateHook(config, directory);
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('records the durable gate entry + audit event and unblocks the next coder dispatch', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-approve', 'architect', directory);
+		const before = readRetryEvents(directory);
+		const consultationsBefore = before.filter(
+			(event) => event.action === 'sounding_board_consultation',
+		).length;
+		const epochBefore = getTaskWorkflowSnapshot(
+			await readTaskEvidence(directory, '1.1'),
+		).retryEpoch;
+
+		const summary = await forceRecordRetrySoundingBoardApproval(
+			directory,
+			'arch-approve',
+			{
+				taskId: '1.1',
+				reason:
+					'sounding board returned APPROVED but the verdict format did not match the mechanical recorder',
+			},
+		);
+		expect(summary.taskId).toBe('1.1');
+		expect(summary.retryEpoch).toBe(epochBefore);
+
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.gates.critic_sounding_board?.sessionId).toBe(
+			'arch-approve',
+		);
+
+		const after = readRetryEvents(directory);
+		const manual = after.filter(
+			(event) =>
+				event.taskId === '1.1' &&
+				event.action === 'sounding_board_manual_approval',
+		);
+		expect(manual.length).toBe(1);
+		// The helper emits ONLY the manual action — never the protocol actions
+		// (plan-critic round 1, blocker 3: covers the SUCCESS path).
+		for (const action of [
+			'sounding_board_consultation',
+			'simplification',
+			'user_escalation',
+		]) {
+			expect(
+				after.filter(
+					(event) => event.taskId === '1.1' && event.action === action,
+				).length,
+			).toBe(
+				action === 'sounding_board_consultation' ? consultationsBefore : 0,
+			);
+		}
+
+		// The next coder dispatch passes the retry-critic check (a different
+		// gate error is acceptable) and the admitted retry is durable.
+		let postError = '';
+		try {
+			await dispatchCoder('parent-1', 'post-approval');
+		} catch (error) {
+			postError = error instanceof Error ? error.message : String(error);
+		}
+		expect(postError).not.toContain('TASK_RETRY_CRITIC_REQUIRED');
+		expect(
+			readRetryEvents(directory).some(
+				(event) => event.taskId === '1.1' && event.action === 'simplification',
+			),
+		).toBe(true);
+	});
+
+	test('rejects a non-architect session and writes nothing', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('coder-session', 'coder', directory);
+		await expect(
+			forceRecordRetrySoundingBoardApproval(directory, 'coder-session', {
+				taskId: '1.1',
+				reason: 'self-unblock attempt',
+			}),
+		).rejects.toThrow('APPROVE_RETRY_SOUNDING_BOARD_ARCHITECT_REQUIRED');
+		expect(
+			(await readTaskEvidence(directory, '1.1'))?.gates.critic_sounding_board,
+		).toBeUndefined();
+	});
+
+	test('rejects a task id that is not in the current plan', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-approve', 'architect', directory);
+		await expect(
+			forceRecordRetrySoundingBoardApproval(directory, 'arch-approve', {
+				taskId: '9.9',
+				reason: 'foreign task',
+			}),
+		).rejects.toThrow('APPROVE_RETRY_UNKNOWN_TASK');
+		expect(
+			fs.existsSync(path.join(directory, '.swarm', 'evidence', '9.9.json')),
+		).toBe(false);
+	});
+
+	test('rejects a plan task with no durable workflow evidence', async () => {
+		ensureAgentSession('arch-approve', 'architect', directory);
+		// 1.2 exists in the plan but was never dispatched: no evidence file.
+		await expect(
+			forceRecordRetrySoundingBoardApproval(directory, 'arch-approve', {
+				taskId: '1.2',
+				reason: 'nothing to recover',
+			}),
+		).rejects.toThrow('APPROVE_RETRY_NO_WORKFLOW');
+	});
+
+	test('rejects a task whose breaker never consulted the sounding board', async () => {
+		// One no-op dispatch on 1.2: evidence exists, retryCount 1, no escalation.
+		const session = ensureAgentSession('parent-2', 'architect', directory);
+		session.currentTaskId = '1.2';
+		await dispatchCoder('parent-2', 'warm-1-2', '1.2');
+		ensureAgentSession('arch-approve', 'architect', directory);
+		await expect(
+			forceRecordRetrySoundingBoardApproval(directory, 'arch-approve', {
+				taskId: '1.2',
+				reason: 'skip the consultation',
+			}),
+		).rejects.toThrow('APPROVE_RETRY_CONSULTATION_REQUIRED');
+		expect(
+			readRetryEvents(directory).filter((event) => event.taskId === '1.2'),
+		).toEqual([]);
+		expect(
+			(await readTaskEvidence(directory, '1.2'))?.gates.critic_sounding_board,
+		).toBeUndefined();
+	});
+
+	test('remaps a corrupt retry audit index to a typed recovery error', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-approve', 'architect', directory);
+		fs.writeFileSync(
+			path.join(directory, '.swarm', 'events-authority-index.json'),
+			'{not json at all',
+		);
+		await expect(
+			forceRecordRetrySoundingBoardApproval(directory, 'arch-approve', {
+				taskId: '1.1',
+				reason: 'index corrupt',
+			}),
+		).rejects.toThrow('APPROVE_RETRY_AUDIT_INDEX_UNREADABLE');
+	});
+
+	test('the manual entry is cleared by accepted_mutation like a mechanical one', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-approve', 'architect', directory);
+		await forceRecordRetrySoundingBoardApproval(directory, 'arch-approve', {
+			taskId: '1.1',
+			reason: 'recovery',
+		});
+		expect(
+			(await readTaskEvidence(directory, '1.1'))?.gates.critic_sounding_board,
+		).toBeDefined();
+
+		// The admitted retry mutates a file and settles: accepted_mutation
+		// rotates the generation and clearWorkflowGateProof drops the entry.
+		const args = {
+			subagent_type: 'coder',
+			task_id: '1.1',
+			prompt:
+				'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+		};
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent-1', callID: 'simplified-retry' },
+			{ args },
+		);
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const simplifiedRepair = true;\n',
+		);
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent-1', callID: 'simplified-retry', args },
+			{ state: 'completed', output: 'implemented the simplified repair' },
+		);
+
+		const evidence = await readTaskEvidence(directory, '1.1');
+		expect(evidence?.gates.critic_sounding_board).toBeUndefined();
+		expect(getTaskWorkflowSnapshot(evidence).generation).toBe(1);
+	});
+});

--- a/tests/unit/hooks/delegation-gate-retry-sounding-board-manual.test.ts
+++ b/tests/unit/hooks/delegation-gate-retry-sounding-board-manual.test.ts
@@ -152,6 +152,7 @@ describe('forceRecordRetrySoundingBoardApproval (issue #2703)', () => {
 		);
 		expect(summary.taskId).toBe('1.1');
 		expect(summary.retryEpoch).toBe(epochBefore);
+		expect(summary.auditEventRecorded).toBe(true);
 
 		const evidence = await readTaskEvidence(directory, '1.1');
 		expect(evidence?.gates.critic_sounding_board?.sessionId).toBe(
@@ -195,6 +196,43 @@ describe('forceRecordRetrySoundingBoardApproval (issue #2703)', () => {
 				(event) => event.taskId === '1.1' && event.action === 'simplification',
 			),
 		).toBe(true);
+	});
+
+	test('is idempotent per (session, epoch): second call rewrites nothing and emits no second audit event', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-approve', 'architect', directory);
+		const first = await forceRecordRetrySoundingBoardApproval(
+			directory,
+			'arch-approve',
+			{ taskId: '1.1', reason: 'recovery' },
+		);
+		const afterFirst = await readTaskEvidence(directory, '1.1');
+		const transitionId = getTaskWorkflowSnapshot(afterFirst).lastTransitionId;
+		expect(transitionId).toBe(
+			`retry-sb-manual:arch-approve:epoch${first.retryEpoch}`,
+		);
+
+		const second = await forceRecordRetrySoundingBoardApproval(
+			directory,
+			'arch-approve',
+			{ taskId: '1.1', reason: 'repeated invocation' },
+		);
+		expect(second.auditEventRecorded).toBe(true);
+		const afterSecond = await readTaskEvidence(directory, '1.1');
+		// Epoch-stable transitionId: the duplicate transition is a no-op, so
+		// lastTransitionId (and the gate entry) are unchanged.
+		expect(getTaskWorkflowSnapshot(afterSecond).lastTransitionId).toBe(
+			transitionId,
+		);
+		expect(afterSecond?.gates.critic_sounding_board?.sessionId).toBe(
+			'arch-approve',
+		);
+		const manualEvents = readRetryEvents(directory).filter(
+			(event) =>
+				event.taskId === '1.1' &&
+				event.action === 'sounding_board_manual_approval',
+		);
+		expect(manualEvents.length).toBe(1);
 	});
 
 	test('rejects a non-architect session and writes nothing', async () => {

--- a/tests/unit/tools/approve-retry-sounding-board.test.ts
+++ b/tests/unit/tools/approve-retry-sounding-board.test.ts
@@ -42,6 +42,7 @@ interface ToolResult {
 	retry_epoch?: number;
 	method?: string;
 	user_confirmed?: boolean;
+	audit_event_recorded?: boolean;
 }
 
 describe('approve_retry_sounding_board tool (issue #2703)', () => {
@@ -176,6 +177,7 @@ describe('approve_retry_sounding_board tool (issue #2703)', () => {
 		expect(result.task_id).toBe('1.1');
 		expect(result.method).toBe('manual_override');
 		expect(result.user_confirmed).toBe(false);
+		expect(result.audit_event_recorded).toBe(true);
 		expect(typeof result.generation).toBe('number');
 		expect(typeof result.retry_epoch).toBe('number');
 	});

--- a/tests/unit/tools/approve-retry-sounding-board.test.ts
+++ b/tests/unit/tools/approve-retry-sounding-board.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { PluginConfig } from '../../../src/config';
+import { createDelegationGateHook } from '../../../src/hooks/delegation-gate';
+import { ensureAgentSession, resetSwarmState } from '../../../src/state';
+import {
+	approve_retry_sounding_board,
+	executeApproveRetrySoundingBoard,
+} from '../../../src/tools/approve-retry-sounding-board';
+import { writeApprovedPlan } from '../../helpers/approved-plan';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const config = {
+	max_iterations: 5,
+	qa_retry_limit: 3,
+	inject_phase_reminders: true,
+	hooks: { delegation_gate: true },
+	worktree: { policy: 'disabled' },
+} as PluginConfig;
+
+function git(directory: string, args: string[]): void {
+	const result = spawnSync('git', ['-C', directory, ...args], {
+		cwd: directory,
+		stdin: 'ignore',
+		stdout: 'pipe',
+		stderr: 'pipe',
+		encoding: 'utf8',
+		timeout: 5_000,
+		maxBuffer: 128 * 1024,
+		windowsHide: true,
+	});
+	if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+interface ToolResult {
+	success?: boolean;
+	message?: string;
+	task_id?: string;
+	generation?: number;
+	retry_epoch?: number;
+	method?: string;
+	user_confirmed?: boolean;
+}
+
+describe('approve_retry_sounding_board tool (issue #2703)', () => {
+	let directory = '';
+	let cleanup = (): void => {};
+
+	async function dispatchCoder(
+		hook: ReturnType<typeof createDelegationGateHook>,
+		callID: string,
+	): Promise<void> {
+		const args = {
+			subagent_type: 'coder',
+			task_id: '1.1',
+			prompt:
+				'TASK: 1.1\nFILE: src/feature.ts\nACCEPTANCE: feature is implemented and verified',
+		};
+		await hook.toolBefore(
+			{ tool: 'Task', sessionID: 'parent-1', callID },
+			{ args },
+		);
+		await hook.toolAfter(
+			{ tool: 'Task', sessionID: 'parent-1', callID, args },
+			{ state: 'completed', output: 'no changes required' },
+		);
+	}
+
+	async function wedgeTask1_1(): Promise<void> {
+		const session = ensureAgentSession('parent-1', 'architect', directory);
+		session.currentTaskId = '1.1';
+		const hook = createDelegationGateHook(config, directory);
+		for (let attempt = 1; attempt <= 3; attempt += 1) {
+			await dispatchCoder(hook, `no-op-${attempt}`);
+		}
+		await expect(dispatchCoder(hook, 'threshold-probe')).rejects.toThrow(
+			'Dispatch critic_sounding_board',
+		);
+	}
+
+	beforeEach(async () => {
+		resetSwarmState();
+		({ dir: directory, cleanup } = createSafeTestDir('tool-retry-sb-'));
+		git(directory, ['init']);
+		git(directory, ['config', 'user.email', 'tests@example.com']);
+		git(directory, ['config', 'user.name', 'Tests']);
+		fs.mkdirSync(path.join(directory, 'src'), { recursive: true });
+		fs.writeFileSync(
+			path.join(directory, 'src', 'feature.ts'),
+			'export const feature = 1;\n',
+		);
+		git(directory, ['add', 'src/feature.ts']);
+		git(directory, ['commit', '-m', 'test: seed repository']);
+		fs.appendFileSync(
+			path.join(directory, '.git', 'info', 'exclude'),
+			'\n.swarm/\n',
+		);
+		await writeApprovedPlan(directory, [
+			{ id: '1.1', files: ['src/feature.ts'] },
+		]);
+	});
+
+	afterEach(() => {
+		resetSwarmState();
+		cleanup();
+	});
+
+	test('rejects invalid args (missing fields, over-length reason)', async () => {
+		const missingTask = JSON.parse(
+			await executeApproveRetrySoundingBoard({ reason: 'x' }, directory, {
+				sessionID: 's',
+			}),
+		) as ToolResult;
+		expect(missingTask.success).toBe(false);
+		expect(missingTask.message).toContain('task_id');
+
+		const missingReason = JSON.parse(
+			await executeApproveRetrySoundingBoard({ task_id: '1.1' }, directory, {
+				sessionID: 's',
+			}),
+		) as ToolResult;
+		expect(missingReason.success).toBe(false);
+		expect(missingReason.message).toContain('reason');
+
+		const overLength = JSON.parse(
+			await executeApproveRetrySoundingBoard(
+				{ task_id: '1.1', reason: 'r'.repeat(501) },
+				directory,
+				{ sessionID: 's' },
+			),
+		) as ToolResult;
+		expect(overLength.success).toBe(false);
+		expect(overLength.message).toContain('reason');
+	});
+
+	test('rejects an unknown extra arg (strict schema)', async () => {
+		const result = JSON.parse(
+			await executeApproveRetrySoundingBoard(
+				{ task_id: '1.1', reason: 'x', extra: true },
+				directory,
+				{ sessionID: 's' },
+			),
+		) as ToolResult;
+		expect(result.success).toBe(false);
+	});
+
+	test('requires an active sessionID', async () => {
+		const result = JSON.parse(
+			await executeApproveRetrySoundingBoard(
+				{ task_id: '1.1', reason: 'x' },
+				directory,
+				{},
+			),
+		) as ToolResult;
+		expect(result.success).toBe(false);
+		expect(result.message).toContain('sessionID');
+	});
+
+	test('records a manual approval from an architect session with audit markers', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('arch-tool', 'architect', directory);
+		const result = JSON.parse(
+			await executeApproveRetrySoundingBoard(
+				{
+					task_id: '1.1',
+					reason:
+						'sounding board returned APPROVED but the recorder missed the verdict format',
+				},
+				directory,
+				{ sessionID: 'arch-tool' },
+			),
+		) as ToolResult;
+		expect(result.success).toBe(true);
+		expect(result.task_id).toBe('1.1');
+		expect(result.method).toBe('manual_override');
+		expect(result.user_confirmed).toBe(false);
+		expect(typeof result.generation).toBe('number');
+		expect(typeof result.retry_epoch).toBe('number');
+	});
+
+	test('surfaces typed helper failures as success:false JSON, not throws', async () => {
+		await wedgeTask1_1();
+		ensureAgentSession('coder-session', 'coder', directory);
+		const result = JSON.parse(
+			await executeApproveRetrySoundingBoard(
+				{ task_id: '1.1', reason: 'self-unblock attempt' },
+				directory,
+				{ sessionID: 'coder-session' },
+			),
+		) as ToolResult;
+		expect(result.success).toBe(false);
+		expect(result.message).toContain(
+			'APPROVE_RETRY_SOUNDING_BOARD_ARCHITECT_REQUIRED',
+		);
+	});
+
+	test('is exported through the tool barrel surface with a createSwarmTool shape', () => {
+		expect(typeof approve_retry_sounding_board.execute).toBe('function');
+		expect(approve_retry_sounding_board.args).toBeDefined();
+	});
+});

--- a/tests/unit/types/events.type-safety.test.ts
+++ b/tests/unit/types/events.type-safety.test.ts
@@ -67,9 +67,11 @@ describe('src/types/events.ts - ADVERSARIAL TESTS', () => {
 				'sounding_board_consultation',
 				'simplification',
 				'user_escalation',
+				// #2703: recorded only by forceRecordRetrySoundingBoardApproval.
+				'sounding_board_manual_approval',
 			];
 
-			expect(validActions).toHaveLength(3);
+			expect(validActions).toHaveLength(4);
 		});
 
 		test('PrecedentManipulationDetectedEvent rejects invalid pattern values', () => {

--- a/tests/unit/types/events.type-safety.test.ts
+++ b/tests/unit/types/events.type-safety.test.ts
@@ -67,10 +67,8 @@ describe('src/types/events.ts - ADVERSARIAL TESTS', () => {
 				'sounding_board_consultation',
 				'simplification',
 				'user_escalation',
-				// #2703: recorded only by forceRecordRetrySoundingBoardApproval.
-				'sounding_board_manual_approval',
+				'sounding_board_manual_approval', // #2703: manual-override recorder only.
 			];
-
 			expect(validActions).toHaveLength(4);
 		});
 


### PR DESCRIPTION
# fix(gates): recover an unpersisted sounding-board APPROVED verdict (issue #2703)

Closes #2703

## Summary

The coder retry circuit breaker's `critic_sounding_board` gate blocked every
coder dispatch for a task until durable `gates.critic_sounding_board` evidence
existed in `.swarm/evidence/<taskId>.json` — but the only writer was the
mechanical toolAfter recorder, whose conjunctive preconditions (verdict
parsing through the plan-critic rubric, dispatch-time task attribution,
launch-generation binding, non-terminal output state) can each miss on a
legitimate APPROVED verdict. Notably, the sounding board's own instructed
RESPONSE FORMAT line (`Verdict: UNNECESSARY | REPHRASE | APPROVED | RESOLVE`)
is structurally unparseable by that rubric. Once any precondition missed,
every subsequent coder dispatch was blocked with `TASK_RETRY_CRITIC_REQUIRED`
across sessions and resets, and the only workaround was re-planning the task
under a fresh id. The sibling `critic_pre_plan` gate received exactly this
escape hatch in #2012 (`approve_plan_critic`); the retry gate never did.

This change:

- adds `forceRecordRetrySoundingBoardApproval` (`src/hooks/delegation-gate.ts`)
  — the architect-facing manual recorder that writes the exact evidence the
  mechanical path would have written (same `gate_recorded` transition, same
  retention semantics), fail-closed on: active architect session, plan-known
  task id, existing durable workflow evidence, and a prior
  `sounding_board_consultation` escalation for the task's CURRENT retry epoch.
  It records evidence only — it never emits consultation/simplification/
  user-escalation events, so it cannot fabricate or skip the escalation
  protocol. A corrupt retry-audit index surfaces as a typed
  `APPROVE_RETRY_AUDIT_INDEX_UNREADABLE` with repair guidance instead of
  wedging the recovery path;
- adds the `approve_retry_sounding_board` tool (`task_id` + audited `reason`),
  registered through the full metadata/manifest/barrel chain
  (`agents: ['architect']`);
- adds a `sounding_board_manual_approval` action value to the
  `coder_retry_circuit_breaker` authority event (deduped per task+epoch) so a
  manual override is durably distinguishable from a mechanical recording;
- makes the `/swarm reset-session` footer truthful: in-memory state cleared,
  durable per-task retry gates intentionally survive (the old unconditional
  "All circuit breakers … have been cleared" claim was false for exactly this
  gate), and the recovery tool is named for a blocked task.

Gate semantics are unchanged: the escalation sequence, retry thresholds, and
generation/epoch retention are untouched; a manual entry is cleared by
`accepted_mutation`/`repair_idle` exactly like a mechanical one.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; the new tool/helper
  run only on explicit invocation.
- 2 (runtime portability): touched — the plugin bundle gained the new tool
  file; `bun run build` + `tests/unit/build/bundle-portability.test.ts` 12/0 +
  `bundle-plugin-shape.test.ts` 10/0 + `tests/smoke/packaging.test.ts` 10/0 +
  `node --input-type=module -e "await import('./dist/index.js')"` →
  `plugin id: opencode-swarm | has server: true`. No `bun:` resolution, no
  `Bun.*` calls, entry shape unchanged; `bun run typecheck` clean.
- 3 (subprocesses): not touched — no spawn sites added or modified.
- 4 (.swarm containment): not touched — all writes go through the existing
  `recordGateEvidence` / `appendCoreEventSync` seams under `.swarm/`.
- 5 (plan durability): not touched — plan.json/plan.md/ledger untouched.
- 6 (test_runner safety): not touched — no scope or registration-policy change.
- 7 (test writing): touched — three new bun:test files
  (`delegation-gate-retry-sounding-board-manual`, `approve-retry-sounding-board`,
  `reset-session-retry-disclosure`): real fixtures on `createSafeTestDir` temp
  dirs, zero `mock.module`, each well under the 500-line cap;
  `check:mock-cleanup`, `check:test-file-cap`, `check:test-tmpdir`,
  `check:test-clock` all exit 0.
- 8 (session state): not touched — no new session-keyed or module-global
  state (`ensureAgentSession` used read-only for the architect check).
- 9 (guardrails/retry): touched — this is the invariant's home surface. The
  manual override is action-local and epoch-bound: it records evidence only,
  binds to the exact plan task + current durable retry epoch, is architect-
  session-enforced, cannot substitute for the consultation escalation, and is
  cleared by the same generation-rotation retention as mechanical proof.
  Evidence: frozen checks C1/C2/C5 (RED→GREEN / ERROR→GREEN) + the 7-test
  helper suite incl. success-path action-count parity and retention parity;
  the independent implementation reviewer and final critic both re-derived
  the no-gap closure (cross-session recovery, epoch rotation, re-planned
  tasks) from source.
- 10 (chat/system msg): not touched.
- 11 (tool registration): touched — `TOOL_METADATA` entry, `TOOL_MANIFEST`
  thunk, barrel export, and the `check-core-events-usage` prompt-doc row
  (mirroring the `approve-plan-critic.ts` precedent);
  `scripts/check-tool-registration.ts` → "131 tools, coherent across
  metadata, handlers, the plugin object, TOOL_NAMES, AGENT_TOOL_MAP, and the
  barrel"; `manifest-parity` 9/0 and `architect-tool-lists` 10/0; `drift:check`
  clean.
- 12 (release/cache): touched — `docs/releases/pending/2703-retry-critic-verdict-recovery.md`
  added; version/CHANGELOG untouched (release-please owns them).

## Test plan

- Five frozen acceptance checks (independent check-author context, red
  checkpoint frozen pre-fix, checkpoint verified OK, replayed post-fix):
  - C1 (DISCRIMINATING): wedged task → manual recording → next coder dispatch
    passes the retry-critic check + `simplification` admission — base RED
    (`CHECK FAIL: C1: tool module missing`), head GREEN.
  - C2 (NEW-SURFACE): `method: 'manual_override'` + audit event bound to
    taskId/current retryEpoch + durable gate bound to the architect session —
    base ERROR, head GREEN.
  - C3 (PRESERVING): mechanical happy path still records — GREEN→GREEN.
  - C4 (DISCRIMINATING): reset footer drops the unconditional all-clear,
    discloses durable survival, names the tool — base RED, head GREEN.
  - C5 (NEW-SURFACE): non-architect / plan-unknown / no-consultation
    rejections with no durable writes and no fabricated escalations — base
    ERROR, head GREEN.
- New unit suites (per-file, CI-equivalent isolation): 8/0 + 6/0 + 3/0 after the feedback round (adds the double-invocation idempotency test).
- Blast radius per-file, 0 fail: `delegation-gate-coder-transactions-2098`
  (4/0, the pinned retry lifecycle incl. the mechanical path),
  `manifest-parity` (9/0), `architect-tool-lists` (10/0), the seven
  reset-session sibling suites, `core-events-authority-index` (13/0),
  `core-events-readers` (9/0), `architect-retry-circuit-breaker` (11/0),
  `index-commands` (13/0), `destructive-purge-consume-2508` (8/0),
  `guardrail-reset` (2/0). Mock-consumer sweep: no test mocks the changed
  modules.
- Repo gates: `typecheck`, `lint:ci` (0 errors), `check:events`,
  `check:registry-citations` (85/85 anchors — no new drift from shifted
  lines), `check:core-events`, `check:mock-cleanup`, `check:test-file-cap`,
  `check:invariants`, `drift:check`, `check:runtime-src-refs`,
  `check:cross-contamination`, `check:test-clock`, `check:test-tmpdir`,
  `scan-deferred` (clean).
- Full protocol trace (root cause, frozen checks, plan critic with 2 rounds,
  independent implementation review, final critic — all APPROVE):
  `.agents/issue-traces/2703-retry-critic-verdict-recovery/` (local-only,
  gitignored by design).

## Acceptance Criteria -> Evidence

- AC1 (recovery path persists an obtained APPROVED verdict; next coder
  dispatch passes the critic check) → C1: `repro/C1.base.log` RED /
  `repro/C1.head.log` GREEN + helper test "records the durable gate entry +
  audit event and unblocks the next coder dispatch".
- AC2 (audited + identity-bound: architect session, plan-known task,
  manual_override markers, distinguishable core event) → C2 GREEN + tool
  test "records a manual approval from an architect session with audit
  markers" + helper rejection tests.
- AC3 (mechanical recording path unchanged) → C3 GREEN→GREEN + the untouched
  2098 suite 4/0.
- AC4 (reset-session output discloses durable retry-gate survival + names the
  recovery) → C4 RED→GREEN + `reset-session-retry-disclosure.test.ts` 3/0.
- AC5 (fail-closed boundaries; no escalation fabrication) → C5 GREEN + helper
  tests 2-7 (non-architect, unknown task, no workflow, no consultation,
  corrupt index, retention parity).

## Feedback round (post swarm-pr-review) — f2489dac4

A full swarm-pr-review pass (6 base lanes, 11 risk-family micro lanes, 2 independent reviewer shards, critic challenge) validated 10 findings; all are closed in `fix(gates): pr-review feedback round on #2715 — budget, TOCTOU, idempotency, wording` (f2489dac4), independently re-reviewed (fix reviewer APPROVE 7/7) and critic-approved. Highlights:

- **PRR-X1 (HIGH, CI-blocking)**: the new tool's 417-char metadata description pushed three architect prompt renders past the 160,000-char budget ceiling (parent headroom was only ~79 chars). Fixed by a terse metadata description (the full host tool schema is unchanged and still carries every precondition) plus a documented `ARCHITECT_PROMPT_BUDGET_CHARS` 160,000 → 161,000 raise citing #2703.
- **PRR-C1**: the manual recorder now passes `expectedGeneration`, so a write racing a generation rotation fails closed instead of resurrecting a cleared gate.
- **PRR-R2/T4/T5**: epoch-stable transitionId makes repeated invocations idempotent (pinned by a new test asserting exactly one audit event and an unchanged lastTransitionId).
- **PRR-R1 residual**: the tool result now reports `audit_event_recorded` and says so when the audit append failed.
- **PRR-M1/M2**: refreshed the two pre-existing event-union test surfaces (action array 3 → 4; helper type).
- **PRR-D1/D2/O1**: reset footer says "have the architect record it"; the release fragment discloses the task + current-retry-epoch binding as the epoch-scoped analog of the issue's task+generation suggestion.

Rejected findings (with evidence in the review handoff): T3 (spawnSync CI-cause — disproved; the real cause was X1), T2 (admission assertion is load-bearing), P1 (eviction math negligible), S1/S2 (pre-existing conventions + defense-in-depth), C2 (bounded self-healing), U1 (defense chain accurate), Z1 (full-auto catch-all matches the `approve_plan_critic` convention — documented non-goal).

Re-validation at f2489dac4: typecheck clean; biome clean; `architect-prompt-budget.test.ts` 8/8 (was 3 fail); affected suites 76/0 across 7 files; frozen acceptance checks C1–C5 replay all PASS; events/citations/core-events/mock-cleanup/file-cap/invariants/drift/clock/contamination gates green.

## Waivers (or none)

None — every clause of the Full-Resolution Contract is satisfied with
recorded evidence; no waiver requested. Declared non-goals (pre-approved in
the reviewed plan): the human-only `/swarm` command twin and auto-recorder
parser hardening — both out of the issue's asked scope, disclosed in the
trace and the release fragment.

## Merge status

PR head: f2489dac4543c0ea678fa15fb7e8ba2407b65183
State: AWAITING_USER_APPROVAL — merge requires separately recorded human
approval bound to this exact head; the fix-round reviewer and critic verdicts
bind to this head (see `.zcode/session/tasks/pr2715-feedback/gates.md`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/opencode-swarm/pull/2715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


