### PR TITLE
fix(memory): serialize cohort destination migration under its live lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Every PR that touches a relevant area must list which of these invariants it tou
   }));
   ```
 - **`mock.module` allowlist growth ratchet (issue #1666):** `scripts/mock-allowlist.txt` is closed against unapproved growth by `bun run check:invariants` Check 4. Adding a new `mock.module` target requires a matching standalone marker line `# APPROVED-NEW: <normalized-target>` in `scripts/mock-allowlist.txt` (preserved across regen by `scripts/generate-mock-allowlist.sh`). `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR. Prefer `_internals` DI for new code — the allowlist is a legacy-pattern debt surface, not a way to bypass the seam convention.
+- **Family-migration destination-lock admission (issue #2577):** `bun run check:invariants` Check 8 fail-closes the memory and knowledge family-migration engines — a destination-lock acquisition failure must `throw` (typed contention/storage), never proceed unlocked. The check errors on a swallowed admission, a missing engine file (single-engine drift), or a drifted scan anchor.
 - Use `os.tmpdir()` + `path.join(...)` for temp paths. No hardcoded `/tmp` or `C:\` strings.
 - `mkdtempSync` must be wrapped in `realpathSync` if the result is `chdir`'d on macOS.
 

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -793,6 +793,7 @@ Split criteria: one behavioral aspect per file, shared test utilities extracted 
 
 - Run `bun run check:mock-cleanup` — it enforces Check 2: every `mock.module('node:*', ...)` must spread real exports (e.g., `...realFs`, `...realChildProcess`).
 - Run `bun run check:invariants` — Check 3 enforces the `scripts/mock-allowlist.txt` membership, and Check 4 (issue #1666) ratchets the allowlist closed against unapproved growth. Adding a new `mock.module` target requires a matching `# APPROVED-NEW: <normalized-target>` marker line in `scripts/mock-allowlist.txt`; `MOCK_ALLOWLIST_ENFORCE=0` soft-warns for a deliberate growth PR.
+- Run `bun run check:invariants` — Check 8 (issue #2577) fail-closes the family-migration engines' destination-lock admission: each engine's destination `proper-lockfile` acquire must keep a real `throw` in its adjacent catch (a swallowed admission failure is the FUNCTIONAL-6 unlocked-migration defect). The scan is CRLF-normalized, skips comment lines, and errors on a missing engine file (when the other engine is present) or on zero recognizable acquire sites, so renames cannot silence it vacuously.
 - Run the new bounded tests alongside the existing real-git tests; no cross-file pollution.
 - New test files must be under 500 lines — `delegation-gate.test.ts` split is the exemplar pattern.
 - FR-009 Lean Turbo tests cover: acquire-locks, plan-lanes, review, runner-status, generate-mutants, set-qa-gates, get-qa-gate-profile.

--- a/docs/releases/pending/2577-memory-cohort-migration-lock.md
+++ b/docs/releases/pending/2577-memory-cohort-migration-lock.md
@@ -1,0 +1,27 @@
+# Memory cohort migration destination locking (#2577)
+
+## What changed
+
+- `/swarm memory link` and `/swarm memory unlink` migrations now fail closed
+  when the destination storage-directory lock cannot be acquired, instead of
+  proceeding unlocked after the lock acquisition failure was silently
+  swallowed.
+- The failure is typed (`MemoryMigrationLockError` with a `contention` or
+  `storage` category and a stable code), bounded, and retryable: the shared
+  acquisition retry budget (~4.3 s) is honored first, and the surfaced message
+  tells the user to retry the command.
+- Destination and source stores are preserved byte-for-byte on a failed
+  admission — no partial merge, no `backups/` litter — and a held live lock is
+  never stolen.
+- Added deterministic held-lock, taxonomy, serialization, retryable-admission,
+  and idempotency regression coverage.
+
+## Why
+
+The migration engine caught every destination-lock acquisition failure
+(including `ELOCKED` after the bounded retries) and ran the destination
+read/merge/write without the lock, so a legitimate concurrent writer on the
+same storage directory — the local JSONL provider, a sibling worktree's link,
+or a peer unlink — was not excluded and rows appended between the migration's
+read and write were silently dropped while the command reported success
+(issue #2577, audit FUNCTIONAL-6).

--- a/docs/releases/pending/2577-memory-cohort-migration-lock.md
+++ b/docs/releases/pending/2577-memory-cohort-migration-lock.md
@@ -8,7 +8,7 @@
   swallowed.
 - The failure is typed (`MemoryMigrationLockError` with a `contention` or
   `storage` category and a stable code), bounded, and retryable: the shared
-  acquisition retry budget (~4.3 s) is honored first, and the surfaced message
+  acquisition retry budget (~4.2 s) is honored first, and the surfaced message
   tells the user to retry the command.
 - Destination and source stores are preserved byte-for-byte on a failed
   admission — no partial merge, no `backups/` litter — and a held live lock is

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -974,6 +974,83 @@ export function checkRawAdvisoryPush(repoRoot: string): CheckResult {
 	return { messages, violations: 0 };
 }
 
+
+/**
+ * Check 8 (issue #2577): the family-migration engines' DESTINATION lock
+ * acquisition must fail closed. A catch that swallows the acquisition failure
+ * (the FUNCTIONAL-6 defect: proceed unlocked) lets the migration's
+ * read/merge/write race a legitimate concurrent writer holding the live
+ * destination lock. The check locates each `destRelease = await ...lock(`
+ * acquire, finds its adjacent catch, and requires a `throw` inside the catch
+ * body - matching both engines' fail-closed shape (typed or wrapped rethrow).
+ */
+export function checkMigrationLockAdmission(repoRoot: string): CheckResult {
+	const messages = [
+		'=== Check 8: family-migration destination lock admission fails closed (issue #2577) ===',
+	];
+	let violations = 0;
+	const engines = [
+		'src/memory/memory-family-migration.ts',
+		'src/knowledge/family-migration.ts',
+	];
+	for (const rel of engines) {
+		const file = path.join(repoRoot, ...rel.split('/'));
+		let content: string;
+		try {
+			content = fs.readFileSync(file, 'utf8');
+		} catch {
+			messages.push(`NOTE: ${rel} not found - Check 8 skipped for this path.`);
+			continue;
+		}
+		// Normalize CRLF so the strict catch-close match below cannot be defeated
+		// by a Windows autocrlf working copy (reviewer finding: a trailing CR made
+		// the scanner walk past a swallowing catch).
+		const lines = content.replace(/\r\n/g, '\n').split('\n');
+		for (let i = 0; i < lines.length; i++) {
+			if (!/destRelease\s*=\s*await\s/.test(lines[i])) continue;
+			if (!/\.lock\(/.test(lines[i]) && !/\.lock\(/.test(lines[i + 1] ?? '')) {
+				continue;
+			}
+			let catchIdx = -1;
+			for (let j = i + 1; j < Math.min(i + 12, lines.length); j++) {
+				if (/^\s*}\s*catch/.test(lines[j])) {
+					catchIdx = j;
+					break;
+				}
+			}
+			if (catchIdx === -1) {
+				messages.push(
+					`ERROR: ${rel}:${i + 1} destination lock acquire has no adjacent catch - re-anchor Check 8.`,
+				);
+				violations++;
+				continue;
+			}
+			const catchIndent = lines[catchIdx].match(/^\s*/)?.[0] ?? '';
+			let sawThrow = false;
+			for (let j = catchIdx + 1; j < lines.length; j++) {
+				if (lines[j] === `${catchIndent}}`) break;
+				// Comment lines never satisfy the fail-closed requirement: the
+				// memory engine's own catch comment says "This throw stays", and
+				// counting that word would mask a swallow mutation.
+				const body = lines[j].trimStart();
+				if (body.startsWith('//') || body.startsWith('*')) continue;
+				if (/\bthrow\b/.test(lines[j])) {
+					sawThrow = true;
+					break;
+				}
+			}
+			if (!sawThrow) {
+				messages.push(
+					`ERROR: ${rel}:${catchIdx + 1} destination lock acquisition failure is swallowed - a held live destination lock must fail closed (issue #2577, FUNCTIONAL-6).`,
+				);
+				violations++;
+			} else {
+				messages.push(`OK: ${rel}:${i + 1} destination lock admission fails closed.`);
+			}
+		}
+	}
+	return { messages, violations };
+}
 /**
  * Check 7 (issue #2477): every ACTIVE quarantine entry carries structured
  * OWNER and EXPIRY metadata in its comment block. Grammar:
@@ -1119,6 +1196,7 @@ export async function main(startDir: string = process.cwd()): Promise<number> {
 			violations: advisory.violations,
 		},
 		checkQuarantineMetadata(repoRoot),
+		checkMigrationLockAdmission(repoRoot),
 	];
 
 	for (const output of outputs) {
@@ -1140,7 +1218,12 @@ export async function main(startDir: string = process.cwd()): Promise<number> {
 	console.log(
 		'            5 (knowledge array dedup guardrail) | 6 (advisory-injection ratchet) |',
 	);
-	console.log('            7 (quarantine OWNER/EXPIRY metadata)');
+	console.log(
+		'            7 (quarantine OWNER/EXPIRY metadata) |',
+	);
+	console.log(
+		'            8 (family-migration destination lock admission)',
+	);
 	if (violations > 0) {
 		console.log(`${violations} invariant violation(s) found.`);
 		return 1;

--- a/scripts/check-invariants.ts
+++ b/scripts/check-invariants.ts
@@ -993,24 +993,45 @@ export function checkMigrationLockAdmission(repoRoot: string): CheckResult {
 		'src/memory/memory-family-migration.ts',
 		'src/knowledge/family-migration.ts',
 	];
+	const missingEngines: string[] = [];
+	const contents = new Map<string, string>();
 	for (const rel of engines) {
 		const file = path.join(repoRoot, ...rel.split('/'));
-		let content: string;
 		try {
-			content = fs.readFileSync(file, 'utf8');
+			contents.set(rel, fs.readFileSync(file, 'utf8'));
 		} catch {
-			messages.push(`NOTE: ${rel} not found - Check 8 skipped for this path.`);
-			continue;
+			missingEngines.push(rel);
 		}
+	}
+	if (missingEngines.length === engines.length) {
+		// No family-migration surface at all (fixture trees, subsystem-free
+		// repos): nothing to scan. Exactly ONE missing engine, however, is
+		// drift - a rename or move must not silently silence its half.
+		for (const rel of missingEngines) {
+			messages.push(`NOTE: ${rel} not found - Check 8 skipped for this path.`);
+		}
+		return { messages, violations };
+	}
+	for (const rel of missingEngines) {
+		messages.push(
+			`ERROR: ${rel} not found - Check 8 cannot verify destination lock admission; re-anchor Check 8.`,
+		);
+		violations++;
+	}
+	for (const rel of engines) {
+		const content = contents.get(rel);
+		if (content === undefined) continue;
 		// Normalize CRLF so the strict catch-close match below cannot be defeated
 		// by a Windows autocrlf working copy (reviewer finding: a trailing CR made
 		// the scanner walk past a swallowing catch).
 		const lines = content.replace(/\r\n/g, '\n').split('\n');
+		let acquireMatches = 0;
 		for (let i = 0; i < lines.length; i++) {
 			if (!/destRelease\s*=\s*await\s/.test(lines[i])) continue;
 			if (!/\.lock\(/.test(lines[i]) && !/\.lock\(/.test(lines[i + 1] ?? '')) {
 				continue;
 			}
+			acquireMatches++;
 			let catchIdx = -1;
 			for (let j = i + 1; j < Math.min(i + 12, lines.length); j++) {
 				if (/^\s*}\s*catch/.test(lines[j])) {
@@ -1047,6 +1068,15 @@ export function checkMigrationLockAdmission(repoRoot: string): CheckResult {
 			} else {
 				messages.push(`OK: ${rel}:${i + 1} destination lock admission fails closed.`);
 			}
+		}
+		if (acquireMatches === 0) {
+			// Zero recognizable acquire sites in a PRESENT engine file means the
+			// scan anchor drifted (e.g. the release variable was renamed): the
+			// guardrail would be passing vacuously, so fail closed instead.
+			messages.push(
+				`ERROR: ${rel} contains no recognizable destination lock acquire (destRelease = await ...lock()) - re-anchor Check 8.`,
+			);
+			violations++;
 		}
 	}
 	return { messages, violations };

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -77,6 +77,7 @@ export {
 	type MemorySupersededChain,
 	shouldCompactMemory,
 } from './maintenance';
+export { MemoryMigrationLockError } from './memory-family-migration';
 // #1850 Linked Knowledge 5/5: cohort memory sharing.
 export {
 	invalidateMemoryStoreDirCache,

--- a/src/memory/memory-family-migration.ts
+++ b/src/memory/memory-family-migration.ts
@@ -21,6 +21,10 @@
  * Lock discipline: `proper-lockfile` on the destination cohort dir with a
  * bumped `stale` (30s) for the migration critical section — reused from the
  * knowledge family so there is one source of truth for the lock config.
+ * Admission is fail-closed (#2577): if the destination lock cannot be
+ * acquired (a legitimate concurrent writer holds it, or acquisition fails for
+ * a storage reason), the migration throws a typed
+ * {@link MemoryMigrationLockError} and never runs unlocked.
  *
  * No writes happen here on the plugin-init path (invariant 1). Called only
  * from the `/swarm memory link` / `/swarm memory unlink` command handlers.
@@ -29,7 +33,7 @@
 import { copyFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { mkdir, rename } from 'node:fs/promises';
 import * as path from 'node:path';
-import lockfile from 'proper-lockfile';
+import lockfileImport from 'proper-lockfile';
 import { atomicWriteFile } from '../evidence/task-file.js';
 import {
 	MIGRATION_LOCK_RETRIES,
@@ -44,6 +48,67 @@ import {
 } from './outcome-events.js';
 import type { VettedMemoryRoot } from './storage-root.js';
 import { isCohortRoot, rootStoragePath } from './storage-root.js';
+
+/**
+ * Minimal typing for the async `proper-lockfile` API this engine uses,
+ * exposed through {@link _internals} so tests can classify acquisition
+ * failures deterministically (same DI pattern as `src/full-auto/state.ts`).
+ */
+type MigrationLockFile = {
+	lock: typeof import('proper-lockfile')['lock'];
+};
+const lockfile = lockfileImport as unknown as MigrationLockFile;
+
+/** Failure category for destination-lock admission (#2577, #2575 contract). */
+export type MemoryMigrationLockErrorCategory = 'contention' | 'storage';
+
+/**
+ * Typed failure for acquiring the destination migration lock. Thrown BEFORE
+ * the merge loop opens, so no destination or source write ever happens on a
+ * failed admission. Mirrors `FullAutoStateLockError` in
+ * `src/full-auto/state.ts` (#2575): stable category + code, cause preserved
+ * for diagnostics, and messages that never echo absolute host paths.
+ */
+export class MemoryMigrationLockError extends Error {
+	readonly category: MemoryMigrationLockErrorCategory;
+	readonly cause: unknown;
+	readonly code: `MEMORY_MIGRATION_LOCK_${Uppercase<MemoryMigrationLockErrorCategory>}`;
+
+	constructor(
+		category: MemoryMigrationLockErrorCategory,
+		message: string,
+		cause?: unknown,
+	) {
+		super(message);
+		this.name = 'MemoryMigrationLockError';
+		this.category = category;
+		this.code =
+			`MEMORY_MIGRATION_LOCK_${category.toUpperCase()}` as MemoryMigrationLockError['code'];
+		this.cause = cause;
+	}
+}
+
+function lockErrorCode(error: unknown): string | undefined {
+	return typeof error === 'object' && error !== null && 'code' in error
+		? String((error as { code?: unknown }).code)
+		: undefined;
+}
+
+function makeAdmissionError(cause: unknown): MemoryMigrationLockError {
+	if (lockErrorCode(cause) === 'ELOCKED') {
+		return new MemoryMigrationLockError(
+			'contention',
+			'memory-family-migration: destination lock contention after bounded retries; retry the link or unlink command',
+			cause,
+		);
+	}
+	const code = lockErrorCode(cause);
+	return new MemoryMigrationLockError(
+		'storage',
+		`memory-family-migration: destination lock acquisition failed${code ? ` (${code})` : ''}`,
+		cause,
+	);
+}
 
 /**
  * #1850 (H-008): max number of source-DB backups retained in
@@ -425,20 +490,24 @@ export async function migrateMemoryFamily(
 
 	// #1850 (reviewer critical fix): the destination may be EITHER a cohort
 	// root (link direction: local → cohort) OR a local root (unlink direction:
-	// cohort → local). Both are valid. We lock the destination directory when
-	// possible; local roots are single-writer by construction (no cross-process
-	// contender), so locking is best-effort for them. The source is always read
+	// cohort → local). Both are valid and both are lockable — the local JSONL
+	// provider locks the same storage directory during normal writes, so local
+	// roots have real cross-process contenders too. The source is always read
 	// under its own brief snapshot.
 	await mkdir(destStoragePath, { recursive: true });
 	let destRelease: (() => Promise<void>) | null = null;
 	try {
-		destRelease = await lockfile.lock(destStoragePath, {
+		destRelease = await _internals.lockfile.lock(destStoragePath, {
 			...MIGRATION_LOCK_RETRIES,
 			stale: MIGRATION_LOCK_STALE_MS,
 		});
-	} catch {
-		// Local roots or missing dirs may not be lockable; proceed unlocked.
-		// The destination write is still atomic (temp + rename per member).
+	} catch (error) {
+		// #2577 (FUNCTIONAL-6): admission is fail-closed. This throw stays
+		// syntactically INSIDE this catch - before the merge-loop try below
+		// opens and with destRelease still null - so a held live destination
+		// lock can never be bypassed and the destination/source are preserved
+		// on failed admission. Do not relocate it into the merge loop.
+		throw makeAdmissionError(error);
 	}
 
 	const perMember: Array<{
@@ -550,4 +619,5 @@ export const _internals = {
 	stageSqliteDb,
 	mergeStagedSqlite,
 	countRowsSafe,
+	lockfile,
 };

--- a/src/memory/memory-family-migration.ts
+++ b/src/memory/memory-family-migration.ts
@@ -18,9 +18,13 @@
  * (`handleMemoryLinkCommand`), so a mid-migration failure leaves the worktree
  * in its prior link state and a retry is idempotent.
  *
- * Lock discipline: `proper-lockfile` on the destination cohort dir with a
- * bumped `stale` (30s) for the migration critical section — reused from the
- * knowledge family so there is one source of truth for the lock config.
+ * Lock discipline: `proper-lockfile` on the destination storage dir (cohort
+ * OR local — both directions) with a bumped `stale` (30s) for the migration
+ * critical section — reused from the knowledge family so there is one source
+ * of truth for the lock config. `realpath: false` keeps the lock identity on
+ * the literal path so it is the SAME lock the local JSONL provider takes on
+ * this directory (PRR-U1): symlinked roots (e.g. macOS /var → /private/var)
+ * must not split the exclusion into two identities.
  * Admission is fail-closed (#2577): if the destination lock cannot be
  * acquired (a legitimate concurrent writer holds it, or acquisition fails for
  * a storage reason), the migration throws a typed
@@ -500,6 +504,10 @@ export async function migrateMemoryFamily(
 		destRelease = await _internals.lockfile.lock(destStoragePath, {
 			...MIGRATION_LOCK_RETRIES,
 			stale: MIGRATION_LOCK_STALE_MS,
+			// Same identity as the JSONL provider's lock on this directory
+			// (which passes realpath:false) so the exclusion holds even when
+			// the storage path contains symlink components (PRR-U1).
+			realpath: false,
 		});
 	} catch (error) {
 		// #2577 (FUNCTIONAL-6): admission is fail-closed. This throw stays

--- a/tests/helpers/invariant-gate-fixtures.ts
+++ b/tests/helpers/invariant-gate-fixtures.ts
@@ -96,12 +96,16 @@ export function buildInvariantsOracleExpected(): {
 		...SIX_CHECK_BLOCK,
 		'=== Check 7: quarantine entries carry OWNER + EXPIRY metadata (issue #2477) ===',
 		'All active quarantine entries carry OWNER + EXPIRY metadata.',
+		'=== Check 8: family-migration destination lock admission fails closed (issue #2577) ===',
+		'NOTE: src/memory/memory-family-migration.ts not found - Check 8 skipped for this path.',
+		'NOTE: src/knowledge/family-migration.ts not found - Check 8 skipped for this path.',
 		'',
 		'=== Summary ===',
 		'Checks run: 1 (subprocess timeout, advisory) | 2 (process.cwd ban) |',
 		'            3 (mock.module allowlist) | 4 (allowlist growth ratchet) |',
 		'            5 (knowledge array dedup guardrail) | 6 (advisory-injection ratchet) |',
-		'            7 (quarantine OWNER/EXPIRY metadata)',
+		'            7 (quarantine OWNER/EXPIRY metadata) |',
+		'            8 (family-migration destination lock admission)',
 		'1 invariant violation(s) found.',
 	].join('\n');
 	const legacyExpected = [

--- a/tests/unit/memory/memory-family-migration-locking.test.ts
+++ b/tests/unit/memory/memory-family-migration-locking.test.ts
@@ -127,7 +127,10 @@ describe('memory family migration destination-lock admission', () => {
 		);
 		const destBefore = snapshotTree(dest);
 		const sourceBefore = snapshotTree(source);
-		const release = await lockfile.lock(dest, { stale: 60_000 });
+		const release = await lockfile.lock(dest, {
+			stale: 60_000,
+			realpath: false,
+		});
 		try {
 			const startedAt = performance.now();
 			let rejection: unknown;
@@ -145,10 +148,16 @@ describe('memory family migration destination-lock admission', () => {
 			// Bounded, host-path-free failure text (the #2575 no-leak rule).
 			expect(error.message.length).toBeLessThanOrEqual(4096);
 			expect(error.message).not.toContain(tmpDir);
-			expect(typeof error.category).toBe('string');
-			expect(typeof error.code).toBe('string');
-			// The shared bounded retry budget must be honored before failing.
-			expect(elapsedMs).toBeGreaterThanOrEqual(500);
+			expect(error.category).toBe('contention');
+			expect(error.code).toBe('MEMORY_MIGRATION_LOCK_CONTENTION');
+			// The underlying ELOCKED-shaped cause is preserved for diagnostics.
+			expect((error as { cause?: { code?: string } }).cause).toMatchObject({
+				code: 'ELOCKED',
+			});
+			// The shared bounded retry budget must be honored before failing:
+			// the schedule sums to 4200 ms, so a short-circuited retry loop
+			// (well under half the budget) must not pass this floor.
+			expect(elapsedMs).toBeGreaterThanOrEqual(2000);
 			// Failed admission preserves destination and source exactly.
 			expect(snapshotTree(dest)).toEqual(destBefore);
 			expect(snapshotTree(source)).toEqual(sourceBefore);
@@ -171,8 +180,12 @@ describe('memory family migration destination-lock admission', () => {
 		seedJsonl(source, 'memories.jsonl', ['cohort-1']);
 		const destBefore = snapshotTree(dest);
 		const sourceBefore = snapshotTree(source);
-		const release = await lockfile.lock(dest, { stale: 60_000 });
+		const release = await lockfile.lock(dest, {
+			stale: 60_000,
+			realpath: false,
+		});
 		try {
+			const startedAt = performance.now();
 			const rejection = await migrateMemoryFamily(
 				localRoot(wtDir),
 				cohortRoot(cohortDir, wtDir),
@@ -180,15 +193,27 @@ describe('memory family migration destination-lock admission', () => {
 				() => undefined,
 				(err: unknown) => err,
 			);
+			const elapsedMs = performance.now() - startedAt;
 			expect(rejection).toBeDefined();
-			expect((rejection as Error).message.toLowerCase()).toContain(
-				'contention',
-			);
+			const error = rejection as Error & {
+				category?: string;
+				code?: string;
+			};
+			expect(error.message.toLowerCase()).toContain('contention');
+			expect(error.message.toLowerCase()).toContain('retry');
+			expect(error.message.length).toBeLessThanOrEqual(4096);
+			expect(error.message).not.toContain(tmpDir);
+			expect(error.category).toBe('contention');
+			expect(error.code).toBe('MEMORY_MIGRATION_LOCK_CONTENTION');
+			// Same bounded-retry evidence floor as the link direction.
+			expect(elapsedMs).toBeGreaterThanOrEqual(2000);
 			expect(snapshotTree(dest)).toEqual(destBefore);
 			expect(snapshotTree(source)).toEqual(sourceBefore);
 			// The unlocked unlink path used to mkdir backups/ before any
 			// memory.db check; failed admission must not litter.
 			expect(fs.existsSync(path.join(dest, 'backups'))).toBe(false);
+			// The holder's live lock was not stolen or deleted.
+			expect(fs.existsSync(`${dest}.lock`)).toBe(true);
 		} finally {
 			await release().catch(() => {});
 		}
@@ -286,7 +311,10 @@ describe('memory family migration destination-lock admission', () => {
 			['dest-1'],
 			['src-1'],
 		);
-		const release = await lockfile.lock(dest, { stale: 60_000 });
+		const release = await lockfile.lock(dest, {
+			stale: 60_000,
+			realpath: false,
+		});
 		const migration = migrateMemoryFamily(destRoot, srcRoot);
 		await new Promise<void>((resolve) => {
 			setTimeout(() => {

--- a/tests/unit/memory/memory-family-migration-locking.test.ts
+++ b/tests/unit/memory/memory-family-migration-locking.test.ts
@@ -1,0 +1,327 @@
+/**
+ * #2577: destination-lock admission contract for the memory family migration.
+ *
+ * A held live destination lock must not be bypassable: when acquisition of the
+ * destination storage-directory lock fails, `migrateMemoryFamily` fails closed
+ * with a typed, bounded, retryable error and leaves both the destination and
+ * the source untouched. Mirrors the #2575 Full-Auto locking suite
+ * (tests/unit/full-auto/state-locking.test.ts) for the memory cohort engine.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import lockfile from 'proper-lockfile';
+import {
+	_internals,
+	migrateMemoryFamily,
+} from '../../../src/memory/memory-family-migration';
+import type { VettedMemoryRoot } from '../../../src/memory/storage-root';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const originalLockfile = _internals.lockfile;
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = canonicalMkdtemp('swarm-migration-lock-');
+	_internals.lockfile = originalLockfile;
+});
+
+afterEach(() => {
+	_internals.lockfile = originalLockfile;
+	try {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup after a failed contention test.
+	}
+});
+
+function localRoot(directory: string): VettedMemoryRoot {
+	return { kind: 'local', root: path.join(directory, '.swarm'), directory };
+}
+
+function cohortRoot(cohortDir: string, directory: string): VettedMemoryRoot {
+	return {
+		kind: 'cohort',
+		cohortRoot: path.join(cohortDir, 'memory'),
+		cohortId: 'lock-test-cohort',
+		generation: 1,
+		linkId: 'lock-test-link',
+		directory,
+	};
+}
+
+function seedJsonl(storageDir: string, filename: string, ids: string[]): void {
+	fs.mkdirSync(storageDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(storageDir, filename),
+		ids.map((id) => JSON.stringify({ id })).join('\n') + '\n',
+		'utf-8',
+	);
+}
+
+function readIds(storageDir: string, filename: string): string[] {
+	const p = path.join(storageDir, filename);
+	if (!fs.existsSync(p)) return [];
+	return fs
+		.readFileSync(p, 'utf-8')
+		.split('\n')
+		.filter((l) => l.trim())
+		.map((l) => (JSON.parse(l) as { id: string }).id);
+}
+
+interface TreeSnapshot {
+	entries: string[];
+	files: Map<string, string>;
+}
+
+function snapshotTree(rootDir: string): TreeSnapshot {
+	const entries: string[] = [];
+	const files = new Map<string, string>();
+	const walk = (dir: string, rel: string): void => {
+		for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+			const relPath = rel ? `${rel}/${item.name}` : item.name;
+			entries.push(`${item.isDirectory() ? 'd' : 'f'} ${relPath}`);
+			if (item.isDirectory()) walk(path.join(dir, item.name), relPath);
+			else {
+				files.set(relPath, fs.readFileSync(path.join(dir, item.name), 'utf-8'));
+			}
+		}
+	};
+	walk(rootDir, '');
+	entries.sort();
+	return { entries, files };
+}
+
+function seedLinkPair(
+	base: string,
+	destIds: string[],
+	srcIds: string[],
+): {
+	dest: string;
+	source: string;
+	destRoot: VettedMemoryRoot;
+	srcRoot: VettedMemoryRoot;
+} {
+	const wtDir = path.join(base, 'wt');
+	const cohortDir = path.join(base, 'cohort');
+	const dest = path.join(cohortDir, 'memory');
+	const source = path.join(wtDir, '.swarm', 'memory');
+	seedJsonl(dest, 'memories.jsonl', destIds);
+	seedJsonl(source, 'memories.jsonl', srcIds);
+	return {
+		dest,
+		source,
+		destRoot: cohortRoot(cohortDir, wtDir),
+		srcRoot: localRoot(wtDir),
+	};
+}
+
+describe('memory family migration destination-lock admission', () => {
+	test('held live destination lock fails closed typed and untouched (link direction)', async () => {
+		const { dest, source, destRoot, srcRoot } = seedLinkPair(
+			path.join(tmpDir, 'link'),
+			['dest-1'],
+			['src-1'],
+		);
+		const destBefore = snapshotTree(dest);
+		const sourceBefore = snapshotTree(source);
+		const release = await lockfile.lock(dest, { stale: 60_000 });
+		try {
+			const startedAt = performance.now();
+			let rejection: unknown;
+			await migrateMemoryFamily(destRoot, srcRoot).catch((err) => {
+				rejection = err;
+			});
+			const elapsedMs = performance.now() - startedAt;
+			expect(rejection).toBeDefined();
+			const error = rejection as Error & {
+				category?: string;
+				code?: string;
+			};
+			expect(error.message.toLowerCase()).toContain('contention');
+			expect(error.message.toLowerCase()).toContain('retry');
+			// Bounded, host-path-free failure text (the #2575 no-leak rule).
+			expect(error.message.length).toBeLessThanOrEqual(4096);
+			expect(error.message).not.toContain(tmpDir);
+			expect(typeof error.category).toBe('string');
+			expect(typeof error.code).toBe('string');
+			// The shared bounded retry budget must be honored before failing.
+			expect(elapsedMs).toBeGreaterThanOrEqual(500);
+			// Failed admission preserves destination and source exactly.
+			expect(snapshotTree(dest)).toEqual(destBefore);
+			expect(snapshotTree(source)).toEqual(sourceBefore);
+			expect(fs.existsSync(path.join(dest, 'backups'))).toBe(false);
+			// The holder's live lock was not stolen or deleted.
+			expect(fs.existsSync(`${dest}.lock`)).toBe(true);
+		} finally {
+			await release().catch(() => {});
+		}
+	}, 20_000);
+
+	test('held live destination lock fails closed typed and untouched (unlink direction)', async () => {
+		// Unlink migrates cohort -> local: the destination is the LOCAL root,
+		// which the JSONL provider legitimately locks on the same path.
+		const wtDir = path.join(tmpDir, 'unlink-wt');
+		const cohortDir = path.join(tmpDir, 'unlink-cohort');
+		const dest = path.join(wtDir, '.swarm', 'memory');
+		const source = path.join(cohortDir, 'memory');
+		seedJsonl(dest, 'memories.jsonl', ['local-1']);
+		seedJsonl(source, 'memories.jsonl', ['cohort-1']);
+		const destBefore = snapshotTree(dest);
+		const sourceBefore = snapshotTree(source);
+		const release = await lockfile.lock(dest, { stale: 60_000 });
+		try {
+			const rejection = await migrateMemoryFamily(
+				localRoot(wtDir),
+				cohortRoot(cohortDir, wtDir),
+			).then(
+				() => undefined,
+				(err: unknown) => err,
+			);
+			expect(rejection).toBeDefined();
+			expect((rejection as Error).message.toLowerCase()).toContain(
+				'contention',
+			);
+			expect(snapshotTree(dest)).toEqual(destBefore);
+			expect(snapshotTree(source)).toEqual(sourceBefore);
+			// The unlocked unlink path used to mkdir backups/ before any
+			// memory.db check; failed admission must not litter.
+			expect(fs.existsSync(path.join(dest, 'backups'))).toBe(false);
+		} finally {
+			await release().catch(() => {});
+		}
+	}, 20_000);
+
+	test('classifies an ELOCKED acquisition failure as typed contention', async () => {
+		const { dest, source, destRoot, srcRoot } = seedLinkPair(
+			path.join(tmpDir, 'taxonomy-locked'),
+			['dest-1'],
+			['src-1'],
+		);
+		const destBefore = snapshotTree(dest);
+		const sourceBefore = snapshotTree(source);
+		_internals.lockfile = {
+			lock: () =>
+				Promise.reject(
+					Object.assign(new Error('Lock file is already being held'), {
+						code: 'ELOCKED',
+					}),
+				),
+		};
+		const rejection = await migrateMemoryFamily(destRoot, srcRoot).then(
+			() => undefined,
+			(err: unknown) => err,
+		);
+		expect(rejection).toBeDefined();
+		const error = rejection as Error & { category?: string; code?: string };
+		expect(error.category).toBe('contention');
+		expect(error.code).toBe('MEMORY_MIGRATION_LOCK_CONTENTION');
+		expect(snapshotTree(dest)).toEqual(destBefore);
+		expect(snapshotTree(source)).toEqual(sourceBefore);
+	});
+
+	test('classifies a non-ELOCKED acquisition failure as typed storage', async () => {
+		const { dest, destRoot, srcRoot } = seedLinkPair(
+			path.join(tmpDir, 'taxonomy-storage'),
+			['dest-1'],
+			['src-1'],
+		);
+		const destBefore = snapshotTree(dest);
+		_internals.lockfile = {
+			lock: () =>
+				Promise.reject(
+					Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+				),
+		};
+		const rejection = await migrateMemoryFamily(destRoot, srcRoot).then(
+			() => undefined,
+			(err: unknown) => err,
+		);
+		expect(rejection).toBeDefined();
+		const error = rejection as Error & { category?: string; code?: string };
+		expect(error.category).toBe('storage');
+		expect(error.code).toBe('MEMORY_MIGRATION_LOCK_STORAGE');
+		expect(error.message.toLowerCase()).not.toContain('contention');
+		expect(snapshotTree(dest)).toEqual(destBefore);
+	});
+
+	test('two concurrent legitimate migrations serialize without lost rows', async () => {
+		const wtA = path.join(tmpDir, 'wt-a');
+		const wtB = path.join(tmpDir, 'wt-b');
+		const cohortDir = path.join(tmpDir, 'cohort');
+		const dest = path.join(cohortDir, 'memory');
+		seedJsonl(dest, 'memories.jsonl', ['dest-1']);
+		seedJsonl(path.join(wtA, '.swarm', 'memory'), 'memories.jsonl', [
+			'a-1',
+			'a-2',
+		]);
+		seedJsonl(path.join(wtB, '.swarm', 'memory'), 'memories.jsonl', [
+			'b-1',
+			'b-2',
+		]);
+		const [a, b] = await Promise.all([
+			migrateMemoryFamily(cohortRoot(cohortDir, wtA), localRoot(wtA)),
+			migrateMemoryFamily(cohortRoot(cohortDir, wtB), localRoot(wtB)),
+		]);
+		expect(a.perMember.find((m) => m.filename === 'memories.jsonl')).toEqual({
+			filename: 'memories.jsonl',
+			merged: 2,
+			skipped: 0,
+		});
+		expect(b.perMember.find((m) => m.filename === 'memories.jsonl')).toEqual({
+			filename: 'memories.jsonl',
+			merged: 2,
+			skipped: 0,
+		});
+		expect(new Set(readIds(dest, 'memories.jsonl'))).toEqual(
+			new Set(['dest-1', 'a-1', 'a-2', 'b-1', 'b-2']),
+		);
+	}, 20_000);
+
+	test('completes when contention clears within the bounded retry budget', async () => {
+		const { dest, destRoot, srcRoot } = seedLinkPair(
+			path.join(tmpDir, 'retryable'),
+			['dest-1'],
+			['src-1'],
+		);
+		const release = await lockfile.lock(dest, { stale: 60_000 });
+		const migration = migrateMemoryFamily(destRoot, srcRoot);
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				release()
+					.catch(() => {})
+					.then(resolve, resolve);
+			}, 1_200);
+		});
+		const result = await migration;
+		expect(
+			result.perMember.find((m) => m.filename === 'memories.jsonl'),
+		).toMatchObject({ merged: 1, skipped: 0 });
+		expect(readIds(dest, 'memories.jsonl')).toEqual(['dest-1', 'src-1']);
+	}, 20_000);
+
+	test('uncontended migration retains counts and stays idempotent', async () => {
+		const { dest, destRoot, srcRoot } = seedLinkPair(
+			path.join(tmpDir, 'uncontended'),
+			['dest-1', 'dest-2'],
+			['src-1', 'dest-1'],
+		);
+		const first = await migrateMemoryFamily(destRoot, srcRoot);
+		expect(
+			first.perMember.find((m) => m.filename === 'memories.jsonl'),
+		).toEqual({ filename: 'memories.jsonl', merged: 1, skipped: 1 });
+		expect(readIds(dest, 'memories.jsonl')).toEqual([
+			'dest-1',
+			'dest-2',
+			'src-1',
+		]);
+		const afterFirst = snapshotTree(dest);
+		const second = await migrateMemoryFamily(destRoot, srcRoot);
+		expect(
+			second.perMember.find((m) => m.filename === 'memories.jsonl'),
+		).toEqual({ filename: 'memories.jsonl', merged: 0, skipped: 2 });
+		expect(snapshotTree(dest)).toEqual(afterFirst);
+	});
+});

--- a/tests/unit/scripts/check-invariants.test.ts
+++ b/tests/unit/scripts/check-invariants.test.ts
@@ -188,10 +188,6 @@ function setupFixtureDir(fixtureName: string): string {
 	// every fixture tree must carry the four lists (header-only = no active
 	// entries; the bash owner leg never reads them).
 	seedQuarantineListFiles(fixtureDir);
-	// Check 8 (issue #2577) skips non-blockingly when NEITHER family-migration
-	// engine is present (fixture trees have no family-migration surface), so
-	// no engine stubs are needed here; the single-engine-missing drift case is
-	// covered by tests/unit/scripts/check-migration-lock-admission.test.ts.
 
 	return fixtureDir;
 }

--- a/tests/unit/scripts/check-invariants.test.ts
+++ b/tests/unit/scripts/check-invariants.test.ts
@@ -188,6 +188,10 @@ function setupFixtureDir(fixtureName: string): string {
 	// every fixture tree must carry the four lists (header-only = no active
 	// entries; the bash owner leg never reads them).
 	seedQuarantineListFiles(fixtureDir);
+	// Check 8 (issue #2577) skips non-blockingly when NEITHER family-migration
+	// engine is present (fixture trees have no family-migration surface), so
+	// no engine stubs are needed here; the single-engine-missing drift case is
+	// covered by tests/unit/scripts/check-migration-lock-admission.test.ts.
 
 	return fixtureDir;
 }

--- a/tests/unit/scripts/check-migration-lock-admission.test.ts
+++ b/tests/unit/scripts/check-migration-lock-admission.test.ts
@@ -37,6 +37,35 @@ function makeRepoWithEngine(
 	);
 	fs.mkdirSync(path.dirname(enginePath), { recursive: true });
 	fs.writeFileSync(enginePath, engineBody.split('\n').join(newline), 'utf-8');
+	// Minimal fail-closed knowledge-engine stub so the engine-under-test is
+	// the only variable: Check 8 now fails closed on missing engine files.
+	const stubPath = path.join(
+		repoDir,
+		'src',
+		'knowledge',
+		'family-migration.ts',
+	);
+	fs.mkdirSync(path.dirname(stubPath), { recursive: true });
+	fs.writeFileSync(
+		stubPath,
+		[
+			'export async function migrateKnowledgeFamily() {',
+			'\tlet destRelease: (() => Promise<void>) | null = null;',
+			'\tdestRelease = await lockfile.lock(destinationDir, {});',
+			'\ttry {',
+			'\t\tawait runMerge();',
+			'\t} catch (error) {',
+			'\t\tthrow error;',
+			'\t} finally {',
+			'\t\tif (destRelease) await destRelease();',
+			'\t}',
+			'}',
+		]
+			.join('\n')
+			.split('\n')
+			.join(newline),
+		'utf-8',
+	);
 	tempRoots.push(repoDir);
 	return repoDir;
 }
@@ -145,13 +174,107 @@ describe('checkMigrationLockAdmission (Check 8, issue #2577)', () => {
 		).toBe(true);
 	});
 
-	test('skips with a NOTE when no engine file is present', () => {
+	test('skips with NOTEs when neither engine is present (fixture trees)', () => {
 		const repoDir = canonicalMkdtemp('migration-lock-admission-empty-');
 		tempRoots.push(repoDir);
 		const result = checkMigrationLockAdmission(repoDir);
+		// A tree with NO family-migration surface has nothing to scan.
 		expect(result.violations).toBe(0);
 		expect(result.messages.filter((m) => m.startsWith('NOTE: ')).length).toBe(
 			2,
 		);
+	});
+
+	test('fails closed when exactly one engine file is missing (PRR-R1)', () => {
+		// One engine present, the other gone: a rename/move must not silently
+		// silence the guardrail's half of the scan.
+		const repoDir = canonicalMkdtemp('migration-lock-admission-half-');
+		const stubPath = path.join(
+			repoDir,
+			'src',
+			'knowledge',
+			'family-migration.ts',
+		);
+		fs.mkdirSync(path.dirname(stubPath), { recursive: true });
+		fs.writeFileSync(
+			stubPath,
+			[
+				'export async function migrateKnowledgeFamily() {',
+				'\tlet destRelease: (() => Promise<void>) | null = null;',
+				'\tdestRelease = await lockfile.lock(destinationDir, {});',
+				'\ttry {',
+				'\t\tawait runMerge();',
+				'\t} catch (error) {',
+				'\t\tthrow error;',
+				'\t} finally {',
+				'\t\tif (destRelease) await destRelease();',
+				'\t}',
+				'}',
+			].join('\n'),
+			'utf-8',
+		);
+		tempRoots.push(repoDir);
+		const result = checkMigrationLockAdmission(repoDir);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes(
+					'memory-family-migration.ts not found - Check 8 cannot verify destination lock admission',
+				),
+			),
+		).toBe(true);
+	});
+
+	test('fails closed when a present engine has no recognizable acquire (PRR-T3)', () => {
+		// A renamed release variable makes the acquire pattern match nothing;
+		// the guardrail must not pass vacuously.
+		const renamed = FAIL_CLOSED_ENGINE.replace(/destRelease/g, 'cohortRelease');
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(renamed, '\n'),
+		);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes(
+					'contains no recognizable destination lock acquire (destRelease = await ...lock()) - re-anchor Check 8.',
+				),
+			),
+		).toBe(true);
+	});
+
+	test('flags an acquire with no adjacent catch within the scan window (PRR-T2)', () => {
+		// The acquire exists but its catch is beyond the 12-line forward
+		// window: the scanner must report the re-anchor error, not pass.
+		const noCatch = [
+			'export async function migrateMemoryFamily() {',
+			'\tlet destRelease: (() => Promise<void>) | null = null;',
+			'\tdestRelease = await lockfile.lock(destStoragePath);',
+			'\tconst perMember: string[] = [];',
+			'\tfor (const member of MEMORY_FAMILY) {',
+			'\t\tperMember.push(member.filename);',
+			'\t}',
+			'\tif (perMember.length === 0) {',
+			'\t\tthrow new Error("nothing to migrate");',
+			'\t}',
+			'\tawait commitAll(perMember);',
+			'\t// ... more than 12 lines pass before any catch appears ...',
+			'\t// ... more than 12 lines pass before any catch appears ...',
+			'\t// ... more than 12 lines pass before any catch appears ...',
+			'\ttry {',
+			'\t\tawait finalize();',
+			'\t} catch (err) {',
+			'\t\tthrow err;',
+			'\t}',
+			'}',
+		].join('\n');
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(noCatch, '\n'),
+		);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes('destination lock acquire has no adjacent catch'),
+			),
+		).toBe(true);
 	});
 });

--- a/tests/unit/scripts/check-migration-lock-admission.test.ts
+++ b/tests/unit/scripts/check-migration-lock-admission.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure-function coverage for `checkMigrationLockAdmission` (check:invariants
+ * Check 8, issue #2577) — runs against temp fixture trees instead of spawning
+ * the full invariant script. Pins the catch-shape scan on PRESENT engine
+ * files (the shared oracle fixture only exercises the file-absent NOTE
+ * branch), including the CRLF normalization: a Windows autocrlf working copy
+ * must not let a swallowing catch scan past its own catch body.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { checkMigrationLockAdmission } from '../../../scripts/check-invariants';
+import { canonicalMkdtemp } from '../../helpers/tmpdir';
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		try {
+			fs.rmSync(root, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup.
+		}
+	}
+});
+
+function makeRepoWithEngine(
+	engineBody: string,
+	newline: '\n' | '\r\n',
+): string {
+	const repoDir = canonicalMkdtemp('migration-lock-admission-2577-');
+	const enginePath = path.join(
+		repoDir,
+		'src',
+		'memory',
+		'memory-family-migration.ts',
+	);
+	fs.mkdirSync(path.dirname(enginePath), { recursive: true });
+	fs.writeFileSync(enginePath, engineBody.split('\n').join(newline), 'utf-8');
+	tempRoots.push(repoDir);
+	return repoDir;
+}
+
+const FAIL_CLOSED_ENGINE = [
+	'export async function migrateMemoryFamily() {',
+	'\tlet destRelease: (() => Promise<void>) | null = null;',
+	'\ttry {',
+	'\t\tdestRelease = await _internals.lockfile.lock(destStoragePath, {',
+	'\t\t\tstale: MIGRATION_LOCK_STALE_MS,',
+	'\t\t});',
+	'\t} catch (error) {',
+	'\t\tthrow makeAdmissionError(error);',
+	'\t}',
+	'\ttry {',
+	'\t\tthrow new Error("late validation failure");',
+	'\t} finally {',
+	'\t\tif (destRelease) await destRelease();',
+	'\t}',
+	'}',
+].join('\n');
+
+// The FUNCTIONAL-6 defect shape: a later, unrelated throw must NOT satisfy
+// the admission catch's fail-closed requirement.
+const SWALLOWING_ENGINE = [
+	'export async function migrateMemoryFamily() {',
+	'\tlet destRelease: (() => Promise<void>) | null = null;',
+	'\ttry {',
+	'\t\tdestRelease = await _internals.lockfile.lock(destStoragePath, {',
+	'\t\t\tstale: MIGRATION_LOCK_STALE_MS,',
+	'\t\t});',
+	'\t} catch {',
+	'\t\t// Local roots may not be lockable; proceed unlocked.',
+	'\t}',
+	'\tthrow new Error("late validation failure");',
+	'}',
+].join('\n');
+
+// The live engine's post-fix shape with the real throw mutated away: the
+// catch comment still says "This throw stays", and that word inside the
+// comment must NOT satisfy the fail-closed scan (Round-2 reviewer finding).
+const COMMENT_THROW_SWALLOWING_ENGINE = [
+	'export async function migrateMemoryFamily() {',
+	'\tlet destRelease: (() => Promise<void>) | null = null;',
+	'\ttry {',
+	'\t\tdestRelease = await _internals.lockfile.lock(destStoragePath, {',
+	'\t\t\tstale: MIGRATION_LOCK_STALE_MS,',
+	'\t\t});',
+	'\t} catch (error) {',
+	'\t\t// #2577 (FUNCTIONAL-6): admission is fail-closed. This throw stays',
+	'\t\t// syntactically INSIDE this catch - do not relocate it.',
+	'\t\tvoid makeAdmissionError(error);',
+	'\t}',
+	'\tthrow new Error("late validation failure");',
+	'}',
+].join('\n');
+
+describe('checkMigrationLockAdmission (Check 8, issue #2577)', () => {
+	test('passes a present engine whose admission catch throws (LF)', () => {
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(FAIL_CLOSED_ENGINE, '\n'),
+		);
+		expect(result.violations).toBe(0);
+		expect(
+			result.messages.some((m) =>
+				m.includes('destination lock admission fails closed.'),
+			),
+		).toBe(true);
+	});
+
+	test('flags a present engine that swallows the admission failure (LF)', () => {
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(SWALLOWING_ENGINE, '\n'),
+		);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes('destination lock acquisition failure is swallowed'),
+			),
+		).toBe(true);
+	});
+
+	test('flags the swallowing engine on a CRLF (autocrlf) working copy', () => {
+		// Regression pin for the reviewer-found false negative: the strict
+		// catch-close match must not be defeated by trailing CR bytes.
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(SWALLOWING_ENGINE, '\r\n'),
+		);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes('destination lock acquisition failure is swallowed'),
+			),
+		).toBe(true);
+	});
+
+	test('flags a swallow whose catch comment merely says "throw" (Round-2 finding)', () => {
+		const result = checkMigrationLockAdmission(
+			makeRepoWithEngine(COMMENT_THROW_SWALLOWING_ENGINE, '\n'),
+		);
+		expect(result.violations).toBe(1);
+		expect(
+			result.messages.some((m) =>
+				m.includes('destination lock acquisition failure is swallowed'),
+			),
+		).toBe(true);
+	});
+
+	test('skips with a NOTE when no engine file is present', () => {
+		const repoDir = canonicalMkdtemp('migration-lock-admission-empty-');
+		tempRoots.push(repoDir);
+		const result = checkMigrationLockAdmission(repoDir);
+		expect(result.violations).toBe(0);
+		expect(result.messages.filter((m) => m.startsWith('NOTE: ')).length).toBe(
+			2,
+		);
+	});
+});


### PR DESCRIPTION
Closes #2577

## Summary

- The memory family migration (`migrateMemoryFamily`, backing `/swarm memory link` and `/swarm memory unlink`) swallowed every destination-lock acquisition failure — including `ELOCKED` after the shared ~4.2 s bounded retry budget — and ran the destination read/merge/write unlocked, so a legitimate concurrent writer on the same storage directory (local JSONL provider, sibling worktree link, peer unlink) was not excluded and appended rows could be silently dropped while the command reported success (issue #2577, audit FUNCTIONAL-6).
- Admission now fails closed with a typed `MemoryMigrationLockError` (category `contention` for ELOCKED, `storage` otherwise; stable `MEMORY_MIGRATION_LOCK_*` code; bounded, host-path-free, retry-instructing message), thrown inside the acquisition catch before the merge loop opens — destination and source are preserved byte-for-byte on failed admission and a held live lock is never stolen. Mirrors the #2575 Full-Auto locking contract and the knowledge engine's fail-closed sibling.
- New invariant-gate Check 8 (`scripts/check-invariants.ts`) statically enforces that both family-migration engines' destination-lock acquisitions fail closed (CRLF-normalized, comment-aware scan that fail-closes on single-engine drift or a drifted anchor rather than passing vacuously), with scan regression coverage; deterministic held-lock/taxonomy/serialization/retryable/idempotency suite added for the migration engine. The migration lock now takes `realpath: false` so its lock identity matches the local JSONL provider's on the same directory (symlink-safe exclusion), and the typed error is re-exported from the memory barrel.

## Invariant audit

- 1 (plugin init): not touched — no init-path code changed; the migration engine is command-handler-only (verified by module header and call sites).
- 2 (runtime portability): not touched — no bundle/export/runtime-resolution changes; `bun run build` + `node --input-type=module -e "await import('./dist/index.js')"` pass.
- 3 (subprocesses): not touched — no subprocess code changed (new tests spawn nothing; fixtures are in-process).
- 4 (.swarm containment): not touched — engine paths unchanged; tests use `canonicalMkdtemp` external fixtures only.
- 5 (plan durability): not touched — no plan ledger/projection/checkpoint code changed.
- 6 (test_runner safety): not touched — validation used per-file `bun test` and script gates, never broad `test_runner` scopes.
- 7 (test writing): touched — new `tests/unit/memory/memory-family-migration-locking.test.ts` (7 tests, 355 lines, under the 500-line cap) and `tests/unit/scripts/check-migration-lock-admission.test.ts` (8 tests, 280 lines) use bun:test, `_internals` DI with afterEach restore, `canonicalMkdtemp`, `performance.now` for elapsed measurement (test-clock ratchet clean in a simulated-commit worktree), no `mock.module`; `check:mock-cleanup`, `check:test-file-cap`, `check:test-clock`, `check:test-tmpdir` all pass.
- 8 (session state): not touched — no session-scoped state added (the typed error is invocation-local).
- 9 (guardrails/retry): touched — the destination admission is now bounded (shared retry budget preserved byte-for-byte), typed (contention vs storage), and fail-closed (never runs the critical section unlocked); release-failure handling remains best-effort as in both engines.
- 10 (chat/system msg): not touched — chat transform and guidance-carrier code unchanged.
- 11 (tool registration): not touched — no tool/metadata/manifest/agent-map changes.
- 12 (release/cache): touched — `docs/releases/pending/2577-memory-cohort-migration-lock.md` added; no version/changelog hand edits.

## Test plan

- New regression suite: `bun test tests/unit/memory/memory-family-migration-locking.test.ts` → 7 pass / 0 fail (held live lock link + unlink directions, ELOCKED/EACCES taxonomy, concurrent serialization without lost rows, retryable admission, uncontended idempotency).
- Check 8 scan suite: `bun test tests/unit/scripts/check-migration-lock-admission.test.ts` → 8 pass / 0 fail (present+throw OK, present+swallow flagged, CRLF swallow flagged, comment-throw swallow flagged, neither-engine NOTE skip, single-engine-missing flagged, renamed-anchor flagged, no-adjacent-catch flagged).
- Sibling suites: memory-family-outcome-collision 9/9, memory-family-manifest 5/5, commands/memory-link 10/10, full-auto/state-locking 10/10, check-invariants.test.ts 13/13, check-bash-gates-legacy-oracle.test.ts 6/6, check-invariants-regressions.test.ts 4/4.
- Gates: `bun run typecheck`, `bun run build` + Node ESM import of `dist/index.js`, `bunx @biomejs/biome@2.3.14 ci .` (0 errors), `check:invariants` (incl. new Check 8), `check:mock-cleanup`, `check:test-file-cap`, `check:test-clock` (simulated-commit worktree), `check:test-tmpdir`, `git diff --check` — all pass.
- Frozen acceptance checks (issue-tracer trace): C1/C2 RED→GREEN (held live destination lock, both command directions), C3/C4/C5 GREEN-to-GREEN; checkpoint manifest verified.
- CI remains authoritative for the full matrix after publication.

## Root Cause

`src/memory/memory-family-migration.ts` caught the destination `proper-lockfile` acquisition failure in a bare `catch` whose comment claimed "missing dirs may not be lockable; proceed unlocked" — void because `mkdir(recursive)` precedes the acquire and the local JSONL provider locks the same directory during normal writes. The unlocked path then executed the destination read (line 481), merge, and `atomicWriteFile` (line 492) while a live lock was held.

## Fix

- `src/memory/memory-family-migration.ts`: typed fail-closed admission (`MemoryMigrationLockError` + `makeAdmissionError`), the lock module routed through the `_internals` seam for deterministic taxonomy tests, the throw pinned inside the acquisition catch (before the merge-loop try, `destRelease` still null), header/inline comments corrected.
- `scripts/check-invariants.ts`: Check 8 guardrail (catch-shape scan over both engines, CRLF-normalized) + summary registration; `tests/helpers/invariant-gate-fixtures.ts`: oracle expected-output updated for the new block.
- Tests + release fragment as listed above.

## Recurrence Prevention (defect class)

- Defect class: a cross-process lock acquisition whose failure is caught and downgraded to proceed-unlocked, letting the guarded read/merge/write race a legitimate live-lock holder.
- Sweep result: 26 production acquire sites classified by an independent explorer (FAIL_CLOSED_THROW / FAIL_CLOSED_ALT); zero SWALLOW_AND_PROCEED remain post-fix; the source-snapshot swallow in the knowledge engine is a documented read-only tradeoff (out of class).
- Guardrail: CI check rung — invariant-gate Check 8 fails on a swallowing catch (demonstrated on the pre-fix file: 1 violation at the original line) and passes on the fix; scan itself regression-tested including the CRLF case.

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1: a held live destination lock cannot be bypassed | Frozen checks C1 (link direction) and C2 (unlink direction): base=RED head=GREEN via `repro-check.sh run`; suite tests "held live destination lock fails closed typed and untouched" (both directions); taxonomy tests pin ELOCKED→contention / other→storage |
| AC2: two legitimate migrations serialize without lost rows; destination+source preserved on failed admission | C3 (GREEN-to-GREEN, exact id-union across memories/proposals/audit) + suite test "two concurrent legitimate migrations serialize without lost rows"; C1/C2 assert byte-identical destination/source and no `backups/` litter after failed admission |
| AC3: a single uncontended migration retains the intended result | C4 (counts, id order, idempotent second run) + suite test "uncontended migration retains counts and stays idempotent"; existing outcome-collision and memory-link command suites unchanged-green |

## Regression Protection

- New: `tests/unit/memory/memory-family-migration-locking.test.ts` (7 tests) and `tests/unit/scripts/check-migration-lock-admission.test.ts` (8 tests).
- Negative/adversarial cases: held-lock both directions, storage-category admission failure, CRLF-encoded swallowing catch.
- Independent implementation review (Round 1 REJECTED → corrections: Check 8 CRLF normalization + present-file scan regression coverage; Round 2 verdict recorded in the trace) and final critic gate run on the final diff.
- Test drift review: none found; all sibling suites green.

## Risk and Rollback

- Risk level: low-medium — a legitimately slow concurrent holder now produces a typed retryable failure instead of a false success (the requested behavior); retry is idempotent by union-merge design.
- Rollback: revert the single source file (plus tests/fragment/guardrail) — no persistence or schema changes.
- Residual risk: lock-release failures remain best-effort-swallowed exactly as in both engines (documented disposition, admission is the defect class); realpath/stale-window divergence between the migration and provider lock configs is pre-existing and out of scope (assumption A4 in the trace).

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.

PR head: 593596ab544c204653b8b2b2a70da5ec0f22592a

## Issue Closure

Closes #2577

## Feedback closure

- Post-CI swarm-pr-review (6 base lanes + 11 risk-family micro lanes; two independent reviewer shards, 20 candidates, all VERIFIED, none HIGH/CRITICAL) drove this follow-up commit: strengthened unlink-direction held-lock assertions to parity with link (elapsed floor, category/code, cause, holder lock), raised the retry-evidence floor to >=2000 ms of the 4200 ms budget, aligned the migration lock to `realpath: false` (same lock identity as the provider, symlink-safe), re-exported `MemoryMigrationLockError` from the memory barrel, hardened Check 8 to fail closed on single-engine drift and on a drifted scan anchor (with new tests for both plus the no-adjacent-catch branch), documented Check 8 in AGENTS.md and docs/engineering-invariants.md, corrected the retry-budget figure to ~4.2 s, and fixed this body's test counts. Accepted-limitation findings (lone-CR endings, single-line catch, nested-try anchoring, nested-scope throw) are recorded in the review handoff rather than fixed; the runtime suite remains the binding guarantee.
